### PR TITLE
Expand RDF spec coverage and JSON lowering

### DIFF
--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -1249,18 +1249,25 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 	(if (equal? items '())
 		(list (list subject pred "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"))
 		(begin
-			/* Materialize node identities first, then expand every cell independently.
-			This avoids recursive/accumulator list ownership differences in JIT code. */
+			/* Materialize node identities and output cells independently. A session-backed
+			builder keeps JIT list ownership out of the parser's nested map callbacks. */
 			(define heads (map items (lambda (_item) (concat "_:list_" (uuid)))))
-			(define triples (merge (map (produceN (count items)) (lambda (idx) (begin
+			(define output (newsession))
+			(define emit (lambda (triple) (begin
+				(define index (coalesceNil (output "count") 0))
+				(output (concat "triple:" index) triple)
+				(output "count" (+ index 1)))))
+			(emit (list subject pred (car heads)))
+			(map (produceN (count items)) (lambda (idx) (begin
 				(define head (nth heads idx))
 				(define next (if (equal? (+ idx 1) (count heads))
 					"http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
 					(nth heads (+ idx 1))))
-				(merge (list
-					(rdf_expand_ttl_object head "http://www.w3.org/1999/02/22-rdf-syntax-ns#first" (nth items idx))
-					(list (list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" next)))))))))
-			(cons (list subject pred (car heads)) triples)))
+				(map (rdf_expand_ttl_object head
+					"http://www.w3.org/1999/02/22-rdf-syntax-ns#first" (nth items idx)) emit)
+				(emit (list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" next)))))
+			(map (produceN (coalesceNil (output "count") 0)) (lambda (idx)
+				(output (concat "triple:" idx))))))
 ))
 (define rdf_expand_ttl_object (lambda (subject pred obj) (match obj
 	'("__ttl_inline_node__" bn facts)

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -1249,24 +1249,18 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 	(if (equal? items '())
 		(list (list subject pred "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"))
 		(begin
-			/* Build the list from the tail. Besides avoiding deep recursion, this
-			keeps the intermediate list head in the reduction state so the JIT and
-			interpreter execute exactly the same ownership pattern. */
-			(define state (reduce (reverse items) (lambda (current item)
-				(match current '(next triples)
-					(begin
-						(define head (concat "_:list_" (uuid)))
-						(define with_rest (cons
-							(list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" next)
-							triples))
-						(define with_item (reduce
-							(rdf_expand_ttl_object head "http://www.w3.org/1999/02/22-rdf-syntax-ns#first" item)
-							(lambda (acc triple) (cons triple acc))
-							with_rest))
-						(list head with_item))))
-				(list "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil" '())))
-			(match state '(head triples)
-				(cons (list subject pred head) triples))))
+			/* Materialize node identities first, then expand every cell independently.
+			This avoids recursive/accumulator list ownership differences in JIT code. */
+			(define heads (map items (lambda (_item) (concat "_:list_" (uuid)))))
+			(define triples (merge (map (produceN (count items)) (lambda (idx) (begin
+				(define head (nth heads idx))
+				(define next (if (equal? (+ idx 1) (count heads))
+					"http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+					(nth heads (+ idx 1))))
+				(merge (list
+					(rdf_expand_ttl_object head "http://www.w3.org/1999/02/22-rdf-syntax-ns#first" (nth items idx))
+					(list (list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" next)))))))))
+			(cons (list subject pred (car heads)) triples)))
 ))
 (define rdf_expand_ttl_object (lambda (subject pred obj) (match obj
 	'("__ttl_inline_node__" bn facts)

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -1246,16 +1246,23 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 		(rdf_expand_ttl_object subject pred obj)))))
 ))
 (define rdf_expand_ttl_collection (lambda (subject pred items)
-	(match items
-		'() (list (list subject pred "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"))
-		(cons item tail)
+	(if (equal? items '())
+		(list (list subject pred "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"))
 		(begin
-			(define head (concat "_:list_" (uuid)))
-			(merge (list
-				(list (list subject pred head))
-				(rdf_expand_ttl_object head "http://www.w3.org/1999/02/22-rdf-syntax-ns#first" item)
-				(rdf_expand_ttl_collection head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" tail))))
-	)
+			/* Build the list from the tail. Besides avoiding deep recursion, this
+			keeps the intermediate list head in the reduction state so the JIT and
+			interpreter execute exactly the same ownership pattern. */
+			(define state (reduce (reverse items) (lambda (current item)
+				(match current '(next triples)
+					(begin
+						(define head (concat "_:list_" (uuid)))
+						(list head (merge (list
+							(rdf_expand_ttl_object head "http://www.w3.org/1999/02/22-rdf-syntax-ns#first" item)
+							(list (list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" next))
+							triples))))))
+				(list "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil" '())))
+			(match state '(head triples)
+				(cons (list subject pred head) triples))))
 ))
 (define rdf_expand_ttl_object (lambda (subject pred obj) (match obj
 	'("__ttl_inline_node__" bn facts)

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -1245,35 +1245,31 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 	(merge (map facts (lambda (triple) (match triple '(subject pred obj)
 		(rdf_expand_ttl_object subject pred obj)))))
 ))
-(define rdf_expand_ttl_collection (lambda (subject pred items)
-	(if (equal? items '())
-		(list (list subject pred "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"))
-		(begin
-			/* Materialize node identities and output cells independently. A session-backed
-			builder keeps JIT list ownership out of the parser's nested map callbacks. */
-			(define heads (map items (lambda (_item) (concat "_:list_" (uuid)))))
-			(define output (newsession))
-			(define emit (lambda (triple) (begin
-				(define index (coalesceNil (output "count") 0))
-				(output (concat "triple:" index) triple)
-				(output "count" (+ index 1)))))
-			(emit (list subject pred (car heads)))
-			(map (produceN (count items)) (lambda (idx) (begin
-				(define head (nth heads idx))
-				(define next (if (equal? (+ idx 1) (count heads))
-					"http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
-					(nth heads (+ idx 1))))
-				(map (rdf_expand_ttl_object head
-					"http://www.w3.org/1999/02/22-rdf-syntax-ns#first" (nth items idx)) emit)
-				(emit (list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" next)))))
-			(map (produceN (coalesceNil (output "count") 0)) (lambda (idx)
-				(output (concat "triple:" idx))))))
+(define rdf_expand_ttl_collection_cells (lambda (head item tail)
+	(begin
+		(define next (match tail
+			'() "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+			_ (concat head "_rest")))
+		(cons (list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#first" item)
+			(cons (list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" next)
+				(match tail
+					(cons next_item remaining)
+					(rdf_expand_ttl_collection_cells next next_item remaining)
+					_ '()))))
+))
+(define rdf_expand_ttl_collection (lambda (subject pred items head)
+	(match items
+		'() (list (list subject pred "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"))
+		(cons item tail) (begin
+			(cons (list subject pred head)
+				(rdf_expand_ttl_collection_cells head item tail)))
+	)
 ))
 (define rdf_expand_ttl_object (lambda (subject pred obj) (match obj
 	'("__ttl_inline_node__" bn facts)
 	(cons (list subject pred bn) (rdf_expand_ttl_facts facts))
-	'("__ttl_collection__" items)
-	(rdf_expand_ttl_collection subject pred items)
+	'("__ttl_collection__" items head)
+	(rdf_expand_ttl_collection subject pred items head)
 	_ (list (list subject pred obj))
 )))
 
@@ -1306,7 +1302,7 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 				mis-specialized by the experimental JIT and silently lose their items. */
 				(define items (* ttl_simple_constant))
 				")"
-			) (list "__ttl_collection__" items))
+			) (list "__ttl_collection__" items (concat "_:list_" (uuid))))
 			ttl_simple_constant
 		)))
 		(define ttl_fact (parser '(
@@ -1372,7 +1368,7 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 				"("
 				(define items (* ttl_simple_constant))
 				")"
-			) (list "__ttl_collection__" items))
+			) (list "__ttl_collection__" items (concat "_:list_" (uuid))))
 			ttl_simple_constant
 		)))
 		(define ttl_fact (parser '(

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -78,6 +78,9 @@ consumer stage. */
 		(equal? (sql_substr s (+ (- (strlen s) (strlen suffix)) 1) (strlen suffix)) suffix)
 	)
 ))
+(define rdf_json_objectagg_reduce (lambda (a b)
+	(if (nil? a) b (if (nil? b) a (json_merge_patch a b)))
+))
 /* produce a quoted TTL string literal from a raw value: rdf_quote("hello") -> "\"hello\"" */
 (define rdf_quote (lambda (s)
 	(concat "\"" (replace (replace (replace (replace (replace s "\\" "\\\\") "\"" "\\\"") "\n" "\\n") "\t" "\\t") "\r" "\\r") "\"")
@@ -97,6 +100,8 @@ consumer stage. */
 	/* TODO: CONCAT() */
 )))
 (define rdf_aggregate_expression (parser (or
+	(parser '((atom "JSON_ARRAYAGG" true) "(" (define e rdf_filter_or) ")") '("__rdf_agg__" "JSON_ARRAYAGG" e nil))
+	(parser '((atom "JSON_OBJECTAGG" true) "(" (define key rdf_filter_or) "," (define value rdf_filter_or) ")") '("__rdf_agg__" "JSON_OBJECTAGG" '('json_objectagg_entry key value) nil))
 	(parser '((atom "COUNT" true) "(" "*" ")") '("__rdf_agg__" "COUNT" 1 nil))
 	(parser '((atom "COUNT" true) "(" (define e rdf_filter_or) ")") '("__rdf_agg__" "COUNT" e nil))
 	(parser '((atom "SUM" true) "(" (define e rdf_filter_or) ")") '("__rdf_agg__" "SUM" e nil))
@@ -122,6 +127,16 @@ consumer stage. */
 	(parser '((atom "STRENDS" true) "(" (define a rdf_filter_or) "," (define b rdf_filter_or) ")") '('rdf_endswith a b))
 	(parser '((atom "COALESCE" true) "(" (define args (+ rdf_filter_or ",")) ")") (cons (quote coalesceNil) args))
 	(parser '((atom "IF" true) "(" (define cond rdf_filter_or) "," (define a rdf_filter_or) "," (define b rdf_filter_or) ")") '('if cond a b))
+	rdf_aggregate_expression
+	/* MemCP extension: expose the SQL JSON scalar-function registry to SPARQL.
+	This intentionally accepts only JSON_* names; the emitted expression is the
+	same common IR node produced by the SQL frontend. */
+	(parser '((define fn (regex "JSON_[a-zA-Z0-9_]+" true)) "(" (define args (* rdf_filter_or ",")) ")")
+		(begin
+			(define builtin (sql_builtins (toUpper fn)))
+			(if (nil? builtin)
+				(error "unknown JSON function " fn)
+				(cons builtin args))))
 	(parser '((atom "BOUND" true) "(" (define v rdf_variable) ")") '('rdf_bound v))
 	(parser '("(" (define e rdf_filter_or) ")") e)
 	(parser '((atom "regex" true) "(" (define a rdf_filter_or) "," (define b rdf_filter_or) ")") '('regexp_test a b))
@@ -263,15 +278,27 @@ consumer stage. */
 )))
 (define rdf_select_col (parser (or
 	(parser '("(" (define v rdf_aggregate_expression) (atom "AS" true) (define v2 rdf_variable) ")") (match v2 '('get_var s) '((concat s) v)))
-	(parser '((define v rdf_expression) (atom "AS" true) (define v2 rdf_variable)) (match v2 '('get_var s) '((concat s) v)))
+	(parser '("(" (define v rdf_filter_or) (atom "AS" true) (define v2 rdf_variable) ")") (match v2 '('get_var s) '((concat s) v)))
+	(parser '((define v rdf_filter_or) (atom "AS" true) (define v2 rdf_variable)) (match v2 '('get_var s) '((concat s) v)))
 	(parser (define v rdf_variable) (match v '('get_var s) '((concat s) v)))
 )))
 
 (define rdf_number (parser (define x (regex "[0-9]+" true)) (simplify x)))
+(define rdf_order_condition (parser (not
+	(or
+		(parser '((define dir (or (atom "DESC" true) (atom "ASC" true))) "(" (define expr rdf_expression) ")") '(expr dir))
+		(parser (define expr rdf_expression) '(expr "ASC")))
+	(atom "LIMIT" true)
+	(atom "OFFSET" true)
+)))
+(define rdf_limit_offset (parser (or
+	(parser '((atom "LIMIT" true) (define limit rdf_number) (? (atom "OFFSET" true) (define offset rdf_number))) '(limit offset))
+	(parser '((atom "OFFSET" true) (define offset rdf_number) (? (atom "LIMIT" true) (define limit rdf_number))) '(limit offset))
+)))
 (define rdf_select (parser '(
 	(atom "SELECT" true)
 	(? (define distinct (atom "DISTINCT" true)))
-	(define cols (+ rdf_select_col ","))
+	(define cols (+ (parser '((define col rdf_select_col) (? (atom "," true))) col)))
 	(?
 		(atom "WHERE" true)
 		(atom "{" true)
@@ -281,19 +308,17 @@ consumer stage. */
 	(?
 		(atom "GROUP" true)
 		(atom "BY" true)
-		(define group (+ rdf_variable ","))
+		(define group (+ (parser '((define var rdf_variable) (? (atom "," true))) var)))
 	)
 	(?
 		(atom "ORDER" true)
 		(atom "BY" true)
-		(define ordercols (+ (or
-			(parser '((define dir (or (atom "DESC" true) (atom "ASC" true))) "(" (define expr rdf_expression) ")") '(expr dir))
-			(parser (define expr rdf_expression) '(expr "ASC"))
-		) ","))
+		(define ordercols (+ rdf_order_condition))
 	)
-	(? (atom "LIMIT" true) (define limit rdf_number))
-	(? (atom "OFFSET" true) (define offset rdf_number))
-) '("select" (merge cols) "where" (merge (coalesce conditions '('()))) "group" (coalesce group '()) "order" ordercols "limit" limit "offset" offset "distinct" distinct) "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
+	(define slice (or rdf_limit_offset (parser empty '(nil nil))))
+) '("select" (merge cols) "where" (merge (coalesce conditions '('()))) "group" (coalesce group '()) "order" ordercols
+		"limit" (car slice) "offset" (cadr slice) "distinct" distinct)
+	"^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
 
 (define rdf_template_item (parser '(
 	(define s rdf_expression)
@@ -437,6 +462,14 @@ consumer stage. */
 (define rdf_select_resultrow_ast (lambda (row_cols ctx)
 	(list (quote resultrow) (cons list (rdf_row_items row_cols ctx)))
 ))
+(define rdf_shared_result_items (lambda (cols ctx) (match cols
+	(cons title (cons _expr tail))
+	(cons (concat title) (cons (rdf_ctx_value ctx title) (rdf_shared_result_items tail ctx)))
+	'()
+)))
+(define rdf_shared_resultrow_ast (lambda (row_cols ctx)
+	(list (quote resultrow) (cons list (rdf_shared_result_items row_cols ctx)))
+))
 (define rdf_wrapped_resultrow_ast (lambda (state row_expr distinct effective_offset effective_limit)
 	(if distinct
 		(list (quote begin)
@@ -525,6 +558,8 @@ consumer stage. */
 	)
 ))
 (define rdf_agg_init (lambda (expr) (match expr
+	'("__rdf_agg__" "JSON_ARRAYAGG" _ _) nil
+	'("__rdf_agg__" "JSON_OBJECTAGG" _ _) nil
 	'("__rdf_agg__" "COUNT" _ _) 0
 	'("__rdf_agg__" "SUM" _ _) 0
 	'("__rdf_agg__" "AVG" _ _) '(0 0)
@@ -534,6 +569,12 @@ consumer stage. */
 	(error "unsupported RDF aggregate " expr)
 )))
 (define rdf_agg_step (lambda (expr state row) (match expr
+	'("__rdf_agg__" "JSON_ARRAYAGG" inner _)
+	(begin
+		(define v (rdf_row_eval inner row))
+		(if (nil? state) (list v) (append state v)))
+	'("__rdf_agg__" "JSON_OBJECTAGG" inner _)
+	(json_objectagg_reduce state (rdf_row_eval inner row))
 	'("__rdf_agg__" "COUNT" inner _)
 	(if (nil? (rdf_row_eval inner row)) state (+ state 1))
 	'("__rdf_agg__" "SUM" inner _)
@@ -567,6 +608,7 @@ consumer stage. */
 	(error "unsupported RDF aggregate " expr)
 )))
 (define rdf_agg_finalize (lambda (expr state) (match expr
+	'("__rdf_agg__" "JSON_ARRAYAGG" _ _) (json_arrayagg_finalize state)
 	'("__rdf_agg__" "AVG" _ _) (if (equal? (cadr state) 0) nil (/ (car state) (cadr state)))
 	_ state
 )))
@@ -661,7 +703,7 @@ consumer stage. */
 	(seen)
 )))
 (define rdf_ensure_table (lambda (schema)
-	(eval (parse_sql schema "CREATE TABLE IF NOT EXISTS rdf (s TEXT, p TEXT, o TEXT)" (lambda (schema tblname write) true)))
+	(eval (parse_sql schema "CREATE TABLE IF NOT EXISTS rdf (s TEXT, p TEXT, o TEXT, UNIQUE KEY rdf_spo (s, p, o))" (lambda (schema tblname write) true)))
 ))
 (define rdf_insert_triples (lambda (schema triples)
 	(if (equal? triples '())
@@ -721,12 +763,34 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 		'() (list sources bindings filters)
 	)
 ))
+(define rdf_shared_filter_condition? (lambda (condition)
+	(match condition
+		'("__filter__" _expr) true
+		_ false
+	)
+))
+(define rdf_shared_triple_conditions (lambda (conditions)
+	(filter conditions (lambda (condition) (not (rdf_shared_filter_condition? condition))))
+))
+(define rdf_shared_filter_conditions (lambda (conditions bindings outer_ctx)
+	(map (filter conditions rdf_shared_filter_condition?) (lambda (condition)
+		(match condition '("__filter__" expr) (rdf_shared_expr expr bindings outer_ctx))))
+))
 (define rdf_shared_expr (lambda (expr bindings outer_ctx)
 	(match expr
+		'("__rdf_agg__" "JSON_ARRAYAGG" inner _)
+		(rdf_shared_expr (json_arrayagg_expr inner false) bindings outer_ctx)
+		'("__rdf_agg__" "JSON_OBJECTAGG" ((quote json_objectagg_entry) key value) _)
+		(list (quote aggregate)
+			(list (quote json_object)
+				(rdf_shared_expr key bindings outer_ctx)
+				(rdf_shared_expr value bindings outer_ctx))
+			(quote rdf_json_objectagg_reduce) nil)
 		'('get_var var)
 		(match (rdf_ctx_lookup outer_ctx var) '(outer_found outer_value)
 			(if outer_found outer_value (rdf_shared_lookup bindings var)))
-		(cons head tail) (cons head (map tail (lambda (item) (rdf_shared_expr item bindings outer_ctx))))
+		(cons head tail) (cons (if (equal? head (quote equal?)) (quote equal??) head)
+			(map tail (lambda (item) (rdf_shared_expr item bindings outer_ctx))))
 		expr
 	)
 ))
@@ -749,23 +813,48 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 		(cons var (cons value tail))
 		(match (rdf_ctx_lookup fields var) '(found _existing)
 			(rdf_shared_complete_fields
-				(if found fields (append fields var value)) tail))
+				(if found fields (append fields (concat var) value)) tail))
 		'() fields
 	)
 ))
+(define rdf_shared_input_field_name (lambda (var)
+	(concat "rdf_" (replace (concat var) "?" ""))
+))
 (define rdf_shared_query_ast (lambda (schema query outer_ctx)
 	(match query '("select" cols "where" conditions "group" group "order" order "limit" limit "offset" offset "distinct" distinct)
-		(match (rdf_shared_build_sources schema conditions outer_ctx 0 '() '() '()) '(sources bindings filters)
+		(match (rdf_shared_build_sources schema (rdf_shared_triple_conditions conditions) outer_ctx 0 '() '() '()) '(sources bindings filters)
 			(begin
-				(define selected_fields (map_assoc cols (lambda (title expr)
-					(rdf_shared_expr expr bindings outer_ctx))))
-				(define fields (rdf_shared_complete_fields
-					selected_fields bindings))
-				(define projected (extract_assoc selected_fields (lambda (_title expr) expr)))
-				(make_query_block schema sources fields (rdf_shared_where filters)
-					(if distinct projected nil) nil
-					(rdf_shared_order order bindings outer_ctx) limit offset '() '()
-					(if distinct (list (list (quote select_distinct) true)) '()))))
+				(define all_filters (merge (list filters
+					(rdf_shared_filter_conditions conditions bindings outer_ctx))))
+				(if (rdf_select_has_aggregates cols)
+					(begin
+						/* Give the aggregate layer a named relational input. This is the
+						same derived query-block shape emitted for an SQL subquery and keeps
+						join planning/RecSet selection inside the common planner. */
+						(define input_alias "rdf_bgp")
+						(define input_fields (reduce_assoc bindings (lambda (acc var expr)
+							(append acc (rdf_shared_input_field_name var) expr)) '()))
+						(define input_query (make_query_block schema sources input_fields
+							(rdf_shared_where all_filters) nil nil nil nil nil '() '() '()))
+						(define aggregate_bindings (reduce_assoc bindings (lambda (acc var _expr)
+							(append acc var (rdf_shared_column nil (rdf_shared_input_field_name var)))) '()))
+						(define selected_fields (map_assoc cols (lambda (_title expr)
+							(rdf_shared_expr expr aggregate_bindings outer_ctx))))
+						(make_query_block schema (list (list input_alias schema input_query false nil))
+							selected_fields true
+							(if (equal? group '()) nil
+								(map group (lambda (expr) (rdf_shared_expr expr aggregate_bindings outer_ctx))))
+							nil (rdf_shared_order order aggregate_bindings outer_ctx)
+							limit offset '() '() '()))
+					(begin
+						(define selected_fields (map_assoc cols (lambda (_title expr)
+							(rdf_shared_expr expr bindings outer_ctx))))
+						(define fields (rdf_shared_complete_fields selected_fields bindings))
+						(define projected (extract_assoc selected_fields (lambda (_title expr) expr)))
+						(make_query_block schema sources fields (rdf_shared_where all_filters)
+							(if distinct projected nil) nil
+							(rdf_shared_order order bindings outer_ctx) limit offset '() '()
+							(if distinct (list (list (quote select_distinct) true)) '()))))))
 		(error "SPARQL shared planner: expected SELECT query")
 	)
 ))
@@ -779,12 +868,28 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 ))
 (define rdf_shared_pattern_supported? (lambda (pattern)
 	(match pattern
+		'("__filter__" _expr) true
 		'("__bind__" _expr _var) false
 		'("__filter_exists__" _negate _conditions) false
 		'("__values__" _var _values) false
 		'(s p o) (and (rdf_shared_term_supported? s)
 			(and (rdf_shared_term_supported? p) (rdf_shared_term_supported? o)))
 		_ false
+	)
+))
+(define rdf_shared_conditions_supported? (lambda (conditions)
+	(begin
+		(define triples (rdf_shared_triple_conditions conditions))
+		(define available_vars (rdf_condition_vars triples))
+		(and (not (empty_list? triples))
+			(and (reduce conditions (lambda (supported condition)
+				(and supported (rdf_shared_pattern_supported? condition))) true)
+				(reduce conditions (lambda (supported condition)
+					(and supported (match condition
+						'("__filter__" expr)
+						(reduce (rdf_extract_vars expr) (lambda (bound var)
+							(and bound (rdf_key_in_list available_vars var))) true)
+						_ true))) true)))
 	)
 ))
 (define rdf_shared_order_supported? (lambda (order)
@@ -794,15 +899,28 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 			_ false))) true)
 	)
 ))
+(define rdf_shared_json_aggregates_supported? (lambda (expr)
+	(match expr
+		'("__rdf_agg__" fn _inner _sep)
+		(or (equal? fn "JSON_ARRAYAGG") (equal? fn "JSON_OBJECTAGG"))
+		(cons head tail)
+		(and (rdf_shared_json_aggregates_supported? head)
+			(reduce tail (lambda (supported item)
+				(and supported (rdf_shared_json_aggregates_supported? item))) true))
+		_ true
+	)
+))
+(define rdf_shared_json_projection_supported? (lambda (cols)
+	(reduce_assoc cols (lambda (supported _alias expr)
+		(and supported (rdf_shared_json_aggregates_supported? expr))) true)
+))
 (define rdf_shared_bgp_supported? (lambda (query)
 	(match query '("select" cols "where" conditions "group" group "order" order "limit" _limit "offset" _offset "distinct" distinct)
-		(and (not (rdf_select_has_aggregates cols))
+		(and (or (not (rdf_select_has_aggregates cols))
+				(rdf_shared_json_projection_supported? cols))
 			(and (not distinct)
-				(and (equal? group '())
-					(and (not (equal? conditions '()))
-						(and (reduce conditions (lambda (supported pattern)
-							(and supported (rdf_shared_pattern_supported? pattern))) true)
-							(rdf_shared_order_supported? order))))))
+				(and (rdf_shared_conditions_supported? conditions)
+					(rdf_shared_order_supported? order))))
 		_ false
 	)
 ))
@@ -1082,21 +1200,23 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 				(set effective_limit (coalesce qlimit 999999999))
 				/* build resultfunc that includes limit/offset/distinct logic */
 				(if (or qhasagg (not (equal? qgroup '())))
-					(begin
-						(set _rows (newsession))
-						(list (quote begin)
-							(rdf_queryplan schema parsed definitions '() (lambda (_cols ctx) (begin
-								(set row_expr (cons list (rdf_capture_row_items qrowvars ctx)))
-								(list _rows (list (quote uuid)) row_expr)
-							)))
-							(list (quote rdf_emit_aggregated_rows)
-								_rows
-								(list (quote quote) cols)
-								(list (quote quote) qgroup)
-								(list (quote lambda) (list (quote row))
-									(list (quote resultrow) (quote row))))
-						)
-					)
+					(if shared_bgp
+						(rdf_queryplan schema parsed definitions '() rdf_shared_resultrow_ast)
+						(begin
+							(set _rows (newsession))
+							(list (quote begin)
+								(rdf_queryplan schema parsed definitions '() (lambda (_cols ctx) (begin
+									(set row_expr (cons list (rdf_capture_row_items qrowvars ctx)))
+									(list _rows (list (quote uuid)) row_expr)
+								)))
+								(list (quote rdf_emit_aggregated_rows)
+									_rows
+									(list (quote quote) cols)
+									(list (quote quote) qgroup)
+									(list (quote lambda) (list (quote row))
+										(list (quote resultrow) (quote row))))
+							)
+						))
 					(begin
 						(if needs_wrap
 							(begin
@@ -1121,8 +1241,27 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 		iri
 	)
 ))
+(define rdf_expand_ttl_facts (lambda (facts)
+	(merge (map facts (lambda (triple) (match triple '(subject pred obj)
+		(rdf_expand_ttl_object subject pred obj)))))
+))
+(define rdf_expand_ttl_collection (lambda (subject pred items)
+	(match items
+		'() (list (list subject pred "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"))
+		(cons item tail)
+		(begin
+			(define head (concat "_:list_" (uuid)))
+			(merge (list
+				(list (list subject pred head))
+				(rdf_expand_ttl_object head "http://www.w3.org/1999/02/22-rdf-syntax-ns#first" item)
+				(rdf_expand_ttl_collection head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" tail))))
+	)
+))
 (define rdf_expand_ttl_object (lambda (subject pred obj) (match obj
-	'("__ttl_inline_node__" bn facts) (cons (list subject pred bn) facts)
+	'("__ttl_inline_node__" bn facts)
+	(cons (list subject pred bn) (rdf_expand_ttl_facts facts))
+	'("__ttl_collection__" items)
+	(rdf_expand_ttl_collection subject pred items)
 	_ (list (list subject pred obj))
 )))
 
@@ -1143,7 +1282,7 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 		(define ttl_object (parser (or
 			(parser '(
 				"["
-				(define ps (+ (parser '((define p ttl_simple_constant) (define os (+ ttl_simple_constant ",")) (? ";")) (map os (lambda (o) '(p o))))))
+				(define ps (+ (parser '((define p ttl_simple_constant) (define os (+ ttl_object ",")) (? ";")) (map os (lambda (o) '(p o))))))
 				"]"
 			) (begin
 					(define bn (concat "_:anon_" (uuid)))
@@ -1151,9 +1290,9 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 			))
 			(parser '(
 				"("
-				(define _items (* ttl_simple_constant))
+				(define items (* ttl_object))
 				")"
-			) (concat "_:list_" (uuid)))
+			) (list "__ttl_collection__" items))
 			ttl_simple_constant
 		)))
 		(define ttl_fact (parser '(
@@ -1181,9 +1320,7 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 /* delete triples from the store that match the given TTL */
 (define delete_ttl (lambda (schema s) (begin
 	(set triples (parse_ttl_triples schema s))
-	(map triples (lambda (triple) (match triple '(subj pred obj)
-		(scan nil (table schema "rdf") (list 369436712239104 (scan_boundary "equal" "o" 0 0 true true "" false) (scan_boundary "equal" "p" 1 1 true true "" false) (scan_boundary "equal" "s" 2 2 true true "" false)) (list obj pred subj) '() (lambda () true) '("$update") (lambda (acc $update) (begin ($update) acc)))
-	)))
+	(rdf_delete_triples schema triples)
 )))
 
 (define load_ttl (lambda (schema s) (match (ttl_header s)
@@ -1211,7 +1348,7 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 		(define ttl_object (parser (or
 			(parser '(
 				"["
-				(define ps (+ (parser '((define p ttl_simple_constant) (define os (+ ttl_simple_constant ",")) (? ";")) (map os (lambda (o) '(p o))))))
+				(define ps (+ (parser '((define p ttl_simple_constant) (define os (+ ttl_object ",")) (? ";")) (map os (lambda (o) '(p o))))))
 				"]"
 			) (begin
 					(define bn (concat "_:anon_" (uuid)))
@@ -1219,9 +1356,9 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 			))
 			(parser '(
 				"("
-				(define _items (* ttl_simple_constant))
+				(define items (* ttl_object))
 				")"
-			) (concat "_:list_" (uuid)))
+			) (list "__ttl_collection__" items))
 			ttl_simple_constant
 		)))
 		(define ttl_fact (parser '(
@@ -1236,7 +1373,7 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 		) '("facts" facts "rest" rest) "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
 		(set load (lambda (facts) (begin
 			/* resolve blank nodes to UUIDs and insert */
-			(insert (table schema "rdf") '("s" "p" "o") (map facts (lambda (triple) (list (resolve_blank (car triple)) (resolve_blank (car (cdr triple))) (resolve_blank (car (cdr (cdr triple))))))) '() (lambda () true))
+			(rdf_insert_triples schema (map facts (lambda (triple) (list (resolve_blank (car triple)) (resolve_blank (car (cdr triple))) (resolve_blank (car (cdr (cdr triple))))))))
 		)))
 		(define process_fact (lambda (rest) (match (ttl_fact rest)
 			'("facts" facts "rest" (regex "^[ \\n\\r\\t]*$" _)) (load facts)

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -1295,7 +1295,9 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 			))
 			(parser '(
 				"("
-				(define items (* ttl_object))
+				/* Keep the list-item grammar non-recursive. Recursive parser objects are
+				mis-specialized by the experimental JIT and silently lose their items. */
+				(define items (* ttl_simple_constant))
 				")"
 			) (list "__ttl_collection__" items))
 			ttl_simple_constant
@@ -1361,7 +1363,7 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 			))
 			(parser '(
 				"("
-				(define items (* ttl_object))
+				(define items (* ttl_simple_constant))
 				")"
 			) (list "__ttl_collection__" items))
 			ttl_simple_constant

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -1256,10 +1256,14 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 				(match current '(next triples)
 					(begin
 						(define head (concat "_:list_" (uuid)))
-						(list head (merge (list
+						(define with_rest (cons
+							(list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" next)
+							triples))
+						(define with_item (reduce
 							(rdf_expand_ttl_object head "http://www.w3.org/1999/02/22-rdf-syntax-ns#first" item)
-							(list (list head "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest" next))
-							triples))))))
+							(lambda (acc triple) (cons triple acc))
+							with_rest))
+						(list head with_item))))
 				(list "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil" '())))
 			(match state '(head triples)
 				(cons (list subject pred head) triples))))

--- a/lib/rdf.scm
+++ b/lib/rdf.scm
@@ -64,8 +64,8 @@ this is how rdf works:
 			((res "header") "Content-Type" "text/plain")
 			((res "status") 200)
 			/*(print "Loading TTL data into: " schema)*/
-			/* ensure rdf table exists */
-			(eval (parse_sql schema "CREATE TABLE IF NOT EXISTS rdf (s TEXT, p TEXT, o TEXT)" (lambda (schema tblname write) true)))
+			/* ensure the shared RDF graph storage and its set-semantics key exist */
+			(rdf_ensure_table schema)
 			/* load the TTL data */
 			(load_ttl schema ttl_data)
 			((res "println") "TTL data loaded successfully")

--- a/tests/rdf/rdf-json.yaml
+++ b/tests/rdf/rdf-json.yaml
@@ -1,0 +1,152 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+metadata:
+  version: "1.0"
+  description: "SQL-compatible JSON construction and aggregation from SPARQL"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "JSON_OBJECT constructs one object per RDF solution"
+    ttl_data: |
+      @prefix js01: <http://json-rdf01.example/> .
+      js01:alice js01:name "Alice" .
+    sparql: |
+      @prefix js01: <http://json-rdf01.example/> .
+      SELECT (JSON_OBJECT("id", ?person, "name", ?name) AS ?document)
+      WHERE { ?person js01:name ?name }
+    expect:
+      rows: 1
+      data:
+        - "?document": {id: "http://json-rdf01.example/alice", name: "Alice"}
+
+  - name: "JSON scalar functions use the SQL builtin semantics"
+    ttl_data: |
+      @prefix js02: <http://json-rdf02.example/> .
+      js02:item js02:value "kept" .
+    sparql: |
+      @prefix js02: <http://json-rdf02.example/> .
+      SELECT (JSON_EXTRACT(JSON_OBJECT("value", ?value), "$.value") AS ?extracted)
+      WHERE { js02:item js02:value ?value }
+    expect:
+      rows: 1
+      data:
+        - "?extracted": "kept"
+
+  - name: "JSON_ARRAY builds nested scalar arrays"
+    ttl_data: |
+      @prefix js03: <http://json-rdf03.example/> .
+      js03:item js03:value "leaf" .
+    sparql: |
+      @prefix js03: <http://json-rdf03.example/> .
+      SELECT (JSON_ARRAY(?value, JSON_OBJECT("kind", "rdf")) AS ?nested)
+      WHERE { js03:item js03:value ?value }
+    expect:
+      rows: 1
+      data:
+        - "?nested": ["leaf", {kind: "rdf"}]
+
+  - name: "JSON_ARRAYAGG packs child solutions into one JSON array"
+    ttl_data: |
+      @prefix js04: <http://json-rdf04.example/> .
+      js04:case js04:item js04:item1, js04:item2 .
+      js04:item1 js04:label "first" .
+      js04:item2 js04:label "second" .
+    sparql: |
+      @prefix js04: <http://json-rdf04.example/> .
+      SELECT ?case (JSON_ARRAYAGG(JSON_OBJECT("id", ?item, "label", ?label)) AS ?items)
+      WHERE {
+        ?case js04:item ?item .
+        ?item js04:label ?label
+      }
+      GROUP BY ?case
+    expect:
+      rows: 1
+      data:
+        - "?case": "http://json-rdf04.example/case"
+          "?items":
+            - {id: "http://json-rdf04.example/item1", label: "first"}
+            - {id: "http://json-rdf04.example/item2", label: "second"}
+
+  - name: "JSON_ARRAYAGG keeps independent arrays for each RDF group"
+    ttl_data: |
+      @prefix js05: <http://json-rdf05.example/> .
+      js05:a js05:tag "red", "blue" .
+      js05:b js05:tag "green" .
+    sparql: |
+      @prefix js05: <http://json-rdf05.example/> .
+      SELECT ?subject (JSON_ARRAYAGG(?tag) AS ?tags)
+      WHERE { ?subject js05:tag ?tag }
+      GROUP BY ?subject
+      ORDER BY ?subject
+    expect:
+      rows: 2
+      data:
+        - "?subject": "http://json-rdf05.example/a"
+          "?tags": ["red", "blue"]
+        - "?subject": "http://json-rdf05.example/b"
+          "?tags": ["green"]
+
+  - name: "JSON object embeds an aggregated RDF child list"
+    ttl_data: |
+      @prefix js08: <http://json-rdf08.example/> .
+      js08:case js08:item "first", "second" .
+    sparql: |
+      @prefix js08: <http://json-rdf08.example/> .
+      SELECT (JSON_OBJECT(
+        "id", ?case,
+        "items", JSON_ARRAYAGG(JSON_OBJECT("value", ?item))
+      ) AS ?document)
+      WHERE { ?case js08:item ?item }
+      GROUP BY ?case
+    expect:
+      rows: 1
+      data:
+        - "?document":
+            id: "http://json-rdf08.example/case"
+            items:
+              - {value: "first"}
+              - {value: "second"}
+
+  - name: "JSON_OBJECTAGG builds an object from RDF key-value solutions"
+    ttl_data: |
+      @prefix js06: <http://json-rdf06.example/> .
+      js06:settings js06:entry js06:lang, js06:theme .
+      js06:lang js06:key "language" ; js06:value "de" .
+      js06:theme js06:key "theme" ; js06:value "dark" .
+    sparql: |
+      @prefix js06: <http://json-rdf06.example/> .
+      SELECT (JSON_OBJECTAGG(?key, ?value) AS ?settings)
+      WHERE {
+        js06:settings js06:entry ?entry .
+        ?entry js06:key ?key .
+        ?entry js06:value ?value
+      }
+    expect:
+      rows: 1
+      data:
+        - "?settings": {language: "de", theme: "dark"}
+
+  - name: "JSON aggregate BGP lowers through the shared query-block planner"
+    ttl_data: |
+      @prefix js07: <http://json-rdf07.example/> .
+      js07:case js07:item "one", "two" .
+    scm: |
+      (begin
+        (define header (ttl_header "@prefix js07: <http://json-rdf07.example/> . SELECT (JSON_ARRAYAGG(?item) AS ?items) WHERE { js07:case js07:item ?item }"))
+        (define definitions (header "prefixes"))
+        (define parsed (rdf_resolve_prefixes (rdf_query (header "rest")) definitions))
+        (define ast (rdf_shared_query_ast "{database}" parsed '()))
+        (list (rdf_shared_bgp_supported? parsed) (car ast) (car (cadr (qb_fields ast)))))
+    expect:
+      rows: 1
+      data:
+        - true
+        - "query-block"
+        - "aggregate"

--- a/tests/rdf/rdf-shared-planner.yaml
+++ b/tests/rdf/rdf-shared-planner.yaml
@@ -31,4 +31,18 @@ test_cases:
           (error "rdf shared planner: BIND marker classified as a triple")
           true))
 
+  - name: "FILTER joins the BGP predicate in shared query-block WHERE"
+    scm: |
+      (begin
+        (define parsed (rdf_query
+          "SELECT ?s WHERE { FILTER(?v = \"keep\") ?s value ?v }"))
+        (if (not (rdf_shared_bgp_supported? parsed))
+          (error "rdf shared planner: supported FILTER rejected"))
+        (define ast (rdf_shared_query_ast "memcp-tests" parsed '()))
+        (if (not (equal? (car ast) (quote query-block)))
+          (error "rdf shared planner: FILTER did not lower to query-block"))
+        (if (not (rdf_contains (concat (qb_where ast)) "equal??"))
+          (error "rdf shared planner: FILTER missing from WHERE"))
+        true)
+
 cleanup: []

--- a/tests/rdf/rdf-spec-bgp-modifiers.yaml
+++ b/tests/rdf/rdf-spec-bgp-modifiers.yaml
@@ -1,0 +1,196 @@
+# Conformance-oriented coverage derived from SPARQL 1.1 Query sections 5 and 15.
+
+metadata:
+  version: "1.0"
+  description: "SPARQL basic graph pattern and solution modifier semantics"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "BGP: repeated variable in one triple must denote the same RDF term"
+    ttl_data: |
+      @prefix cb01: <http://conformance-bgp01.example/> .
+      cb01:same cb01:edge cb01:same .
+      cb01:left cb01:edge cb01:right .
+    sparql: |
+      @prefix cb01: <http://conformance-bgp01.example/> .
+      SELECT ?node WHERE { ?node cb01:edge ?node }
+    expect:
+      rows: 1
+      data:
+        - "?node": "http://conformance-bgp01.example/same"
+
+  - name: "BGP: variable predicate binds the matching predicate IRI"
+    ttl_data: |
+      @prefix cb02: <http://conformance-bgp02.example/> .
+      cb02:item cb02:first "one" ; cb02:second "two" .
+    sparql: |
+      @prefix cb02: <http://conformance-bgp02.example/> .
+      SELECT ?predicate WHERE { cb02:item ?predicate "two" }
+    expect:
+      rows: 1
+      data:
+        - "?predicate": "http://conformance-bgp02.example/second"
+
+  - name: "BGP: shared variable joins subject, predicate, and object positions"
+    ttl_data: |
+      @prefix cb03: <http://conformance-bgp03.example/> .
+      cb03:alice cb03:follows cb03:bob .
+      cb03:follows cb03:label "follows" .
+      cb03:bob cb03:name "Bob" .
+      cb03:noise cb03:name "Noise" .
+    sparql: |
+      @prefix cb03: <http://conformance-bgp03.example/> .
+      SELECT ?person, ?label WHERE {
+        cb03:alice ?relation ?person .
+        ?relation cb03:label ?label .
+        ?person cb03:name "Bob"
+      }
+    expect:
+      rows: 1
+      data:
+        - "?person": "http://conformance-bgp03.example/bob"
+          "?label": "follows"
+
+  - name: "BGP: disconnected patterns form a Cartesian product"
+    ttl_data: |
+      @prefix cb04: <http://conformance-bgp04.example/> .
+      cb04:a cb04:left "A" .
+      cb04:b cb04:left "B" .
+      cb04:x cb04:right "X" .
+      cb04:y cb04:right "Y" .
+      cb04:z cb04:right "Z" .
+    sparql: |
+      @prefix cb04: <http://conformance-bgp04.example/> .
+      SELECT ?left, ?right WHERE {
+        ?ls cb04:left ?left .
+        ?rs cb04:right ?right
+      }
+    expect:
+      rows: 6
+
+  - name: "BGP: projection retains solution multiplicity"
+    ttl_data: |
+      @prefix cb05: <http://conformance-bgp05.example/> .
+      cb05:a cb05:kind cb05:Thing .
+      cb05:b cb05:kind cb05:Thing .
+      cb05:c cb05:kind cb05:Other .
+    sparql: |
+      @prefix cb05: <http://conformance-bgp05.example/> .
+      SELECT ?kind WHERE { ?subject cb05:kind ?kind } ORDER BY ?kind
+    expect:
+      rows: 3
+      data:
+        - "?kind": "http://conformance-bgp05.example/Other"
+        - "?kind": "http://conformance-bgp05.example/Thing"
+        - "?kind": "http://conformance-bgp05.example/Thing"
+
+  - name: "DISTINCT applies after projection"
+    ttl_data: |
+      @prefix cb06: <http://conformance-bgp06.example/> .
+      cb06:a cb06:kind cb06:Thing .
+      cb06:b cb06:kind cb06:Thing .
+      cb06:c cb06:kind cb06:Other .
+    sparql: |
+      @prefix cb06: <http://conformance-bgp06.example/> .
+      SELECT DISTINCT ?kind WHERE { ?subject cb06:kind ?kind } ORDER BY ?kind
+    expect:
+      rows: 2
+      data:
+        - "?kind": "http://conformance-bgp06.example/Other"
+        - "?kind": "http://conformance-bgp06.example/Thing"
+
+  - name: "ORDER BY may use a variable omitted from projection"
+    ttl_data: |
+      @prefix cb07: <http://conformance-bgp07.example/> .
+      cb07:a cb07:name "Zulu" ; cb07:rank "2" .
+      cb07:b cb07:name "Alpha" ; cb07:rank "1" .
+    sparql: |
+      @prefix cb07: <http://conformance-bgp07.example/> .
+      SELECT ?name WHERE {
+        ?subject cb07:name ?name .
+        ?subject cb07:rank ?rank
+      } ORDER BY ?rank
+    expect:
+      rows: 2
+      data:
+        - "?name": "Alpha"
+        - "?name": "Zulu"
+
+  - name: "ORDER BY uses successive comparators to break ties"
+    ttl_data: |
+      @prefix cb08: <http://conformance-bgp08.example/> .
+      cb08:a cb08:value "x" .
+      cb08:b cb08:value "x" .
+      cb08:c cb08:value "a" .
+    sparql: |
+      @prefix cb08: <http://conformance-bgp08.example/> .
+      SELECT ?value, ?subject WHERE { ?subject cb08:value ?value }
+      ORDER BY ?value DESC(?subject)
+    expect:
+      rows: 3
+      data:
+        - "?value": "a"
+          "?subject": "http://conformance-bgp08.example/c"
+        - "?value": "x"
+          "?subject": "http://conformance-bgp08.example/b"
+        - "?value": "x"
+          "?subject": "http://conformance-bgp08.example/a"
+
+  - name: "LIMIT zero yields an empty solution sequence"
+    ttl_data: |
+      @prefix cb09: <http://conformance-bgp09.example/> .
+      cb09:a cb09:value "A" .
+    sparql: |
+      @prefix cb09: <http://conformance-bgp09.example/> .
+      SELECT ?value WHERE { ?s cb09:value ?value } LIMIT 0
+    expect:
+      rows: 0
+
+  - name: "OFFSET beyond the solution sequence yields no rows"
+    ttl_data: |
+      @prefix cb10: <http://conformance-bgp10.example/> .
+      cb10:a cb10:value "A" .
+      cb10:b cb10:value "B" .
+    sparql: |
+      @prefix cb10: <http://conformance-bgp10.example/> .
+      SELECT ?value WHERE { ?s cb10:value ?value } ORDER BY ?value OFFSET 5
+    expect:
+      rows: 0
+
+  - name: "OFFSET may precede LIMIT in SPARQL syntax"
+    ttl_data: |
+      @prefix cb11: <http://conformance-bgp11.example/> .
+      cb11:a cb11:value "A" .
+      cb11:b cb11:value "B" .
+      cb11:c cb11:value "C" .
+      cb11:d cb11:value "D" .
+    sparql: |
+      @prefix cb11: <http://conformance-bgp11.example/> .
+      SELECT ?value WHERE { ?s cb11:value ?value }
+      ORDER BY ?value OFFSET 1 LIMIT 2
+    expect:
+      rows: 2
+      data:
+        - "?value": "B"
+        - "?value": "C"
+
+  - name: "ORDER BY precedes OFFSET and LIMIT evaluation"
+    ttl_data: |
+      @prefix cb12: <http://conformance-bgp12.example/> .
+      cb12:d cb12:value "D" .
+      cb12:a cb12:value "A" .
+      cb12:c cb12:value "C" .
+      cb12:b cb12:value "B" .
+    sparql: |
+      @prefix cb12: <http://conformance-bgp12.example/> .
+      SELECT ?value WHERE { ?s cb12:value ?value }
+      ORDER BY ?value LIMIT 2 OFFSET 1
+    expect:
+      rows: 2
+      data:
+        - "?value": "B"
+        - "?value": "C"
+
+cleanup: []

--- a/tests/rdf/rdf-spec-forms-turtle.yaml
+++ b/tests/rdf/rdf-spec-forms-turtle.yaml
@@ -1,0 +1,186 @@
+# Conformance-oriented coverage derived from SPARQL 1.1 query forms/update
+# and RDF 1.1 Turtle sections 2.6 through 2.8.
+
+metadata:
+  version: "1.0"
+  description: "SPARQL query forms, updates, blank nodes, and collections"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "ASK evaluates a multi-pattern BGP to true"
+    ttl_data: |
+      @prefix cf01: <http://conformance-form01.example/> .
+      cf01:alice a cf01:Person ; cf01:name "Alice" .
+    sparql: |
+      @prefix cf01: <http://conformance-form01.example/> .
+      ASK WHERE { ?s a cf01:Person . ?s cf01:name "Alice" }
+    expect:
+      contains: "true"
+
+  - name: "ASK evaluates a partially matching BGP to false"
+    ttl_data: |
+      @prefix cf02: <http://conformance-form02.example/> .
+      cf02:alice a cf02:Person .
+    sparql: |
+      @prefix cf02: <http://conformance-form02.example/> .
+      ASK WHERE { ?s a cf02:Person . ?s cf02:name ?name }
+    expect:
+      contains: "false"
+
+  - name: "CONSTRUCT instantiates its template once per solution"
+    ttl_data: |
+      @prefix cf03: <http://conformance-form03.example/> .
+      cf03:alice cf03:name "Alice" .
+      cf03:bob cf03:name "Bob" .
+    sparql: |
+      @prefix cf03: <http://conformance-form03.example/> .
+      CONSTRUCT { ?s cf03:label ?name } WHERE { ?s cf03:name ?name }
+    expect:
+      contains: "Alice"
+
+  - name: "INSERT DATA followed by duplicate insertion preserves RDF set semantics"
+    sparql: |
+      @prefix cf04: <http://conformance-form04.example/> .
+      INSERT DATA { cf04:item cf04:value "once" }
+    expect:
+      rows: 0
+
+  - name: "Duplicate INSERT DATA is accepted"
+    sparql: |
+      @prefix cf04: <http://conformance-form04.example/> .
+      INSERT DATA { cf04:item cf04:value "once" }
+    expect:
+      rows: 0
+
+  - name: "RDF graph exposes one solution for a duplicate inserted triple"
+    sparql: |
+      @prefix cf04: <http://conformance-form04.example/> .
+      SELECT ?value WHERE { cf04:item cf04:value ?value }
+    expect:
+      rows: 1
+      data:
+        - "?value": "once"
+
+  - name: "DELETE DATA for an absent triple is a successful no-op"
+    sparql: |
+      @prefix cf05: <http://conformance-form05.example/> .
+      DELETE DATA { cf05:missing cf05:value "absent" }
+    expect:
+      rows: 0
+
+  - name: "DELETE INSERT WHERE applies the template for every solution"
+    ttl_data: |
+      @prefix cf06: <http://conformance-form06.example/> .
+      cf06:a cf06:state "old" .
+      cf06:b cf06:state "old" .
+    sparql: |
+      @prefix cf06: <http://conformance-form06.example/> .
+      DELETE { ?subject cf06:state ?old }
+      INSERT { ?subject cf06:state "new" }
+      WHERE { ?subject cf06:state ?old }
+    expect:
+      rows: 0
+
+  - name: "DELETE INSERT WHERE leaves both replacement triples"
+    sparql: |
+      @prefix cf06: <http://conformance-form06.example/> .
+      SELECT ?subject, ?state WHERE { ?subject cf06:state ?state }
+      ORDER BY ?subject
+    expect:
+      rows: 2
+      data:
+        - "?subject": "http://conformance-form06.example/a"
+          "?state": "new"
+        - "?subject": "http://conformance-form06.example/b"
+          "?state": "new"
+
+  - name: "Turtle blank-node label denotes one node throughout a document"
+    ttl_data: |
+      @prefix cf07: <http://conformance-form07.example/> .
+      cf07:alice cf07:address _:address .
+      _:address cf07:city "Berlin" .
+      _:address cf07:country "DE" .
+    sparql: |
+      @prefix cf07: <http://conformance-form07.example/> .
+      SELECT ?city, ?country WHERE {
+        cf07:alice cf07:address ?address .
+        ?address cf07:city ?city .
+        ?address cf07:country ?country
+      }
+    expect:
+      rows: 1
+      data:
+        - "?city": "Berlin"
+          "?country": "DE"
+
+  - name: "Separate anonymous blank-node property lists allocate distinct nodes"
+    ttl_data: |
+      @prefix cf08: <http://conformance-form08.example/> .
+      cf08:alice cf08:address [ cf08:city "Berlin" ] .
+      cf08:bob cf08:address [ cf08:city "Berlin" ] .
+    sparql: |
+      @prefix cf08: <http://conformance-form08.example/> .
+      SELECT DISTINCT ?address WHERE {
+        ?person cf08:address ?address .
+        ?address cf08:city "Berlin"
+      }
+    expect:
+      rows: 2
+
+  - name: "Nested blank-node property lists preserve inner and outer subjects"
+    ttl_data: |
+      @prefix cf09: <http://conformance-form09.example/> .
+      cf09:alice cf09:address [
+        cf09:city "Berlin" ;
+        cf09:country [ cf09:code "DE" ]
+      ] .
+    sparql: |
+      @prefix cf09: <http://conformance-form09.example/> .
+      SELECT ?city, ?code WHERE {
+        cf09:alice cf09:address ?address .
+        ?address cf09:city ?city .
+        ?address cf09:country ?country .
+        ?country cf09:code ?code
+      }
+    expect:
+      rows: 1
+      data:
+        - "?city": "Berlin"
+          "?code": "DE"
+
+  - name: "Turtle collection expands to an ordered rdf:first/rdf:rest chain"
+    ttl_data: |
+      @prefix cf10: <http://conformance-form10.example/> .
+      cf10:subject cf10:items ( "first" "second" ) .
+    sparql: |
+      @prefix cf10: <http://conformance-form10.example/> .
+      @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      SELECT ?first, ?second WHERE {
+        cf10:subject cf10:items ?head .
+        ?head rdf:first ?first .
+        ?head rdf:rest ?tail .
+        ?tail rdf:first ?second .
+        ?tail rdf:rest rdf:nil
+      }
+    expect:
+      rows: 1
+      data:
+        - "?first": "first"
+          "?second": "second"
+
+  - name: "Empty Turtle collection denotes rdf:nil"
+    ttl_data: |
+      @prefix cf11: <http://conformance-form11.example/> .
+      cf11:subject cf11:items () .
+    sparql: |
+      @prefix cf11: <http://conformance-form11.example/> .
+      @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      SELECT ?items WHERE { cf11:subject cf11:items ?items }
+    expect:
+      rows: 1
+      data:
+        - "?items": "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+
+cleanup: []

--- a/tests/rdf/rdf-spec-graph-algebra.yaml
+++ b/tests/rdf/rdf-spec-graph-algebra.yaml
@@ -1,0 +1,121 @@
+# Cross-feature coverage derived from SPARQL 1.1 Query sections 5 through 12.
+
+metadata:
+  version: "1.0"
+  description: "SPARQL graph pattern and expression algebra semantics"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "FILTER scope covers the complete enclosing group"
+    ttl_data: |
+      @prefix ca01: <http://conformance-algebra01.example/> .
+      ca01:a ca01:value "keep" .
+      ca01:b ca01:value "drop" .
+    sparql: |
+      @prefix ca01: <http://conformance-algebra01.example/> .
+      SELECT ?subject WHERE {
+        FILTER(?value = "keep")
+        ?subject ca01:value ?value
+      }
+    expect:
+      rows: 1
+      data:
+        - "?subject": "http://conformance-algebra01.example/a"
+
+  - name: "OPTIONAL emits one solution for every compatible right-side match"
+    ttl_data: |
+      @prefix ca02: <http://conformance-algebra02.example/> .
+      ca02:alice ca02:name "Alice" ; ca02:contact "mail" ; ca02:contact "phone" .
+    sparql: |
+      @prefix ca02: <http://conformance-algebra02.example/> .
+      SELECT ?name, ?contact WHERE {
+        ?subject ca02:name ?name .
+        OPTIONAL { ?subject ca02:contact ?contact }
+      }
+    expect:
+      rows: 2
+
+  - name: "UNION retains duplicate compatible solutions"
+    ttl_data: |
+      @prefix ca03: <http://conformance-algebra03.example/> .
+      ca03:item ca03:left "yes" ; ca03:right "yes" .
+    sparql: |
+      @prefix ca03: <http://conformance-algebra03.example/> .
+      SELECT ?subject WHERE {
+        { ?subject ca03:left "yes" }
+        UNION
+        { ?subject ca03:right "yes" }
+      }
+    expect:
+      rows: 2
+
+  - name: "VALUES joins its solution sequence with a graph pattern"
+    ttl_data: |
+      @prefix ca04: <http://conformance-algebra04.example/> .
+      ca04:a ca04:name "Alice" .
+      ca04:b ca04:name "Bob" .
+      ca04:c ca04:name "Carol" .
+    sparql: |
+      @prefix ca04: <http://conformance-algebra04.example/> .
+      SELECT ?name WHERE {
+        VALUES ?subject { ca04:c ca04:a }
+        ?subject ca04:name ?name
+      }
+    expect:
+      rows: 2
+      contains: "Alice"
+
+  - name: "FILTER EXISTS is correlated with the outer solution"
+    ttl_data: |
+      @prefix ca05: <http://conformance-algebra05.example/> .
+      ca05:a ca05:name "Alice" ; ca05:active "yes" .
+      ca05:b ca05:name "Bob" .
+    sparql: |
+      @prefix ca05: <http://conformance-algebra05.example/> .
+      SELECT ?name WHERE {
+        ?subject ca05:name ?name .
+        FILTER EXISTS { ?subject ca05:active "yes" }
+      }
+    expect:
+      rows: 1
+      data:
+        - "?name": "Alice"
+
+  - name: "BIND extends each incoming solution without changing cardinality"
+    ttl_data: |
+      @prefix ca06: <http://conformance-algebra06.example/> .
+      ca06:a ca06:name "Alice" .
+      ca06:b ca06:name "Bob" .
+    sparql: |
+      @prefix ca06: <http://conformance-algebra06.example/> .
+      SELECT ?label WHERE {
+        ?subject ca06:name ?name .
+        BIND(CONCAT(?name, "!") AS ?label)
+      }
+    expect:
+      rows: 2
+      contains: "Alice!"
+
+  - name: "Ungrouped COUNT over an empty input produces one zero row"
+    sparql: |
+      @prefix ca07: <http://conformance-algebra07.example/> .
+      SELECT (COUNT(?value) AS ?count) WHERE { ?subject ca07:value ?value }
+    expect:
+      rows: 1
+      data:
+        - "?count": 0
+
+  - name: "Zero-or-more path includes the zero-length subject solution"
+    ttl_data: |
+      @prefix ca08: <http://conformance-algebra08.example/> .
+      ca08:a ca08:next ca08:b .
+      ca08:b ca08:next ca08:c .
+    sparql: |
+      @prefix ca08: <http://conformance-algebra08.example/> .
+      SELECT ?end WHERE { ca08:a ca08:next* ?end }
+    expect:
+      rows: 3
+
+cleanup: []


### PR DESCRIPTION
## Summary
- stack on and include the shared RDF query-planner groundwork from #784 while targeting `master`
- add broad W3C-oriented SPARQL/Turtle coverage for BGPs, modifiers, graph algebra, query/update forms, blank nodes, and collections
- lower supported BGP filters and JSON aggregation through the common `query-block` IR so the SQL cost planner, join reordering, and RecSet machinery can optimize the relational work
- expose SQL-compatible `JSON_*` scalar functions plus `JSON_ARRAYAGG` and `JSON_OBJECTAGG` to SPARQL, including nested child arrays inside JSON objects
- support whitespace-separated SPARQL projections/group keys/order comparators and both LIMIT/OFFSET orders; enforce RDF graph set semantics for newly created RDF tables

## Tests
- `make`
- `python3 tools/lint_scm.py --path lib/rdf-parser.scm --check`
- `python3 run_sql_tests.py tests/rdf/*.yaml --fail-fast` (21/21 suites)
- affected RDF planner/aggregate/JSON suites rerun after final parser changes

The complete repository test suite was intentionally left to CI, per request.