### PR TITLE
Recover multi-shard transactions atomically

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -62,6 +62,13 @@ type database struct {
 	// a read capability; cleanup takes the exclusive capability. Query and DML
 	// paths do not participate.
 	persistenceLifecycle sync.RWMutex `json:"-"`
+	// transactionLog is the database-wide commit authority for transactional
+	// shard WAL entries. Shard logs may contain prepared records after a crash;
+	// recovery exposes them only when this log contains their durable commit.
+	transactionOnce sync.Once           `json:"-"`
+	transactionMu   sync.RWMutex        `json:"-"`
+	transactionLog  PersistenceLogfile  `json:"-"`
+	committedTx     map[string]struct{} `json:"-"`
 
 	// lazy-loading/shared-resource state (not serialized)
 	srState SharedState `json:"-"`
@@ -86,7 +93,64 @@ func (db *database) blobRefState() *blobRefState {
 }
 
 func newDatabase() *database {
-	return &database{blobRefs: new(blobRefState)}
+	return &database{blobRefs: new(blobRefState), committedTx: make(map[string]struct{})}
+}
+
+const transactionLogName = ".transactions"
+
+func (db *database) initializeTransactionLog() {
+	db.transactionOnce.Do(func() {
+		committed := make(map[string]struct{})
+		_, entries, logfile := db.persistence.ReplayLog(transactionLogName)
+		for entry := range entries {
+			commit, ok := entry.(LogEntryCommit)
+			if !ok || commit.txID == "" {
+				panic("invalid entry in transaction commit log")
+			}
+			committed[commit.txID] = struct{}{}
+		}
+		db.transactionMu.Lock()
+		db.committedTx = committed
+		db.transactionLog = logfile
+		db.transactionMu.Unlock()
+	})
+}
+
+func (db *database) transactionCommitted(txID string) bool {
+	if txID == "" {
+		return true
+	}
+	db.initializeTransactionLog()
+	db.transactionMu.RLock()
+	_, committed := db.committedTx[txID]
+	db.transactionMu.RUnlock()
+	return committed
+}
+
+func (db *database) commitTransaction(txID string, durable bool) {
+	if txID == "" {
+		return
+	}
+	db.initializeTransactionLog()
+	db.transactionMu.Lock()
+	defer db.transactionMu.Unlock()
+	if _, exists := db.committedTx[txID]; exists {
+		return
+	}
+	db.transactionLog.Write(LogEntryCommit{txID: txID})
+	if durable {
+		db.transactionLog.Sync()
+	}
+	db.committedTx[txID] = struct{}{}
+}
+
+func (db *database) closeTransactionLog() {
+	db.transactionMu.Lock()
+	defer db.transactionMu.Unlock()
+	if db.transactionLog != nil {
+		db.transactionLog.Close()
+		db.transactionLog = nil
+	}
 }
 
 type rebuildDatabaseResult struct {
@@ -289,6 +353,9 @@ func rebuildDatabases(all bool, repartition bool, includeEphemeral bool) string 
 
 func UnloadDatabases() {
 	fmt.Println("table compression done in ", rebuildDatabases(false, false, true))
+	for _, db := range databases.GetAll() {
+		db.closeTransactionLog()
+	}
 	data, _ := json.Marshal(Settings)
 	if settings, err := os.OpenFile(Basepath+"/settings.json", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640); err == nil {
 		defer settings.Close()
@@ -489,6 +556,7 @@ func (db *database) saveLockedAndUnlock(mode schemaSaveMode) {
 // ensureLoaded loads schema.json into the database struct exactly once.
 func (db *database) ensureLoaded() {
 	db.loadOnce.Do(func() {
+		db.initializeTransactionLog()
 		if db.srState != COLD {
 			return
 		}
@@ -1223,6 +1291,7 @@ func DropDatabase(schema string, ifexists bool) bool {
 	}
 
 	// remove remains of the folder structure
+	db.closeTransactionLog()
 	db.persistence.Remove()
 	// also remove backend config file if it exists
 	os.Remove(Basepath + "/" + schema + ".json")

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -1013,11 +1013,11 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 			s.logfile = t.schema.persistence.OpenLog(s.uuid.String())
 			if len(s.inserts) > 0 {
 				columns, values := s.materializedInsertedRowsLocked(0)
-				s.logfile.Write(LogEntryInsert{columns, values})
+				s.logfile.Write(LogEntryInsert{cols: columns, values: values})
 				for i := range s.inserts {
 					recid := s.main_count + uint32(i)
 					if s.deletions.Get(uint(recid)) {
-						s.logfile.Write(LogEntryDelete{recid})
+						s.logfile.Write(LogEntryDelete{idx: recid})
 					}
 				}
 			}
@@ -1051,7 +1051,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 			wasDeleted := ps.deletions.Get(uint(recid))
 			ps.deletions.Set(uint(recid), true)
 			if !wasDeleted {
-				ps.logVisibilityChangeLocked(recid, true)
+				ps.logVisibilityChangeLocked(recid, true, "")
 			}
 			ps.mu.Unlock()
 			if !wasDeleted && t.PersistencyMode == Safe && ps.logfile != nil {

--- a/storage/persistence-ceph.go
+++ b/storage/persistence-ceph.go
@@ -342,33 +342,26 @@ func (s *CephStorage) OpenLog(shard string) PersistenceLogfile {
 	return lf
 }
 
-func (s *CephStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogfile) {
+func (s *CephStorage) ReplayLog(shard string) (map[string]struct{}, chan interface{}, PersistenceLogfile) {
 	s.ensureOpen()
 
 	out := make(chan interface{}, 64)
+	committed := make(map[string]struct{})
+	segments, err := listLogSegments(s, shard)
+	if err == nil {
+		hybridsort.Slice(segments, func(i, j int) bool { return segments[i].seg < segments[j].seg })
+		for _, seg := range segments {
+			data := s.readLogSegment(seg)
+			collectLogStreamCommits(data, committed)
+		}
+	} else {
+		segments = nil
+	}
 
-	// Replay existing segments synchronously; caller consumes channel.
 	go func() {
 		defer close(out)
-		segments, err := listLogSegments(s, shard)
-		if err != nil {
-			// no logs yet -> nothing to replay
-			return
-		}
-		hybridsort.Slice(segments, func(i, j int) bool { return segments[i].seg < segments[j].seg })
-
 		for _, seg := range segments {
-			stat, err := s.ioctx.Stat(seg.obj)
-			if err != nil || stat.Size == 0 {
-				continue
-			}
-			data := make([]byte, stat.Size)
-			n, err := s.ioctx.Read(seg.obj, data, 0)
-			if err != nil || n == 0 {
-				continue
-			}
-			// decode framed records
-			decodeLogStream(data[:n], out)
+			decodeLogStream(s.readLogSegment(seg), out)
 		}
 	}()
 
@@ -377,7 +370,20 @@ func (s *CephStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogf
 	if err != nil {
 		panic(err)
 	}
-	return out, lf
+	return committed, out, lf
+}
+
+func (s *CephStorage) readLogSegment(seg logSegInfo) []byte {
+	stat, err := s.ioctx.Stat(seg.obj)
+	if err != nil || stat.Size == 0 {
+		return nil
+	}
+	data := make([]byte, stat.Size)
+	n, err := s.ioctx.Read(seg.obj, data, 0)
+	if err != nil || n == 0 {
+		return nil
+	}
+	return data[:n]
 }
 
 func (s *CephStorage) RemoveLog(shard string) {
@@ -492,29 +498,38 @@ func openOrCreateCephLogfile(s *CephStorage, shard string) (*CephLogfile, error)
 // - replace JSON with a binary codec (varint + column-id encoding + typed values).
 
 type encDelete struct {
-	T   string `json:"t"`
-	Idx uint32 `json:"idx"`
+	T    string `json:"t"`
+	Idx  uint32 `json:"idx"`
+	TxID string `json:"txid,omitempty"`
 }
 type encInsert struct {
 	T      string        `json:"t"`
 	Cols   []string      `json:"cols"`
 	Values [][]scm.Scmer `json:"values"`
+	TxID   string        `json:"txid,omitempty"`
+}
+type encCommit struct {
+	T    string `json:"t"`
+	TxID string `json:"txid"`
 }
 
 func encodeLogEntry(e interface{}) []byte {
 	var payload []byte
 	switch l := e.(type) {
 	case LogEntryDelete:
-		tmp, _ := json.Marshal(encDelete{T: "delete", Idx: l.idx})
+		tmp, _ := json.Marshal(encDelete{T: "delete", Idx: l.idx, TxID: l.txID})
 		payload = tmp
 	case LogEntryUndelete:
-		tmp, _ := json.Marshal(encDelete{T: "undelete", Idx: l.idx})
+		tmp, _ := json.Marshal(encDelete{T: "undelete", Idx: l.idx, TxID: l.txID})
 		payload = tmp
 	case LogEntryInsert:
-		tmp, _ := json.Marshal(encInsert{T: "insert", Cols: l.cols, Values: l.values})
+		tmp, _ := json.Marshal(encInsert{T: "insert", Cols: l.cols, Values: l.values, TxID: l.txID})
 		payload = tmp
 	case LogEntryInsertHidden:
-		tmp, _ := json.Marshal(encInsert{T: "insert_hidden", Cols: l.cols, Values: l.values})
+		tmp, _ := json.Marshal(encInsert{T: "insert_hidden", Cols: l.cols, Values: l.values, TxID: l.txID})
+		payload = tmp
+	case LogEntryCommit:
+		tmp, _ := json.Marshal(encCommit{T: "commit", TxID: l.txID})
 		payload = tmp
 	default:
 		// ignore unknown
@@ -549,15 +564,20 @@ func decodeLogStream(data []byte, out chan interface{}) {
 			continue
 		}
 		switch head.T {
+		case "commit":
+			var commit encCommit
+			if json.Unmarshal(payload, &commit) == nil && commit.TxID != "" {
+				out <- LogEntryCommit{txID: commit.TxID}
+			}
 		case "delete":
 			var d encDelete
 			if json.Unmarshal(payload, &d) == nil {
-				out <- LogEntryDelete{idx: uint32(d.Idx)}
+				out <- LogEntryDelete{idx: uint32(d.Idx), txID: d.TxID}
 			}
 		case "undelete":
 			var d encDelete
 			if json.Unmarshal(payload, &d) == nil {
-				out <- LogEntryUndelete{idx: uint32(d.Idx)}
+				out <- LogEntryUndelete{idx: uint32(d.Idx), txID: d.TxID}
 			}
 		case "insert", "insert_hidden":
 			var ins encInsert
@@ -569,11 +589,27 @@ func decodeLogStream(data []byte, out chan interface{}) {
 					}
 				}
 				if head.T == "insert_hidden" {
-					out <- LogEntryInsertHidden{cols: ins.Cols, values: ins.Values}
+					out <- LogEntryInsertHidden{cols: ins.Cols, values: ins.Values, txID: ins.TxID}
 				} else {
-					out <- LogEntryInsert{cols: ins.Cols, values: ins.Values}
+					out <- LogEntryInsert{cols: ins.Cols, values: ins.Values, txID: ins.TxID}
 				}
 			}
+		}
+	}
+}
+
+func collectLogStreamCommits(data []byte, committed map[string]struct{}) {
+	for i := 0; i+4 <= len(data); {
+		n := int(binary.LittleEndian.Uint32(data[i : i+4]))
+		i += 4
+		if n <= 0 || i+n > len(data) {
+			return
+		}
+		payload := data[i : i+n]
+		i += n
+		var commit encCommit
+		if json.Unmarshal(payload, &commit) == nil && commit.T == "commit" && commit.TxID != "" {
+			committed[commit.TxID] = struct{}{}
 		}
 	}
 }

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -23,9 +23,11 @@ import "bufio"
 import "bytes"
 import "strings"
 import "errors"
+import "strconv"
 import "path/filepath"
 import "crypto/sha256"
 import "encoding/json"
+
 import "github.com/launix-de/memcp/scm"
 
 type FileStorage struct {
@@ -255,10 +257,15 @@ func (s *FileStorage) OpenLog(shard string) PersistenceLogfile {
 	return FileLogfile{f}
 }
 
-func (s *FileStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogfile) {
+func (s *FileStorage) ReplayLog(shard string) (map[string]struct{}, chan interface{}, PersistenceLogfile) {
 	os.MkdirAll(s.path, 0750)
 	f, err := os.OpenFile(s.path+shard+".log", os.O_RDWR|os.O_CREATE, 0750)
 	if err != nil {
+		panic(err)
+	}
+	committed := fileCommittedTransactions(f)
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		_ = f.Close()
 		panic(err)
 	}
 	replay := make(chan interface{}, 64)
@@ -272,7 +279,13 @@ func (s *FileStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogf
 				if len(b) == 0 && errors.Is(err, io.EOF) {
 					break
 				}
-				if len(b) > 0 && b[len(b)-1] == '\n' {
+				complete := len(b) > 0 && b[len(b)-1] == '\n'
+				if errors.Is(err, io.EOF) && !complete {
+					// A record without its delimiter may be a torn final write. It
+					// was never a complete WAL frame and must not affect recovery.
+					break
+				}
+				if complete {
 					b = b[:len(b)-1]
 				}
 				if len(b) > 0 && b[len(b)-1] == '\r' {
@@ -280,20 +293,44 @@ func (s *FileStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogf
 				}
 				if len(b) == 0 && err == nil {
 					// nop
+				} else if len(b) >= 10 && string(b[0:10]) == "commit-tx " {
+					fields := strings.Fields(string(b[10:]))
+					if len(fields) != 2 || fields[0] == "" || fields[1] != fileCommitChecksum(fields[0]) {
+						panic("corrupt commit log: " + string(b))
+					}
+					replay <- LogEntryCommit{txID: fields[0]}
+				} else if len(b) >= 10 && string(b[0:10]) == "delete-tx " {
+					txID, idx := decodeFileDeleteTx(b[10:])
+					replay <- LogEntryDelete{idx: idx, txID: txID}
+				} else if len(b) >= 12 && string(b[0:12]) == "undelete-tx " {
+					txID, idx := decodeFileDeleteTx(b[12:])
+					replay <- LogEntryUndelete{idx: idx, txID: txID}
+				} else if len(b) >= 17 && string(b[0:17]) == "insert-hidden-tx " {
+					txID, payload := decodeFileTxPrefix(b[17:])
+					cols, values := decodeFileInsertLog(payload)
+					replay <- LogEntryInsertHidden{cols: cols, values: values, txID: txID}
+				} else if len(b) >= 10 && string(b[0:10]) == "insert-tx " {
+					txID, payload := decodeFileTxPrefix(b[10:])
+					cols, values := decodeFileInsertLog(payload)
+					replay <- LogEntryInsert{cols: cols, values: values, txID: txID}
 				} else if len(b) >= 7 && string(b[0:7]) == "delete " {
 					var idx uint32
-					json.Unmarshal(b[7:], &idx)
-					replay <- LogEntryDelete{idx}
+					if decodeErr := json.Unmarshal(b[7:], &idx); decodeErr != nil {
+						panic("corrupt delete log: " + string(b))
+					}
+					replay <- LogEntryDelete{idx: idx}
 				} else if len(b) >= 9 && string(b[0:9]) == "undelete " {
 					var idx uint32
-					json.Unmarshal(b[9:], &idx)
-					replay <- LogEntryUndelete{idx}
+					if decodeErr := json.Unmarshal(b[9:], &idx); decodeErr != nil {
+						panic("corrupt undelete log: " + string(b))
+					}
+					replay <- LogEntryUndelete{idx: idx}
 				} else if len(b) >= 14 && string(b[0:14]) == "insert-hidden " {
 					cols, values := decodeFileInsertLog(b[14:])
-					replay <- LogEntryInsertHidden{cols, values}
+					replay <- LogEntryInsertHidden{cols: cols, values: values}
 				} else if len(b) >= 7 && string(b[0:7]) == "insert " {
 					cols, values := decodeFileInsertLog(b[7:])
-					replay <- LogEntryInsert{cols, values}
+					replay <- LogEntryInsert{cols: cols, values: values}
 				} else {
 					panic("unknown log sequence: " + string(b))
 				}
@@ -308,7 +345,60 @@ func (s *FileStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogf
 	} else {
 		close(replay)
 	}
-	return replay, FileLogfile{f}
+	return committed, replay, FileLogfile{f}
+}
+
+func fileCommittedTransactions(f *os.File) map[string]struct{} {
+	committed := make(map[string]struct{})
+	reader := bufio.NewReaderSize(f, 256*1024)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) == 0 && errors.Is(err, io.EOF) {
+			break
+		}
+		if errors.Is(err, io.EOF) && (len(line) == 0 || line[len(line)-1] != '\n') {
+			break
+		}
+		line = bytes.TrimSuffix(line, []byte{'\n'})
+		line = bytes.TrimSuffix(line, []byte{'\r'})
+		if bytes.HasPrefix(line, []byte("commit-tx ")) {
+			fields := strings.Fields(string(line[len("commit-tx "):]))
+			if len(fields) != 2 || fields[0] == "" || fields[1] != fileCommitChecksum(fields[0]) {
+				panic("corrupt commit log: " + string(line))
+			}
+			committed[fields[0]] = struct{}{}
+		}
+		if err != nil {
+			panic(err)
+		}
+	}
+	return committed
+}
+
+func decodeFileTxPrefix(payload []byte) (string, []byte) {
+	separator := bytes.IndexByte(payload, ' ')
+	if separator <= 0 {
+		panic("corrupt transactional WAL entry: " + string(payload))
+	}
+	txID := string(payload[:separator])
+	if txID == "" {
+		panic("corrupt transactional WAL id: " + string(payload))
+	}
+	return txID, payload[separator+1:]
+}
+
+func fileCommitChecksum(txID string) string {
+	checksum := sha256.Sum256([]byte(txID))
+	return fmt.Sprintf("%x", checksum[:])
+}
+
+func decodeFileDeleteTx(payload []byte) (string, uint32) {
+	txID, recidPayload := decodeFileTxPrefix(payload)
+	idx, err := strconv.ParseUint(string(recidPayload), 10, 32)
+	if err != nil {
+		panic("corrupt transactional visibility log: " + string(payload))
+	}
+	return txID, uint32(idx)
 }
 
 func decodeFileInsertLog(b []byte) ([]string, [][]scm.Scmer) {
@@ -317,8 +407,12 @@ func decodeFileInsertLog(b []byte) ([]string, [][]scm.Scmer) {
 		// new format: columns ][ values
 		var cols []string
 		var values [][]scm.Scmer
-		json.Unmarshal([]byte(body[:pos+1]), &cols)
-		json.Unmarshal([]byte(body[pos+1:]), &values)
+		if err := json.Unmarshal([]byte(body[:pos+1]), &cols); err != nil {
+			panic("corrupt insert columns log: " + string(b))
+		}
+		if err := json.Unmarshal([]byte(body[pos+1:]), &values); err != nil {
+			panic("corrupt insert values log: " + string(b))
+		}
 		for i := 0; i < len(values); i++ {
 			for j := 0; j < len(values[i]); j++ {
 				values[i][j] = scm.TransformFromJSON(values[i][j])
@@ -355,6 +449,10 @@ type FileLogfile struct {
 func (w FileLogfile) Write(logentry interface{}) {
 	switch l := logentry.(type) {
 	case LogEntryDelete:
+		if l.txID != "" {
+			fmt.Fprintf(w.w, "delete-tx %s %d\n", l.txID, l.idx)
+			return
+		}
 		var b bytes.Buffer
 		b.WriteString("delete ")
 		tmp, _ := json.Marshal(l.idx)
@@ -362,6 +460,10 @@ func (w FileLogfile) Write(logentry interface{}) {
 		b.WriteString("\n")
 		w.w.Write(b.Bytes())
 	case LogEntryUndelete:
+		if l.txID != "" {
+			fmt.Fprintf(w.w, "undelete-tx %s %d\n", l.txID, l.idx)
+			return
+		}
 		var b bytes.Buffer
 		b.WriteString("undelete ")
 		tmp, _ := json.Marshal(l.idx)
@@ -369,15 +471,24 @@ func (w FileLogfile) Write(logentry interface{}) {
 		b.WriteString("\n")
 		w.w.Write(b.Bytes())
 	case LogEntryInsert:
-		w.writeInsert("insert ", l.cols, l.values)
+		w.writeInsert("insert ", l.txID, l.cols, l.values)
 	case LogEntryInsertHidden:
-		w.writeInsert("insert-hidden ", l.cols, l.values)
+		w.writeInsert("insert-hidden ", l.txID, l.cols, l.values)
+	case LogEntryCommit:
+		fmt.Fprintf(w.w, "commit-tx %s %s\n", l.txID, fileCommitChecksum(l.txID))
 	}
 }
 
-func (w FileLogfile) writeInsert(prefix string, cols []string, values [][]scm.Scmer) {
+func (w FileLogfile) writeInsert(prefix string, txID string, cols []string, values [][]scm.Scmer) {
 	var b bytes.Buffer
-	b.WriteString(prefix)
+	if txID == "" {
+		b.WriteString(prefix)
+	} else {
+		b.WriteString(strings.TrimSuffix(prefix, " "))
+		b.WriteString("-tx ")
+		b.WriteString(txID)
+		b.WriteByte(' ')
+	}
 	tmp, _ := json.Marshal(cols)
 	b.Write(tmp)
 	tmp, _ = json.Marshal(values)

--- a/storage/persistence-s3.go
+++ b/storage/persistence-s3.go
@@ -399,33 +399,25 @@ func (s *S3Storage) OpenLog(shard string) PersistenceLogfile {
 	return lf
 }
 
-func (s *S3Storage) ReplayLog(shard string) (chan interface{}, PersistenceLogfile) {
+func (s *S3Storage) ReplayLog(shard string) (map[string]struct{}, chan interface{}, PersistenceLogfile) {
 	s.ensureOpen()
 
 	out := make(chan interface{}, 64)
+	committed := make(map[string]struct{})
+	segments, err := listS3LogSegments(s, shard)
+	if err == nil {
+		hybridsort.Slice(segments, func(i, j int) bool { return segments[i].seg < segments[j].seg })
+		for _, seg := range segments {
+			collectS3LogStreamCommits(s.readLogSegment(seg), committed)
+		}
+	} else {
+		segments = nil
+	}
 
 	go func() {
 		defer close(out)
-		segments, err := listS3LogSegments(s, shard)
-		if err != nil {
-			return
-		}
-		hybridsort.Slice(segments, func(i, j int) bool { return segments[i].seg < segments[j].seg })
-
 		for _, seg := range segments {
-			resp, err := s.client.GetObject(context.Background(), &s3.GetObjectInput{
-				Bucket: aws.String(s.factory.Bucket),
-				Key:    aws.String(seg.key),
-			})
-			if err != nil {
-				continue
-			}
-			data, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil || len(data) == 0 {
-				continue
-			}
-			decodeS3LogStream(data, out)
+			decodeS3LogStream(s.readLogSegment(seg), out)
 		}
 	}()
 
@@ -433,7 +425,23 @@ func (s *S3Storage) ReplayLog(shard string) (chan interface{}, PersistenceLogfil
 	if err != nil {
 		panic(err)
 	}
-	return out, lf
+	return committed, out, lf
+}
+
+func (s *S3Storage) readLogSegment(seg s3LogSegInfo) []byte {
+	resp, err := s.client.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String(s.factory.Bucket),
+		Key:    aws.String(seg.key),
+	})
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+	return data
 }
 
 func (s *S3Storage) RemoveLog(shard string) {
@@ -544,29 +552,38 @@ func openOrCreateS3Logfile(s *S3Storage, shard string) (*S3Logfile, error) {
 
 // Log encoding (same as Ceph)
 type s3EncDelete struct {
-	T   string `json:"t"`
-	Idx uint32 `json:"idx"`
+	T    string `json:"t"`
+	Idx  uint32 `json:"idx"`
+	TxID string `json:"txid,omitempty"`
 }
 type s3EncInsert struct {
 	T      string        `json:"t"`
 	Cols   []string      `json:"cols"`
 	Values [][]scm.Scmer `json:"values"`
+	TxID   string        `json:"txid,omitempty"`
+}
+type s3EncCommit struct {
+	T    string `json:"t"`
+	TxID string `json:"txid"`
 }
 
 func encodeS3LogEntry(e interface{}) []byte {
 	var payload []byte
 	switch l := e.(type) {
 	case LogEntryDelete:
-		tmp, _ := json.Marshal(s3EncDelete{T: "delete", Idx: l.idx})
+		tmp, _ := json.Marshal(s3EncDelete{T: "delete", Idx: l.idx, TxID: l.txID})
 		payload = tmp
 	case LogEntryUndelete:
-		tmp, _ := json.Marshal(s3EncDelete{T: "undelete", Idx: l.idx})
+		tmp, _ := json.Marshal(s3EncDelete{T: "undelete", Idx: l.idx, TxID: l.txID})
 		payload = tmp
 	case LogEntryInsert:
-		tmp, _ := json.Marshal(s3EncInsert{T: "insert", Cols: l.cols, Values: l.values})
+		tmp, _ := json.Marshal(s3EncInsert{T: "insert", Cols: l.cols, Values: l.values, TxID: l.txID})
 		payload = tmp
 	case LogEntryInsertHidden:
-		tmp, _ := json.Marshal(s3EncInsert{T: "insert_hidden", Cols: l.cols, Values: l.values})
+		tmp, _ := json.Marshal(s3EncInsert{T: "insert_hidden", Cols: l.cols, Values: l.values, TxID: l.txID})
+		payload = tmp
+	case LogEntryCommit:
+		tmp, _ := json.Marshal(s3EncCommit{T: "commit", TxID: l.txID})
 		payload = tmp
 	default:
 		return nil
@@ -599,15 +616,20 @@ func decodeS3LogStream(data []byte, out chan interface{}) {
 			continue
 		}
 		switch head.T {
+		case "commit":
+			var commit s3EncCommit
+			if json.Unmarshal(payload, &commit) == nil && commit.TxID != "" {
+				out <- LogEntryCommit{txID: commit.TxID}
+			}
 		case "delete":
 			var d s3EncDelete
 			if json.Unmarshal(payload, &d) == nil {
-				out <- LogEntryDelete{idx: uint32(d.Idx)}
+				out <- LogEntryDelete{idx: uint32(d.Idx), txID: d.TxID}
 			}
 		case "undelete":
 			var d s3EncDelete
 			if json.Unmarshal(payload, &d) == nil {
-				out <- LogEntryUndelete{idx: uint32(d.Idx)}
+				out <- LogEntryUndelete{idx: uint32(d.Idx), txID: d.TxID}
 			}
 		case "insert", "insert_hidden":
 			var ins s3EncInsert
@@ -618,11 +640,27 @@ func decodeS3LogStream(data []byte, out chan interface{}) {
 					}
 				}
 				if head.T == "insert_hidden" {
-					out <- LogEntryInsertHidden{cols: ins.Cols, values: ins.Values}
+					out <- LogEntryInsertHidden{cols: ins.Cols, values: ins.Values, txID: ins.TxID}
 				} else {
-					out <- LogEntryInsert{cols: ins.Cols, values: ins.Values}
+					out <- LogEntryInsert{cols: ins.Cols, values: ins.Values, txID: ins.TxID}
 				}
 			}
+		}
+	}
+}
+
+func collectS3LogStreamCommits(data []byte, committed map[string]struct{}) {
+	for i := 0; i+4 <= len(data); {
+		n := int(binary.LittleEndian.Uint32(data[i : i+4]))
+		i += 4
+		if n <= 0 || i+n > len(data) {
+			return
+		}
+		payload := data[i : i+n]
+		i += n
+		var commit s3EncCommit
+		if json.Unmarshal(payload, &commit) == nil && commit.T == "commit" && commit.TxID != "" {
+			committed[commit.TxID] = struct{}{}
 		}
 	}
 }

--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -57,8 +57,11 @@ type PersistenceEngine interface {
 	// WalkBlobs calls fn for every blob hash stored on disk, one at a time.
 	// fn may return an error to stop iteration early.
 	WalkBlobs(fn func(hash string) error) error
-	OpenLog(shard string) PersistenceLogfile                       // open for writing
-	ReplayLog(shard string) (chan interface{}, PersistenceLogfile) // replay existing log
+	OpenLog(shard string) PersistenceLogfile // open for writing
+	// ReplayLog returns the transaction IDs committed in this WAL before it
+	// streams entries. This keeps recovery memory proportional to commit count,
+	// rather than retaining every row mutation until the final marker is known.
+	ReplayLog(shard string) (map[string]struct{}, chan interface{}, PersistenceLogfile)
 	RemoveLog(shard string)
 	// WalkShardFiles calls fn for every shard-related file (column files, log files)
 	// stored on disk, one at a time. The name passed to fn is exactly the value
@@ -95,18 +98,25 @@ func finishColumnWrite(w io.WriteCloser, durable bool) {
 }
 
 type LogEntryDelete struct {
-	idx uint32
+	idx  uint32
+	txID string
 }
 type LogEntryUndelete struct {
-	idx uint32
+	idx  uint32
+	txID string
 }
 type LogEntryInsert struct {
 	cols   []string
 	values [][]scm.Scmer
+	txID   string
 }
 type LogEntryInsertHidden struct {
 	cols   []string
 	values [][]scm.Scmer
+	txID   string
+}
+type LogEntryCommit struct {
+	txID string
 }
 
 // for CREATE TABLE

--- a/storage/persistence_transaction_test.go
+++ b/storage/persistence_transaction_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func TestFileTransactionalWALRoundTrip(t *testing.T) {
+	engine := &FileStorage{path: filepath.Join(t.TempDir(), "db") + "/"}
+	logfile := engine.OpenLog("roundtrip")
+	txID := "boot-id/17"
+	logfile.Write(LogEntryInsertHidden{
+		cols:   []string{"id"},
+		values: [][]scm.Scmer{{scm.NewInt(7)}},
+		txID:   txID,
+	})
+	logfile.Write(LogEntryDelete{idx: 3, txID: txID})
+	logfile.Write(LogEntryUndelete{idx: 4, txID: txID})
+	logfile.Write(LogEntryCommit{txID: txID})
+	logfile.Sync()
+	logfile.Close()
+
+	committed, entries, replayLog := engine.ReplayLog("roundtrip")
+	defer replayLog.Close()
+	if _, ok := committed[txID]; !ok {
+		t.Fatal("transaction commit was not discovered before replay")
+	}
+	var restored []interface{}
+	for entry := range entries {
+		restored = append(restored, entry)
+	}
+	if len(restored) != 4 {
+		t.Fatalf("restored %d WAL entries, want 4", len(restored))
+	}
+	insert, ok := restored[0].(LogEntryInsertHidden)
+	if !ok || insert.txID != txID || len(insert.values) != 1 || scm.ToInt(insert.values[0][0]) != 7 {
+		t.Fatalf("restored transactional insert = %#v", restored[0])
+	}
+	if deletion, ok := restored[1].(LogEntryDelete); !ok || deletion.idx != 3 || deletion.txID != txID {
+		t.Fatalf("restored transactional delete = %#v", restored[1])
+	}
+	if undeletion, ok := restored[2].(LogEntryUndelete); !ok || undeletion.idx != 4 || undeletion.txID != txID {
+		t.Fatalf("restored transactional undelete = %#v", restored[2])
+	}
+	if commit, ok := restored[3].(LogEntryCommit); !ok || commit.txID != txID {
+		t.Fatalf("restored transaction commit = %#v", restored[3])
+	}
+}
+
+func TestFileWALIgnoresTornFinalCommit(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "db")
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	validID := "boot-id/31"
+	tornID := "boot-id/32"
+	body := "commit-tx " + validID + " " + fileCommitChecksum(validID) + "\n" +
+		"commit-tx " + tornID + " " + fileCommitChecksum(tornID)
+	if err := os.WriteFile(filepath.Join(dir, transactionLogName+".log"), []byte(body), 0640); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := &FileStorage{path: dir + "/"}
+	_, entries, logfile := engine.ReplayLog(transactionLogName)
+	defer logfile.Close()
+	var restored []interface{}
+	for entry := range entries {
+		restored = append(restored, entry)
+	}
+	if len(restored) != 1 {
+		t.Fatalf("restored %d commit records, want only the complete record", len(restored))
+	}
+	commit, ok := restored[0].(LogEntryCommit)
+	if !ok || commit.txID != validID {
+		t.Fatalf("restored commit = %#v, want %q", restored[0], validID)
+	}
+}
+
+func TestDatabaseCommitAuthoritySurvivesReopen(t *testing.T) {
+	engine := &FileStorage{path: filepath.Join(t.TempDir(), "db") + "/"}
+	db := newDatabase()
+	db.persistence = engine
+	db.commitTransaction("boot-id/23", true)
+	db.closeTransactionLog()
+
+	reloaded := newDatabase()
+	reloaded.persistence = engine
+	if !reloaded.transactionCommitted("boot-id/23") {
+		t.Fatal("durable database commit was not restored")
+	}
+	if reloaded.transactionCommitted("boot-id/24") {
+		t.Fatal("transaction without a commit record was restored")
+	}
+	reloaded.closeTransactionLog()
+}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1333,8 +1333,8 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 			if result && dualWriteRow != nil {
 				t.t.dualWriteInsertFromOld(t, newRecid, dualWriteCols, dualWriteRow, currentTx)
 			}
-			// transaction bookkeeping + deferred sync
-			// (shard is already registered via OpenMapReducer — no per-row RegisterTouchedShard)
+			// Transaction bookkeeping. The owning MapReducer registers this shard
+			// once on Close, and only when at least one callback mutated it.
 			if result {
 				if tx := currentTx; tx != nil {
 					switch tx.Mode {
@@ -1974,12 +1974,6 @@ func (t *storageShard) initMapReducer(mr *ShardMapReducer, cols []string, mapRed
 			}
 		}
 	}
-	// Register shard for deferred fsync once, not per row.
-	if mr.hasUpdateCol {
-		if tx := mr.currentTx; tx != nil {
-			tx.RegisterTouchedShard(t)
-		}
-	}
 }
 
 // OpenMapReducer creates a retained MapReducer for operators whose mapper
@@ -2371,6 +2365,9 @@ func (m *ShardMapReducer) processDeltaBlockBatch(acc scm.Scmer, recids []uint32,
 // batches — that must happen after all shard locks are released.
 // Call FlushTriggerBatch() separately after the scan completes.
 func (m *ShardMapReducer) Close() {
+	if m.hasUpdateCol && m.currentTx != nil && m.currentTx.getShardTx(m.shard) != nil {
+		m.currentTx.RegisterTouchedShard(m.shard)
+	}
 	if m.mainBulkBuffer != nil {
 		clear(m.mainBulkBuffer.values)
 		width := cap(m.mainBulkBuffer.values) / defaultScanBufferSize

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -139,7 +139,7 @@ func (s *storageShard) nextForMaintenanceLocked(deletedRecid *uint32) *storageSh
 // when transaction commit/rollback changes it after the rebuild snapshot. A
 // successor already tracked by the same transaction applies its own masks
 // and must not be locked recursively here. Caller must hold s.mu.Lock().
-func (s *storageShard) syncNextVisibilityLocked(oldRecid uint32, trackedByTx map[*storageShard]struct{}) {
+func (s *storageShard) syncNextVisibilityLocked(oldRecid uint32, trackedByTx map[*storageShard]struct{}, currentTx *TxContext) {
 	current := s
 	currentRecid := oldRecid
 	currentIsSource := true
@@ -166,7 +166,12 @@ func (s *storageShard) syncNextVisibilityLocked(oldRecid uint32, trackedByTx map
 		next.deletions.Set(uint(newRecid), deleted)
 		next.rollbackProtected.Set(uint(newRecid), protected)
 		if wasDeleted != deleted {
-			next.logVisibilityChangeLocked(newRecid, deleted)
+			txID := ""
+			if currentTx != nil {
+				txID = currentTx.durableID()
+				currentTx.RegisterTouchedShard(next)
+			}
+			next.logVisibilityChangeLocked(newRecid, deleted, txID)
 		}
 		if !currentIsSource {
 			current.mu.Unlock()
@@ -182,15 +187,15 @@ func (s *storageShard) syncNextVisibilityLocked(oldRecid uint32, trackedByTx map
 
 // logVisibilityChangeLocked persists a visibility transition without changing
 // row identity. Caller must hold s.mu.Lock().
-func (s *storageShard) logVisibilityChangeLocked(recid uint32, deleted bool) {
+func (s *storageShard) logVisibilityChangeLocked(recid uint32, deleted bool, txID string) {
 	if (s.t.PersistencyMode != Safe && s.t.PersistencyMode != Logged) || s.logfile == nil {
 		return
 	}
 	if deleted {
-		s.logfile.Write(LogEntryDelete{recid})
+		s.logfile.Write(LogEntryDelete{idx: recid, txID: txID})
 		return
 	}
-	s.logfile.Write(LogEntryUndelete{recid})
+	s.logfile.Write(LogEntryUndelete{idx: recid, txID: txID})
 }
 
 // catchUpRebuildLocked replays only mutations that happened after the rebuild
@@ -217,7 +222,7 @@ func (s *storageShard) catchUpRebuildLocked(next *storageShard, snapshotInsertCo
 		// visibility. Persist both directions: omitting the undelete transition
 		// makes a correct in-memory commit reappear as deleted after WAL replay.
 		if wasDeleted != deleted {
-			next.logVisibilityChangeLocked(newRecid, deleted)
+			next.logVisibilityChangeLocked(newRecid, deleted, "")
 		}
 	}
 
@@ -414,21 +419,41 @@ func (u *storageShard) load(t *table) {
 	if t.PersistencyMode == Safe || t.PersistencyMode == Logged {
 		// Replaying the log mutates inserts/deletions; caller holds u.mu.Lock
 		var log chan interface{}
-		log, u.logfile = u.t.schema.persistence.ReplayLog(u.uuid.String())
-		numEntriesRestored := 0
+		localCommitted, log, logfile := u.t.schema.persistence.ReplayLog(u.uuid.String())
+		u.logfile = logfile
+		isCommitted := func(txID string) bool {
+			if txID == "" {
+				return true
+			}
+			if _, exists := localCommitted[txID]; exists {
+				return true
+			}
+			return u.t.schema.transactionCommitted(txID)
+		}
+		entryCount := 0
 		for logentry := range log {
-			numEntriesRestored++
+			entryCount++
 			switch l := logentry.(type) {
 			case LogEntryDelete:
-				u.deletions.Set(uint(l.idx), true) // mark deletion
+				if isCommitted(l.txID) {
+					u.deletions.Set(uint(l.idx), true) // mark deletion
+				}
 			case LogEntryUndelete:
-				u.deletions.Set(uint(l.idx), false)
+				if isCommitted(l.txID) {
+					u.deletions.Set(uint(l.idx), false)
+				}
 			case LogEntryInsert:
 				// WAL insert recids follow the persisted main rows. Resolve that
 				// boundary only when replay actually contains inserts: eager loading
 				// here would defeat cold-column loading for every empty WAL.
 				u.ensureMainCount(true)
+				firstRecid := u.main_count + uint32(len(u.inserts))
 				u.insertDatasetFromLog(l.cols, l.values)
+				if !isCommitted(l.txID) {
+					for i := range l.values {
+						u.deletions.Set(uint(firstRecid+uint32(i)), true)
+					}
+				}
 			case LogEntryInsertHidden:
 				// Hidden transactional inserts use the same RecID namespace. Without
 				// the persisted boundary they would tombstone committed main rows and
@@ -439,12 +464,14 @@ func (u *storageShard) load(t *table) {
 				for i := range l.values {
 					u.deletions.Set(uint(firstRecid+uint32(i)), true)
 				}
+			case LogEntryCommit:
+				// Already consumed while building the shard-local commit set.
 			default:
 				panic("unknown log sequence: " + fmt.Sprint(l))
 			}
 		}
-		if numEntriesRestored > 0 {
-			fmt.Println("restoring delta storage from database "+u.t.schema.Name+" shard "+u.uuid.String()+":", numEntriesRestored, "entries")
+		if entryCount > 0 {
+			fmt.Println("restoring delta storage from database "+u.t.schema.Name+" shard "+u.uuid.String()+":", entryCount, "entries")
 		}
 		// Reconstruct Auto_increment counter from replayed delta rows so that
 		// cross-connection INSERT sequences never re-use IDs after server restart.
@@ -1284,7 +1311,7 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 					currentTx.AddToUndeleteMask(t, newRecid)
 					// Only log the insert (delete applied at commit)
 					if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
-						t.logfile.Write(LogEntryInsertHidden{payloadCols, [][]scm.Scmer{payloadRow}})
+						t.logfile.Write(LogEntryInsertHidden{cols: payloadCols, values: [][]scm.Scmer{payloadRow}, txID: currentTx.durableID()})
 					}
 				} else {
 					// Cursor-stability / no-tx: existing behavior
@@ -1292,8 +1319,12 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 						t.rollbackProtected.Set(uint(targetIdx), true)
 					}
 					if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
-						t.logfile.Write(LogEntryDelete{targetIdx})
-						t.logfile.Write(LogEntryInsert{payloadCols, [][]scm.Scmer{payloadRow}})
+						txID := ""
+						if currentTx != nil {
+							txID = currentTx.durableID()
+						}
+						t.logfile.Write(LogEntryDelete{idx: targetIdx, txID: txID})
+						t.logfile.Write(LogEntryInsert{cols: payloadCols, values: [][]scm.Scmer{payloadRow}, txID: txID})
 					}
 				}
 				maintenanceNext = t.nextForMaintenanceLocked(&targetIdx)
@@ -1397,7 +1428,11 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 						t.rollbackProtected.Set(uint(idx), true)
 					}
 					if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
-						t.logfile.Write(LogEntryDelete{idx})
+						txID := ""
+						if currentTx != nil {
+							txID = currentTx.durableID()
+						}
+						t.logfile.Write(LogEntryDelete{idx: idx, txID: txID})
 					}
 					maintenanceNext = t.nextForMaintenanceLocked(&idx)
 					result = true
@@ -2528,10 +2563,14 @@ func (t *storageShard) insertPreparedLocked(columns []string, values [][]scm.Scm
 	if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
 		// Log the actual inserted rows (not the original columns/values) so that
 		// auto-incremented IDs and column defaults are preserved across restarts.
+		txID := ""
+		if currentTx != nil {
+			txID = currentTx.durableID()
+		}
 		if currentTx != nil && currentTx.Mode == TxACID {
-			t.logfile.Write(LogEntryInsertHidden{payloadCols, payloadVals})
+			t.logfile.Write(LogEntryInsertHidden{cols: payloadCols, values: payloadVals, txID: txID})
 		} else {
-			t.logfile.Write(LogEntryInsert{payloadCols, payloadVals})
+			t.logfile.Write(LogEntryInsert{cols: payloadCols, values: payloadVals, txID: txID})
 		}
 	}
 	if propagateMaintenance {
@@ -3455,7 +3494,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 			}
 			result.deletions.Set(uint(newRecid), true)
 			if result.logfile != nil {
-				result.logfile.Write(LogEntryDelete{newRecid})
+				result.logfile.Write(LogEntryDelete{idx: newRecid})
 			}
 		}
 

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -18,10 +18,14 @@ package storage
 
 import "context"
 import "fmt"
+
 import "github.com/carli2/hybridsort"
 import "runtime"
+import "strconv"
 import "sync"
 import "sync/atomic"
+
+import "github.com/google/uuid"
 import "github.com/launix-de/memcp/scm"
 import NonLockingReadMap "github.com/launix-de/NonLockingReadMap"
 
@@ -122,6 +126,7 @@ type TxContext struct {
 	queryInfo     atomic.Pointer[string]
 	queryActive   atomic.Bool
 	queryMu       sync.Mutex // serializes statements which reuse this transaction object
+	walTxID       atomic.Pointer[string]
 	// fanoutLimit/fanoutInUse bound only additional multi-shard workers. A
 	// single relevant shard never reads or writes this cache line.
 	fanoutLimit atomic.Int32
@@ -162,6 +167,7 @@ func (tx *TxContext) reset(mode TxMode) {
 	tx.Depth = 0
 	tx.fanoutLimit.Store(int32(runtime.GOMAXPROCS(0)))
 	tx.fanoutInUse.Store(0)
+	tx.walTxID.Store(nil)
 	tx.shards = nil
 	tx.touchedShards = sync.Map{}
 	tx.autoCommit = false
@@ -169,6 +175,27 @@ func (tx *TxContext) reset(mode TxMode) {
 	tx.repartitionDeletes = nil
 	tx.invalidationDepth = 0
 	tx.invalidationVisited = nil
+}
+
+var walBootID = uuid.NewString()
+var walTxSequence atomic.Uint64
+
+func nextDurableTxID() string {
+	return walBootID + "/" + strconv.FormatUint(walTxSequence.Add(1), 10)
+}
+
+func (tx *TxContext) durableID() string {
+	if tx == nil {
+		return ""
+	}
+	if txID := tx.walTxID.Load(); txID != nil {
+		return *txID
+	}
+	candidate := nextDurableTxID()
+	if tx.walTxID.CompareAndSwap(nil, &candidate) {
+		return candidate
+	}
+	return *tx.walTxID.Load()
 }
 
 // claimFanoutWorkers reserves at most half of the transaction's remaining
@@ -421,21 +448,49 @@ func (tx *TxContext) UnstageRow(shard *storageShard, recid uint32) bool {
 // RegisterTouchedShard marks a shard as having pending writes for deferred sync.
 // Only Safe-engine shards need an fsync; Memory/Cache/Sloppy shards are skipped.
 func (tx *TxContext) RegisterTouchedShard(shard *storageShard) {
-	if shard.t.PersistencyMode != Safe {
+	if shard.t.PersistencyMode != Safe && shard.t.PersistencyMode != Logged {
 		return
 	}
+	tx.durableID()
 	tx.touchedShards.Store(shard, true)
 }
 
 // SyncTouchedShards flushes all pending log writes to durable storage.
 func (tx *TxContext) SyncTouchedShards() {
+	type databaseCommit struct {
+		db      *database
+		durable bool
+	}
+	shards := make([]*storageShard, 0, 1)
+	databases := make(map[*database]databaseCommit)
 	tx.touchedShards.Range(func(key, _ any) bool {
 		shard := key.(*storageShard)
+		shards = append(shards, shard)
+		commit := databases[shard.t.schema]
+		commit.db = shard.t.schema
+		commit.durable = commit.durable || shard.t.PersistencyMode == Safe
+		databases[shard.t.schema] = commit
+		return true
+	})
+	if len(shards) == 1 {
+		// The common OLTP case needs no coordinator fsync: the commit marker and
+		// its mutations share one WAL and become durable through one barrier.
+		shard := shards[0]
+		shard.logfile.Write(LogEntryCommit{txID: tx.durableID()})
+		if shard.t.PersistencyMode == Safe {
+			shard.logfile.Sync()
+		}
+		tx.touchedShards = sync.Map{}
+		return
+	}
+	for _, shard := range shards {
 		if shard.t.PersistencyMode == Safe && shard.logfile != nil {
 			shard.logfile.Sync()
 		}
-		return true
-	})
+	}
+	for _, commit := range databases {
+		commit.db.commitTransaction(tx.durableID(), commit.durable)
+	}
 	tx.touchedShards = sync.Map{}
 }
 
@@ -516,9 +571,9 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 				shard.mu.Lock()
 				shard.deletions.Set(uint(recid), true)
 				if shard.logfile != nil {
-					shard.logfile.Write(LogEntryDelete{recid})
+					shard.logfile.Write(LogEntryDelete{idx: recid, txID: tx.durableID()})
 				}
-				shard.syncNextVisibilityLocked(recid, trackedShards)
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 				shard.mu.Unlock()
 			}
 			st.InsertRecids = st.InsertRecids[:lens.InsertLen]
@@ -528,9 +583,9 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 				st.DeletedMask.Set(uint(recid), false)
 				shard.mu.Lock()
 				shard.deletions.Set(uint(recid), false)
-				shard.logVisibilityChangeLocked(recid, false)
+				shard.logVisibilityChangeLocked(recid, false, tx.durableID())
 				shard.rollbackProtected.Set(uint(recid), false)
-				shard.syncNextVisibilityLocked(recid, trackedShards)
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 				shard.mu.Unlock()
 			}
 			st.DeletedRecids = st.DeletedRecids[:lens.DeletedLen]
@@ -551,7 +606,7 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 				}
 				shard.deletions.Set(uint(recid), true)
 				shard.rollbackProtected.Set(uint(recid), false)
-				shard.syncNextVisibilityLocked(recid, trackedShards)
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 				if !ownsShardWrite {
 					shard.mu.Unlock()
 				}
@@ -580,7 +635,7 @@ func (tx *TxContext) Commit() error {
 			shard.mu.Lock()
 			for _, recid := range st.DeletedRecids {
 				shard.rollbackProtected.Set(uint(recid), false)
-				shard.syncNextVisibilityLocked(recid, trackedShards)
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 			}
 			shard.mu.Unlock()
 			st.mu.Unlock()
@@ -653,9 +708,9 @@ func (tx *TxContext) commitACID() error {
 			}
 			shard.deletions.Set(uint(recid), true)
 			if shard.logfile != nil {
-				shard.logfile.Write(LogEntryDelete{recid})
+				shard.logfile.Write(LogEntryDelete{idx: recid, txID: tx.durableID()})
 			}
-			shard.syncNextVisibilityLocked(recid, trackedShards)
+			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 		}
 	}
 	// Apply UndeleteMask → clear global deletions (make staged rows visible)
@@ -667,11 +722,15 @@ func (tx *TxContext) commitACID() error {
 			}
 			shard.deletions.Set(uint(recid), false)
 			shard.rollbackProtected.Set(uint(recid), false)
-			shard.logVisibilityChangeLocked(recid, false)
-			shard.syncNextVisibilityLocked(recid, trackedShards)
+			shard.logVisibilityChangeLocked(recid, false, tx.durableID())
+			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 		}
 	}
 
+	// Keep every touched shard locked until the commit authority is durable.
+	// Readers can therefore observe neither a pre-sync transaction nor a state
+	// that crash recovery would still discard.
+	tx.SyncTouchedShards()
 	atomic.AddUint64(&GlobalCommitEpoch, 1)
 
 	for _, s := range shards {
@@ -685,7 +744,6 @@ func (tx *TxContext) commitACID() error {
 	tx.shards = nil
 	tx.mu.Unlock()
 
-	tx.SyncTouchedShards()
 	return nil
 }
 
@@ -715,9 +773,9 @@ func (tx *TxContext) rollbackCursorStability() {
 			shard.mu.Lock()
 			shard.deletions.Set(uint(recid), true)
 			if shard.logfile != nil {
-				shard.logfile.Write(LogEntryDelete{recid})
+				shard.logfile.Write(LogEntryDelete{idx: recid, txID: tx.durableID()})
 			}
-			shard.syncNextVisibilityLocked(recid, trackedShards)
+			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 			shard.mu.Unlock()
 		}
 		// Undo deletes (reverse order): restore global visibility
@@ -725,9 +783,9 @@ func (tx *TxContext) rollbackCursorStability() {
 			recid := st.DeletedRecids[i]
 			shard.mu.Lock()
 			shard.deletions.Set(uint(recid), false)
-			shard.logVisibilityChangeLocked(recid, false)
+			shard.logVisibilityChangeLocked(recid, false, tx.durableID())
 			shard.rollbackProtected.Set(uint(recid), false)
-			shard.syncNextVisibilityLocked(recid, trackedShards)
+			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 			shard.mu.Unlock()
 		}
 		st.mu.Unlock()
@@ -753,7 +811,7 @@ func (tx *TxContext) rollbackACID() {
 		shard.mu.Lock()
 		for _, recid := range st.UndeleteRecids {
 			shard.rollbackProtected.Set(uint(recid), false)
-			shard.syncNextVisibilityLocked(recid, trackedShards)
+			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 		}
 		shard.mu.Unlock()
 		st.mu.Unlock()

--- a/tools/reliability-drill.md
+++ b/tools/reliability-drill.md
@@ -24,6 +24,18 @@ Use `--rebuild-crashes N` to change the default five randomized
 rebuild/kill/recovery rounds. Record `--seed` from the manifest to replay their
 delays exactly.
 
+To race a transaction-wide update across `ShardSize=100` shards with hard
+process kills during `COMMIT`, run:
+
+```sh
+python3 tools/reliability_drill.py --mode atomicity --commit-crashes 100
+```
+
+Every recovered generation must contain either the complete state before the
+transaction or the complete state after it. Mixed `x` values are a failed
+crash-atomicity invariant. Increase `--atomicity-rows` and `--commit-crashes`
+for hour-long runs; both the random seed and every selected delay are retained.
+
 Every run creates a new `/tmp/memcp-reliability-*` directory containing the
 source data directory, one log per server generation, a replay seed,
 `manifest.json`, and (for restore runs) the stopped data-directory snapshot.
@@ -35,6 +47,8 @@ The current drill covers:
 
 - committed multi-shard insert/update/delete plus trigger effects across a
   hard process kill;
+- a hard kill racing `COMMIT` of one table-wide `x=x+1` ACID update across
+  hundreds of shards;
 - complete rollback of an uncommitted ACID transaction after a hard kill;
 - statement rollback when a trigger fails partway through a multi-row insert;
 - a hard kill racing a rebuild and publication of its replacement shards;

--- a/tools/reliability_drill.py
+++ b/tools/reliability_drill.py
@@ -194,6 +194,36 @@ def scalar(client: HttpClient, statement: str) -> int:
 	return int(rows[0]["value"] or 0)
 
 
+def atomic_signature(client: HttpClient) -> dict[str, int]:
+	rows = client.sql(
+		"SELECT COUNT(*) AS row_count, MIN(x) AS min_x, MAX(x) AS max_x, "
+		"COALESCE(SUM(x), 0) AS x_sum FROM drill_atomic"
+	)
+	if len(rows) != 1:
+		raise DrillFailure(f"expected one atomicity signature row, got {rows}")
+	return {key: int(value or 0) for key, value in rows[0].items()}
+
+
+def classify_atomic_signature(observed: dict[str, int], rows: int,
+		committed_x: int) -> int:
+	old = {
+		"row_count": rows, "min_x": committed_x,
+		"max_x": committed_x, "x_sum": rows * committed_x,
+	}
+	new = {
+		"row_count": rows, "min_x": committed_x + 1,
+		"max_x": committed_x + 1, "x_sum": rows * (committed_x + 1),
+	}
+	if observed == old:
+		return committed_x
+	if observed == new:
+		return committed_x + 1
+	raise DrillFailure(
+		"crash recovery exposed a partial multi-shard commit: "
+		f"got {observed}, expected exactly {old} or {new}"
+	)
+
+
 def signature(client: HttpClient) -> dict[str, int]:
 	return {
 		"count": scalar(client, "SELECT COUNT(*) AS value FROM drill_entry"),
@@ -235,6 +265,65 @@ def initialize(client: HttpClient) -> None:
 		timeout=120,
 	)
 	client.scm(f'(rebuild (table "{DATABASE}" "drill_rebuild") true true)', timeout=120)
+
+
+def initialize_atomicity(client: HttpClient, rows: int) -> None:
+	client.sql(f"CREATE DATABASE IF NOT EXISTS {DATABASE}", database="system")
+	client.scm('(settings "ShardSize" 100)')
+	client.sql("CREATE TABLE drill_atomic (id INT PRIMARY KEY, x INT NOT NULL) ENGINE=safe")
+	client.scm(
+		f'(insert (table "{DATABASE}" "drill_atomic") \'("id" "x") '
+		f'(map (produceN {rows}) (lambda (i) (list (+ i 1) 0))))',
+		timeout=300,
+	)
+	client.scm(f'(rebuild (table "{DATABASE}" "drill_atomic") true true)', timeout=300)
+	expect(
+		atomic_signature(client),
+		{"row_count": rows, "min_x": 0, "max_x": 0, "x_sum": 0},
+		"atomicity fixture",
+	)
+
+
+def run_commit_crash(server: OwnedServer, rows: int, rounds: int,
+		rng: random.Random, journal: list[dict]) -> None:
+	committed_x = 0
+	for round_index in range(1, rounds + 1):
+		client = server.client
+		assert client is not None
+		session = f"drill-commit-crash-{round_index}"
+		client.sql("START ACID TRANSACTION", session=session)
+		updated = client.sql("UPDATE drill_atomic SET x = x + 1", session=session, timeout=300)
+		if not updated or int(updated[0].get("affected_rows", 0)) != rows:
+			raise DrillFailure(f"commit-crash update affected unexpected rows: {updated}")
+
+		commit_result: list[object] = []
+		commit_started = threading.Event()
+
+		def commit() -> None:
+			commit_started.set()
+			try:
+				commit_result.append(client.sql("COMMIT", session=session, timeout=300))
+			except Exception as error:
+				commit_result.append(error)
+
+		thread = threading.Thread(target=commit, name="reliability-commit", daemon=True)
+		thread.start()
+		commit_started.wait(timeout=server.timeout)
+		delay = rng.uniform(0.0, 0.05)
+		time.sleep(delay)
+		journal.append({
+			"scenario": "commit-crash",
+			"round": round_index,
+			"delay_seconds": delay,
+			"expected_old_x": committed_x,
+			"expected_new_x": committed_x + 1,
+		})
+		server.kill()
+		thread.join(timeout=2)
+		client = server.start()
+		observed = atomic_signature(client)
+		journal[-1]["observed"] = observed
+		committed_x = classify_atomic_signature(observed, rows, committed_x)
 
 
 def run_committed_crash(server: OwnedServer, journal: list[dict]) -> dict[str, int]:
@@ -421,19 +510,24 @@ def parse_args() -> argparse.Namespace:
 	parser.add_argument("--app", type=Path, default=ROOT / "lib/main.scm")
 	parser.add_argument("--artifacts", type=Path, help="new directory for data, logs, journal, and restore snapshot")
 	parser.add_argument("--seed", type=int, default=random.SystemRandom().randrange(2**63))
-	parser.add_argument("--mode", choices=("crash", "soak", "restore", "all"), default="all")
+	parser.add_argument("--mode", choices=("atomicity", "crash", "soak", "restore", "all"), default="all")
 	parser.add_argument("--workers", type=int, default=4)
 	parser.add_argument("--operations", type=int, default=25, help="rows written by each soak worker")
 	parser.add_argument("--rebuild-crashes", type=int, default=5,
 		help="number of randomized rebuild/kill/recovery rounds")
+	parser.add_argument("--commit-crashes", type=int, default=25,
+		help="number of ACID COMMIT/kill/recovery races in atomicity mode")
+	parser.add_argument("--atomicity-rows", type=int, default=100000,
+		help="rows updated across ShardSize=100 shards in atomicity mode")
 	parser.add_argument("--timeout", type=float, default=30)
 	return parser.parse_args()
 
 
 def main() -> int:
 	args = parse_args()
-	if args.workers < 1 or args.operations < 1 or args.rebuild_crashes < 1 or args.timeout <= 0:
-		raise DrillFailure("workers, operations, rebuild-crashes, and timeout must be positive")
+	if (args.workers < 1 or args.operations < 1 or args.rebuild_crashes < 1 or
+			args.commit_crashes < 1 or args.atomicity_rows < 1 or args.timeout <= 0):
+		raise DrillFailure("workers, operations, crash rounds, row counts, and timeout must be positive")
 	binary = args.binary.expanduser().resolve()
 	app = args.app.expanduser().resolve()
 	if not binary.is_file() or not os.access(binary, os.X_OK):
@@ -452,6 +546,12 @@ def main() -> int:
 	print(f"Seed: {args.seed}")
 	try:
 		client = server.start()
+		if args.mode == "atomicity":
+			initialize_atomicity(client, args.atomicity_rows)
+			run_commit_crash(server, args.atomicity_rows, args.commit_crashes, rng, journal)
+			write_manifest(manifest, args.seed, "passed", journal)
+			print(f"PASS: {len(journal)} reliability scenarios; manifest: {manifest}")
+			return 0
 		initialize(client)
 		wanted = run_committed_crash(server, journal)
 		run_uncommitted_crash(server, wanted, journal)

--- a/tools/test_reliability_drill.py
+++ b/tools/test_reliability_drill.py
@@ -39,6 +39,18 @@ class ReliabilityDrillTests(unittest.TestCase):
 		with self.assertRaises(drill.DrillFailure):
 			drill.expect({"count": 2}, {"count": 3}, "recovery")
 
+	def test_atomicity_oracle_accepts_only_complete_generations(self) -> None:
+		self.assertEqual(drill.classify_atomic_signature({
+			"row_count": 100, "min_x": 4, "max_x": 4, "x_sum": 400,
+		}, 100, 4), 4)
+		self.assertEqual(drill.classify_atomic_signature({
+			"row_count": 100, "min_x": 5, "max_x": 5, "x_sum": 500,
+		}, 100, 4), 5)
+		with self.assertRaises(drill.DrillFailure):
+			drill.classify_atomic_signature({
+				"row_count": 73, "min_x": 5, "max_x": 5, "x_sum": 365,
+			}, 100, 4)
+
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Summary

- add transaction IDs and durable commit records to shard WAL recovery
- use a database commit coordinator for transactions that touch multiple persistent shards
- retain a one-WAL/one-sync fast path for single-shard transactions
- stream WAL replay after a commit-ID pre-pass instead of retaining every mutation in memory
- extend the manual reliability drill with repeatable SIGKILL races during multi-shard ACID COMMIT
- register only shards that an UPDATE mapper actually mutated

## Failure reproduced

On unmodified master, this command reliably exposed a partial transaction:

    python3 tools/reliability_drill.py --mode atomicity --atomicity-rows 20000 --commit-crashes 25 --seed 917263 --artifacts .atomicity-reproducer

Round 2 killed COMMIT after 0.037447 s. Recovery returned 13,566 rows at x=1 instead of either 20,000 rows at x=0 or 20,000 rows at x=1; 6,434 rows from the transaction were missing.

With this branch, the same seed passed all 25 rounds. The final larger run used 100,000 rows, ShardSize=100 (about 1,000 shards), and passed all 25 COMMIT/SIGKILL/restart checks. Every recovered state was exactly all-old or all-new.

## Manual performance A/B

Compared origin/master 8be4a56ed with this branch on the same fresh SAFE fixture, 2,000 rows across 20 shards, 50 warmups, 500 point-update samples, and 3 warmups plus 15 multi-shard transaction samples:

| Case | master | PR | Change |
|---|---:|---:|---:|
| selective SAFE point UPDATE, median | 2.248 ms | 2.100 ms | -6.6% |
| selective SAFE point UPDATE, p95 | 3.250 ms | 3.120 ms | -4.0% |
| 20-shard ACID COMMIT, median | 16.798 ms | 19.488 ms | +16.0% |
| complete 20-shard ACID transaction, median | 20.725 ms | 24.101 ms | +16.3% |

The multi-shard cost is the additional durable coordinator barrier that makes the commit atomic after a crash. The common single-shard path still performs one sync. A first A/B also exposed eager touched-shard registration for non-matching UPDATE shards; moving registration to mapper close removed that regression and slightly improved the selective point case.

## Validation

- go test ./storage ./scm
- go test -race ./storage -run transaction-WAL tests -count=20
- python3 -m unittest tools/test_reliability_drill.py
- tests/storage/persistence/multishard-transaction-recovery.yaml: 8/8
- tests/execution/concurrency/failed-statement-atomicity.yaml: 10/10
- manual 100,000-row / 1,000-shard / 25-crash atomicity drill

Legacy WAL records remain readable and are treated as committed. New transactional records without a valid shard-local or database-wide commit record remain hidden during recovery. The coordinator covers persistent shards within one database; cross-database crash atomicity is outside this PR.