### PR TITLE
Atomically compact transaction logs after rebuild

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -18,12 +18,13 @@ package storage
 
 import "os"
 import "fmt"
+import "sort"
 import "sync"
-import "sync/atomic"
 import "time"
 import "runtime"
 import "strings"
 import "encoding/json"
+import "sync/atomic"
 import "github.com/launix-de/memcp/scm"
 import "github.com/launix-de/NonLockingReadMap"
 
@@ -65,10 +66,11 @@ type database struct {
 	// transactionLog is the database-wide commit authority for transactional
 	// shard WAL entries. Shard logs may contain prepared records after a crash;
 	// recovery exposes them only when this log contains their durable commit.
-	transactionOnce sync.Once           `json:"-"`
-	transactionMu   sync.RWMutex        `json:"-"`
-	transactionLog  PersistenceLogfile  `json:"-"`
-	committedTx     map[string]struct{} `json:"-"`
+	transactionOnce sync.Once          `json:"-"`
+	transactionMu   sync.RWMutex       `json:"-"`
+	transactionLog  PersistenceLogfile `json:"-"`
+	committedTx     map[string]uint64  `json:"-"`
+	transactionGen  uint64             `json:"-"`
 
 	// lazy-loading/shared-resource state (not serialized)
 	srState SharedState `json:"-"`
@@ -93,21 +95,21 @@ func (db *database) blobRefState() *blobRefState {
 }
 
 func newDatabase() *database {
-	return &database{blobRefs: new(blobRefState), committedTx: make(map[string]struct{})}
+	return &database{blobRefs: new(blobRefState), committedTx: make(map[string]uint64)}
 }
 
 const transactionLogName = ".transactions"
 
 func (db *database) initializeTransactionLog() {
 	db.transactionOnce.Do(func() {
-		committed := make(map[string]struct{})
+		committed := make(map[string]uint64)
 		_, entries, logfile := db.persistence.ReplayLog(transactionLogName)
 		for entry := range entries {
 			commit, ok := entry.(LogEntryCommit)
 			if !ok || commit.txID == "" {
 				panic("invalid entry in transaction commit log")
 			}
-			committed[commit.txID] = struct{}{}
+			committed[commit.txID] = 0
 		}
 		db.transactionMu.Lock()
 		db.committedTx = committed
@@ -141,7 +143,48 @@ func (db *database) commitTransaction(txID string, durable bool) {
 	if durable {
 		db.transactionLog.Sync()
 	}
-	db.committedTx[txID] = struct{}{}
+	db.committedTx[txID] = db.transactionGen
+}
+
+func (db *database) transactionCompactionSnapshot() (uint64, bool) {
+	db.initializeTransactionLog()
+	db.transactionMu.Lock()
+	cutoff := db.transactionGen
+	hasTransactions := len(db.committedTx) != 0
+	db.transactionGen++
+	db.transactionMu.Unlock()
+	return cutoff, hasTransactions
+}
+
+func (db *database) compactTransactionLog(cutoff uint64) {
+	db.initializeTransactionLog()
+	db.transactionMu.Lock()
+	defer db.transactionMu.Unlock()
+
+	// Usually only the small set committed while the rebuild was running is
+	// retained. Do not reserve capacity for the much larger obsolete set.
+	var retainedIDs []string
+	for txID, generation := range db.committedTx {
+		if generation > cutoff {
+			retainedIDs = append(retainedIDs, txID)
+		}
+	}
+	sort.Strings(retainedIDs)
+	entries := make([]interface{}, len(retainedIDs))
+	retained := make(map[string]uint64, len(retainedIDs))
+	for i, txID := range retainedIDs {
+		entries[i] = LogEntryCommit{txID: txID}
+		retained[txID] = db.committedTx[txID]
+	}
+
+	// Committers share transactionMu, so nobody can append between this
+	// barrier and publishing the replacement log.
+	db.transactionLog.Sync()
+	replacement := db.persistence.SwapLog(transactionLogName, entries, true)
+	old := db.transactionLog
+	db.transactionLog = replacement
+	db.committedTx = retained
+	old.Close()
 }
 
 func (db *database) closeTransactionLog() {
@@ -159,6 +202,7 @@ type rebuildDatabaseResult struct {
 	// the last committed schema may still reference them.
 	replaced []replacedShardGeneration
 	errors   []string
+	complete bool
 }
 
 type replacedShardGeneration struct {
@@ -323,32 +367,52 @@ func rebuildDatabases(all bool, repartition bool, includeEphemeral bool) string 
 	dbs := databases.GetAll()
 	var errs []string
 	for _, db := range dbs {
-		func(db *database) {
-			db.persistenceLifecycle.RLock()
-			defer db.persistenceLifecycle.RUnlock()
-			result := db.rebuildWithLifecycle(all, repartition, includeEphemeral)
-			if len(result.errors) > 0 {
-				errs = append(errs, result.errors...)
-				return
-			}
-			if err := func() (err error) {
-				defer func() { err = recoverAsError("save failed for database " + db.Name) }()
-				db.save()
-				return nil
-			}(); err != nil {
-				errs = append(errs, err.Error())
-				return
-			}
-			// db.save() committed all replacement UUIDs. A save failure returns
-			// above and deliberately retains every old generation.
-			errs = append(errs, cleanupReplacedShardGenerations(result.replaced, "database "+db.Name)...)
-		}(db)
+		errs = append(errs, rebuildDatabaseAndCompact(db, all, repartition, includeEphemeral)...)
 	}
 	duration := fmt.Sprint(time.Since(start))
 	if len(errs) == 0 {
 		return duration
 	}
 	return duration + " errors: " + strings.Join(errs, " | ")
+}
+
+func rebuildDatabaseAndCompact(db *database, all bool, repartition bool, includeEphemeral bool) []string {
+	db.persistenceLifecycle.RLock()
+	defer db.persistenceLifecycle.RUnlock()
+	var transactionCutoff uint64
+	var hasTransactions bool
+	if err := func() (err error) {
+		defer func() { err = recoverAsError("transaction log snapshot failed for database " + db.Name) }()
+		transactionCutoff, hasTransactions = db.transactionCompactionSnapshot()
+		return nil
+	}(); err != nil {
+		return []string{err.Error()}
+	}
+	result := db.rebuildWithLifecycle(all, repartition, includeEphemeral)
+	if len(result.errors) > 0 {
+		return result.errors
+	}
+	if err := func() (err error) {
+		defer func() { err = recoverAsError("save failed for database " + db.Name) }()
+		db.save()
+		return nil
+	}(); err != nil {
+		return []string{err.Error()}
+	}
+	// db.save() committed all replacement UUIDs. A save failure returns above
+	// and deliberately retains every old generation.
+	errs := cleanupReplacedShardGenerations(result.replaced, "database "+db.Name)
+	if len(errs) != 0 || !result.complete || !hasTransactions {
+		return errs
+	}
+	if err := func() (err error) {
+		defer func() { err = recoverAsError("transaction log compaction failed for database " + db.Name) }()
+		db.compactTransactionLog(transactionCutoff)
+		return nil
+	}(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	return errs
 }
 
 func UnloadDatabases() {
@@ -706,6 +770,7 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 	var allReplaced []replacedShardGeneration
 	var errMu sync.Mutex
 	var rebuildErrors []string
+	var incomplete atomic.Bool
 	dbs := db.tables.GetAll()
 	if len(only) > 0 {
 		dbs = []*table{only[0]}
@@ -785,6 +850,7 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 				return
 			}
 			if !t.maintenanceMu.TryLock() {
+				incomplete.Store(true)
 				return // another rebuild/repartition is in progress
 			}
 			t.mu.Lock() // table lock
@@ -869,6 +935,12 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 				if cold {
 					hasColdShard = true
 				}
+			}
+			// A non-forced rebuild deliberately retains cold generations without
+			// replaying their WAL. Their coordinator references are therefore
+			// unknown and the database transaction log must remain intact.
+			if hasColdShard {
+				incomplete.Store(true)
 			}
 
 			// Collect pre-rebuild shards that were replaced so we can clean them up.
@@ -1078,7 +1150,11 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 	// where a crash/kill leaves schema.json pointing at already-deleted UUIDs.
 	// Failed schema publication intentionally retains the old generation: it is
 	// still referenced by the last committed schema and must remain recoverable.
-	return rebuildDatabaseResult{replaced: allReplaced, errors: rebuildErrors}
+	return rebuildDatabaseResult{
+		replaced: allReplaced,
+		errors:   rebuildErrors,
+		complete: !incomplete.Load() && len(rebuildErrors) == 0,
+	}
 }
 
 func GetDatabase(schema string) *database {

--- a/storage/persistence-ceph.go
+++ b/storage/persistence-ceph.go
@@ -342,6 +342,44 @@ func (s *CephStorage) OpenLog(shard string) PersistenceLogfile {
 	return lf
 }
 
+func (s *CephStorage) SwapLog(shard string, entries []interface{}, durable bool) PersistenceLogfile {
+	s.ensureOpen()
+	oldSegments, err := listLogSegments(s, shard)
+	if err != nil {
+		panic(err)
+	}
+	var next uint32
+	for _, segment := range oldSegments {
+		if segment.seg >= next {
+			next = segment.seg + 1
+		}
+	}
+	var body bytes.Buffer
+	for _, entry := range entries {
+		body.Write(encodeLogEntry(entry))
+	}
+	obj := s.obj(fmt.Sprintf("%s.log.%08d", shard, next))
+	if err := s.ioctx.WriteFull(obj, body.Bytes()); err != nil {
+		panic(err)
+	}
+	if err := writeLogManifest(s, shard, []uint32{next}); err != nil {
+		panic(err)
+	}
+	for _, segment := range oldSegments {
+		if segment.seg != next {
+			_ = s.ioctx.Delete(segment.obj)
+		}
+	}
+	return &CephLogfile{
+		s:               s,
+		shard:           shard,
+		seg:             next,
+		obj:             obj,
+		offset:          uint64(body.Len()),
+		flushEveryBytes: 256 * 1024,
+	}
+}
+
 func (s *CephStorage) ReplayLog(shard string) (map[string]struct{}, chan interface{}, PersistenceLogfile) {
 	s.ensureOpen()
 

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -257,6 +257,64 @@ func (s *FileStorage) OpenLog(shard string) PersistenceLogfile {
 	return FileLogfile{f}
 }
 
+func (s *FileStorage) SwapLog(shard string, entries []interface{}, durable bool) PersistenceLogfile {
+	if err := os.MkdirAll(s.path, 0750); err != nil {
+		panic(err)
+	}
+	tmp, err := os.CreateTemp(s.path, "."+shard+".log.tmp-")
+	if err != nil {
+		panic(err)
+	}
+	tmpName := tmp.Name()
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	for _, entry := range entries {
+		if _, err := tmp.Write(encodeFileLogEntry(entry)); err != nil {
+			_ = tmp.Close()
+			panic(err)
+		}
+	}
+	if durable {
+		if err := tmp.Sync(); err != nil {
+			_ = tmp.Close()
+			panic(err)
+		}
+	}
+	if _, err := tmp.Seek(0, io.SeekEnd); err != nil {
+		_ = tmp.Close()
+		panic(err)
+	}
+	var dir *os.File
+	if durable {
+		dir, err = os.Open(s.path)
+		if err != nil {
+			_ = tmp.Close()
+			panic(err)
+		}
+	}
+	if err := os.Rename(tmpName, s.path+shard+".log"); err != nil {
+		if dir != nil {
+			_ = dir.Close()
+		}
+		_ = tmp.Close()
+		panic(err)
+	}
+	removeTmp = false
+	if dir != nil {
+		// PersistenceLogfile cannot report an ambiguous outcome after rename.
+		// Match the existing best-effort Sync contract while still issuing the
+		// directory barrier needed to persist the chosen complete generation.
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+	return FileLogfile{w: tmp}
+}
+
 func (s *FileStorage) ReplayLog(shard string) (map[string]struct{}, chan interface{}, PersistenceLogfile) {
 	os.MkdirAll(s.path, 0750)
 	f, err := os.OpenFile(s.path+shard+".log", os.O_RDWR|os.O_CREATE, 0750)
@@ -447,40 +505,41 @@ type FileLogfile struct {
 }
 
 func (w FileLogfile) Write(logentry interface{}) {
+	_, _ = w.w.Write(encodeFileLogEntry(logentry))
+}
+
+func encodeFileLogEntry(logentry interface{}) []byte {
+	var b bytes.Buffer
 	switch l := logentry.(type) {
 	case LogEntryDelete:
 		if l.txID != "" {
-			fmt.Fprintf(w.w, "delete-tx %s %d\n", l.txID, l.idx)
-			return
+			fmt.Fprintf(&b, "delete-tx %s %d\n", l.txID, l.idx)
+			break
 		}
-		var b bytes.Buffer
 		b.WriteString("delete ")
 		tmp, _ := json.Marshal(l.idx)
 		b.Write(tmp)
 		b.WriteString("\n")
-		w.w.Write(b.Bytes())
 	case LogEntryUndelete:
 		if l.txID != "" {
-			fmt.Fprintf(w.w, "undelete-tx %s %d\n", l.txID, l.idx)
-			return
+			fmt.Fprintf(&b, "undelete-tx %s %d\n", l.txID, l.idx)
+			break
 		}
-		var b bytes.Buffer
 		b.WriteString("undelete ")
 		tmp, _ := json.Marshal(l.idx)
 		b.Write(tmp)
 		b.WriteString("\n")
-		w.w.Write(b.Bytes())
 	case LogEntryInsert:
-		w.writeInsert("insert ", l.txID, l.cols, l.values)
+		encodeFileInsert(&b, "insert ", l.txID, l.cols, l.values)
 	case LogEntryInsertHidden:
-		w.writeInsert("insert-hidden ", l.txID, l.cols, l.values)
+		encodeFileInsert(&b, "insert-hidden ", l.txID, l.cols, l.values)
 	case LogEntryCommit:
-		fmt.Fprintf(w.w, "commit-tx %s %s\n", l.txID, fileCommitChecksum(l.txID))
+		fmt.Fprintf(&b, "commit-tx %s %s\n", l.txID, fileCommitChecksum(l.txID))
 	}
+	return b.Bytes()
 }
 
-func (w FileLogfile) writeInsert(prefix string, txID string, cols []string, values [][]scm.Scmer) {
-	var b bytes.Buffer
+func encodeFileInsert(b *bytes.Buffer, prefix string, txID string, cols []string, values [][]scm.Scmer) {
 	if txID == "" {
 		b.WriteString(prefix)
 	} else {
@@ -494,7 +553,6 @@ func (w FileLogfile) writeInsert(prefix string, txID string, cols []string, valu
 	tmp, _ = json.Marshal(values)
 	b.Write(tmp)
 	b.WriteString("\n")
-	w.w.Write(b.Bytes())
 }
 func (w FileLogfile) Sync() {
 	w.w.Sync()

--- a/storage/persistence-s3.go
+++ b/storage/persistence-s3.go
@@ -399,6 +399,51 @@ func (s *S3Storage) OpenLog(shard string) PersistenceLogfile {
 	return lf
 }
 
+func (s *S3Storage) SwapLog(shard string, entries []interface{}, durable bool) PersistenceLogfile {
+	s.ensureOpen()
+	oldSegments, err := listS3LogSegments(s, shard)
+	if err != nil {
+		panic(err)
+	}
+	var next uint32
+	for _, segment := range oldSegments {
+		if segment.seg >= next {
+			next = segment.seg + 1
+		}
+	}
+	var body bytes.Buffer
+	for _, entry := range entries {
+		body.Write(encodeS3LogEntry(entry))
+	}
+	key := s.key(fmt.Sprintf("%s.log.%08d", shard, next))
+	if _, err := s.client.PutObject(context.Background(), &s3.PutObjectInput{
+		Bucket: aws.String(s.factory.Bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(body.Bytes()),
+	}); err != nil {
+		panic(err)
+	}
+	if err := writeS3LogManifest(s, shard, []uint32{next}); err != nil {
+		panic(err)
+	}
+	for _, segment := range oldSegments {
+		if segment.seg != next {
+			_, _ = s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+				Bucket: aws.String(s.factory.Bucket),
+				Key:    aws.String(segment.key),
+			})
+		}
+	}
+	return &S3Logfile{
+		s:               s,
+		shard:           shard,
+		seg:             next,
+		key:             key,
+		offset:          uint64(body.Len()),
+		flushEveryBytes: 256 * 1024,
+	}
+}
+
 func (s *S3Storage) ReplayLog(shard string) (map[string]struct{}, chan interface{}, PersistenceLogfile) {
 	s.ensureOpen()
 

--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -58,6 +58,11 @@ type PersistenceEngine interface {
 	// fn may return an error to stop iteration early.
 	WalkBlobs(fn func(hash string) error) error
 	OpenLog(shard string) PersistenceLogfile // open for writing
+	// SwapLog atomically replaces the visible log with entries and returns an
+	// appendable handle for the replacement. A crash may leave private/orphaned
+	// temporary storage, but ReplayLog must observe either the complete old log
+	// or the complete replacement.
+	SwapLog(shard string, entries []interface{}, durable bool) PersistenceLogfile
 	// ReplayLog returns the transaction IDs committed in this WAL before it
 	// streams entries. This keeps recovery memory proportional to commit count,
 	// rather than retaining every row mutation until the final marker is known.

--- a/storage/persistence_transaction_test.go
+++ b/storage/persistence_transaction_test.go
@@ -24,6 +24,14 @@ import (
 	"github.com/launix-de/memcp/scm"
 )
 
+type failingLogSwapPersistence struct {
+	PersistenceEngine
+}
+
+func (f *failingLogSwapPersistence) SwapLog(string, []interface{}, bool) PersistenceLogfile {
+	panic("forced log swap failure")
+}
+
 func TestFileTransactionalWALRoundTrip(t *testing.T) {
 	engine := &FileStorage{path: filepath.Join(t.TempDir(), "db") + "/"}
 	logfile := engine.OpenLog("roundtrip")
@@ -109,6 +117,102 @@ func TestDatabaseCommitAuthoritySurvivesReopen(t *testing.T) {
 	}
 	if reloaded.transactionCommitted("boot-id/24") {
 		t.Fatal("transaction without a commit record was restored")
+	}
+	reloaded.closeTransactionLog()
+}
+
+func TestFileSwapLogPublishesCompleteReplacement(t *testing.T) {
+	engine := &FileStorage{path: filepath.Join(t.TempDir(), "db") + "/"}
+	old := engine.OpenLog(transactionLogName)
+	old.Write(LogEntryCommit{txID: "old/1"})
+	old.Write(LogEntryCommit{txID: "old/2"})
+	old.Sync()
+
+	replacement := engine.SwapLog(transactionLogName, []interface{}{
+		LogEntryCommit{txID: "retained/1"},
+	}, true)
+	// The old descriptor still names the unlinked generation. A late write to
+	// it must not modify the newly published log path.
+	old.Write(LogEntryCommit{txID: "old/late"})
+	old.Sync()
+	old.Close()
+	replacement.Write(LogEntryCommit{txID: "new/1"})
+	replacement.Sync()
+	replacement.Close()
+
+	committed, entries, logfile := engine.ReplayLog(transactionLogName)
+	defer logfile.Close()
+	for range entries {
+	}
+	for _, txID := range []string{"retained/1", "new/1"} {
+		if _, ok := committed[txID]; !ok {
+			t.Errorf("replacement log does not contain %q", txID)
+		}
+	}
+	for _, txID := range []string{"old/1", "old/2", "old/late"} {
+		if _, ok := committed[txID]; ok {
+			t.Errorf("replacement log still contains %q", txID)
+		}
+	}
+}
+
+func TestDatabaseTransactionLogCompactionRetainsNewCommits(t *testing.T) {
+	engine := &FileStorage{path: filepath.Join(t.TempDir(), "db") + "/"}
+	db := newDatabase()
+	db.persistence = engine
+	db.commitTransaction("before/1", true)
+	db.commitTransaction("before/2", true)
+	obsolete, _ := db.transactionCompactionSnapshot()
+	db.commitTransaction("during/1", true)
+	db.compactTransactionLog(obsolete)
+
+	if db.transactionCommitted("before/1") || db.transactionCommitted("before/2") {
+		t.Fatal("compacted transaction IDs remain in the in-memory authority")
+	}
+	if !db.transactionCommitted("during/1") {
+		t.Fatal("commit created during rebuild was removed")
+	}
+	db.closeTransactionLog()
+
+	reloaded := newDatabase()
+	reloaded.persistence = engine
+	if reloaded.transactionCommitted("before/1") || reloaded.transactionCommitted("before/2") {
+		t.Fatal("compacted transaction IDs were restored from disk")
+	}
+	if !reloaded.transactionCommitted("during/1") {
+		t.Fatal("retained transaction ID was not restored from disk")
+	}
+	reloaded.closeTransactionLog()
+}
+
+func TestDatabaseTransactionLogSwapFailureKeepsOldAuthority(t *testing.T) {
+	engine := &FileStorage{path: filepath.Join(t.TempDir(), "db") + "/"}
+	db := newDatabase()
+	db.persistence = engine
+	db.commitTransaction("before/1", true)
+	obsolete, _ := db.transactionCompactionSnapshot()
+	db.persistence = &failingLogSwapPersistence{PersistenceEngine: engine}
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("compaction did not report the forced swap failure")
+			}
+		}()
+		db.compactTransactionLog(obsolete)
+	}()
+	if !db.transactionCommitted("before/1") {
+		t.Fatal("failed swap removed the old in-memory authority")
+	}
+	// The original append handle must remain usable after a pre-publication
+	// swap failure.
+	db.commitTransaction("after-failure/1", true)
+	db.closeTransactionLog()
+
+	reloaded := newDatabase()
+	reloaded.persistence = engine
+	if !reloaded.transactionCommitted("before/1") || !reloaded.transactionCommitted("after-failure/1") {
+		t.Fatal("failed swap changed the durable transaction authority")
 	}
 	reloaded.closeTransactionLog()
 }

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -206,6 +206,75 @@ func createDurabilityTestTable(t *testing.T, databaseName string, rows int) (*ta
 	return tbl, tbl.schema.persistence
 }
 
+func TestForcedDatabaseRebuildCompactsTransactionLog(t *testing.T) {
+	tbl, engine := createDurabilityTestTable(t, "ttxlogrebuild", 4)
+	db := tbl.schema
+	db.commitTransaction("completed-before-rebuild/1", true)
+	logPath := engine.(*FileStorage).path + transactionLogName + ".log"
+	before, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if errs := rebuildDatabaseAndCompact(db, true, false, false); len(errs) != 0 {
+		t.Fatalf("forced rebuild failed: %v", errs)
+	}
+	after, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Size() >= before.Size() {
+		t.Fatalf("transaction log did not shrink: before=%d after=%d", before.Size(), after.Size())
+	}
+	t.Logf("transaction log size: before=%d bytes after=%d bytes", before.Size(), after.Size())
+	if db.transactionCommitted("completed-before-rebuild/1") {
+		t.Fatal("rebuilt transaction remains in the commit authority")
+	}
+	db.closeTransactionLog()
+}
+
+func TestNonForcedDatabaseRebuildKeepsTransactionLogForColdShards(t *testing.T) {
+	tbl, engine := createDurabilityTestTable(t, "ttxlogcold", 4)
+	source := tbl.schema
+	if errs := rebuildDatabaseAndCompact(source, true, false, false); len(errs) != 0 {
+		t.Fatalf("fixture rebuild failed: %v", errs)
+	}
+	source.commitTransaction("needed-by-cold-generation/1", true)
+	source.closeTransactionLog()
+
+	db := newDatabase()
+	db.Name = "ttxlogcold"
+	db.persistence = engine
+	db.srState = COLD
+	db.ensureLoaded()
+	loaded := db.GetTable("items")
+	if loaded == nil {
+		t.Fatal("reloaded database has no items table")
+	}
+	for _, shard := range loaded.ActiveShards() {
+		shard.mu.RLock()
+		cold := shard.srState == COLD
+		shard.mu.RUnlock()
+		if !cold {
+			t.Fatal("fixture unexpectedly materialized a cold shard")
+		}
+	}
+
+	if errs := rebuildDatabaseAndCompact(db, false, false, false); len(errs) != 0 {
+		t.Fatalf("non-forced rebuild failed: %v", errs)
+	}
+	if !db.transactionCommitted("needed-by-cold-generation/1") {
+		t.Fatal("non-forced rebuild discarded the authority for an unreplayed cold WAL")
+	}
+	db.closeTransactionLog()
+
+	reloaded := newDatabase()
+	reloaded.persistence = engine
+	if !reloaded.transactionCommitted("needed-by-cold-generation/1") {
+		t.Fatal("cold-shard transaction authority was removed from disk")
+	}
+	reloaded.closeTransactionLog()
+}
+
 func callBuiltin(t *testing.T, name string, args ...scm.Scmer) scm.Scmer {
 	t.Helper()
 	fn, ok := scm.Globalenv.Vars[scm.Symbol(name)]


### PR DESCRIPTION
## Summary

- compact the database transaction coordinator log only after rebuilt shard generations and schema publication are complete
- retain commits created while rebuild is running through a generation cutoff, without copying the complete commit set
- atomically replace filesystem, S3, and Ceph logs while preserving either the complete old or complete new replay authority
- conservatively retain the coordinator log when a table is busy, a shard remains cold, rebuild fails, schema publication fails, or retired-generation cleanup fails

## Correctness

The old append handle stays authoritative until the replacement has been fully written and published. Committers serialize with the final swap, so commits made after the rebuild snapshot are copied into the replacement and subsequent commits append to its returned handle.

## Validation

- `go test ./storage ./scm`
- `go test -race ./storage -run 'Test(FileSwapLog|DatabaseTransactionLog|ForcedDatabaseRebuildCompacts|NonForcedDatabaseRebuildKeeps)' -count=10`
- `python3 run_sql_tests.py tests/storage/persistence/multishard-transaction-recovery.yaml`
- `python3 run_sql_tests.py tests/storage/persistence/multishard-committed-recovery.yaml`
- `python3 run_sql_tests.py tests/storage/persistence/acid-trigger-recovery.yaml`

All passed locally. The committed multi-shard recovery suite includes restart, rebuild/shutdown compaction, another restart, and data verification.

## Measurement

In the focused forced-rebuild fixture, the coordinator log shrank from 102 bytes to 0 bytes after its only completed transaction had been materialized into the rebuilt shard generation. Empty coordinator logs skip the swap entirely. The change is maintenance-path only and does not add work to query execution; commits retain one map write, with the stored value widened from an empty struct to an 8-byte rebuild generation.