### PR TITLE
test: JIT accumulation form with seeded init + inspecting finish

### DIFF
--- a/scm/jit_parser_acc_test.go
+++ b/scm/jit_parser_acc_test.go
@@ -49,3 +49,55 @@ func TestJITParserAccumulateRepeat(t *testing.T) {
 		t.Fatalf("re-run = %s, want (a b)", String(g))
 	}
 }
+
+// TestJITParserAccumulateSeeded exercises a non-trivial init (seeds a head
+// symbol) + a finish that inspects the accumulator - the shape an optimizer
+// injection for (cons 'op repeat) / the AND-OR cascade would produce.
+func TestJITParserAccumulateSeeded(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	env := &Env{Vars: make(Vars), Outer: &Globalenv}
+
+	seeded := Eval(Read("seeded", `(parser '(
+		(atom "X" true)
+		(define v (+ (regex "[a-z]+" false true) "," nil
+			(lambda () (list (quote head)))
+			(lambda (a x) (append_mut a x))
+			(lambda (a) a)))
+		$
+	) v)`), env)
+	env.Vars[Symbol("seeded_parser")] = seeded
+	sp := seeded.Parser()
+
+	cascade := Eval(Read("cascade", `(parser '(
+		(define b (+ (regex "[a-z]+" false true) (atom "+" false) nil
+			(lambda () (list))
+			(lambda (a x) (append_mut a x))
+			(lambda (a) (if (equal? (count a) 1) (nth a 0) (cons (quote op) a)))))
+		$
+	) b)`), env)
+	env.Vars[Symbol("cascade_parser")] = cascade
+	cp := cascade.Parser()
+
+	jitCompileEnvironmentParsers(env)
+	if sp.Compiled == nil || sp.JITProgram == nil {
+		t.Fatal("seeded grammar not JIT-compiled")
+	}
+	if cp.Compiled == nil || cp.JITProgram == nil {
+		t.Fatal("cascade grammar not JIT-compiled")
+	}
+
+	if g := sp.Execute(" X a,b,c ", env); String(g) != "(head a b c)" {
+		t.Fatalf("seeded JIT = %s, want (head a b c)", String(g))
+	}
+	if g := sp.Execute(" X solo ", env); String(g) != "(head solo)" {
+		t.Fatalf("seeded single = %s, want (head solo)", String(g))
+	}
+	if g := cp.Execute(" p+q+r ", env); String(g) != "(op p q r)" {
+		t.Fatalf("cascade JIT = %s, want (op p q r)", String(g))
+	}
+	if g := cp.Execute(" lone ", env); String(g) != "lone" {
+		t.Fatalf("cascade single = %s, want lone", String(g))
+	}
+}


### PR DESCRIPTION
Follow-up test coverage for #788. `TestJITParserAccumulateRepeat` only ever
exercised `(lambda () (list))` init + identity finish; this adds the non-trivial
shapes:

- init that seeds a head symbol — `(lambda () (list 'head))`
- finish that branches on the accumulator — `(lambda (a) (if (equal? (count a) 1) (nth a 0) (cons 'op a)))`

i.e. the "prepend a constant head onto a repeat" and AND/OR-cascade forms.
Confirms `emitRepeatAccumulate` / `buildAccProc` handle them, matching the
interpreter's `TestInterpreterAccumulateRepeat`.

Context: an optimizer pass that injected these into `(cons 'op repeat)` grammar
rules (CONCAT / COALESCE / IN) worked in isolation but regressed a nested
COALESCE + EXISTS unnesting case (`in-subquery.yaml` "Nested ACL caches …"), so
the injection itself is not landing — only this coverage for the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV