### PR TITLE
Harden transactions against persistence failures

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -129,21 +129,28 @@ func (db *database) transactionCommitted(txID string) bool {
 	return committed
 }
 
-func (db *database) commitTransaction(txID string, durable bool) {
+func (db *database) commitTransaction(txID string, durable bool) error {
 	if txID == "" {
-		return
+		return nil
 	}
 	db.initializeTransactionLog()
 	db.transactionMu.Lock()
 	defer db.transactionMu.Unlock()
 	if _, exists := db.committedTx[txID]; exists {
-		return
+		return nil
 	}
-	db.transactionLog.Write(LogEntryCommit{txID: txID})
-	if durable {
-		db.transactionLog.Sync()
+	if err := persistenceCall(func() { db.transactionLog.Write(LogEntryCommit{txID: txID}) }); err != nil {
+		return err
+	}
+	if err := persistenceCall(func() { db.transactionLog.Flush(durable) }); err != nil {
+		// The authority frame was accepted into the logfile. A failed local
+		// durability barrier or remote publication cannot tell us whether it
+		// will survive a crash, so memory must keep treating it as committed.
+		db.committedTx[txID] = db.transactionGen
+		return markCommitOutcomeUnknown(err)
 	}
 	db.committedTx[txID] = db.transactionGen
+	return nil
 }
 
 func (db *database) transactionCompactionSnapshot() (uint64, bool) {
@@ -179,7 +186,7 @@ func (db *database) compactTransactionLog(cutoff uint64) {
 
 	// Committers share transactionMu, so nobody can append between this
 	// barrier and publishing the replacement log.
-	db.transactionLog.Sync()
+	db.transactionLog.Flush(true)
 	replacement := db.persistence.SwapLog(transactionLogName, entries, true)
 	old := db.transactionLog
 	db.transactionLog = replacement
@@ -441,7 +448,7 @@ func createPersistenceFromConfig(dbName string, raw json.RawMessage) Persistence
 	if !ok {
 		return nil
 	}
-	return factory(dbName, raw)
+	return instrumentPersistence(dbName, factory(dbName, raw))
 }
 
 func LoadDatabases() {
@@ -462,7 +469,7 @@ func LoadDatabases() {
 		if entry.IsDir() {
 			db := newDatabase()
 			db.Name = entry.Name()
-			db.persistence = &FileStorage{path: Basepath + "/" + entry.Name() + "/"}
+			db.persistence = instrumentPersistence(entry.Name(), &FileStorage{path: Basepath + "/" + entry.Name() + "/"})
 			db.srState = COLD
 			databases.Set(db)
 		} else if strings.HasSuffix(entry.Name(), ".json") && entry.Name() != "settings.json" {
@@ -1173,7 +1180,7 @@ func CreateDatabase(schema string, ignoreexists bool /*, persistence Persistence
 	db = newDatabase()
 	db.Name = schema
 	persistence := FileFactory{Basepath} // TODO: remove this, use parameter instead
-	db.persistence = persistence.CreateDatabase(schema)
+	db.persistence = instrumentPersistence(schema, persistence.CreateDatabase(schema))
 	db.tables = NonLockingReadMap.New[table, string]()
 	// Newly created database is live for writes
 	db.srState = WRITE

--- a/storage/gc.go
+++ b/storage/gc.go
@@ -62,13 +62,12 @@ func cleanBlobs(db *database) int {
 	}
 
 	deleted := 0
-	db.persistence.WalkBlobs(func(hash string) error {
+	db.persistence.WalkBlobs(func(hash string) {
 		defer db.lockBlobRef(hash)()
 		if _, live := references[hash]; !live {
 			db.persistence.DeleteBlob(hash)
 			deleted++
 		}
-		return nil
 	})
 	return deleted
 }
@@ -280,13 +279,12 @@ func cleanShards(db *database) int {
 
 	// Walk disk shard files one by one; delete those with an unknown UUID.
 	deleted := 0
-	db.persistence.WalkShardFiles(func(name string) error {
+	db.persistence.WalkShardFiles(func(name string) {
 		uuid := extractShardUUID(name)
 		if uuid != "" && !activeUUIDs[uuid] {
 			db.persistence.DeleteShardFile(name)
 			deleted++
 		}
-		return nil
 	})
 	return deleted
 }

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -1022,7 +1022,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 				}
 			}
 			if t.PersistencyMode == Safe {
-				s.logfile.Sync()
+				s.logfile.Flush(true)
 			}
 		}
 		s.mu.Unlock()
@@ -1055,7 +1055,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 			}
 			ps.mu.Unlock()
 			if !wasDeleted && t.PersistencyMode == Safe && ps.logfile != nil {
-				ps.logfile.Sync()
+				ps.logfile.Flush(true)
 			}
 		}
 		return len(pending)

--- a/storage/persistence-ceph.go
+++ b/storage/persistence-ceph.go
@@ -107,25 +107,27 @@ func (s *CephStorage) ensureOpen() {
 
 	conn, err := rados.NewConnWithClusterAndUser(s.factory.ClusterName, s.factory.UserName)
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "backend.open", err)
 	}
 	if s.factory.ConfFile != "" {
 		if err := conn.ReadConfigFile(s.factory.ConfFile); err != nil {
-			panic(err)
+			raisePersistenceFailure(s.BackendName(), s.prefix, "backend.open", err)
 		}
 	} else {
 		// If no conf provided, caller must have CEPH_ARGS/CEPH_CONF env or defaults.
-		_ = conn.ReadDefaultConfigFile()
+		if err := conn.ReadDefaultConfigFile(); err != nil {
+			raisePersistenceFailure(s.BackendName(), s.prefix, "backend.open", err)
+		}
 	}
 
 	if err := conn.Connect(); err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "backend.open", err)
 	}
 
 	ioctx, err := conn.OpenIOContext(s.factory.Pool)
 	if err != nil {
 		conn.Shutdown()
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "backend.open", err)
 	}
 
 	s.conn = conn
@@ -141,15 +143,18 @@ func (s *CephStorage) ReadSchema() []byte {
 	s.ensureOpen()
 	obj := s.obj("schema.json")
 	// First stat to get size
-	stat, err := s.ioctx.Stat(obj)
+	stat, err := remoteRetryValue(func() (rados.ObjectStat, error) { return s.ioctx.Stat(obj) })
 	if err != nil {
 		// Keep behavior similar to FileStorage: empty means "not found"
-		return nil
+		if errors.Is(err, rados.ErrNotFound) {
+			return nil
+		}
+		raisePersistenceFailure(s.BackendName(), s.prefix, "schema.read", err)
 	}
 	data := make([]byte, stat.Size)
-	n, err := s.ioctx.Read(obj, data, 0)
+	n, err := remoteRetryValue(func() (int, error) { return s.ioctx.Read(obj, data, 0) })
 	if err != nil {
-		return nil
+		raisePersistenceFailure(s.BackendName(), s.prefix, "schema.read", err)
 	}
 	return data[:n]
 }
@@ -159,8 +164,8 @@ func (s *CephStorage) WriteSchema(schema []byte) {
 	obj := s.obj("schema.json")
 	// RADOS full-object overwrite satisfies PersistenceEngine's atomic schema
 	// generation contract: readers see the old or complete new object.
-	if err := s.ioctx.WriteFull(obj, schema); err != nil {
-		panic(err)
+	if err := remoteRetry(func() error { return s.ioctx.WriteFull(obj, schema) }); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "schema.write", err)
 	}
 }
 
@@ -170,14 +175,17 @@ func (s *CephStorage) ReadColumn(shard string, column string) io.ReadCloser {
 
 	// We implement ReadCloser backed by in-memory buffer.
 	// If you want streaming, you'd need chunked reads; for now columns are usually loaded fully anyway.
-	stat, err := s.ioctx.Stat(obj)
+	stat, err := remoteRetryValue(func() (rados.ObjectStat, error) { return s.ioctx.Stat(obj) })
 	if err != nil {
+		if !errors.Is(err, rados.ErrNotFound) {
+			raisePersistenceFailure(s.BackendName(), s.prefix, "column.read.open", err)
+		}
 		return ErrorReader{e: err, notFound: errors.Is(err, rados.ErrNotFound)}
 	}
 	data := make([]byte, stat.Size)
-	n, err := s.ioctx.Read(obj, data, 0)
+	n, err := remoteRetryValue(func() (int, error) { return s.ioctx.Read(obj, data, 0) })
 	if err != nil {
-		return ErrorReader{e: err, notFound: errors.Is(err, rados.ErrNotFound)}
+		raisePersistenceFailure(s.BackendName(), s.prefix, "column.read", err)
 	}
 	return io.NopCloser(bytes.NewReader(data[:n]))
 }
@@ -202,8 +210,8 @@ func (w *cephWriteCloser) Close() error {
 	}
 	w.closed = true
 	// atomic overwrite
-	if err := w.s.ioctx.WriteFull(w.obj, w.buf.Bytes()); err != nil {
-		return err
+	if err := remoteRetry(func() error { return w.s.ioctx.WriteFull(w.obj, w.buf.Bytes()) }); err != nil {
+		raisePersistenceFailure(w.s.BackendName(), w.s.prefix, "object.write", err)
 	}
 	return nil
 }
@@ -216,20 +224,25 @@ func (s *CephStorage) WriteColumn(shard string, column string) io.WriteCloser {
 
 func (s *CephStorage) RemoveColumn(shard string, column string) {
 	s.ensureOpen()
-	_ = s.ioctx.Delete(s.obj(shard + "-" + ProcessColumnName(column)))
+	if err := remoteRetry(func() error { return s.ioctx.Delete(s.obj(shard + "-" + ProcessColumnName(column))) }); err != nil && !errors.Is(err, rados.ErrNotFound) {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "column.remove", err)
+	}
 }
 
 func (s *CephStorage) ReadBlob(hash string) io.ReadCloser {
 	s.ensureOpen()
 	obj := s.obj("blob/" + hash)
-	stat, err := s.ioctx.Stat(obj)
+	stat, err := remoteRetryValue(func() (rados.ObjectStat, error) { return s.ioctx.Stat(obj) })
 	if err != nil {
+		if !errors.Is(err, rados.ErrNotFound) {
+			raisePersistenceFailure(s.BackendName(), s.prefix, "blob.read.open", err)
+		}
 		return ErrorReader{e: err, notFound: errors.Is(err, rados.ErrNotFound)}
 	}
 	data := make([]byte, stat.Size)
-	n, err := s.ioctx.Read(obj, data, 0)
+	n, err := remoteRetryValue(func() (int, error) { return s.ioctx.Read(obj, data, 0) })
 	if err != nil {
-		return ErrorReader{e: err, notFound: errors.Is(err, rados.ErrNotFound)}
+		raisePersistenceFailure(s.BackendName(), s.prefix, "blob.read", err)
 	}
 	return io.NopCloser(bytes.NewReader(data[:n]))
 }
@@ -242,15 +255,17 @@ func (s *CephStorage) WriteBlob(hash string) io.WriteCloser {
 
 func (s *CephStorage) DeleteBlob(hash string) {
 	s.ensureOpen()
-	_ = s.ioctx.Delete(s.obj("blob/" + hash))
+	if err := remoteRetry(func() error { return s.ioctx.Delete(s.obj("blob/" + hash)) }); err != nil && !errors.Is(err, rados.ErrNotFound) {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "blob.delete", err)
+	}
 }
 
-func (s *CephStorage) WalkBlobs(fn func(hash string) error) error {
+func (s *CephStorage) WalkBlobs(fn func(hash string)) {
 	s.ensureOpen()
 	blobPrefix := s.prefix + "/blob/"
 	iter, err := s.ioctx.Iter()
 	if err != nil {
-		return err
+		raisePersistenceFailure(s.BackendName(), s.prefix, "blob.walk", err)
 	}
 	defer iter.Close()
 	for iter.Next() {
@@ -258,20 +273,20 @@ func (s *CephStorage) WalkBlobs(fn func(hash string) error) error {
 		if !strings.HasPrefix(name, blobPrefix) {
 			continue
 		}
-		if err := fn(strings.TrimPrefix(name, blobPrefix)); err != nil {
-			return err
-		}
+		fn(strings.TrimPrefix(name, blobPrefix))
 	}
-	return iter.Err()
+	if err := iter.Err(); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "blob.walk", err)
+	}
 }
 
-func (s *CephStorage) WalkShardFiles(fn func(name string) error) error {
+func (s *CephStorage) WalkShardFiles(fn func(name string)) {
 	s.ensureOpen()
 	pfx := s.prefix + "/"
 	blobPfx := pfx + "blob/"
 	iter, err := s.ioctx.Iter()
 	if err != nil {
-		return err
+		raisePersistenceFailure(s.BackendName(), s.prefix, "shard.walk", err)
 	}
 	defer iter.Close()
 	for iter.Next() {
@@ -283,16 +298,18 @@ func (s *CephStorage) WalkShardFiles(fn func(name string) error) error {
 		if name == "schema.json" || name == "schema.json.old" || strings.HasPrefix(obj, blobPfx) {
 			continue
 		}
-		if err := fn(name); err != nil {
-			return err
-		}
+		fn(name)
 	}
-	return iter.Err()
+	if err := iter.Err(); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "shard.walk", err)
+	}
 }
 
 func (s *CephStorage) DeleteShardFile(name string) {
 	s.ensureOpen()
-	_ = s.ioctx.Delete(s.obj(name))
+	if err := remoteRetry(func() error { return s.ioctx.Delete(s.obj(name)) }); err != nil && !errors.Is(err, rados.ErrNotFound) {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "shard.delete", err)
+	}
 }
 
 func (s *CephStorage) BackendName() string {
@@ -337,7 +354,7 @@ func (s *CephStorage) OpenLog(shard string) PersistenceLogfile {
 	s.ensureOpen()
 	lf, err := openOrCreateCephLogfile(s, shard)
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.open", err)
 	}
 	return lf
 }
@@ -346,7 +363,7 @@ func (s *CephStorage) SwapLog(shard string, entries []interface{}, durable bool)
 	s.ensureOpen()
 	oldSegments, err := listLogSegments(s, shard)
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.swap", err)
 	}
 	var next uint32
 	for _, segment := range oldSegments {
@@ -359,15 +376,17 @@ func (s *CephStorage) SwapLog(shard string, entries []interface{}, durable bool)
 		body.Write(encodeLogEntry(entry))
 	}
 	obj := s.obj(fmt.Sprintf("%s.log.%08d", shard, next))
-	if err := s.ioctx.WriteFull(obj, body.Bytes()); err != nil {
-		panic(err)
+	if err := remoteRetry(func() error { return s.ioctx.WriteFull(obj, body.Bytes()) }); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.swap", err)
 	}
 	if err := writeLogManifest(s, shard, []uint32{next}); err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.swap", err)
 	}
 	for _, segment := range oldSegments {
 		if segment.seg != next {
-			_ = s.ioctx.Delete(segment.obj)
+			if err := s.ioctx.Delete(segment.obj); err != nil && !errors.Is(err, rados.ErrNotFound) {
+				reportPersistenceCleanupFailure(s.BackendName(), s.prefix, "log.swap.cleanup", err)
+			}
 		}
 	}
 	return &CephLogfile{
@@ -386,14 +405,13 @@ func (s *CephStorage) ReplayLog(shard string) (map[string]struct{}, chan interfa
 	out := make(chan interface{}, 64)
 	committed := make(map[string]struct{})
 	segments, err := listLogSegments(s, shard)
-	if err == nil {
-		hybridsort.Slice(segments, func(i, j int) bool { return segments[i].seg < segments[j].seg })
-		for _, seg := range segments {
-			data := s.readLogSegment(seg)
-			collectLogStreamCommits(data, committed)
-		}
-	} else {
-		segments = nil
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.replay", err)
+	}
+	hybridsort.Slice(segments, func(i, j int) bool { return segments[i].seg < segments[j].seg })
+	for _, seg := range segments {
+		data := s.readLogSegment(seg)
+		collectLogStreamCommits(data, committed)
 	}
 
 	go func() {
@@ -406,19 +424,25 @@ func (s *CephStorage) ReplayLog(shard string) (map[string]struct{}, chan interfa
 	// Return an appendable logfile as second return, like FileStorage does.
 	lf, err := openOrCreateCephLogfile(s, shard)
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.replay", err)
 	}
 	return committed, out, lf
 }
 
 func (s *CephStorage) readLogSegment(seg logSegInfo) []byte {
-	stat, err := s.ioctx.Stat(seg.obj)
-	if err != nil || stat.Size == 0 {
+	stat, err := remoteRetryValue(func() (rados.ObjectStat, error) { return s.ioctx.Stat(seg.obj) })
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.read", err)
+	}
+	if stat.Size == 0 {
 		return nil
 	}
 	data := make([]byte, stat.Size)
-	n, err := s.ioctx.Read(seg.obj, data, 0)
-	if err != nil || n == 0 {
+	n, err := remoteRetryValue(func() (int, error) { return s.ioctx.Read(seg.obj, data, 0) })
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.read", err)
+	}
+	if n == 0 {
 		return nil
 	}
 	return data[:n]
@@ -426,9 +450,14 @@ func (s *CephStorage) readLogSegment(seg logSegInfo) []byte {
 
 func (s *CephStorage) RemoveLog(shard string) {
 	s.ensureOpen()
-	segments, _ := listLogSegments(s, shard)
+	segments, err := listLogSegments(s, shard)
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.remove", err)
+	}
 	for _, seg := range segments {
-		_ = s.ioctx.Delete(seg.obj)
+		if err := remoteRetry(func() error { return s.ioctx.Delete(seg.obj) }); err != nil && !errors.Is(err, rados.ErrNotFound) {
+			raisePersistenceFailure(s.BackendName(), s.prefix, "log.remove", err)
+		}
 	}
 }
 
@@ -449,12 +478,12 @@ func listLogSegments(s *CephStorage, shard string) ([]logSegInfo, error) {
 	// This keeps list operation O(segments), avoids pool-wide scans.
 
 	manifestObj := s.obj(fmt.Sprintf("%s.log.manifest", shard))
-	stat, err := s.ioctx.Stat(manifestObj)
+	stat, err := remoteRetryValue(func() (rados.ObjectStat, error) { return s.ioctx.Stat(manifestObj) })
 	if err != nil || stat.Size == 0 {
 		return nil, fmt.Errorf("no manifest")
 	}
 	raw := make([]byte, stat.Size)
-	n, err := s.ioctx.Read(manifestObj, raw, 0)
+	n, err := remoteRetryValue(func() (int, error) { return s.ioctx.Read(manifestObj, raw, 0) })
 	if err != nil || n == 0 {
 		return nil, fmt.Errorf("no manifest")
 	}
@@ -476,7 +505,7 @@ func listLogSegments(s *CephStorage, shard string) ([]logSegInfo, error) {
 func writeLogManifest(s *CephStorage, shard string, segs []uint32) error {
 	manifestObj := s.obj(fmt.Sprintf("%s.log.manifest", shard))
 	raw, _ := json.Marshal(segs)
-	return s.ioctx.WriteFull(manifestObj, raw)
+	return remoteRetry(func() error { return s.ioctx.WriteFull(manifestObj, raw) })
 }
 
 func openOrCreateCephLogfile(s *CephStorage, shard string) (*CephLogfile, error) {
@@ -503,13 +532,16 @@ func openOrCreateCephLogfile(s *CephStorage, shard string) (*CephLogfile, error)
 	obj := s.obj(fmt.Sprintf("%s.log.%08d", shard, seg))
 
 	// Determine current size as append offset
-	st, err := s.ioctx.Stat(obj)
+	st, err := remoteRetryValue(func() (rados.ObjectStat, error) { return s.ioctx.Stat(obj) })
 	if err != nil {
 		// object may not exist yet -> create empty using Truncate
-		if err := s.ioctx.Truncate(obj, 0); err != nil {
+		if err := remoteRetry(func() error { return s.ioctx.Truncate(obj, 0) }); err != nil {
 			return nil, err
 		}
-		st, _ = s.ioctx.Stat(obj)
+		st, err = remoteRetryValue(func() (rados.ObjectStat, error) { return s.ioctx.Stat(obj) })
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &CephLogfile{
@@ -665,21 +697,30 @@ func (w *CephLogfile) Write(logentry interface{}) {
 
 	// optional auto-flush: prevents unbounded buffer in write-heavy workloads
 	if w.buf.Len() >= w.flushEveryBytes {
-		// best-effort flush without forcing caller to call Sync()
-		_ = w.flushLocked(false)
+		if err := w.flushLocked(false); err != nil {
+			raisePersistenceFailure(w.s.BackendName(), w.s.prefix, "log.write", err)
+		}
 	}
 }
 
-func (w *CephLogfile) Sync() {
+func (w *CephLogfile) Flush(durable bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	_ = w.flushLocked(true)
+	if err := w.flushLocked(durable); err != nil {
+		operation := "log.flush"
+		if durable {
+			operation = "log.sync"
+		}
+		raisePersistenceFailure(w.s.BackendName(), w.s.prefix, operation, err)
+	}
 }
 
 func (w *CephLogfile) Close() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	_ = w.flushLocked(true)
+	if err := w.flushLocked(true); err != nil {
+		raisePersistenceFailure(w.s.BackendName(), w.s.prefix, "log.close", err)
+	}
 	// no explicit handle to close for rados object
 }
 
@@ -695,17 +736,22 @@ func (w *CephLogfile) flushLocked(force bool) error {
 		// create next segment and update manifest
 		next := w.seg + 1
 		nextObj := w.s.obj(fmt.Sprintf("%s.log.%08d", w.shard, next))
-		if err := w.s.ioctx.Truncate(nextObj, 0); err != nil {
+		if err := remoteRetry(func() error { return w.s.ioctx.Truncate(nextObj, 0) }); err != nil {
 			return err
 		}
 		// update manifest
-		segs, _ := listLogSegments(w.s, w.shard)
+		segs, err := listLogSegments(w.s, w.shard)
+		if err != nil {
+			return err
+		}
 		var all []uint32
 		for _, si := range segs {
 			all = append(all, si.seg)
 		}
 		all = append(all, next)
-		_ = writeLogManifest(w.s, w.shard, all)
+		if err := writeLogManifest(w.s, w.shard, all); err != nil {
+			return err
+		}
 
 		w.seg = next
 		w.obj = nextObj
@@ -716,12 +762,15 @@ func (w *CephLogfile) flushLocked(force bool) error {
 	payload := w.buf.Bytes()
 
 	// Use a WriteOp so we can later extend with flags / op batching.
-	op := rados.CreateWriteOp()
-	defer op.Release()
-	op.Write(payload, uint64(w.offset))
 	// RADOS has no fsync; durability depends on replication and client ack.
-	// For "Sync semantics" you mainly want to flush buffers and maybe block until op completes.
-	if err := op.Operate(w.s.ioctx, w.obj, rados.OperationNoFlag); err != nil {
+	// Each retry uses a fresh operation object and repeats the same idempotent
+	// offset write.
+	if err := remoteRetry(func() error {
+		op := rados.CreateWriteOp()
+		defer op.Release()
+		op.Write(payload, uint64(w.offset))
+		return op.Operate(w.s.ioctx, w.obj, rados.OperationNoFlag)
+	}); err != nil {
 		// If op fails, keep buffer (caller can retry). We won't clear.
 		return err
 	}

--- a/storage/persistence-errors.go
+++ b/storage/persistence-errors.go
@@ -1,0 +1,120 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "os"
+import "fmt"
+import "time"
+
+const remoteStorageAttempts = 3
+
+// PersistenceFailure is the only panic value emitted for an I/O failure at a
+// persistence boundary. Transaction code may recover this type to abort a
+// write; all unrelated panics must continue to propagate.
+type PersistenceFailure struct {
+	Backend   string
+	Database  string
+	Operation string
+	Err       error
+	// OutcomeUnknown is set only when the operation which publishes commit
+	// authority completed but its final durability barrier failed. Callers must
+	// not roll back in-memory state in that case: recovery may observe the
+	// commit marker even though the client receives an error.
+	OutcomeUnknown bool
+}
+
+func (e *PersistenceFailure) Error() string {
+	message := fmt.Sprintf("persistence %s failed for %s database %s: %v", e.Operation, e.Backend, e.Database, e.Err)
+	if e.OutcomeUnknown {
+		message += " (commit outcome unknown)"
+	}
+	return message
+}
+
+func (e *PersistenceFailure) Unwrap() error { return e.Err }
+
+func raisePersistenceFailure(backend string, database string, operation string, err error) {
+	failure := &PersistenceFailure{
+		Backend: backend, Database: database, Operation: operation, Err: err,
+	}
+	// This must never use MemCP tables: the statistics database may be the
+	// failing backend and recursive failure reporting would never terminate.
+	_, _ = fmt.Fprintf(os.Stderr, "CRITICAL: %s\n", failure.Error())
+	panic(failure)
+}
+
+func reportPersistenceCleanupFailure(backend string, database string, operation string, err error) {
+	_, _ = fmt.Fprintf(os.Stderr, "CRITICAL: persistence %s failed for %s database %s: %v; committed data is intact but orphan cleanup is incomplete\n", operation, backend, database, err)
+}
+
+func reportPersistenceAmbiguousFailure(backend string, database string, operation string, err error) {
+	_, _ = fmt.Fprintf(os.Stderr, "CRITICAL: persistence %s failed for %s database %s: %v; publication completed but crash durability is unknown\n", operation, backend, database, err)
+}
+
+func recoverPersistenceFailure(errp *error) {
+	if recovered := recover(); recovered != nil {
+		if failure, ok := recovered.(*PersistenceFailure); ok {
+			*errp = failure
+			return
+		}
+		panic(recovered)
+	}
+}
+
+func persistenceCall(operation func()) (err error) {
+	defer recoverPersistenceFailure(&err)
+	operation()
+	return nil
+}
+
+func markCommitOutcomeUnknown(err error) error {
+	failure, ok := err.(*PersistenceFailure)
+	if !ok {
+		return err
+	}
+	copy := *failure
+	copy.OutcomeUnknown = true
+	return &copy
+}
+
+func commitOutcomeUnknown(err error) bool {
+	failure, ok := err.(*PersistenceFailure)
+	return ok && failure.OutcomeUnknown
+}
+
+func remoteRetry(operation func() error) error {
+	var err error
+	for attempt := 0; attempt < remoteStorageAttempts; attempt++ {
+		if err = operation(); err == nil {
+			return nil
+		}
+		if attempt+1 < remoteStorageAttempts {
+			time.Sleep(time.Duration(10*(1<<attempt)) * time.Millisecond)
+		}
+	}
+	return err
+}
+
+func remoteRetryValue[T any](operation func() (T, error)) (T, error) {
+	var value T
+	err := remoteRetry(func() error {
+		var err error
+		value, err = operation()
+		return err
+	})
+	return value, err
+}

--- a/storage/persistence-fault.go
+++ b/storage/persistence-fault.go
@@ -1,0 +1,345 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "io"
+import "os"
+import "fmt"
+import "sync"
+import "math/rand"
+import "strconv"
+import "strings"
+import "syscall"
+
+type persistenceFaultInjector struct {
+	mu          sync.Mutex
+	rng         *rand.Rand
+	probability float64
+	operations  map[string]struct{}
+	phase       string
+	skip        uint64
+	remaining   int64
+}
+
+func persistenceFaultInjectorFromEnv(database string) *persistenceFaultInjector {
+	probabilityText := os.Getenv("MEMCP_IO_FAULT_PROBABILITY")
+	if probabilityText == "" {
+		return nil
+	}
+	probability, err := strconv.ParseFloat(probabilityText, 64)
+	if err != nil || probability <= 0 || probability > 1 {
+		panic(fmt.Sprintf("invalid MEMCP_IO_FAULT_PROBABILITY %q", probabilityText))
+	}
+	if filter := os.Getenv("MEMCP_IO_FAULT_DATABASE"); filter != "" && filter != database {
+		return nil
+	}
+	seed := int64(1)
+	if text := os.Getenv("MEMCP_IO_FAULT_SEED"); text != "" {
+		parsed, parseErr := strconv.ParseInt(text, 10, 64)
+		if parseErr != nil {
+			panic(fmt.Sprintf("invalid MEMCP_IO_FAULT_SEED %q", text))
+		}
+		seed = parsed
+	}
+	operations := make(map[string]struct{})
+	for _, operation := range strings.Split(os.Getenv("MEMCP_IO_FAULT_OPERATIONS"), ",") {
+		operation = strings.TrimSpace(operation)
+		if operation != "" {
+			operations[operation] = struct{}{}
+		}
+	}
+	if len(operations) == 0 {
+		operations["*"] = struct{}{}
+	}
+	phase := os.Getenv("MEMCP_IO_FAULT_PHASE")
+	if phase == "" {
+		phase = "before"
+	}
+	if phase != "before" && phase != "partial" {
+		panic(fmt.Sprintf("invalid MEMCP_IO_FAULT_PHASE %q", phase))
+	}
+	remaining := int64(-1)
+	if text := os.Getenv("MEMCP_IO_FAULT_LIMIT"); text != "" {
+		parsed, parseErr := strconv.ParseInt(text, 10, 64)
+		if parseErr != nil || parsed < 1 {
+			panic(fmt.Sprintf("invalid MEMCP_IO_FAULT_LIMIT %q", text))
+		}
+		remaining = parsed
+	}
+	var skip uint64
+	if text := os.Getenv("MEMCP_IO_FAULT_AFTER"); text != "" {
+		parsed, parseErr := strconv.ParseUint(text, 10, 64)
+		if parseErr != nil {
+			panic(fmt.Sprintf("invalid MEMCP_IO_FAULT_AFTER %q", text))
+		}
+		skip = parsed
+	}
+	return &persistenceFaultInjector{
+		rng: rand.New(rand.NewSource(seed)), probability: probability,
+		operations: operations, phase: phase, skip: skip, remaining: remaining,
+	}
+}
+
+func (f *persistenceFaultInjector) trigger(operation string, phase string) bool {
+	if f == nil || f.phase != phase {
+		return false
+	}
+	if _, all := f.operations["*"]; !all {
+		if _, selected := f.operations[operation]; !selected {
+			return false
+		}
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.remaining == 0 {
+		return false
+	}
+	if f.skip > 0 {
+		f.skip--
+		return false
+	}
+	if f.rng.Float64() >= f.probability {
+		return false
+	}
+	if f.remaining > 0 {
+		f.remaining--
+	}
+	return true
+}
+
+type faultPersistence struct {
+	PersistenceEngine
+	database string
+	faults   *persistenceFaultInjector
+}
+
+func instrumentPersistence(database string, engine PersistenceEngine) PersistenceEngine {
+	faults := persistenceFaultInjectorFromEnv(database)
+	if faults == nil {
+		return engine
+	}
+	return &faultPersistence{PersistenceEngine: engine, database: database, faults: faults}
+}
+
+func (p *faultPersistence) fail(operation string, phase string) {
+	if p.faults.trigger(operation, phase) {
+		raisePersistenceFailure(p.BackendName(), p.database, operation, syscall.ENOSPC)
+	}
+}
+
+func (p *faultPersistence) around(operation string, fn func()) {
+	p.fail(operation, "before")
+	// Non-stream operations have no meaningful partial public state. Their
+	// backend implementation remains responsible for atomic publication.
+	p.fail(operation, "partial")
+	fn()
+}
+
+func (p *faultPersistence) ReadSchema() (result []byte) {
+	p.around("schema.read", func() { result = p.PersistenceEngine.ReadSchema() })
+	return result
+}
+
+func (p *faultPersistence) WriteSchema(schema []byte) {
+	p.around("schema.write", func() { p.PersistenceEngine.WriteSchema(schema) })
+}
+
+func (p *faultPersistence) WriteSchemaWithMode(schema []byte, durable bool) {
+	p.around("schema.write", func() {
+		if writer, ok := p.PersistenceEngine.(schemaWriteOptions); ok {
+			writer.WriteSchemaWithMode(schema, durable)
+		} else {
+			p.PersistenceEngine.WriteSchema(schema)
+		}
+	})
+}
+
+func (p *faultPersistence) ReadColumn(shard string, column string) io.ReadCloser {
+	var result io.ReadCloser
+	p.around("column.read.open", func() { result = p.PersistenceEngine.ReadColumn(shard, column) })
+	return &faultReadCloser{ReadCloser: result, owner: p, operation: "column.read"}
+}
+
+func (p *faultPersistence) WriteColumn(shard string, column string) io.WriteCloser {
+	var result io.WriteCloser
+	p.around("column.write.open", func() { result = p.PersistenceEngine.WriteColumn(shard, column) })
+	return &faultWriteCloser{WriteCloser: result, owner: p, operation: "column.write"}
+}
+
+func (p *faultPersistence) RemoveColumn(shard string, column string) {
+	p.around("column.remove", func() { p.PersistenceEngine.RemoveColumn(shard, column) })
+}
+
+func (p *faultPersistence) ReadBlob(hash string) io.ReadCloser {
+	var result io.ReadCloser
+	p.around("blob.read.open", func() { result = p.PersistenceEngine.ReadBlob(hash) })
+	return &faultReadCloser{ReadCloser: result, owner: p, operation: "blob.read"}
+}
+
+func (p *faultPersistence) WriteBlob(hash string) io.WriteCloser {
+	var result io.WriteCloser
+	p.around("blob.write.open", func() { result = p.PersistenceEngine.WriteBlob(hash) })
+	return &faultWriteCloser{WriteCloser: result, owner: p, operation: "blob.write"}
+}
+
+func (p *faultPersistence) DeleteBlob(hash string) {
+	p.around("blob.delete", func() { p.PersistenceEngine.DeleteBlob(hash) })
+}
+
+func (p *faultPersistence) WalkBlobs(fn func(hash string)) {
+	p.around("blob.walk", func() { p.PersistenceEngine.WalkBlobs(fn) })
+}
+
+func (p *faultPersistence) OpenLog(shard string) (result PersistenceLogfile) {
+	p.around("log.open", func() { result = p.PersistenceEngine.OpenLog(shard) })
+	return &faultLogfile{PersistenceLogfile: result, owner: p}
+}
+
+func (p *faultPersistence) SwapLog(shard string, entries []interface{}, durable bool) (result PersistenceLogfile) {
+	p.around("log.swap", func() { result = p.PersistenceEngine.SwapLog(shard, entries, durable) })
+	return &faultLogfile{PersistenceLogfile: result, owner: p}
+}
+
+func (p *faultPersistence) ReplayLog(shard string) (committed map[string]struct{}, entries chan interface{}, result PersistenceLogfile) {
+	p.around("log.replay", func() {
+		committed, entries, result = p.PersistenceEngine.ReplayLog(shard)
+	})
+	return committed, entries, &faultLogfile{PersistenceLogfile: result, owner: p}
+}
+
+func (p *faultPersistence) RemoveLog(shard string) {
+	p.around("log.remove", func() { p.PersistenceEngine.RemoveLog(shard) })
+}
+
+func (p *faultPersistence) WalkShardFiles(fn func(name string)) {
+	p.around("shard.walk", func() { p.PersistenceEngine.WalkShardFiles(fn) })
+}
+
+func (p *faultPersistence) DeleteShardFile(name string) {
+	p.around("shard.delete", func() { p.PersistenceEngine.DeleteShardFile(name) })
+}
+
+func (p *faultPersistence) Remove() {
+	p.around("database.remove", p.PersistenceEngine.Remove)
+}
+
+type faultReadCloser struct {
+	io.ReadCloser
+	owner     *faultPersistence
+	operation string
+}
+
+func (r *faultReadCloser) Missing() bool {
+	if missing, ok := r.ReadCloser.(interface{ Missing() bool }); ok {
+		return missing.Missing()
+	}
+	return false
+}
+
+func (r *faultReadCloser) Read(buffer []byte) (n int, err error) {
+	r.owner.fail(r.operation, "before")
+	if r.owner.faults.trigger(r.operation, "partial") && len(buffer) > 1 {
+		n, err = r.ReadCloser.Read(buffer[:len(buffer)/2])
+		raisePersistenceFailure(r.owner.BackendName(), r.owner.database, r.operation, syscall.EIO)
+	}
+	n, err = r.ReadCloser.Read(buffer)
+	if err != nil && err != io.EOF {
+		if r.Missing() {
+			return n, err
+		}
+		raisePersistenceFailure(r.owner.BackendName(), r.owner.database, r.operation, err)
+	}
+	return n, err
+}
+
+func (r *faultReadCloser) Close() error {
+	operation := r.operation + ".close"
+	r.owner.fail(operation, "before")
+	if err := r.ReadCloser.Close(); err != nil {
+		raisePersistenceFailure(r.owner.BackendName(), r.owner.database, operation, err)
+	}
+	return nil
+}
+
+type faultWriteCloser struct {
+	io.WriteCloser
+	owner     *faultPersistence
+	operation string
+}
+
+func (w *faultWriteCloser) Write(buffer []byte) (n int, err error) {
+	w.owner.fail(w.operation, "before")
+	if w.owner.faults.trigger(w.operation, "partial") && len(buffer) > 0 {
+		prefix := len(buffer) / 2
+		if prefix == 0 {
+			prefix = 1
+		}
+		_, _ = w.WriteCloser.Write(buffer[:prefix])
+		raisePersistenceFailure(w.owner.BackendName(), w.owner.database, w.operation, syscall.ENOSPC)
+	}
+	n, err = w.WriteCloser.Write(buffer)
+	if err != nil || n != len(buffer) {
+		if err == nil {
+			err = io.ErrShortWrite
+		}
+		raisePersistenceFailure(w.owner.BackendName(), w.owner.database, w.operation, err)
+	}
+	return n, nil
+}
+
+func (w *faultWriteCloser) Close() error {
+	w.owner.fail(w.operation+".close", "before")
+	err := w.WriteCloser.Close()
+	if err != nil {
+		raisePersistenceFailure(w.owner.BackendName(), w.owner.database, w.operation+".close", err)
+	}
+	return nil
+}
+
+type partialPersistenceLogfile interface {
+	writePartial(logentry interface{}) error
+}
+
+type faultLogfile struct {
+	PersistenceLogfile
+	owner *faultPersistence
+}
+
+func (w *faultLogfile) Write(logentry interface{}) {
+	w.owner.fail("log.write", "before")
+	if w.owner.faults.trigger("log.write", "partial") {
+		if partial, ok := w.PersistenceLogfile.(partialPersistenceLogfile); ok {
+			if err := partial.writePartial(logentry); err != nil {
+				raisePersistenceFailure(w.owner.BackendName(), w.owner.database, "log.write", err)
+			}
+		}
+		raisePersistenceFailure(w.owner.BackendName(), w.owner.database, "log.write", syscall.ENOSPC)
+	}
+	w.PersistenceLogfile.Write(logentry)
+}
+
+func (w *faultLogfile) Flush(durable bool) {
+	operation := "log.flush"
+	if durable {
+		operation = "log.sync"
+	}
+	w.owner.around(operation, func() { w.PersistenceLogfile.Flush(durable) })
+}
+
+func (w *faultLogfile) Close() {
+	w.owner.around("log.close", w.PersistenceLogfile.Close)
+}

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -24,6 +24,7 @@ import "bytes"
 import "strings"
 import "errors"
 import "strconv"
+import "syscall"
 import "path/filepath"
 import "crypto/sha256"
 import "encoding/json"
@@ -53,10 +54,16 @@ func (f *FileFactory) CreateDatabase(schema string) PersistenceEngine {
 }
 
 func (f *FileStorage) ReadSchema() []byte {
-	jsonbytes, _ := os.ReadFile(f.path + "schema.json")
+	jsonbytes, err := os.ReadFile(f.path + "schema.json")
+	if err != nil && !os.IsNotExist(err) {
+		raisePersistenceFailure(f.BackendName(), f.path, "schema.read", err)
+	}
 	if len(jsonbytes) == 0 {
 		// try to load backup (in case of failure while save)
-		jsonbytes, _ = os.ReadFile(f.path + "schema.json.old")
+		jsonbytes, err = os.ReadFile(f.path + "schema.json.old")
+		if err != nil && !os.IsNotExist(err) {
+			raisePersistenceFailure(f.BackendName(), f.path, "schema.read", err)
+		}
 	}
 	return jsonbytes
 }
@@ -72,26 +79,26 @@ func (s *FileStorage) WriteSchema(jsonbytes []byte) {
 // to the previously committed generation and cannot create a live-path gap.
 func (s *FileStorage) WriteSchemaWithMode(jsonbytes []byte, durable bool) {
 	if err := os.MkdirAll(s.path, 0750); err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 	}
 	tmp, err := os.CreateTemp(s.path, ".schema.json.tmp-")
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 	}
 	tmpName := tmp.Name()
 	defer os.Remove(tmpName)
 	if _, err := tmp.Write(jsonbytes); err != nil {
 		tmp.Close()
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 	}
 	if durable {
 		if err := tmp.Sync(); err != nil {
 			tmp.Close()
-			panic(err)
+			raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 		}
 	}
 	if err := tmp.Close(); err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 	}
 
 	current := s.path + "schema.json"
@@ -104,24 +111,26 @@ func (s *FileStorage) WriteSchemaWithMode(jsonbytes []byte, durable bool) {
 		if err := os.Link(current, backupTmp); err == nil {
 			if err := os.Rename(backupTmp, backup); err != nil {
 				_ = os.Remove(backupTmp)
-				panic(err)
+				raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 			}
+		} else {
+			reportPersistenceCleanupFailure(s.BackendName(), s.path, "schema.backup", err)
 		}
 	}
 	if err := os.Rename(tmpName, current); err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 	}
 	if durable {
 		dir, err := os.Open(s.path)
 		if err != nil {
-			panic(err)
+			raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 		}
 		if err := dir.Sync(); err != nil {
 			dir.Close()
-			panic(err)
+			raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 		}
 		if err := dir.Close(); err != nil {
-			panic(err)
+			raisePersistenceFailure(s.BackendName(), s.path, "schema.write", err)
 		}
 	}
 }
@@ -130,6 +139,9 @@ func (s *FileStorage) ReadColumn(shard string, column string) io.ReadCloser {
 	//f, err := os.C
 	f, err := os.Open(s.path + shard + "-" + ProcessColumnName(column))
 	if err != nil {
+		if !os.IsNotExist(err) {
+			raisePersistenceFailure(s.BackendName(), s.path, "column.read.open", err)
+		}
 		// file does not exist -> no data available
 		return ErrorReader{e: err, notFound: os.IsNotExist(err)}
 	}
@@ -137,16 +149,20 @@ func (s *FileStorage) ReadColumn(shard string, column string) io.ReadCloser {
 }
 
 func (s *FileStorage) WriteColumn(shard string, column string) io.WriteCloser {
-	os.MkdirAll(s.path, 0750)
+	if err := os.MkdirAll(s.path, 0750); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.path, "column.write.open", err)
+	}
 	f, err := os.Create(s.path + shard + "-" + ProcessColumnName(column))
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "column.write.open", err)
 	}
-	return f
+	return &fileObjectWriter{File: f, database: s.path, operation: "column.write"}
 }
 
 func (s *FileStorage) RemoveColumn(shard string, column string) {
-	os.Remove(s.path + shard + "-" + ProcessColumnName(column))
+	if err := os.Remove(s.path + shard + "-" + ProcessColumnName(column)); err != nil && !os.IsNotExist(err) {
+		raisePersistenceFailure(s.BackendName(), s.path, "column.remove", err)
+	}
 }
 
 func (s *FileStorage) blobPath(hash string) string {
@@ -159,6 +175,9 @@ func (s *FileStorage) blobPath(hash string) string {
 func (s *FileStorage) ReadBlob(hash string) io.ReadCloser {
 	f, err := os.Open(s.blobPath(hash))
 	if err != nil {
+		if !os.IsNotExist(err) {
+			raisePersistenceFailure(s.BackendName(), s.path, "blob.read.open", err)
+		}
 		return ErrorReader{e: err, notFound: os.IsNotExist(err)}
 	}
 	return f
@@ -167,12 +186,45 @@ func (s *FileStorage) ReadBlob(hash string) io.ReadCloser {
 func (s *FileStorage) WriteBlob(hash string) io.WriteCloser {
 	p := s.blobPath(hash)
 	dir := p[:strings.LastIndex(p, "/")]
-	os.MkdirAll(dir, 0750)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.path, "blob.write.open", err)
+	}
 	f, err := os.CreateTemp(dir, ".blob-write-")
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "blob.write.open", err)
 	}
-	return &fileBlobWriter{File: f, finalPath: p, directory: dir}
+	return &fileBlobWriter{File: f, finalPath: p, directory: dir, database: s.path}
+}
+
+type fileObjectWriter struct {
+	*os.File
+	database  string
+	operation string
+}
+
+func (w *fileObjectWriter) Write(buffer []byte) (int, error) {
+	n, err := w.File.Write(buffer)
+	if err != nil || n != len(buffer) {
+		if err == nil {
+			err = io.ErrShortWrite
+		}
+		raisePersistenceFailure("filesystem", w.database, w.operation, err)
+	}
+	return n, nil
+}
+
+func (w *fileObjectWriter) Sync() error {
+	if err := w.File.Sync(); err != nil {
+		raisePersistenceFailure("filesystem", w.database, w.operation+".sync", err)
+	}
+	return nil
+}
+
+func (w *fileObjectWriter) Close() error {
+	if err := w.File.Close(); err != nil {
+		raisePersistenceFailure("filesystem", w.database, w.operation+".close", err)
+	}
+	return nil
 }
 
 // fileBlobWriter publishes a content-addressed blob only after the complete
@@ -182,52 +234,82 @@ type fileBlobWriter struct {
 	*os.File
 	finalPath string
 	directory string
+	database  string
+}
+
+func (w *fileBlobWriter) Write(buffer []byte) (int, error) {
+	n, err := w.File.Write(buffer)
+	if err != nil || n != len(buffer) {
+		if err == nil {
+			err = io.ErrShortWrite
+		}
+		raisePersistenceFailure("filesystem", w.database, "blob.write", err)
+	}
+	return n, nil
 }
 
 func (w *fileBlobWriter) Close() error {
 	if err := w.File.Sync(); err != nil {
 		w.File.Close()
 		os.Remove(w.File.Name())
-		return err
+		raisePersistenceFailure("filesystem", w.database, "blob.write.sync", err)
 	}
 	if err := w.File.Close(); err != nil {
 		os.Remove(w.File.Name())
-		return err
+		raisePersistenceFailure("filesystem", w.database, "blob.write.close", err)
 	}
 	err := os.Link(w.File.Name(), w.finalPath)
 	if err != nil && !os.IsExist(err) {
 		os.Remove(w.File.Name())
-		return err
+		raisePersistenceFailure("filesystem", w.database, "blob.write.publish", err)
 	}
 	os.Remove(w.File.Name())
 	dir, err := os.Open(w.directory)
 	if err != nil {
-		return err
+		raisePersistenceFailure("filesystem", w.database, "blob.write.sync", err)
 	}
-	defer dir.Close()
-	return dir.Sync()
+	if err := dir.Sync(); err != nil {
+		_ = dir.Close()
+		raisePersistenceFailure("filesystem", w.database, "blob.write.sync", err)
+	}
+	if err := dir.Close(); err != nil {
+		raisePersistenceFailure("filesystem", w.database, "blob.write.close", err)
+	}
+	return nil
 }
 
 func (s *FileStorage) DeleteBlob(hash string) {
-	os.Remove(s.blobPath(hash))
+	if err := os.Remove(s.blobPath(hash)); err != nil && !os.IsNotExist(err) {
+		raisePersistenceFailure(s.BackendName(), s.path, "blob.delete", err)
+	}
 }
 
-func (s *FileStorage) WalkBlobs(fn func(hash string) error) error {
-	return filepath.Walk(s.path+"blob/", func(p string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
+func (s *FileStorage) WalkBlobs(fn func(hash string)) {
+	err := filepath.Walk(s.path+"blob/", func(p string, info os.FileInfo, err error) error {
+		if err != nil {
 			return err
+		}
+		if info.IsDir() {
+			return nil
 		}
 		if strings.HasPrefix(info.Name(), ".blob-write-") {
 			return nil
 		}
-		return fn(info.Name())
+		fn(info.Name())
+		return nil
 	})
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.path, "blob.walk", err)
+	}
 }
 
-func (s *FileStorage) WalkShardFiles(fn func(name string) error) error {
+func (s *FileStorage) WalkShardFiles(fn func(name string)) {
 	entries, err := os.ReadDir(s.path)
 	if err != nil {
-		return err
+		raisePersistenceFailure(s.BackendName(), s.path, "shard.walk", err)
 	}
 	for _, e := range entries {
 		if e.IsDir() {
@@ -237,33 +319,38 @@ func (s *FileStorage) WalkShardFiles(fn func(name string) error) error {
 		if n == "schema.json" || n == "schema.json.old" {
 			continue
 		}
-		if err := fn(n); err != nil {
-			return err
-		}
+		fn(n)
 	}
-	return nil
 }
 
 func (s *FileStorage) DeleteShardFile(name string) {
-	os.Remove(s.path + name)
+	if err := os.Remove(s.path + name); err != nil && !os.IsNotExist(err) {
+		raisePersistenceFailure(s.BackendName(), s.path, "shard.delete", err)
+	}
 }
 
 func (s *FileStorage) OpenLog(shard string) PersistenceLogfile {
-	os.MkdirAll(s.path, 0750)
+	if err := os.MkdirAll(s.path, 0750); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.path, "log.open", err)
+	}
 	f, err := os.OpenFile(s.path+shard+".log", os.O_RDWR|os.O_CREATE, 0750)
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "log.open", err)
 	}
-	return FileLogfile{f}
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		_ = f.Close()
+		raisePersistenceFailure(s.BackendName(), s.path, "log.open", err)
+	}
+	return FileLogfile{w: f}
 }
 
 func (s *FileStorage) SwapLog(shard string, entries []interface{}, durable bool) PersistenceLogfile {
 	if err := os.MkdirAll(s.path, 0750); err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "log.swap", err)
 	}
 	tmp, err := os.CreateTemp(s.path, "."+shard+".log.tmp-")
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "log.swap", err)
 	}
 	tmpName := tmp.Name()
 	removeTmp := true
@@ -276,25 +363,25 @@ func (s *FileStorage) SwapLog(shard string, entries []interface{}, durable bool)
 	for _, entry := range entries {
 		if _, err := tmp.Write(encodeFileLogEntry(entry)); err != nil {
 			_ = tmp.Close()
-			panic(err)
+			raisePersistenceFailure(s.BackendName(), s.path, "log.swap", err)
 		}
 	}
 	if durable {
 		if err := tmp.Sync(); err != nil {
 			_ = tmp.Close()
-			panic(err)
+			raisePersistenceFailure(s.BackendName(), s.path, "log.swap", err)
 		}
 	}
 	if _, err := tmp.Seek(0, io.SeekEnd); err != nil {
 		_ = tmp.Close()
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "log.swap", err)
 	}
 	var dir *os.File
 	if durable {
 		dir, err = os.Open(s.path)
 		if err != nil {
 			_ = tmp.Close()
-			panic(err)
+			raisePersistenceFailure(s.BackendName(), s.path, "log.swap", err)
 		}
 	}
 	if err := os.Rename(tmpName, s.path+shard+".log"); err != nil {
@@ -302,32 +389,42 @@ func (s *FileStorage) SwapLog(shard string, entries []interface{}, durable bool)
 			_ = dir.Close()
 		}
 		_ = tmp.Close()
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "log.swap", err)
 	}
 	removeTmp = false
 	if dir != nil {
 		// PersistenceLogfile cannot report an ambiguous outcome after rename.
 		// Match the existing best-effort Sync contract while still issuing the
 		// directory barrier needed to persist the chosen complete generation.
-		_ = dir.Sync()
-		_ = dir.Close()
+		if err := dir.Sync(); err != nil {
+			reportPersistenceAmbiguousFailure(s.BackendName(), s.path, "log.swap.sync", err)
+		}
+		if err := dir.Close(); err != nil {
+			reportPersistenceCleanupFailure(s.BackendName(), s.path, "log.swap.close", err)
+		}
 	}
 	return FileLogfile{w: tmp}
 }
 
 func (s *FileStorage) ReplayLog(shard string) (map[string]struct{}, chan interface{}, PersistenceLogfile) {
-	os.MkdirAll(s.path, 0750)
+	if err := os.MkdirAll(s.path, 0750); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.path, "log.replay", err)
+	}
 	f, err := os.OpenFile(s.path+shard+".log", os.O_RDWR|os.O_CREATE, 0750)
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "log.replay", err)
 	}
 	committed := fileCommittedTransactions(f)
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		_ = f.Close()
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.path, "log.replay", err)
 	}
 	replay := make(chan interface{}, 64)
-	fi, _ := f.Stat()
+	fi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		raisePersistenceFailure(s.BackendName(), s.path, "log.replay", err)
+	}
 	if fi.Size() > 0 {
 		go func() {
 			defer close(replay)
@@ -396,14 +493,14 @@ func (s *FileStorage) ReplayLog(shard string) (map[string]struct{}, chan interfa
 					break
 				}
 				if err != nil {
-					panic(err)
+					raisePersistenceFailure(s.BackendName(), s.path, "log.replay", err)
 				}
 			}
 		}()
 	} else {
 		close(replay)
 	}
-	return committed, replay, FileLogfile{f}
+	return committed, replay, FileLogfile{w: f}
 }
 
 func fileCommittedTransactions(f *os.File) map[string]struct{} {
@@ -427,7 +524,7 @@ func fileCommittedTransactions(f *os.File) map[string]struct{} {
 			committed[fields[0]] = struct{}{}
 		}
 		if err != nil {
-			panic(err)
+			raisePersistenceFailure("filesystem", f.Name(), "log.replay", err)
 		}
 	}
 	return committed
@@ -497,7 +594,9 @@ func decodeFileInsertLog(b []byte) ([]string, [][]scm.Scmer) {
 }
 
 func (s *FileStorage) RemoveLog(shard string) {
-	os.Remove(s.path + shard + ".log")
+	if err := os.Remove(s.path + shard + ".log"); err != nil && !os.IsNotExist(err) {
+		raisePersistenceFailure(s.BackendName(), s.path, "log.remove", err)
+	}
 }
 
 type FileLogfile struct {
@@ -505,7 +604,53 @@ type FileLogfile struct {
 }
 
 func (w FileLogfile) Write(logentry interface{}) {
-	_, _ = w.w.Write(encodeFileLogEntry(logentry))
+	frame := encodeFileLogEntry(logentry)
+	if len(frame) == 0 {
+		return
+	}
+	start, err := w.w.Seek(0, io.SeekCurrent)
+	if err != nil {
+		raisePersistenceFailure("filesystem", w.w.Name(), "log.write", err)
+	}
+	n, err := w.w.Write(frame)
+	if err == nil && n == len(frame) {
+		return
+	}
+	if err == nil {
+		err = io.ErrShortWrite
+	}
+	if truncateErr := w.w.Truncate(start); truncateErr != nil {
+		err = fmt.Errorf("%w; WAL rollback failed: %v", err, truncateErr)
+	}
+	if _, seekErr := w.w.Seek(start, io.SeekStart); seekErr != nil {
+		err = fmt.Errorf("%w; WAL seek rollback failed: %v", err, seekErr)
+	}
+	raisePersistenceFailure("filesystem", w.w.Name(), "log.write", err)
+}
+
+func (w FileLogfile) writePartial(logentry interface{}) error {
+	frame := encodeFileLogEntry(logentry)
+	if len(frame) == 0 {
+		return syscall.ENOSPC
+	}
+	start, err := w.w.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+	prefix := len(frame) / 2
+	if prefix == 0 {
+		prefix = 1
+	}
+	if _, err := w.w.Write(frame[:prefix]); err != nil {
+		return err
+	}
+	if err := w.w.Truncate(start); err != nil {
+		return err
+	}
+	if _, err := w.w.Seek(start, io.SeekStart); err != nil {
+		return err
+	}
+	return syscall.ENOSPC
 }
 
 func encodeFileLogEntry(logentry interface{}) []byte {
@@ -554,15 +699,23 @@ func encodeFileInsert(b *bytes.Buffer, prefix string, txID string, cols []string
 	b.Write(tmp)
 	b.WriteString("\n")
 }
-func (w FileLogfile) Sync() {
-	w.w.Sync()
+func (w FileLogfile) Flush(durable bool) {
+	if durable {
+		if err := w.w.Sync(); err != nil {
+			raisePersistenceFailure("filesystem", w.w.Name(), "log.sync", err)
+		}
+	}
 }
 func (w FileLogfile) Close() {
-	w.w.Close()
+	if err := w.w.Close(); err != nil {
+		raisePersistenceFailure("filesystem", w.w.Name(), "log.close", err)
+	}
 }
 
 func (s *FileStorage) Remove() {
-	os.RemoveAll(s.path)
+	if err := os.RemoveAll(s.path); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.path, "database.remove", err)
+	}
 }
 
 func (s *FileStorage) BackendName() string {

--- a/storage/persistence-s3.go
+++ b/storage/persistence-s3.go
@@ -143,10 +143,11 @@ func (s *S3Storage) ensureOpen() {
 			),
 		))
 	}
+	opts = append(opts, config.WithRetryMaxAttempts(remoteStorageAttempts))
 
 	cfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
-		panic(fmt.Sprintf("S3Storage: failed to load AWS config: %v", err))
+		raisePersistenceFailure(s.BackendName(), s.prefix, "backend.open", err)
 	}
 
 	// Build S3 client options
@@ -181,13 +182,19 @@ func (s *S3Storage) ReadSchema() []byte {
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return nil
+		if s3ObjectMissing(err) {
+			return nil
+		}
+		raisePersistenceFailure(s.BackendName(), s.prefix, "schema.read", err)
 	}
-	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil
+		_ = resp.Body.Close()
+		raisePersistenceFailure(s.BackendName(), s.prefix, "schema.read", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "schema.read.close", err)
 	}
 	return data
 }
@@ -204,7 +211,7 @@ func (s *S3Storage) WriteSchema(schema []byte) {
 		Body:   bytes.NewReader(schema),
 	})
 	if err != nil {
-		panic(fmt.Sprintf("S3Storage: failed to write schema: %v", err))
+		raisePersistenceFailure(s.BackendName(), s.prefix, "schema.write", err)
 	}
 }
 
@@ -217,6 +224,9 @@ func (s *S3Storage) ReadColumn(shard string, column string) io.ReadCloser {
 		Key:    aws.String(key),
 	})
 	if err != nil {
+		if !s3ObjectMissing(err) {
+			raisePersistenceFailure(s.BackendName(), s.prefix, "column.read.open", err)
+		}
 		return ErrorReader{e: err, notFound: s3ObjectMissing(err)}
 	}
 	return resp.Body
@@ -247,7 +257,10 @@ func (w *s3WriteCloser) Close() error {
 		Key:    aws.String(w.key),
 		Body:   bytes.NewReader(w.buf.Bytes()),
 	})
-	return err
+	if err != nil {
+		raisePersistenceFailure(w.s.BackendName(), w.s.prefix, "object.write", err)
+	}
+	return nil
 }
 
 func (s *S3Storage) WriteColumn(shard string, column string) io.WriteCloser {
@@ -259,10 +272,13 @@ func (s *S3Storage) WriteColumn(shard string, column string) io.WriteCloser {
 func (s *S3Storage) RemoveColumn(shard string, column string) {
 	s.ensureOpen()
 	key := s.key(shard + "-" + ProcessColumnName(column))
-	_, _ = s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+	_, err := s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
 		Bucket: aws.String(s.factory.Bucket),
 		Key:    aws.String(key),
 	})
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "column.remove", err)
+	}
 }
 
 func (s *S3Storage) ReadBlob(hash string) io.ReadCloser {
@@ -273,6 +289,9 @@ func (s *S3Storage) ReadBlob(hash string) io.ReadCloser {
 		Key:    aws.String(key),
 	})
 	if err != nil {
+		if !s3ObjectMissing(err) {
+			raisePersistenceFailure(s.BackendName(), s.prefix, "blob.read.open", err)
+		}
 		return ErrorReader{e: err, notFound: s3ObjectMissing(err)}
 	}
 	return resp.Body
@@ -287,13 +306,16 @@ func (s *S3Storage) WriteBlob(hash string) io.WriteCloser {
 func (s *S3Storage) DeleteBlob(hash string) {
 	s.ensureOpen()
 	key := s.key("blob/" + hash)
-	_, _ = s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+	_, err := s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
 		Bucket: aws.String(s.factory.Bucket),
 		Key:    aws.String(key),
 	})
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "blob.delete", err)
+	}
 }
 
-func (s *S3Storage) WalkBlobs(fn func(hash string) error) error {
+func (s *S3Storage) WalkBlobs(fn func(hash string)) {
 	s.ensureOpen()
 	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.factory.Bucket),
@@ -303,19 +325,16 @@ func (s *S3Storage) WalkBlobs(fn func(hash string) error) error {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.Background())
 		if err != nil {
-			return err
+			raisePersistenceFailure(s.BackendName(), s.prefix, "blob.walk", err)
 		}
 		for _, obj := range page.Contents {
 			hash := strings.TrimPrefix(*obj.Key, blobPrefix)
-			if err := fn(hash); err != nil {
-				return err
-			}
+			fn(hash)
 		}
 	}
-	return nil
 }
 
-func (s *S3Storage) WalkShardFiles(fn func(name string) error) error {
+func (s *S3Storage) WalkShardFiles(fn func(name string)) {
 	s.ensureOpen()
 	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.factory.Bucket),
@@ -325,27 +344,27 @@ func (s *S3Storage) WalkShardFiles(fn func(name string) error) error {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.Background())
 		if err != nil {
-			return err
+			raisePersistenceFailure(s.BackendName(), s.prefix, "shard.walk", err)
 		}
 		for _, obj := range page.Contents {
 			name := strings.TrimPrefix(*obj.Key, pfx)
 			if name == "schema.json" || name == "schema.json.old" || strings.HasPrefix(name, "blob/") {
 				continue
 			}
-			if err := fn(name); err != nil {
-				return err
-			}
+			fn(name)
 		}
 	}
-	return nil
 }
 
 func (s *S3Storage) DeleteShardFile(name string) {
 	s.ensureOpen()
-	_, _ = s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+	_, err := s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
 		Bucket: aws.String(s.factory.Bucket),
 		Key:    aws.String(s.key(name)),
 	})
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "shard.delete", err)
+	}
 }
 
 func (s *S3Storage) BackendName() string {
@@ -364,13 +383,15 @@ func (s *S3Storage) Remove() {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.Background())
 		if err != nil {
-			break
+			raisePersistenceFailure(s.BackendName(), s.prefix, "database.remove.list", err)
 		}
 		for _, obj := range page.Contents {
-			_, _ = s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			if _, err := s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
 				Bucket: aws.String(s.factory.Bucket),
 				Key:    obj.Key,
-			})
+			}); err != nil {
+				raisePersistenceFailure(s.BackendName(), s.prefix, "database.remove", err)
+			}
 		}
 	}
 }
@@ -394,7 +415,7 @@ func (s *S3Storage) OpenLog(shard string) PersistenceLogfile {
 	s.ensureOpen()
 	lf, err := openOrCreateS3Logfile(s, shard)
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.open", err)
 	}
 	return lf
 }
@@ -403,7 +424,7 @@ func (s *S3Storage) SwapLog(shard string, entries []interface{}, durable bool) P
 	s.ensureOpen()
 	oldSegments, err := listS3LogSegments(s, shard)
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.swap", err)
 	}
 	var next uint32
 	for _, segment := range oldSegments {
@@ -421,17 +442,19 @@ func (s *S3Storage) SwapLog(shard string, entries []interface{}, durable bool) P
 		Key:    aws.String(key),
 		Body:   bytes.NewReader(body.Bytes()),
 	}); err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.swap", err)
 	}
 	if err := writeS3LogManifest(s, shard, []uint32{next}); err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.swap", err)
 	}
 	for _, segment := range oldSegments {
 		if segment.seg != next {
-			_, _ = s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			if _, err := s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
 				Bucket: aws.String(s.factory.Bucket),
 				Key:    aws.String(segment.key),
-			})
+			}); err != nil {
+				reportPersistenceCleanupFailure(s.BackendName(), s.prefix, "log.swap.cleanup", err)
+			}
 		}
 	}
 	return &S3Logfile{
@@ -450,13 +473,12 @@ func (s *S3Storage) ReplayLog(shard string) (map[string]struct{}, chan interface
 	out := make(chan interface{}, 64)
 	committed := make(map[string]struct{})
 	segments, err := listS3LogSegments(s, shard)
-	if err == nil {
-		hybridsort.Slice(segments, func(i, j int) bool { return segments[i].seg < segments[j].seg })
-		for _, seg := range segments {
-			collectS3LogStreamCommits(s.readLogSegment(seg), committed)
-		}
-	} else {
-		segments = nil
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.replay", err)
+	}
+	hybridsort.Slice(segments, func(i, j int) bool { return segments[i].seg < segments[j].seg })
+	for _, seg := range segments {
+		collectS3LogStreamCommits(s.readLogSegment(seg), committed)
 	}
 
 	go func() {
@@ -468,7 +490,7 @@ func (s *S3Storage) ReplayLog(shard string) (map[string]struct{}, chan interface
 
 	lf, err := openOrCreateS3Logfile(s, shard)
 	if err != nil {
-		panic(err)
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.replay", err)
 	}
 	return committed, out, lf
 }
@@ -479,31 +501,38 @@ func (s *S3Storage) readLogSegment(seg s3LogSegInfo) []byte {
 		Key:    aws.String(seg.key),
 	})
 	if err != nil {
-		return nil
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.read", err)
 	}
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.read", err)
 	}
 	return data
 }
 
 func (s *S3Storage) RemoveLog(shard string) {
 	s.ensureOpen()
-	segments, _ := listS3LogSegments(s, shard)
+	segments, err := listS3LogSegments(s, shard)
+	if err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.remove", err)
+	}
 	for _, seg := range segments {
-		_, _ = s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+		if _, err := s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
 			Bucket: aws.String(s.factory.Bucket),
 			Key:    aws.String(seg.key),
-		})
+		}); err != nil {
+			raisePersistenceFailure(s.BackendName(), s.prefix, "log.remove", err)
+		}
 	}
 	// Also remove manifest
 	manifestKey := s.key(fmt.Sprintf("%s.log.manifest", shard))
-	_, _ = s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+	if _, err := s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
 		Bucket: aws.String(s.factory.Bucket),
 		Key:    aws.String(manifestKey),
-	})
+	}); err != nil {
+		raisePersistenceFailure(s.BackendName(), s.prefix, "log.remove", err)
+	}
 }
 
 type s3LogSegInfo struct {
@@ -722,20 +751,30 @@ func (w *S3Logfile) Write(logentry interface{}) {
 	w.buf.Write(frame)
 
 	if w.buf.Len() >= w.flushEveryBytes {
-		_ = w.flushLocked(false)
+		if err := w.flushLocked(false); err != nil {
+			raisePersistenceFailure(w.s.BackendName(), w.s.prefix, "log.write", err)
+		}
 	}
 }
 
-func (w *S3Logfile) Sync() {
+func (w *S3Logfile) Flush(durable bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	_ = w.flushLocked(true)
+	if err := w.flushLocked(durable); err != nil {
+		operation := "log.flush"
+		if durable {
+			operation = "log.sync"
+		}
+		raisePersistenceFailure(w.s.BackendName(), w.s.prefix, operation, err)
+	}
 }
 
 func (w *S3Logfile) Close() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	_ = w.flushLocked(true)
+	if err := w.flushLocked(true); err != nil {
+		raisePersistenceFailure(w.s.BackendName(), w.s.prefix, "log.close", err)
+	}
 }
 
 func (w *S3Logfile) flushLocked(force bool) error {
@@ -749,13 +788,18 @@ func (w *S3Logfile) flushLocked(force bool) error {
 		next := w.seg + 1
 		nextKey := w.s.key(fmt.Sprintf("%s.log.%08d", w.shard, next))
 
-		segs, _ := listS3LogSegments(w.s, w.shard)
+		segs, err := listS3LogSegments(w.s, w.shard)
+		if err != nil {
+			return err
+		}
 		var all []uint32
 		for _, si := range segs {
 			all = append(all, si.seg)
 		}
 		all = append(all, next)
-		_ = writeS3LogManifest(w.s, w.shard, all)
+		if err := writeS3LogManifest(w.s, w.shard, all); err != nil {
+			return err
+		}
 
 		w.seg = next
 		w.key = nextKey
@@ -770,9 +814,16 @@ func (w *S3Logfile) flushLocked(force bool) error {
 			Bucket: aws.String(w.s.factory.Bucket),
 			Key:    aws.String(w.key),
 		})
-		if err == nil {
-			existing, _ = io.ReadAll(resp.Body)
-			resp.Body.Close()
+		if err != nil {
+			return err
+		}
+		existing, err = io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		if err != nil {
+			return err
+		}
+		if closeErr != nil {
+			return closeErr
 		}
 	}
 

--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -43,7 +43,9 @@ type PersistenceEngine interface {
 	ReadSchema() []byte
 	// WriteSchema must publish one complete schema generation atomically. A
 	// reader may observe either the previous or the new generation, never a
-	// missing, empty, or partial schema. Failures must panic.
+	// missing, empty, or partial schema. Every backend I/O failure must panic
+	// with *PersistenceFailure; absence is represented explicitly by a reader
+	// whose Missing method returns true.
 	WriteSchema(schema []byte)
 	ReadColumn(shard string, column string) io.ReadCloser
 	// WriteColumn returns a generation-private writer. Close must either publish
@@ -55,8 +57,9 @@ type PersistenceEngine interface {
 	WriteBlob(hash string) io.WriteCloser
 	DeleteBlob(hash string)
 	// WalkBlobs calls fn for every blob hash stored on disk, one at a time.
-	// fn may return an error to stop iteration early.
-	WalkBlobs(fn func(hash string) error) error
+	// Backend failures follow the common persistence contract and panic with
+	// *PersistenceFailure.
+	WalkBlobs(fn func(hash string))
 	OpenLog(shard string) PersistenceLogfile // open for writing
 	// SwapLog atomically replaces the visible log with entries and returns an
 	// appendable handle for the replacement. A crash may leave private/orphaned
@@ -70,8 +73,8 @@ type PersistenceEngine interface {
 	RemoveLog(shard string)
 	// WalkShardFiles calls fn for every shard-related file (column files, log files)
 	// stored on disk, one at a time. The name passed to fn is exactly the value
-	// expected by DeleteShardFile. fn may return an error to stop iteration early.
-	WalkShardFiles(fn func(name string) error) error
+	// expected by DeleteShardFile. Backend failures panic with *PersistenceFailure.
+	WalkShardFiles(fn func(name string))
 	// DeleteShardFile deletes a file previously yielded by WalkShardFiles.
 	DeleteShardFile(name string)
 	Remove()             // delete from storage
@@ -80,7 +83,10 @@ type PersistenceEngine interface {
 
 type PersistenceLogfile interface {
 	Write(logentry interface{})
-	Sync()
+	// Flush publishes every accepted frame. durable additionally requests the
+	// backend's strongest durability barrier (fsync for local files). Remote
+	// backends must transmit buffered writes even when durable is false.
+	Flush(durable bool)
 	Close()
 }
 
@@ -93,12 +99,12 @@ func finishColumnWrite(w io.WriteCloser, durable bool) {
 		if syncer, ok := w.(interface{ Sync() error }); ok {
 			if err := syncer.Sync(); err != nil {
 				_ = w.Close()
-				panic(err)
+				raisePersistenceFailure("unknown", "unknown", "column.write.sync", err)
 			}
 		}
 	}
 	if err := w.Close(); err != nil {
-		panic(err)
+		raisePersistenceFailure("unknown", "unknown", "column.write.close", err)
 	}
 }
 

--- a/storage/persistence_failure_test.go
+++ b/storage/persistence_failure_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoteRetryIsBounded(t *testing.T) {
+	want := errors.New("remote unavailable")
+	attempts := 0
+	err := remoteRetry(func() error {
+		attempts++
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("remoteRetry returned %v, want %v", err, want)
+	}
+	if attempts != remoteStorageAttempts {
+		t.Fatalf("remoteRetry made %d attempts, want %d", attempts, remoteStorageAttempts)
+	}
+}
+
+func TestRemoteRetryStopsAfterSuccess(t *testing.T) {
+	attempts := 0
+	err := remoteRetry(func() error {
+		attempts++
+		if attempts < 2 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 {
+		t.Fatalf("remoteRetry made %d attempts, want 2", attempts)
+	}
+}
+
+func TestRemoteRetryValueReturnsSuccessfulAttempt(t *testing.T) {
+	attempts := 0
+	value, err := remoteRetryValue(func() (int, error) {
+		attempts++
+		if attempts < 2 {
+			return 0, errors.New("transient")
+		}
+		return 42, nil
+	})
+	if err != nil || value != 42 || attempts != 2 {
+		t.Fatalf("remoteRetryValue = (%d, %v) after %d attempts", value, err, attempts)
+	}
+}
+
+func TestFaultInjectorRejectsPostPublicationFailure(t *testing.T) {
+	t.Setenv("MEMCP_IO_FAULT_PROBABILITY", "1")
+	t.Setenv("MEMCP_IO_FAULT_PHASE", "after")
+	defer func() {
+		if recover() == nil {
+			t.Fatal("after-publication fault phase was accepted")
+		}
+	}()
+	_ = persistenceFaultInjectorFromEnv("test")
+}
+
+func TestPartialFilesystemWALWriteLeavesNoTornFrame(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "fault-db") + "/"
+	raw := &FileStorage{path: dir}
+	t.Setenv("MEMCP_IO_FAULT_PROBABILITY", "1")
+	t.Setenv("MEMCP_IO_FAULT_OPERATIONS", "log.write")
+	t.Setenv("MEMCP_IO_FAULT_PHASE", "partial")
+	t.Setenv("MEMCP_IO_FAULT_AFTER", "1")
+	t.Setenv("MEMCP_IO_FAULT_LIMIT", "1")
+	logfile := instrumentPersistence("fault-db", raw).OpenLog("shard")
+	logfile.Write(LogEntryDelete{idx: 1})
+
+	func() {
+		defer func() {
+			recovered := recover()
+			if _, ok := recovered.(*PersistenceFailure); !ok {
+				t.Fatalf("partial write panic = %T, want *PersistenceFailure", recovered)
+			}
+		}()
+		logfile.Write(LogEntryDelete{idx: 2})
+	}()
+	logfile.Write(LogEntryDelete{idx: 3})
+	logfile.Close()
+
+	_, entries, replayLog := raw.ReplayLog("shard")
+	var recids []uint32
+	for entry := range entries {
+		if deletion, ok := entry.(LogEntryDelete); ok {
+			recids = append(recids, deletion.idx)
+		}
+	}
+	replayLog.Close()
+	if len(recids) != 2 || recids[0] != 1 || recids[1] != 3 {
+		t.Fatalf("replayed delete recids = %v, want [1 3]", recids)
+	}
+}
+
+func TestFilesystemLogErrorsUsePersistenceFailure(t *testing.T) {
+	raw := &FileStorage{path: filepath.Join(t.TempDir(), "closed-log") + "/"}
+	logfile := raw.OpenLog("shard")
+	logfile.Close()
+	defer func() {
+		if _, ok := recover().(*PersistenceFailure); !ok {
+			t.Fatal("closed WAL write did not panic with *PersistenceFailure")
+		}
+	}()
+	logfile.Write(LogEntryDelete{idx: 1})
+}
+
+func TestFilesystemWalkErrorsUsePersistenceFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "blob"), []byte("not a directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	raw := &FileStorage{path: dir + "/"}
+	for _, walk := range []func(){
+		func() { raw.WalkBlobs(func(string) {}) },
+		func() { (&FileStorage{path: filepath.Join(dir, "missing") + "/"}).WalkShardFiles(func(string) {}) },
+	} {
+		func() {
+			defer func() {
+				if _, ok := recover().(*PersistenceFailure); !ok {
+					t.Fatal("filesystem walk did not panic with *PersistenceFailure")
+				}
+			}()
+			walk()
+		}()
+	}
+}

--- a/storage/persistence_transaction_test.go
+++ b/storage/persistence_transaction_test.go
@@ -44,7 +44,7 @@ func TestFileTransactionalWALRoundTrip(t *testing.T) {
 	logfile.Write(LogEntryDelete{idx: 3, txID: txID})
 	logfile.Write(LogEntryUndelete{idx: 4, txID: txID})
 	logfile.Write(LogEntryCommit{txID: txID})
-	logfile.Sync()
+	logfile.Flush(true)
 	logfile.Close()
 
 	committed, entries, replayLog := engine.ReplayLog("roundtrip")
@@ -126,7 +126,7 @@ func TestFileSwapLogPublishesCompleteReplacement(t *testing.T) {
 	old := engine.OpenLog(transactionLogName)
 	old.Write(LogEntryCommit{txID: "old/1"})
 	old.Write(LogEntryCommit{txID: "old/2"})
-	old.Sync()
+	old.Flush(true)
 
 	replacement := engine.SwapLog(transactionLogName, []interface{}{
 		LogEntryCommit{txID: "retained/1"},
@@ -134,10 +134,10 @@ func TestFileSwapLogPublishesCompleteReplacement(t *testing.T) {
 	// The old descriptor still names the unlinked generation. A late write to
 	// it must not modify the newly published log path.
 	old.Write(LogEntryCommit{txID: "old/late"})
-	old.Sync()
+	old.Flush(true)
 	old.Close()
 	replacement.Write(LogEntryCommit{txID: "new/1"})
-	replacement.Sync()
+	replacement.Flush(true)
 	replacement.Close()
 
 	committed, entries, logfile := engine.ReplayLog(transactionLogName)

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -139,7 +139,7 @@ func (s *storageShard) nextForMaintenanceLocked(deletedRecid *uint32) *storageSh
 // when transaction commit/rollback changes it after the rebuild snapshot. A
 // successor already tracked by the same transaction applies its own masks
 // and must not be locked recursively here. Caller must hold s.mu.Lock().
-func (s *storageShard) syncNextVisibilityLocked(oldRecid uint32, trackedByTx map[*storageShard]struct{}, currentTx *TxContext) {
+func (s *storageShard) syncNextVisibilityLocked(oldRecid uint32, trackedByTx map[*storageShard]struct{}, currentTx *TxContext, persist bool) {
 	current := s
 	currentRecid := oldRecid
 	currentIsSource := true
@@ -165,7 +165,13 @@ func (s *storageShard) syncNextVisibilityLocked(oldRecid uint32, trackedByTx map
 		wasDeleted := next.deletions.Get(uint(newRecid))
 		next.deletions.Set(uint(newRecid), deleted)
 		next.rollbackProtected.Set(uint(newRecid), protected)
-		if wasDeleted != deleted {
+		generation := next.generation.Load()
+		// A transaction may span several completed rebuilds. Intermediate
+		// generations still need their in-memory visibility forwarded so the
+		// RecID translation chain remains valid, but retirement has closed their
+		// WALs. Only the current (or not-yet-published) generation is durable state.
+		persistNext := persist && (generation == nil || !generation.retired.Load())
+		if persistNext && wasDeleted != deleted {
 			txID := ""
 			if currentTx != nil {
 				txID = currentTx.durableID()
@@ -1317,6 +1323,10 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 					// Cursor-stability / no-tx: existing behavior
 					if currentTx != nil {
 						t.rollbackProtected.Set(uint(targetIdx), true)
+						// Register undo state before WAL I/O. A storage panic must
+						// be able to reverse every mutation already made in memory.
+						currentTx.LogDelete(t, targetIdx)
+						currentTx.LogInsert(t, newRecid)
 					}
 					if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
 						txID := ""
@@ -1333,18 +1343,8 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 			if result && dualWriteRow != nil {
 				t.t.dualWriteInsertFromOld(t, newRecid, dualWriteCols, dualWriteRow, currentTx)
 			}
-			// Transaction bookkeeping. The owning MapReducer registers this shard
-			// once on Close, and only when at least one callback mutated it.
-			if result {
-				if tx := currentTx; tx != nil {
-					switch tx.Mode {
-					case TxCursorStability:
-						tx.LogDelete(t, targetIdx)
-						tx.LogInsert(t, newRecid)
-					}
-				} else if t.t.PersistencyMode == Safe && t.logfile != nil {
-					defer t.logfile.Sync()
-				}
+			if result && currentTx == nil && t.t.PersistencyMode == Safe && t.logfile != nil {
+				defer t.logfile.Flush(true)
 			}
 			if withTrigger && triggerOldRow != nil {
 				if alreadyLocked {
@@ -1426,6 +1426,7 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 					t.deletions.Set(uint(idx), true) // mark as deleted
 					if currentTx != nil {
 						t.rollbackProtected.Set(uint(idx), true)
+						currentTx.LogDelete(t, idx)
 					}
 					if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
 						txID := ""
@@ -1438,10 +1439,8 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 					result = true
 				}()
 				// deferred sync (shard already registered via OpenMapReducer)
-				if tx != nil {
-					tx.LogDelete(t, idx)
-				} else if t.t.PersistencyMode == Safe && t.logfile != nil {
-					defer t.logfile.Sync()
+				if tx == nil && t.t.PersistencyMode == Safe && t.logfile != nil {
+					defer t.logfile.Flush(true)
 				}
 			}
 			if withTrigger && triggerDeletedRow != nil {
@@ -2557,6 +2556,25 @@ func (t *storageShard) insertPreparedLocked(columns []string, values [][]scm.Scm
 	if needMaterializedRows {
 		payloadCols, payloadVals = t.materializedInsertedRowsLocked(firstNewInsertIdx)
 	}
+	// Register visibility and undo state before WAL I/O. Persistence failures
+	// panic, and the transaction rollback must already know every inserted row.
+	if tx := currentTx; tx != nil {
+		switch tx.Mode {
+		case TxACID:
+			for i := range values {
+				recid := firstNewRecid + uint32(i)
+				t.deletions.Set(uint(recid), true)
+				t.rollbackProtected.Set(uint(recid), true)
+				tx.AddToUndeleteMask(t, recid)
+			}
+			tx.RegisterTouchedShard(t)
+		case TxCursorStability:
+			for i := range values {
+				tx.LogInsert(t, firstNewRecid+uint32(i))
+			}
+			tx.RegisterTouchedShard(t)
+		}
+	}
 	if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
 		// Log the actual inserted rows (not the original columns/values) so that
 		// auto-incremented IDs and column defaults are preserved across restarts.
@@ -2580,27 +2598,8 @@ func (t *storageShard) insertPreparedLocked(columns []string, values [][]scm.Scm
 			t.t.dualWriteInsertFromOld(t, firstNewRecid, payloadCols, payloadVals, currentTx)
 		}
 	}
-	// transaction bookkeeping
-	if tx := currentTx; tx != nil {
-		switch tx.Mode {
-		case TxACID:
-			// ACID: hide rows globally, add to undelete mask so this tx can see them
-			for i := range values {
-				recid := firstNewRecid + uint32(i)
-				t.deletions.Set(uint(recid), true)
-				t.rollbackProtected.Set(uint(recid), true)
-				tx.AddToUndeleteMask(t, recid)
-			}
-			tx.RegisterTouchedShard(t)
-		case TxCursorStability:
-			// Cursor-stability: log inserts for undo on rollback
-			for i := range values {
-				tx.LogInsert(t, firstNewRecid+uint32(i))
-			}
-			tx.RegisterTouchedShard(t)
-		}
-	} else if t.t.PersistencyMode == Safe && t.logfile != nil {
-		t.logfile.Sync() // write barrier; no tx means immediate sync
+	if currentTx == nil && t.t.PersistencyMode == Safe && t.logfile != nil {
+		t.logfile.Flush(true) // write barrier; no tx means immediate sync
 	}
 	// execute AFTER INSERT triggers outside the shard write lock, matching the
 	// AFTER UPDATE/DELETE paths and avoiding lock inversion with computed-column

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -1889,8 +1889,15 @@ func TestRepartitionPostFlipUpdateDoesNotDuplicateRow(t *testing.T) {
 	}()
 	<-blocking.entered
 
+	topology := tbl.pinActiveTopology()
+	topologyReleased := false
+	defer func() {
+		if !topologyReleased {
+			topology.releaseOperation()
+		}
+	}()
 	var target *storageShard
-	for _, shard := range tbl.ActiveShards() {
+	for _, shard := range topology.shards {
 		if shard.Count() > 0 {
 			target = shard
 			break
@@ -1914,6 +1921,12 @@ func TestRepartitionPostFlipUpdateDoesNotDuplicateRow(t *testing.T) {
 	if !<-updateDone {
 		t.Fatal("post-publication update did not change the row")
 	}
+	topology.releaseOperation()
+	topologyReleased = true
+	// Releasing the final operation pin starts asynchronous retirement. Wait
+	// until its pending mutations have been applied before counting rows.
+	tbl.maintenanceMu.Lock()
+	tbl.maintenanceMu.Unlock()
 
 	if got := tbl.Count(); got != rows {
 		t.Fatalf("repartition count after post-flip update = %d, want %d", got, rows)

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -22,6 +22,7 @@ import "fmt"
 import "github.com/carli2/hybridsort"
 import "runtime"
 import "strconv"
+import "strings"
 import "sync"
 import "sync/atomic"
 
@@ -455,8 +456,10 @@ func (tx *TxContext) RegisterTouchedShard(shard *storageShard) {
 	tx.touchedShards.Store(shard, true)
 }
 
-// SyncTouchedShards flushes all pending log writes to durable storage.
-func (tx *TxContext) SyncTouchedShards() {
+// SyncTouchedShards flushes all pending log writes to durable storage. Only a
+// standardized persistence panic is converted to an error; programmer panics
+// keep their original crash semantics.
+func (tx *TxContext) SyncTouchedShards() error {
 	type databaseCommit struct {
 		db      *database
 		durable bool
@@ -476,22 +479,38 @@ func (tx *TxContext) SyncTouchedShards() {
 		// The common OLTP case needs no coordinator fsync: the commit marker and
 		// its mutations share one WAL and become durable through one barrier.
 		shard := shards[0]
-		shard.logfile.Write(LogEntryCommit{txID: tx.durableID()})
-		if shard.t.PersistencyMode == Safe {
-			shard.logfile.Sync()
+		durable := shard.t.PersistencyMode == Safe
+		if err := persistenceCall(func() { shard.logfile.Write(LogEntryCommit{txID: tx.durableID()}) }); err != nil {
+			return err
+		}
+		if err := persistenceCall(func() { shard.logfile.Flush(durable) }); err != nil {
+			tx.touchedShards = sync.Map{}
+			return markCommitOutcomeUnknown(err)
 		}
 		tx.touchedShards = sync.Map{}
-		return
+		return nil
 	}
 	for _, shard := range shards {
-		if shard.t.PersistencyMode == Safe && shard.logfile != nil {
-			shard.logfile.Sync()
+		if shard.logfile != nil {
+			durable := shard.t.PersistencyMode == Safe
+			if err := persistenceCall(func() { shard.logfile.Flush(durable) }); err != nil {
+				return err
+			}
 		}
 	}
+	authorityPublished := false
 	for _, commit := range databases {
-		commit.db.commitTransaction(tx.durableID(), commit.durable)
+		if err := commit.db.commitTransaction(tx.durableID(), commit.durable); err != nil {
+			tx.touchedShards = sync.Map{}
+			if authorityPublished {
+				return markCommitOutcomeUnknown(err)
+			}
+			return err
+		}
+		authorityPublished = true
 	}
 	tx.touchedShards = sync.Map{}
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -573,7 +592,7 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 				if shard.logfile != nil {
 					shard.logfile.Write(LogEntryDelete{idx: recid, txID: tx.durableID()})
 				}
-				shard.syncNextVisibilityLocked(recid, trackedShards, tx)
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx, true)
 				shard.mu.Unlock()
 			}
 			st.InsertRecids = st.InsertRecids[:lens.InsertLen]
@@ -585,7 +604,7 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 				shard.deletions.Set(uint(recid), false)
 				shard.logVisibilityChangeLocked(recid, false, tx.durableID())
 				shard.rollbackProtected.Set(uint(recid), false)
-				shard.syncNextVisibilityLocked(recid, trackedShards, tx)
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx, true)
 				shard.mu.Unlock()
 			}
 			st.DeletedRecids = st.DeletedRecids[:lens.DeletedLen]
@@ -606,7 +625,7 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 				}
 				shard.deletions.Set(uint(recid), true)
 				shard.rollbackProtected.Set(uint(recid), false)
-				shard.syncNextVisibilityLocked(recid, trackedShards, tx)
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx, true)
 				if !ownsShardWrite {
 					shard.mu.Unlock()
 				}
@@ -615,7 +634,7 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 		}
 		st.mu.Unlock()
 		if tx.Mode == TxCursorStability && shard.t.PersistencyMode == Safe && shard.logfile != nil {
-			shard.logfile.Sync()
+			shard.logfile.Flush(true)
 		}
 	}
 }
@@ -630,24 +649,36 @@ func (tx *TxContext) Commit() error {
 	case TxCursorStability:
 		tx.mu.Lock()
 		trackedShards := tx.trackedShardSetLocked()
+		var propagationErr error
 		for shard, st := range tx.shards {
 			st.mu.Lock()
 			shard.mu.Lock()
-			for _, recid := range st.DeletedRecids {
-				shard.rollbackProtected.Set(uint(recid), false)
-				shard.syncNextVisibilityLocked(recid, trackedShards, tx)
-			}
+			propagationErr = persistenceCall(func() {
+				for _, recid := range st.DeletedRecids {
+					shard.rollbackProtected.Set(uint(recid), false)
+					shard.syncNextVisibilityLocked(recid, trackedShards, tx, true)
+				}
+			})
 			shard.mu.Unlock()
 			st.mu.Unlock()
+			if propagationErr != nil {
+				break
+			}
 		}
 		tx.mu.Unlock()
-		tx.finishRepartitionActions(true)
-		tx.mu.Lock()
-		tx.releaseActiveTransactionsLocked()
-		tx.State = TxCommitted
-		tx.shards = nil
-		tx.mu.Unlock()
-		tx.SyncTouchedShards()
+		if propagationErr != nil {
+			tx.rollbackCursorStability(false)
+			return propagationErr
+		}
+		if err := tx.SyncTouchedShards(); err != nil {
+			if commitOutcomeUnknown(err) {
+				tx.finishCursorStabilityCommit()
+			} else {
+				tx.rollbackCursorStability(false)
+			}
+			return err
+		}
+		tx.finishCursorStabilityCommit()
 	case TxACID:
 		if err := tx.commitACID(); err != nil {
 			return err
@@ -699,38 +730,60 @@ func (tx *TxContext) commitACID() error {
 		}
 	}
 
-	// Apply DeleteMask → set global deletions + write log
-	for _, shard := range shards {
-		st := tx.shards[shard]
-		for _, recid := range st.DeleteRecids {
-			if !st.DeleteMask.Get(uint(recid)) {
-				continue
+	applyErr := persistenceCall(func() {
+		// Apply DeleteMask → set global deletions + write log.
+		for _, shard := range shards {
+			st := tx.shards[shard]
+			for _, recid := range st.DeleteRecids {
+				if !st.DeleteMask.Get(uint(recid)) {
+					continue
+				}
+				shard.deletions.Set(uint(recid), true)
+				if shard.logfile != nil {
+					shard.logfile.Write(LogEntryDelete{idx: recid, txID: tx.durableID()})
+				}
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx, true)
 			}
-			shard.deletions.Set(uint(recid), true)
-			if shard.logfile != nil {
-				shard.logfile.Write(LogEntryDelete{idx: recid, txID: tx.durableID()})
-			}
-			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 		}
-	}
-	// Apply UndeleteMask → clear global deletions (make staged rows visible)
-	for _, shard := range shards {
-		st := tx.shards[shard]
-		for _, recid := range st.UndeleteRecids {
-			if !st.UndeleteMask.Get(uint(recid)) {
-				continue // un-staged (row overwritten/deleted in same tx)
+		// Apply UndeleteMask → clear global deletions (make staged rows visible).
+		for _, shard := range shards {
+			st := tx.shards[shard]
+			for _, recid := range st.UndeleteRecids {
+				if !st.UndeleteMask.Get(uint(recid)) {
+					continue // un-staged (row overwritten/deleted in same tx)
+				}
+				shard.deletions.Set(uint(recid), false)
+				shard.rollbackProtected.Set(uint(recid), false)
+				shard.logVisibilityChangeLocked(recid, false, tx.durableID())
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx, true)
 			}
-			shard.deletions.Set(uint(recid), false)
-			shard.rollbackProtected.Set(uint(recid), false)
-			shard.logVisibilityChangeLocked(recid, false, tx.durableID())
-			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
 		}
+	})
+	if applyErr != nil {
+		tx.abortACIDCommit(shards, trackedShards)
+		return applyErr
 	}
 
 	// Keep every touched shard locked until the commit authority is durable.
 	// Readers can therefore observe neither a pre-sync transaction nor a state
 	// that crash recovery would still discard.
-	tx.SyncTouchedShards()
+	if err := tx.SyncTouchedShards(); err != nil {
+		if commitOutcomeUnknown(err) {
+			atomic.AddUint64(&GlobalCommitEpoch, 1)
+			for _, shard := range shards {
+				shard.mu.Unlock()
+			}
+			tx.finishRepartitionActions(true)
+			tx.mu.Lock()
+			tx.releaseActiveTransactionsLocked()
+			tx.State = TxCommitted
+			tx.shards = nil
+			tx.mu.Unlock()
+			return err
+		}
+		tx.abortACIDCommit(shards, trackedShards)
+		return err
+	}
 	atomic.AddUint64(&GlobalCommitEpoch, 1)
 
 	for _, s := range shards {
@@ -747,6 +800,46 @@ func (tx *TxContext) commitACID() error {
 	return nil
 }
 
+// abortACIDCommit restores visibility after a definite pre-authority failure.
+// Every shard in shards must be write-locked by the caller.
+func (tx *TxContext) abortACIDCommit(shards []*storageShard, trackedShards map[*storageShard]struct{}) {
+	for _, shard := range shards {
+		st := tx.shards[shard]
+		for _, recid := range st.DeleteRecids {
+			if st.DeleteMask.Get(uint(recid)) {
+				shard.deletions.Set(uint(recid), false)
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx, false)
+			}
+		}
+		for _, recid := range st.UndeleteRecids {
+			if st.UndeleteMask.Get(uint(recid)) {
+				shard.deletions.Set(uint(recid), true)
+				shard.rollbackProtected.Set(uint(recid), false)
+				shard.syncNextVisibilityLocked(recid, trackedShards, tx, false)
+			}
+		}
+	}
+	for _, shard := range shards {
+		shard.mu.Unlock()
+	}
+	tx.finishRepartitionActions(false)
+	tx.mu.Lock()
+	tx.releaseActiveTransactionsLocked()
+	tx.State = TxAborted
+	tx.shards = nil
+	tx.mu.Unlock()
+	tx.touchedShards = sync.Map{}
+}
+
+func (tx *TxContext) finishCursorStabilityCommit() {
+	tx.finishRepartitionActions(true)
+	tx.mu.Lock()
+	tx.releaseActiveTransactionsLocked()
+	tx.State = TxCommitted
+	tx.shards = nil
+	tx.mu.Unlock()
+}
+
 // ---------------------------------------------------------------------------
 // Rollback
 // ---------------------------------------------------------------------------
@@ -755,14 +848,14 @@ func (tx *TxContext) commitACID() error {
 func (tx *TxContext) Rollback() {
 	switch tx.Mode {
 	case TxCursorStability:
-		tx.rollbackCursorStability()
+		tx.rollbackCursorStability(true)
 	case TxACID:
 		tx.rollbackACID()
 	}
 }
 
 // rollbackCursorStability replays undo masks in reverse to restore global state.
-func (tx *TxContext) rollbackCursorStability() {
+func (tx *TxContext) rollbackCursorStability(persist bool) {
 	tx.mu.Lock()
 	trackedShards := tx.trackedShardSetLocked()
 	for shard, st := range tx.shards {
@@ -772,10 +865,10 @@ func (tx *TxContext) rollbackCursorStability() {
 			recid := st.InsertRecids[i]
 			shard.mu.Lock()
 			shard.deletions.Set(uint(recid), true)
-			if shard.logfile != nil {
+			if persist && shard.logfile != nil {
 				shard.logfile.Write(LogEntryDelete{idx: recid, txID: tx.durableID()})
 			}
-			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
+			shard.syncNextVisibilityLocked(recid, trackedShards, tx, persist)
 			shard.mu.Unlock()
 		}
 		// Undo deletes (reverse order): restore global visibility
@@ -783,14 +876,16 @@ func (tx *TxContext) rollbackCursorStability() {
 			recid := st.DeletedRecids[i]
 			shard.mu.Lock()
 			shard.deletions.Set(uint(recid), false)
-			shard.logVisibilityChangeLocked(recid, false, tx.durableID())
+			if persist {
+				shard.logVisibilityChangeLocked(recid, false, tx.durableID())
+			}
 			shard.rollbackProtected.Set(uint(recid), false)
-			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
+			shard.syncNextVisibilityLocked(recid, trackedShards, tx, persist)
 			shard.mu.Unlock()
 		}
 		st.mu.Unlock()
-		if shard.t.PersistencyMode == Safe && shard.logfile != nil {
-			shard.logfile.Sync()
+		if persist && shard.t.PersistencyMode == Safe && shard.logfile != nil {
+			shard.logfile.Flush(true)
 		}
 	}
 	tx.repartitionDeletes = nil
@@ -811,7 +906,7 @@ func (tx *TxContext) rollbackACID() {
 		shard.mu.Lock()
 		for _, recid := range st.UndeleteRecids {
 			shard.rollbackProtected.Set(uint(recid), false)
-			shard.syncNextVisibilityLocked(recid, trackedShards, tx)
+			shard.syncNextVisibilityLocked(recid, trackedShards, tx, false)
 		}
 		shard.mu.Unlock()
 		st.mu.Unlock()
@@ -875,14 +970,16 @@ func WithAutocommit(session scm.Scmer, ss *scm.SessionState, querySeq uint64, qu
 	tx.beginQuery(ss, querySeq, query)
 	defer tx.endQuery(querySeq)
 	txValue := scm.NewAny(tx)
-
-	if !sessionFn(scm.NewString("transaction")).IsNil() {
-		return scm.Apply(fn, txValue)
+	explicit := !sessionFn(scm.NewString("transaction")).IsNil()
+	if explicit && tx.State != TxActive && !strings.EqualFold(strings.TrimSpace(query), "ROLLBACK") {
+		panic("transaction is aborted; ROLLBACK required")
 	}
 
-	tx.reset(TxCursorStability)
-	tx.autoCommit = true
-	tx.Session = session
+	if !explicit {
+		tx.reset(TxCursorStability)
+		tx.autoCommit = true
+		tx.Session = session
+	}
 
 	var result scm.Scmer
 	var panicVal any
@@ -901,11 +998,22 @@ func WithAutocommit(session scm.Scmer, ss *scm.SessionState, querySeq uint64, qu
 
 	if panicVal != nil {
 		if tx.State == TxActive {
-			tx.Rollback()
+			if _, persistenceFailure := panicVal.(*PersistenceFailure); persistenceFailure {
+				if tx.Mode == TxCursorStability {
+					tx.rollbackCursorStability(false)
+				} else {
+					tx.rollbackACID()
+				}
+			} else {
+				tx.Rollback()
+			}
 		}
 		panic(panicVal)
 	}
 
+	// BEGIN installs the explicit marker while fn is running. Re-read it here
+	// so the BEGIN statement itself does not immediately autocommit the newly
+	// created transaction.
 	if !sessionFn(scm.NewString("transaction")).IsNil() {
 		return result
 	}

--- a/tools/reliability-drill.md
+++ b/tools/reliability-drill.md
@@ -20,6 +20,23 @@ For a longer concurrent write/rebuild workload:
 python3 tools/reliability_drill.py --mode all --workers 12 --operations 1000
 ```
 
+To inject a partial WAL write and a failed WAL sync, verify that both
+transactions fail, retry the writes, and crash-recover the exact result:
+
+```sh
+python3 tools/reliability_drill.py --mode io-failures
+```
+
+The server-side injector is enabled only when
+`MEMCP_IO_FAULT_PROBABILITY` is set. Tests can scope it with
+`MEMCP_IO_FAULT_DATABASE`, select comma-separated operations with
+`MEMCP_IO_FAULT_OPERATIONS`, reproduce the random sequence with
+`MEMCP_IO_FAULT_SEED`, skip matching calls with `MEMCP_IO_FAULT_AFTER`, and
+bound injections with `MEMCP_IO_FAULT_LIMIT`. `MEMCP_IO_FAULT_PHASE` accepts
+`before` or `partial`. Partial stream and WAL failures execute a real prefix
+write before raising the standard persistence panic; an unsafe synthetic
+post-publication failure is deliberately not offered.
+
 Use `--rebuild-crashes N` to change the default five randomized
 rebuild/kill/recovery rounds. Record `--seed` from the manifest to replay their
 delays exactly.
@@ -53,6 +70,9 @@ The current drill covers:
 - statement rollback when a trigger fails partway through a multi-row insert;
 - a hard kill racing a rebuild and publication of its replacement shards;
 - concurrent disjoint writers and rebuilds followed by another hard kill;
+- deterministic partial-write failures in autocommit and explicit transactions,
+  aborted-transaction enforcement, sync failures, successful retries, and exact
+  crash recovery;
 - graceful offline snapshot, restore into a separate data directory, and
   checksum comparison.
 

--- a/tools/reliability_drill.py
+++ b/tools/reliability_drill.py
@@ -110,7 +110,7 @@ class OwnedServer:
 		self.log_handle = None
 		self.client: HttpClient | None = None
 
-	def start(self) -> HttpClient:
+	def start(self, extra_env: dict[str, str] | None = None) -> HttpClient:
 		if self.process is not None:
 			raise DrillFailure("refusing to start a second process under one server owner")
 		self.generation += 1
@@ -123,10 +123,13 @@ class OwnedServer:
 			f"--api-port={api_port}", f"--mysql-port={mysql_port}",
 			"--disable-mysql", "--no-repl", str(self.app),
 		]
+		environment = os.environ.copy()
+		if extra_env:
+			environment.update(extra_env)
 		self.process = subprocess.Popen(
 			command, cwd=ROOT, stdin=subprocess.DEVNULL,
 			stdout=self.log_handle, stderr=subprocess.STDOUT,
-			start_new_session=True,
+			start_new_session=True, env=environment,
 		)
 		self.client = HttpClient(api_port, self.timeout)
 		deadline = time.monotonic() + self.timeout
@@ -326,6 +329,96 @@ def run_commit_crash(server: OwnedServer, rows: int, rounds: int,
 		committed_x = classify_atomic_signature(observed, rows, committed_x)
 
 
+def io_fault_environment(operation: str, phase: str, seed: int) -> dict[str, str]:
+	return {
+		"MEMCP_IO_FAULT_PROBABILITY": "1",
+		"MEMCP_IO_FAULT_SEED": str(seed),
+		"MEMCP_IO_FAULT_OPERATIONS": operation,
+		"MEMCP_IO_FAULT_PHASE": phase,
+		"MEMCP_IO_FAULT_LIMIT": "1",
+		"MEMCP_IO_FAULT_DATABASE": DATABASE,
+	}
+
+
+def expect_write_failure(client: HttpClient, statement: str,
+		session: str | None, context: str) -> None:
+	try:
+		client.sql(statement, session=session, timeout=300)
+	except DrillFailure:
+		return
+	raise DrillFailure(f"{context} unexpectedly succeeded")
+
+
+def run_io_failures(server: OwnedServer, rows: int, seed: int,
+		journal: list[dict]) -> None:
+	want_zero = {"row_count": rows, "min_x": 0, "max_x": 0, "x_sum": 0}
+	want_one = {"row_count": rows, "min_x": 1, "max_x": 1, "x_sum": rows}
+	want_two = {"row_count": rows, "min_x": 2, "max_x": 2, "x_sum": rows * 2}
+
+	server.stop()
+	client = server.start(io_fault_environment("log.write", "partial", seed))
+	session = "drill-explicit-write-failure"
+	client.sql("START ACID TRANSACTION", session=session)
+	expect_write_failure(
+		client, "UPDATE drill_atomic SET x = x + 1", session,
+		"partially written explicit transaction",
+	)
+	expect(atomic_signature(client), want_zero, "failed explicit transaction changed visible rows")
+	expect_write_failure(
+		client, "UPDATE drill_atomic SET x = x + 1", session,
+		"write in aborted explicit transaction",
+	)
+	client.sql("ROLLBACK", session=session)
+	# The database itself has no sticky failure mode. Once the failed
+	# transaction is acknowledged, a fresh write retries storage immediately.
+	client.sql("UPDATE drill_atomic SET x = x + 1", session=session, timeout=300)
+	expect(atomic_signature(client), want_one, "write did not recover after explicit rollback")
+	client.sql("UPDATE drill_atomic SET x = x - 1", session=session, timeout=300)
+	expect(atomic_signature(client), want_zero, "explicit failure retry cleanup failed")
+	journal.append({
+		"scenario": "explicit-partial-log-write-failure", "seed": seed,
+		"expected_after_failure": want_zero, "expected_after_retry": want_one,
+	})
+
+	server.stop()
+	client = server.start(io_fault_environment("log.write", "partial", seed))
+	expect_write_failure(
+		client, "UPDATE drill_atomic SET x = x + 1", None,
+		"partially written autocommit transaction",
+	)
+	expect(atomic_signature(client), want_zero, "partial WAL failure changed visible rows")
+	client.sql("UPDATE drill_atomic SET x = x + 1", timeout=300)
+	expect(atomic_signature(client), want_one, "write did not recover after one injected failure")
+	journal.append({
+		"scenario": "partial-log-write-failure", "seed": seed,
+		"expected_after_failure": want_zero, "expected_after_retry": want_one,
+	})
+	server.kill()
+	client = server.start()
+	expect(atomic_signature(client), want_one, "partial WAL failure corrupted crash recovery")
+
+	server.stop()
+	client = server.start(io_fault_environment("log.sync", "before", seed + 1))
+	session = "drill-sync-failure"
+	client.sql("START ACID TRANSACTION", session=session)
+	client.sql("UPDATE drill_atomic SET x = x + 1", session=session, timeout=300)
+	expect_write_failure(client, "COMMIT", session, "failed multi-shard sync")
+	expect(atomic_signature(client), want_one, "failed commit changed visible rows")
+
+	retry_session = "drill-sync-retry"
+	client.sql("START ACID TRANSACTION", session=retry_session)
+	client.sql("UPDATE drill_atomic SET x = x + 1", session=retry_session, timeout=300)
+	client.sql("COMMIT", session=retry_session, timeout=300)
+	expect(atomic_signature(client), want_two, "commit did not recover after sync failure")
+	journal.append({
+		"scenario": "log-sync-failure", "seed": seed + 1,
+		"expected_after_failure": want_one, "expected_after_retry": want_two,
+	})
+	server.kill()
+	client = server.start()
+	expect(atomic_signature(client), want_two, "failed sync corrupted crash recovery")
+
+
 def run_committed_crash(server: OwnedServer, journal: list[dict]) -> dict[str, int]:
 	client = server.client
 	assert client is not None
@@ -510,7 +603,7 @@ def parse_args() -> argparse.Namespace:
 	parser.add_argument("--app", type=Path, default=ROOT / "lib/main.scm")
 	parser.add_argument("--artifacts", type=Path, help="new directory for data, logs, journal, and restore snapshot")
 	parser.add_argument("--seed", type=int, default=random.SystemRandom().randrange(2**63))
-	parser.add_argument("--mode", choices=("atomicity", "crash", "soak", "restore", "all"), default="all")
+	parser.add_argument("--mode", choices=("atomicity", "io-failures", "crash", "soak", "restore", "all"), default="all")
 	parser.add_argument("--workers", type=int, default=4)
 	parser.add_argument("--operations", type=int, default=25, help="rows written by each soak worker")
 	parser.add_argument("--rebuild-crashes", type=int, default=5,
@@ -519,6 +612,8 @@ def parse_args() -> argparse.Namespace:
 		help="number of ACID COMMIT/kill/recovery races in atomicity mode")
 	parser.add_argument("--atomicity-rows", type=int, default=100000,
 		help="rows updated across ShardSize=100 shards in atomicity mode")
+	parser.add_argument("--io-failure-rows", type=int, default=300,
+		help="rows updated across ShardSize=100 shards in I/O failure mode")
 	parser.add_argument("--timeout", type=float, default=30)
 	return parser.parse_args()
 
@@ -526,7 +621,8 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
 	args = parse_args()
 	if (args.workers < 1 or args.operations < 1 or args.rebuild_crashes < 1 or
-			args.commit_crashes < 1 or args.atomicity_rows < 1 or args.timeout <= 0):
+			args.commit_crashes < 1 or args.atomicity_rows < 1 or
+			args.io_failure_rows < 1 or args.timeout <= 0):
 		raise DrillFailure("workers, operations, crash rounds, row counts, and timeout must be positive")
 	binary = args.binary.expanduser().resolve()
 	app = args.app.expanduser().resolve()
@@ -549,6 +645,12 @@ def main() -> int:
 		if args.mode == "atomicity":
 			initialize_atomicity(client, args.atomicity_rows)
 			run_commit_crash(server, args.atomicity_rows, args.commit_crashes, rng, journal)
+			write_manifest(manifest, args.seed, "passed", journal)
+			print(f"PASS: {len(journal)} reliability scenarios; manifest: {manifest}")
+			return 0
+		if args.mode == "io-failures":
+			initialize_atomicity(client, args.io_failure_rows)
+			run_io_failures(server, args.io_failure_rows, args.seed, journal)
 			write_manifest(manifest, args.seed, "passed", journal)
 			print(f"PASS: {len(journal)} reliability scenarios; manifest: {manifest}")
 			return 0

--- a/tools/test_reliability_drill.py
+++ b/tools/test_reliability_drill.py
@@ -39,6 +39,15 @@ class ReliabilityDrillTests(unittest.TestCase):
 		with self.assertRaises(drill.DrillFailure):
 			drill.expect({"count": 2}, {"count": 3}, "recovery")
 
+	def test_io_fault_environment_is_reproducible_and_scoped(self) -> None:
+		environment = drill.io_fault_environment("log.write", "partial", 42)
+		self.assertEqual(environment["MEMCP_IO_FAULT_PROBABILITY"], "1")
+		self.assertEqual(environment["MEMCP_IO_FAULT_SEED"], "42")
+		self.assertEqual(environment["MEMCP_IO_FAULT_OPERATIONS"], "log.write")
+		self.assertEqual(environment["MEMCP_IO_FAULT_PHASE"], "partial")
+		self.assertEqual(environment["MEMCP_IO_FAULT_LIMIT"], "1")
+		self.assertEqual(environment["MEMCP_IO_FAULT_DATABASE"], drill.DATABASE)
+
 	def test_atomicity_oracle_accepts_only_complete_generations(self) -> None:
 		self.assertEqual(drill.classify_atomic_signature({
 			"row_count": 100, "min_x": 4, "max_x": 4, "x_sum": 400,


### PR DESCRIPTION
## Summary

- add deterministic, environment-scoped persistence fault injection for before-call and real partial stream/WAL writes
- standardize backend I/O failures as `*PersistenceFailure` and log them directly to stderr without depending on `system_statistic.errors`
- roll back definite pre-authority failures in memory without issuing more failing I/O, and keep explicit transactions aborted until `ROLLBACK`
- distinguish failed post-authority durability barriers as commit-outcome-unknown instead of performing an unsafe in-memory rollback
- bound S3 SDK attempts and Ceph retries to three attempts
- replace the WAL `Sync()` contract with `Flush(durable bool)`, so `logged` S3/Ceph transactions transmit buffered WAL data without forcing local-filesystem fsync semantics
- make filesystem WAL frame writes recover their prior offset and length after short/partial writes

The common single-shard commit path still performs one flush/durability barrier, not two. Multi-shard commits retain the required prepare barriers before publishing coordinator authority.

## Reliability drill

The opt-in `tools/reliability_drill.py --mode io-failures` suite was added test-first. On the baseline, the partial-WAL scenario failed because the transaction incorrectly returned success. During implementation it also exposed a one-row in-memory rollback leak and an explicit transaction that accepted later statements after being aborted; both are now covered.

Final deterministic run (`--io-failure-rows 201 --seed 42`) passed three scenarios:

1. partial WAL failure in an explicit ACID transaction, aborted-state enforcement, `ROLLBACK`, and successful retry
2. partial WAL failure in autocommit, exact rollback, successful retry, and crash recovery
3. failed pre-authority sync for a multi-shard ACID update, exact rollback, successful retry, and crash recovery

## Local validation

- `go test ./storage ./scm`
- `go test -tags ceph ./storage`
- `python3 -m unittest tools/test_reliability_drill.py`
- `go build -o memcp .`
- `python3 tools/reliability_drill.py --mode io-failures --io-failure-rows 201 --seed 42 --artifacts .reliability-final`

The full repository suite is intentionally delegated to CI per the repository policy.

## Remaining policy decision

A failure after commit authority has been accepted cannot honestly be reported as a definite rollback: an fsync timeout or remote response loss may still leave the marker durable. This PR reports that case as `commit outcome unknown` and preserves committed in-memory visibility to avoid immediate memory/recovery divergence. A later design can add an isolated SCM critical-event hook; it should be asynchronous, bounded, time-limited, independent of database persistence, and unable to alter commit semantics.

## Performance A/B

CI compared the final candidate against the exact PR base with identical fixtures and runner settings. The previously variable cold aggregate-pushdown case measured 85.070 ms -> 85.375 ms (+0.4%); its warm counterpart measured 5.278 ms -> 5.196 ms (-1.6%). The complete Performance A/B job passed.
