### PR TITLE
Add a noncritical SPARQL 1.1 conformance matrix

### DIFF
--- a/tests/rdf/SPARQL11-COVERAGE.md
+++ b/tests/rdf/SPARQL11-COVERAGE.md
@@ -1,0 +1,66 @@
+# SPARQL 1.1 conformance inventory
+
+Copyright (C) 2026 Carl-Philip Hänsch
+
+This directory treats the stable SPARQL 1.1 W3C Recommendations and the RDF
+1.1/Turtle term model required by them as the conformance target. SPARQL 1.2 is
+still a draft and is deliberately not mixed into this baseline.
+
+Every test introduced by the full-spec inventory is explicitly marked
+`noncritical: true`. A passing noncritical case describes capability already
+present; a failing noncritical case is an implementation candidate. Once a
+feature is selected and implemented, its cases should become critical in that
+feature PR.
+
+## Executable coverage
+
+| Recommendation area | Executable suites |
+| --- | --- |
+| Query syntax, RDF terms, operators, built-ins | `rdf-spec11-terms-expressions.yaml`, `rdf-filter.yaml`, `rdf-bind-functions.yaml` |
+| Basic and group graph patterns | `rdf-spec11-algebra-complete.yaml`, `rdf-spec-graph-algebra.yaml` |
+| OPTIONAL, UNION, MINUS, EXISTS | `rdf-spec11-algebra-complete.yaml`, `rdf-optional.yaml`, `rdf-union-exists.yaml` |
+| Property paths | `rdf-spec11-property-paths-complete.yaml`, `rdf-advanced-sparql.yaml` |
+| Assignment and inline data | `rdf-spec11-algebra-complete.yaml`, `rdf-queryplan-coverage.yaml` |
+| Aggregates, grouping, HAVING | `rdf-spec11-algebra-complete.yaml`, `rdf-aggregates.yaml` |
+| Subqueries | `rdf-spec11-algebra-complete.yaml`, `rdf-advanced-sparql.yaml` |
+| RDF datasets and GRAPH | `rdf-spec11-query-forms-datasets.yaml`, `rdf-named-graphs.yaml` |
+| Solution modifiers | `rdf-spec11-query-forms-datasets.yaml`, `rdf-spec-bgp-modifiers.yaml` |
+| SELECT, CONSTRUCT, ASK, DESCRIBE | `rdf-spec11-query-forms-datasets.yaml`, `rdf-spec-forms-turtle.yaml` |
+| Federated SERVICE patterns | `rdf-spec11-query-forms-datasets.yaml` |
+| Update and graph management | `rdf-spec11-update-complete.yaml`, `rdf-update.yaml`, `rdf-named-graphs.yaml` |
+| JSON, XML, CSV, TSV result formats | `rdf-spec11-protocol-results-entailment.yaml`, `rdf-results-json.yaml` |
+| Direct POST media types and protocol errors | `rdf-spec11-protocol-results-entailment.yaml` |
+| Simple and RDFS entailment behavior | `rdf-spec11-protocol-results-entailment.yaml` |
+| Positive Turtle syntax and RDF term construction | `rdf-spec11-turtle-complete.yaml`, `rdf-turtle-advanced.yaml` |
+| Normative query/update rejection rules | `rdf-spec11-negative-syntax.yaml` |
+
+## Harness gaps
+
+The existing YAML runner sends query text to the MemCP RDF endpoint using
+POST. It cannot yet express arbitrary HTTP methods or inspect an endpoint that
+is not the configured RDF query path. Consequently these protocol surfaces
+cannot be tested honestly by this test-only PR:
+
+- SPARQL Protocol GET with the `query` parameter;
+- form-encoded POST and protocol dataset parameters;
+- Graph Store HTTP Protocol GET, PUT, POST, DELETE, and HEAD;
+- discovery through a SPARQL Service Description endpoint;
+- protocol-level response status distinctions beyond the runner's generic
+  success/error contract.
+
+Those cases require a separate runner-capability PR. They are recorded here so
+that "full standard" does not silently imply coverage that the current harness
+cannot execute.
+
+## Scope notes
+
+- Entailment regimes are optional capabilities. The cases state observable
+  expectations for any regime MemCP later chooses to advertise.
+- Remote `SERVICE` success needs a deterministic in-CI peer endpoint. The
+  current cases cover parsing, failure, and `SILENT`; a peer fixture belongs in
+  the protocol harness extension.
+- Negative Turtle parser tests likewise need an expected-error contract on the
+  `ttl_data` loader. This PR covers all positive Turtle term and syntax
+  families and records the missing negative-loader contract here.
+- JSON functions are MemCP extensions and remain covered separately in
+  `rdf-json.yaml`; they are not counted as SPARQL conformance.

--- a/tests/rdf/rdf-spec11-algebra-complete.yaml
+++ b/tests/rdf/rdf-spec11-algebra-complete.yaml
@@ -1,0 +1,252 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Executable inventory for SPARQL 1.1 graph-pattern algebra, sections 5-12.
+
+metadata:
+  version: "1.0"
+  description: "Complete SPARQL 1.1 graph-pattern, grouping, and subquery feature matrix"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "SPARQL 1.1 5.2 empty group graph pattern has one solution"
+    noncritical: true
+    sparql: 'SELECT ("yes" AS ?value) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?value": "yes"}]
+
+  - name: "SPARQL 1.1 5.2 nested group graph patterns compose"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-groups.example/> .
+      ex:item ex:value "yes" .
+    sparql: |
+      PREFIX ex: <http://spec11-groups.example/>
+      SELECT ?value WHERE { { { ex:item ex:value ?value } } }
+    expect:
+      rows: 1
+      data: [{"?value": "yes"}]
+
+  - name: "SPARQL 1.1 6 OPTIONAL may contain UNION and FILTER"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-optional-nested.example/> .
+      ex:a ex:name "A" ; ex:left "L" .
+      ex:b ex:name "B" ; ex:right "R" .
+    sparql: |
+      PREFIX ex: <http://spec11-optional-nested.example/>
+      SELECT ?name ?value WHERE {
+        ?s ex:name ?name
+        OPTIONAL {
+          { ?s ex:left ?value } UNION { ?s ex:right ?value }
+          FILTER(?value != "hidden")
+        }
+      }
+      ORDER BY ?name
+    expect:
+      rows: 2
+      data:
+        - {"?name": "A", "?value": "L"}
+        - {"?name": "B", "?value": "R"}
+
+  - name: "SPARQL 1.1 6 OPTIONAL filter uses left and right bindings"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-optional-filter.example/> .
+      ex:a ex:wanted "x" ; ex:candidate "x" .
+      ex:b ex:wanted "x" ; ex:candidate "y" .
+    sparql: |
+      PREFIX ex: <http://spec11-optional-filter.example/>
+      SELECT ?s ?candidate WHERE {
+        ?s ex:wanted ?wanted
+        OPTIONAL { ?s ex:candidate ?candidate FILTER(?wanted = ?candidate) }
+      }
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 7 UNION accepts arbitrary group patterns"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-union-group.example/> .
+      ex:a ex:type "left" ; ex:enabled true .
+      ex:b ex:type "right" ; ex:enabled true .
+    sparql: |
+      PREFIX ex: <http://spec11-union-group.example/>
+      SELECT ?s WHERE {
+        { ?s ex:type "left" OPTIONAL { ?s ex:enabled ?flag } }
+        UNION
+        { ?s ex:type "right" FILTER EXISTS { ?s ex:enabled true } }
+      }
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 8.2 MINUS removes compatible solutions"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-minus.example/> .
+      ex:a ex:name "A" . ex:b ex:name "B" ; ex:deleted true .
+    sparql: |
+      PREFIX ex: <http://spec11-minus.example/>
+      SELECT ?name WHERE {
+        ?s ex:name ?name
+        MINUS { ?s ex:deleted true }
+      }
+    expect:
+      rows: 1
+      data: [{"?name": "A"}]
+
+  - name: "SPARQL 1.1 8.2 MINUS with disjoint variables preserves solutions"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-minus-domain.example/> .
+      ex:a ex:name "A" . ex:x ex:flag true .
+    sparql: |
+      PREFIX ex: <http://spec11-minus-domain.example/>
+      SELECT ?name WHERE { ?s ex:name ?name MINUS { ?x ex:flag true } }
+    expect:
+      rows: 1
+      data: [{"?name": "A"}]
+
+  - name: "SPARQL 1.1 8.1 EXISTS supports nested arbitrary patterns"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-exists-nested.example/> .
+      ex:a ex:name "A" ; ex:left true .
+    sparql: |
+      PREFIX ex: <http://spec11-exists-nested.example/>
+      SELECT ?name WHERE {
+        ?s ex:name ?name
+        FILTER EXISTS { { ?s ex:left true } UNION { ?s ex:right true } }
+      }
+    expect:
+      rows: 1
+      data: [{"?name": "A"}]
+
+  - name: "SPARQL 1.1 10.1 BIND expression errors leave the variable unbound"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'SELECT ?result ?kept WHERE { BIND((1 / 0) AS ?result) BIND("yes" AS ?kept) }'
+    expect:
+      rows: 1
+      contains: '"kept"'
+      not_contains: '"result"'
+
+  - name: "SPARQL 1.1 10.1 BIND cannot rebind an in-scope variable"
+    noncritical: true
+    sparql: 'SELECT ?value WHERE { BIND("first" AS ?value) BIND("second" AS ?value) }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 10.2 tuple VALUES binds multiple variables"
+    noncritical: true
+    sparql: |
+      SELECT ?name ?rank WHERE {
+        VALUES (?name ?rank) { ("Alpha" 1) ("Beta" 2) }
+      }
+      ORDER BY ?rank
+    expect:
+      rows: 2
+      data:
+        - {"?name": "Alpha", "?rank": 1}
+        - {"?name": "Beta", "?rank": 2}
+
+  - name: "SPARQL 1.1 10.2 VALUES supports UNDEF"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'SELECT ?left ?right WHERE { VALUES (?left ?right) { ("A" UNDEF) (UNDEF "B") } }'
+    expect:
+      rows: 2
+      contains: '"left"'
+
+  - name: "SPARQL 1.1 10.2 trailing VALUES applies after solution modifiers"
+    noncritical: true
+    sparql: 'SELECT ?value WHERE {} VALUES ?value { "A" "B" }'
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 11 aggregate DISTINCT eliminates duplicate inputs"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-aggregate-distinct.example/> .
+      ex:a ex:value "same" . ex:b ex:value "same" .
+    sparql: |
+      PREFIX ex: <http://spec11-aggregate-distinct.example/>
+      SELECT (COUNT(DISTINCT ?value) AS ?count) WHERE { ?s ex:value ?value }
+    expect:
+      rows: 1
+      data: [{"?count": 1}]
+
+  - name: "SPARQL 1.1 11 SAMPLE returns one group member"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-sample.example/> .
+      ex:a ex:value "A" . ex:b ex:value "B" .
+    sparql: |
+      PREFIX ex: <http://spec11-sample.example/>
+      SELECT (SAMPLE(?value) AS ?sample) WHERE { ?s ex:value ?value }
+    expect: {rows: 1}
+
+  - name: "SPARQL 1.1 11 GROUP_CONCAT default separator is a space"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-group-concat.example/> .
+      ex:a ex:value "A" . ex:b ex:value "B" .
+    sparql: |
+      PREFIX ex: <http://spec11-group-concat.example/>
+      SELECT (GROUP_CONCAT(?value) AS ?joined) WHERE { ?s ex:value ?value }
+    expect:
+      rows: 1
+      contains: "A B"
+
+  - name: "SPARQL 1.1 11 GROUP BY accepts expressions and aliases"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-group-expression.example/> .
+      ex:a ex:label "alpha" . ex:b ex:label "apple" . ex:c ex:label "beta" .
+    sparql: |
+      PREFIX ex: <http://spec11-group-expression.example/>
+      SELECT ?initial (COUNT(*) AS ?count) WHERE { ?s ex:label ?label }
+      GROUP BY (SUBSTR(?label, 1, 1) AS ?initial)
+      ORDER BY ?initial
+    expect:
+      rows: 2
+      data:
+        - {"?initial": "a", "?count": 2}
+        - {"?initial": "b", "?count": 1}
+
+  - name: "SPARQL 1.1 11 HAVING accepts multiple constraints"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-having.example/> .
+      ex:a ex:group "A" ; ex:value 1, 2 . ex:b ex:group "B" ; ex:value 1 .
+    sparql: |
+      PREFIX ex: <http://spec11-having.example/>
+      SELECT ?group (COUNT(?value) AS ?count) WHERE { ?s ex:group ?group ; ex:value ?value }
+      GROUP BY ?group HAVING(COUNT(?value) > 1) HAVING(?group = "A")
+    expect:
+      rows: 1
+      data: [{"?group": "A", "?count": 2}]
+
+  - name: "SPARQL 1.1 12 subquery SELECT star exposes its projected scope"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-subquery-star.example/> .
+      ex:item ex:value "yes" .
+    sparql: |
+      PREFIX ex: <http://spec11-subquery-star.example/>
+      SELECT ?s ?value WHERE { { SELECT * WHERE { ?s ex:value ?value } } }
+    expect:
+      rows: 1
+      data: [{"?s": "http://spec11-subquery-star.example/item", "?value": "yes"}]
+
+  - name: "SPARQL 1.1 12 subquery solution modifiers apply before the outer join"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-subquery-modifiers.example/> .
+      ex:a ex:rank 1 . ex:b ex:rank 2 .
+    sparql: |
+      PREFIX ex: <http://spec11-subquery-modifiers.example/>
+      SELECT ?s WHERE { { SELECT ?s WHERE { ?s ex:rank ?rank } ORDER BY DESC(?rank) LIMIT 1 } }
+    expect:
+      rows: 1
+      data: [{"?s": "http://spec11-subquery-modifiers.example/b"}]
+
+cleanup: []

--- a/tests/rdf/rdf-spec11-negative-syntax.yaml
+++ b/tests/rdf/rdf-spec11-negative-syntax.yaml
@@ -1,0 +1,89 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Representative normative rejection cases from the SPARQL 1.1 grammar and
+# update constraints. These stay noncritical with the rest of the inventory.
+
+metadata:
+  version: "1.0"
+  description: "SPARQL 1.1 negative query and update syntax conformance matrix"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "SPARQL 1.1 rejects an undefined prefix"
+    noncritical: true
+    sparql: 'SELECT ?s WHERE { ?s missing:p ?o }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 rejects a literal in subject position"
+    noncritical: true
+    sparql: 'SELECT ?o WHERE { "literal" <http://spec11-negative.example/p> ?o }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 rejects a literal in predicate position"
+    noncritical: true
+    sparql: 'SELECT ?o WHERE { <http://spec11-negative.example/s> "predicate" ?o }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 rejects a blank node in predicate position"
+    noncritical: true
+    sparql: 'SELECT ?o WHERE { <http://spec11-negative.example/s> _:predicate ?o }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 rejects SELECT expressions without aliases"
+    noncritical: true
+    sparql: 'SELECT STR(?s) WHERE { ?s ?p ?o }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 rejects projection of an ungrouped variable"
+    noncritical: true
+    sparql: 'SELECT ?s (COUNT(*) AS ?count) WHERE { ?s ?p ?o }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 rejects VALUES rows with too few entries"
+    noncritical: true
+    sparql: 'SELECT * WHERE { VALUES (?a ?b) { (1) } }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 rejects VALUES rows with too many entries"
+    noncritical: true
+    sparql: 'SELECT * WHERE { VALUES (?a ?b) { (1 2 3) } }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 rejects BIND rebinding an existing variable"
+    noncritical: true
+    sparql: 'SELECT ?s WHERE { ?s ?p ?o BIND("replacement" AS ?s) }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 rejects aggregate calls in FILTER before grouping"
+    noncritical: true
+    sparql: 'SELECT ?s WHERE { ?s ?p ?o FILTER(COUNT(*) > 1) }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 Update rejects variables in INSERT DATA"
+    noncritical: true
+    sparql: 'INSERT DATA { ?s <http://spec11-negative.example/p> "value" }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 Update rejects variables in DELETE DATA"
+    noncritical: true
+    sparql: 'DELETE DATA { <http://spec11-negative.example/s> <http://spec11-negative.example/p> ?o }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 Update rejects blank nodes in DELETE DATA"
+    noncritical: true
+    sparql: 'DELETE DATA { _:node <http://spec11-negative.example/p> "value" }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 Update rejects blank nodes in DELETE templates"
+    noncritical: true
+    sparql: 'DELETE { _:node <http://spec11-negative.example/p> ?o } WHERE { ?s <http://spec11-negative.example/p> ?o }'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 Update rejects GRAPH variables in DATA blocks"
+    noncritical: true
+    sparql: 'INSERT DATA { GRAPH ?g { <http://spec11-negative.example/s> <http://spec11-negative.example/p> "value" } }'
+    expect: {error: true}
+
+cleanup: []

--- a/tests/rdf/rdf-spec11-property-paths-complete.yaml
+++ b/tests/rdf/rdf-spec11-property-paths-complete.yaml
@@ -1,0 +1,126 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Executable inventory for every SPARQL 1.1 property-path production.
+
+metadata:
+  version: "1.0"
+  description: "Complete SPARQL 1.1 property-path syntax and endpoint semantics"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "SPARQL 1.1 9 PredicatePath matches one edge"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-link.example/> . ex:a ex:p ex:b .
+    sparql: 'PREFIX ex: <http://spec11-path-link.example/> SELECT ?o WHERE { ex:a ex:p ?o }'
+    expect: {rows: 1, data: [{"?o": "http://spec11-path-link.example/b"}]}
+
+  - name: "SPARQL 1.1 9 InversePath reverses an edge"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-inverse.example/> . ex:a ex:parent ex:b .
+    sparql: 'PREFIX ex: <http://spec11-path-inverse.example/> SELECT ?child WHERE { ex:b ^ex:parent ?child }'
+    expect: {rows: 1, data: [{"?child": "http://spec11-path-inverse.example/a"}]}
+
+  - name: "SPARQL 1.1 9 SequencePath hides intermediate variables"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-sequence.example/> . ex:a ex:p ex:b . ex:b ex:q ex:c .
+    sparql: 'PREFIX ex: <http://spec11-path-sequence.example/> SELECT ?o WHERE { ex:a ex:p/ex:q ?o }'
+    expect: {rows: 1, data: [{"?o": "http://spec11-path-sequence.example/c"}]}
+
+  - name: "SPARQL 1.1 9 AlternativePath retains both alternatives"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-alternative.example/> . ex:a ex:p ex:b ; ex:q ex:c .
+    sparql: 'PREFIX ex: <http://spec11-path-alternative.example/> SELECT ?o WHERE { ex:a (ex:p|ex:q) ?o }'
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 9 ZeroOrOnePath includes zero and one edge"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-optional.example/> . ex:a ex:p ex:b .
+    sparql: 'PREFIX ex: <http://spec11-path-optional.example/> SELECT ?o WHERE { ex:a ex:p? ?o }'
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 9 ZeroOrMorePath handles cycles without duplicates"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-star-cycle.example/> . ex:a ex:p ex:b . ex:b ex:p ex:a .
+    sparql: 'PREFIX ex: <http://spec11-path-star-cycle.example/> SELECT ?o WHERE { ex:a ex:p* ?o } ORDER BY ?o'
+    expect:
+      rows: 2
+      data:
+        - {"?o": "http://spec11-path-star-cycle.example/a"}
+        - {"?o": "http://spec11-path-star-cycle.example/b"}
+
+  - name: "SPARQL 1.1 9 OneOrMorePath excludes a zero-length acyclic endpoint"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-plus.example/> . ex:a ex:p ex:b . ex:b ex:p ex:c .
+    sparql: 'PREFIX ex: <http://spec11-path-plus.example/> SELECT ?o WHERE { ex:a ex:p+ ?o }'
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 9 NegatedPropertySet excludes a forward predicate"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-negated.example/> . ex:a ex:blocked ex:b ; ex:allowed ex:c .
+    sparql: 'PREFIX ex: <http://spec11-path-negated.example/> SELECT ?o WHERE { ex:a !ex:blocked ?o }'
+    expect: {rows: 1, data: [{"?o": "http://spec11-path-negated.example/c"}]}
+
+  - name: "SPARQL 1.1 9 NegatedPropertySet mixes forward and inverse exclusions"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-negated-mixed.example/> .
+      ex:a ex:blocked ex:center . ex:center ex:allowed ex:c . ex:x ex:reverseBlocked ex:center .
+    sparql: |
+      PREFIX ex: <http://spec11-path-negated-mixed.example/>
+      SELECT ?o WHERE { ex:center !(ex:blocked|^ex:reverseBlocked) ?o }
+    expect: {rows: 1, data: [{"?o": "http://spec11-path-negated-mixed.example/c"}]}
+
+  - name: "SPARQL 1.1 9 repetition applies to a composite path"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-composite.example/> .
+      ex:a ex:p ex:b . ex:b ex:q ex:c . ex:c ex:p ex:d . ex:d ex:q ex:e .
+    sparql: 'PREFIX ex: <http://spec11-path-composite.example/> SELECT ?o WHERE { ex:a (ex:p/ex:q)+ ?o }'
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 9 path supports a variable subject"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-variable-subject.example/> . ex:a ex:p ex:b . ex:b ex:p ex:c .
+    sparql: 'PREFIX ex: <http://spec11-path-variable-subject.example/> SELECT ?s WHERE { ?s ex:p+ ex:c } ORDER BY ?s'
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 9 path supports two variable endpoints"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-two-vars.example/> . ex:a ex:p ex:b . ex:b ex:p ex:c .
+    sparql: 'PREFIX ex: <http://spec11-path-two-vars.example/> SELECT ?s ?o WHERE { ?s ex:p+ ?o }'
+    expect: {rows: 3}
+
+  - name: "SPARQL 1.1 9 path supports two fixed endpoints"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-path-fixed.example/> . ex:a ex:p ex:b . ex:b ex:p ex:c .
+    sparql: 'PREFIX ex: <http://spec11-path-fixed.example/> ASK WHERE { ex:a ex:p+ ex:c }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "SPARQL 1.1 9 path evaluation stays in the active named graph"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-path-graph.example/>
+      INSERT DATA { GRAPH ex:g { ex:a ex:p ex:b . ex:b ex:p ex:c } }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 9 named graph path query"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-path-graph.example/>
+      SELECT ?o WHERE { GRAPH ex:g { ex:a ex:p+ ?o } }
+    expect: {rows: 2}
+
+cleanup: []

--- a/tests/rdf/rdf-spec11-protocol-results-entailment.yaml
+++ b/tests/rdf/rdf-spec11-protocol-results-entailment.yaml
@@ -1,0 +1,141 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Executable portions of the SPARQL 1.1 Protocol, result formats, graph result
+# serialization, and advertised entailment behavior.
+
+metadata:
+  version: "1.0"
+  description: "SPARQL 1.1 protocol media types, result formats, and entailment matrix"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "SPARQL 1.1 Protocol direct POST accepts application sparql-query"
+    noncritical: true
+    headers:
+      Content-Type: "application/sparql-query"
+      Accept: "application/sparql-results+json"
+    sparql: 'SELECT ("yes" AS ?value) WHERE {}'
+    expect: {rows: 1, content_type: "application/sparql-results+json"}
+
+  - name: "SPARQL 1.1 Query Results JSON SELECT media type"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'SELECT ("yes" AS ?value) WHERE {}'
+    expect:
+      rows: 1
+      content_type: "application/sparql-results+json"
+      contains: '"bindings"'
+
+  - name: "SPARQL 1.1 Query Results JSON ASK media type"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'ASK WHERE {}'
+    expect:
+      rows: 1
+      content_type: "application/sparql-results+json"
+      contains: '"boolean":true'
+
+  - name: "SPARQL 1.1 Query Results XML SELECT serialization"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+xml"}
+    sparql: 'SELECT ("yes" AS ?value) WHERE {}'
+    expect:
+      content_type: "application/sparql-results+xml"
+      contains: "<sparql"
+
+  - name: "SPARQL 1.1 Query Results XML ASK serialization"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+xml"}
+    sparql: 'ASK WHERE {}'
+    expect:
+      content_type: "application/sparql-results+xml"
+      contains: "<boolean>true</boolean>"
+
+  - name: "SPARQL 1.1 Query Results CSV serialization"
+    noncritical: true
+    headers: {Accept: "text/csv"}
+    sparql: 'SELECT ("yes" AS ?value) WHERE {}'
+    expect:
+      content_type: "text/csv"
+      contains: "value"
+
+  - name: "SPARQL 1.1 Query Results TSV serialization"
+    noncritical: true
+    headers: {Accept: "text/tab-separated-values"}
+    sparql: 'SELECT ("yes" AS ?value) WHERE {}'
+    expect:
+      content_type: "text/tab-separated-values"
+      contains: "?value"
+
+  - name: "SPARQL 1.1 CONSTRUCT negotiates Turtle graph output"
+    noncritical: true
+    ttl_data: '@prefix ex: <http://spec11-result-turtle.example/> . ex:s ex:p ex:o .'
+    headers: {Accept: "text/turtle"}
+    sparql: 'PREFIX ex: <http://spec11-result-turtle.example/> CONSTRUCT { ?s ex:p ?o } WHERE { ?s ex:p ?o }'
+    expect:
+      content_type: "text/turtle"
+      contains: "spec11-result-turtle.example"
+
+  - name: "SPARQL 1.1 CONSTRUCT negotiates RDF XML graph output"
+    noncritical: true
+    ttl_data: '@prefix ex: <http://spec11-result-rdfxml.example/> . ex:s ex:p ex:o .'
+    headers: {Accept: "application/rdf+xml"}
+    sparql: 'PREFIX ex: <http://spec11-result-rdfxml.example/> CONSTRUCT { ?s ex:p ?o } WHERE { ?s ex:p ?o }'
+    expect:
+      content_type: "application/rdf+xml"
+      contains: "rdf:RDF"
+
+  - name: "SPARQL 1.1 malformed query returns a protocol error"
+    noncritical: true
+    headers: {Content-Type: "application/sparql-query"}
+    sparql: 'SELECT WHERE {'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 RDF entailment recognizes asserted triples"
+    noncritical: true
+    ttl_data: '@prefix ex: <http://spec11-entailment-simple.example/> . ex:s ex:p ex:o .'
+    sparql: 'PREFIX ex: <http://spec11-entailment-simple.example/> ASK WHERE { ex:s ex:p ex:o }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "SPARQL 1.1 RDFS entailment follows subClassOf"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-entailment-class.example/> .
+      @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      ex:Case rdfs:subClassOf ex:Record . ex:item rdf:type ex:Case .
+    sparql: |
+      PREFIX ex: <http://spec11-entailment-class.example/>
+      ASK WHERE { ex:item a ex:Record }
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "SPARQL 1.1 RDFS entailment follows subPropertyOf"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-entailment-property.example/> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      ex:specific rdfs:subPropertyOf ex:general . ex:s ex:specific ex:o .
+    sparql: 'PREFIX ex: <http://spec11-entailment-property.example/> ASK WHERE { ex:s ex:general ex:o }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "SPARQL 1.1 RDFS entailment applies domain typing"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-entailment-domain.example/> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      ex:p rdfs:domain ex:Subject . ex:s ex:p ex:o .
+    sparql: 'PREFIX ex: <http://spec11-entailment-domain.example/> ASK WHERE { ex:s a ex:Subject }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "SPARQL 1.1 RDFS entailment applies range typing"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-entailment-range.example/> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      ex:p rdfs:range ex:Object . ex:s ex:p ex:o .
+    sparql: 'PREFIX ex: <http://spec11-entailment-range.example/> ASK WHERE { ex:o a ex:Object }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+cleanup: []

--- a/tests/rdf/rdf-spec11-query-forms-datasets.yaml
+++ b/tests/rdf/rdf-spec11-query-forms-datasets.yaml
@@ -1,0 +1,185 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Executable inventory for SPARQL 1.1 query forms, datasets, federation,
+# solution sequences, and standard result serialization.
+
+metadata:
+  version: "1.0"
+  description: "Complete SPARQL 1.1 query-form, dataset, federation, and result matrix"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "SPARQL 1.1 15.3 ORDER BY accepts expression conditions"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-order-expression.example/> . ex:a ex:name "b" . ex:b ex:name "A" .
+    sparql: |
+      PREFIX ex: <http://spec11-order-expression.example/>
+      SELECT ?name WHERE { ?s ex:name ?name } ORDER BY LCASE(?name)
+    expect:
+      rows: 2
+      data: [{"?name": "A"}, {"?name": "b"}]
+
+  - name: "SPARQL 1.1 15.3 ORDER BY supports multiple ASC and DESC conditions"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-order-multiple.example/> .
+      ex:a ex:group "A" ; ex:rank 1 . ex:b ex:group "A" ; ex:rank 2 . ex:c ex:group "B" ; ex:rank 1 .
+    sparql: |
+      PREFIX ex: <http://spec11-order-multiple.example/>
+      SELECT ?group ?rank WHERE { ?s ex:group ?group ; ex:rank ?rank }
+      ORDER BY ASC(?group) DESC(?rank)
+    expect:
+      rows: 3
+      data:
+        - {"?group": "A", "?rank": 2}
+        - {"?group": "A", "?rank": 1}
+        - {"?group": "B", "?rank": 1}
+
+  - name: "SPARQL 1.1 15.4 projection expressions expose aliases"
+    noncritical: true
+    sparql: 'SELECT (CONCAT("A", "B") AS ?value) WHERE {}'
+    expect: {rows: 1, data: [{"?value": "AB"}]}
+
+  - name: "SPARQL 1.1 15.5 DISTINCT removes duplicate solution mappings"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-distinct.example/> . ex:a ex:value "same" . ex:b ex:value "same" .
+    sparql: 'PREFIX ex: <http://spec11-distinct.example/> SELECT DISTINCT ?value WHERE { ?s ex:value ?value }'
+    expect: {rows: 1}
+
+  - name: "SPARQL 1.1 15.6 REDUCED permits duplicate elimination"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-reduced.example/> . ex:a ex:value "same" . ex:b ex:value "same" .
+    sparql: 'PREFIX ex: <http://spec11-reduced.example/> SELECT REDUCED ?value WHERE { ?s ex:value ?value }'
+    expect: {rows: 1}
+
+  - name: "SPARQL 1.1 15.7 OFFSET and LIMIT slice after ordering"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-slice.example/> . ex:a ex:rank 1 . ex:b ex:rank 2 . ex:c ex:rank 3 .
+    sparql: 'PREFIX ex: <http://spec11-slice.example/> SELECT ?rank WHERE { ?s ex:rank ?rank } ORDER BY ?rank OFFSET 1 LIMIT 1'
+    expect: {rows: 1, data: [{"?rank": 2}]}
+
+  - name: "SPARQL 1.1 16.1 SELECT permits an omitted WHERE keyword"
+    noncritical: true
+    sparql: 'SELECT ("yes" AS ?value) { }'
+    expect: {rows: 1, data: [{"?value": "yes"}]}
+
+  - name: "SPARQL 1.1 16.2 CONSTRUCT template applies solution modifiers"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-construct-modifier.example/> . ex:a ex:rank 1 . ex:b ex:rank 2 .
+    sparql: |
+      PREFIX ex: <http://spec11-construct-modifier.example/>
+      CONSTRUCT { ?s ex:selected ?rank } WHERE { ?s ex:rank ?rank }
+      ORDER BY DESC(?rank) LIMIT 1
+    expect: {rows: 1}
+
+  - name: "SPARQL 1.1 16.2 CONSTRUCT WHERE shorthand"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-construct-short.example/> . ex:item ex:value "yes" .
+    sparql: 'PREFIX ex: <http://spec11-construct-short.example/> CONSTRUCT WHERE { ?s ex:value ?o }'
+    expect: {rows: 1}
+
+  - name: "SPARQL 1.1 16.3 ASK accepts an RDF dataset clause"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-ask-dataset.example/>
+      INSERT DATA { GRAPH ex:g { ex:s ex:p ex:o } }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 16.3 ASK evaluates FROM datasets"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-ask-dataset.example/> ASK FROM ex:g WHERE { ex:s ex:p ex:o }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "SPARQL 1.1 16.4 DESCRIBE accepts an IRI"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-describe-iri.example/> . ex:item ex:name "Item" .
+    sparql: 'PREFIX ex: <http://spec11-describe-iri.example/> DESCRIBE ex:item'
+    expect: {rows: 1}
+
+  - name: "SPARQL 1.1 16.4 DESCRIBE accepts variables and WHERE"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-describe-var.example/> . ex:item ex:name "Item" .
+    sparql: 'PREFIX ex: <http://spec11-describe-var.example/> DESCRIBE ?s WHERE { ?s ex:name "Item" }'
+    expect: {rows: 1}
+
+  - name: "SPARQL 1.1 16.4 DESCRIBE star describes every result resource"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-describe-star.example/> . ex:a ex:name "A" . ex:b ex:name "B" .
+    sparql: 'PREFIX ex: <http://spec11-describe-star.example/> DESCRIBE * WHERE { ?s ex:name ?name }'
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 13 multiple FROM graphs form one RDF merge"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-dataset-merge.example/>
+      INSERT DATA { GRAPH ex:g1 { ex:s ex:p ex:o } }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 13 prepare second graph for RDF merge"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-dataset-merge.example/>
+      INSERT DATA { GRAPH ex:g2 { ex:s ex:p ex:o . ex:x ex:p ex:y } }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 13 RDF merge deduplicates equal triples"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-dataset-merge.example/>
+      SELECT ?s FROM ex:g1 FROM ex:g2 WHERE { ?s ex:p ?o }
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 13 FROM NAMED exposes only declared named graphs"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-dataset-merge.example/>
+      SELECT ?g ?s FROM NAMED ex:g2 WHERE { GRAPH ?g { ?s ex:p ?o } }
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 14 SERVICE invokes a remote endpoint"
+    noncritical: true
+    sparql: |
+      SELECT ?s WHERE {
+        SERVICE <http://127.0.0.1:1/sparql> { ?s ?p ?o }
+      }
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 14 SERVICE SILENT suppresses endpoint failure"
+    noncritical: true
+    sparql: |
+      SELECT ("survived" AS ?value) WHERE {
+        SERVICE SILENT <http://127.0.0.1:1/sparql> { ?s ?p ?o }
+      }
+    expect: {rows: 1, data: [{"?value": "survived"}]}
+
+  - name: "SPARQL Results JSON preserves datatype metadata"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT ("42"^^xsd:integer AS ?value) WHERE {}
+    expect:
+      rows: 1
+      contains: '"datatype":"http://www.w3.org/2001/XMLSchema#integer"'
+
+  - name: "SPARQL Results JSON omits unbound variables"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'SELECT ?missing ("yes" AS ?value) WHERE {}'
+    expect:
+      rows: 1
+      contains: '"value"'
+      not_contains: '"missing"'
+
+cleanup: []

--- a/tests/rdf/rdf-spec11-terms-expressions.yaml
+++ b/tests/rdf/rdf-spec11-terms-expressions.yaml
@@ -1,0 +1,280 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Feature-complete executable inventory for SPARQL 1.1 sections 4 and 17.
+# Every case is intentionally noncritical until its semantics are implemented.
+
+metadata:
+  version: "1.0"
+  description: "SPARQL 1.1 RDF term, operator, and built-in function conformance matrix"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "SPARQL 1.1 4.1.2 language-tagged literals preserve their language"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-terms.example/> .
+      ex:subject ex:label "Berlin"@de .
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: |
+      PREFIX ex: <http://spec11-terms.example/>
+      SELECT ?label WHERE { ex:subject ex:label ?label }
+    expect:
+      rows: 1
+      contains: '"xml:lang":"de"'
+
+  - name: "SPARQL 1.1 4.1.2 language tags participate in term identity"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-terms-lang.example/> .
+      ex:subject ex:label "Berlin"@de, "Berlin"@en .
+    sparql: |
+      PREFIX ex: <http://spec11-terms-lang.example/>
+      SELECT ?label WHERE { ex:subject ex:label ?label }
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 4.1.2 datatype IRIs participate in term identity"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-terms-datatype.example/> .
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+      ex:subject ex:value "1"^^xsd:string, "1"^^xsd:integer .
+    sparql: |
+      PREFIX ex: <http://spec11-terms-datatype.example/>
+      SELECT ?value WHERE { ex:subject ex:value ?value }
+    expect: {rows: 2}
+
+  - name: "SPARQL 1.1 17.4.1.8 sameTerm retains lexical form"
+    noncritical: true
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT (sameTerm("01"^^xsd:integer, "1"^^xsd:integer) AS ?result) WHERE {}
+    expect:
+      rows: 1
+      data: [{"?result": false}]
+
+  - name: "SPARQL 1.1 17.3 value equality compares typed numeric values"
+    noncritical: true
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT (("01"^^xsd:integer = "1"^^xsd:integer) AS ?result) WHERE {}
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.2.6 LANG returns a normalized language tag"
+    noncritical: true
+    sparql: 'SELECT (LANG("Hallo"@DE) AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": "de"}]
+
+  - name: "SPARQL 1.1 17.4.3.12 LANGMATCHES supports language ranges"
+    noncritical: true
+    sparql: 'SELECT (LANGMATCHES("de-DE", "de") AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.2.7 DATATYPE returns the literal datatype"
+    noncritical: true
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT (DATATYPE("42"^^xsd:integer) AS ?result) WHERE {}
+    expect:
+      rows: 1
+      contains: "http://www.w3.org/2001/XMLSchema#integer"
+
+  - name: "SPARQL 1.1 17.4.2.12 STRLANG constructs a language literal"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'SELECT (STRLANG("Hallo", "de") AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      contains: '"xml:lang":"de"'
+
+  - name: "SPARQL 1.1 17.4.2.11 STRDT constructs a typed literal"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT (STRDT("42", xsd:integer) AS ?result) WHERE {}
+    expect:
+      rows: 1
+      contains: "http://www.w3.org/2001/XMLSchema#integer"
+
+  - name: "SPARQL 1.1 17.4.2.9 BNODE creates blank nodes"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'SELECT (BNODE() AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      contains: '"type":"bnode"'
+
+  - name: "SPARQL 1.1 17.4.2.9 BNODE labels are stable within one solution"
+    noncritical: true
+    sparql: 'SELECT (sameTerm(BNODE("key"), BNODE("key")) AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.2.1 isIRI distinguishes IRIs from strings"
+    noncritical: true
+    sparql: 'SELECT (isIRI(<http://spec11.example/iri>) AS ?iri) (isIRI("http://spec11.example/iri") AS ?string) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?iri": true, "?string": false}]
+
+  - name: "SPARQL 1.1 17.4.2.4 isLiteral recognizes typed literals"
+    noncritical: true
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT (isLiteral("7"^^xsd:integer) AS ?result) WHERE {}
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.2.5 isNumeric recognizes numeric datatypes"
+    noncritical: true
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT (isNumeric("7"^^xsd:integer) AS ?result) WHERE {}
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.1 arithmetic supports addition and multiplication"
+    noncritical: true
+    sparql: 'SELECT ((2 + 3 * 4) AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": 14}]
+
+  - name: "SPARQL 1.1 17.4.1 arithmetic supports unary minus and division"
+    noncritical: true
+    sparql: 'SELECT ((-12 / 3) AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": -4}]
+
+  - name: "SPARQL 1.1 17.4.1.9 IN tests membership"
+    noncritical: true
+    sparql: 'SELECT ((2 IN (1, 2, 3)) AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.1.10 NOT IN tests non-membership"
+    noncritical: true
+    sparql: 'SELECT ((4 NOT IN (1, 2, 3)) AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.3.3 RAND returns a numeric value"
+    noncritical: true
+    sparql: 'SELECT ((RAND() >= 0 && RAND() < 1) AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.3.5 STRBEFORE returns the prefix"
+    noncritical: true
+    sparql: 'SELECT (STRBEFORE("alpha:beta", ":") AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": "alpha"}]
+
+  - name: "SPARQL 1.1 17.4.3.6 STRAFTER returns the suffix"
+    noncritical: true
+    sparql: 'SELECT (STRAFTER("alpha:beta", ":") AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": "beta"}]
+
+  - name: "SPARQL 1.1 17.4.3.9 ENCODE_FOR_URI escapes reserved characters"
+    noncritical: true
+    sparql: 'SELECT (ENCODE_FOR_URI("A B") AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": "A%20B"}]
+
+  - name: "SPARQL 1.1 17.4.3.14 REGEX supports flags"
+    noncritical: true
+    sparql: 'SELECT (REGEX("Berlin", "berlin", "i") AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.3.15 REPLACE supports flags"
+    noncritical: true
+    sparql: 'SELECT (REPLACE("Berlin berlin", "berlin", "X", "i") AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": "X X"}]
+
+  - name: "SPARQL 1.1 17.4.5.1 NOW is stable within a query"
+    noncritical: true
+    sparql: 'SELECT ((NOW() = NOW()) AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": true}]
+
+  - name: "SPARQL 1.1 17.4.5 date component functions"
+    noncritical: true
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT (YEAR("2026-09-07T12:34:56Z"^^xsd:dateTime) AS ?year)
+             (MONTH("2026-09-07T12:34:56Z"^^xsd:dateTime) AS ?month)
+             (DAY("2026-09-07T12:34:56Z"^^xsd:dateTime) AS ?day)
+      WHERE {}
+    expect:
+      rows: 1
+      data: [{"?year": 2026, "?month": 9, "?day": 7}]
+
+  - name: "SPARQL 1.1 17.4.5 time component functions"
+    noncritical: true
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT (HOURS("2026-09-07T12:34:56Z"^^xsd:dateTime) AS ?hours)
+             (MINUTES("2026-09-07T12:34:56Z"^^xsd:dateTime) AS ?minutes)
+             (SECONDS("2026-09-07T12:34:56Z"^^xsd:dateTime) AS ?seconds)
+      WHERE {}
+    expect:
+      rows: 1
+      data: [{"?hours": 12, "?minutes": 34, "?seconds": 56}]
+
+  - name: "SPARQL 1.1 17.4.5 timezone functions"
+    noncritical: true
+    sparql: |
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+      SELECT (TZ("2026-09-07T12:34:56+02:00"^^xsd:dateTime) AS ?tz) WHERE {}
+    expect:
+      rows: 1
+      data: [{"?tz": "+02:00"}]
+
+  - name: "SPARQL 1.1 17.4.6 MD5 hash"
+    noncritical: true
+    sparql: 'SELECT (MD5("abc") AS ?result) WHERE {}'
+    expect:
+      rows: 1
+      data: [{"?result": "900150983cd24fb0d6963f7d28e17f72"}]
+
+  - name: "SPARQL 1.1 17.4.6 SHA family hashes"
+    noncritical: true
+    sparql: 'SELECT (SHA1("abc") AS ?sha1) (SHA256("abc") AS ?sha256) WHERE {}'
+    expect:
+      rows: 1
+      contains: "a9993e364706816aba3e25717850c26c9cd0d89d"
+
+  - name: "SPARQL 1.1 17.4.1 expression errors leave projection variables unbound"
+    noncritical: true
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'SELECT ((1 / 0) AS ?error) ("kept" AS ?value) WHERE {}'
+    expect:
+      rows: 1
+      contains: '"value":"kept"'
+      not_contains: '"error"'
+
+cleanup: []

--- a/tests/rdf/rdf-spec11-turtle-complete.yaml
+++ b/tests/rdf/rdf-spec11-turtle-complete.yaml
@@ -1,0 +1,178 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Positive Turtle 1.1 syntax and RDF 1.1 term-semantics inventory.
+
+metadata:
+  version: "1.0"
+  description: "Complete positive Turtle 1.1 syntax and RDF term feature matrix"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "Turtle 1.1 2.4 BASE resolves relative IRIs"
+    noncritical: true
+    ttl_data: |
+      @base <http://spec11-turtle-base.example/root/> .
+      <subject> <predicate> <object> .
+    sparql: 'ASK WHERE { <http://spec11-turtle-base.example/root/subject> <http://spec11-turtle-base.example/root/predicate> <http://spec11-turtle-base.example/root/object> }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "Turtle 1.1 SPARQL BASE directive needs no trailing dot"
+    noncritical: true
+    ttl_data: |
+      BASE <http://spec11-turtle-sparql-base.example/>
+      <s> <p> <o> .
+    sparql: 'ASK WHERE { <http://spec11-turtle-sparql-base.example/s> <http://spec11-turtle-sparql-base.example/p> <http://spec11-turtle-sparql-base.example/o> }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "Turtle 1.1 SPARQL PREFIX directive needs no trailing dot"
+    noncritical: true
+    ttl_data: |
+      PREFIX ex: <http://spec11-turtle-sparql-prefix.example/>
+      ex:s ex:p ex:o .
+    sparql: 'PREFIX ex: <http://spec11-turtle-sparql-prefix.example/> ASK WHERE { ex:s ex:p ex:o }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "Turtle 1.1 prefixed names support escaped local characters"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-turtle-pname.example/> .
+      ex:subject ex:has\~value "yes" .
+    sparql: 'ASK WHERE { <http://spec11-turtle-pname.example/subject> <http://spec11-turtle-pname.example/has~value> "yes" }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "Turtle 1.1 IRIREF supports Unicode escapes"
+    noncritical: true
+    ttl_data: '<http://spec11-turtle-iri.example/\u0061> <http://spec11-turtle-iri.example/p> "yes" .'
+    sparql: 'ASK WHERE { <http://spec11-turtle-iri.example/a> <http://spec11-turtle-iri.example/p> "yes" }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "Turtle 1.1 single-quoted string literal"
+    noncritical: true
+    ttl_data: '<http://spec11-turtle-string.example/single> <http://spec11-turtle-string.example/p> ''single'' .'
+    sparql: 'SELECT ?o WHERE { <http://spec11-turtle-string.example/single> <http://spec11-turtle-string.example/p> ?o }'
+    expect: {rows: 1, data: [{"?o": "single"}]}
+
+  - name: "Turtle 1.1 long single-quoted string literal"
+    noncritical: true
+    ttl_data: "<http://spec11-turtle-string.example/long-single> <http://spec11-turtle-string.example/p> '''line one\nline two''' ."
+    sparql: 'SELECT ?o WHERE { <http://spec11-turtle-string.example/long-single> <http://spec11-turtle-string.example/p> ?o }'
+    expect: {rows: 1, contains: "line one"}
+
+  - name: "Turtle 1.1 long double-quoted string literal"
+    noncritical: true
+    ttl_data: |
+      <http://spec11-turtle-string.example/long-double> <http://spec11-turtle-string.example/p> """line one
+      line two""" .
+    sparql: 'SELECT ?o WHERE { <http://spec11-turtle-string.example/long-double> <http://spec11-turtle-string.example/p> ?o }'
+    expect: {rows: 1, contains: "line two"}
+
+  - name: "Turtle 1.1 string escape sequences"
+    noncritical: true
+    ttl_data: |
+      <http://spec11-turtle-string.example/escapes> <http://spec11-turtle-string.example/p> "tab:\t newline:\n quote:\" slash:\\" .
+    sparql: 'SELECT ?o WHERE { <http://spec11-turtle-string.example/escapes> <http://spec11-turtle-string.example/p> ?o }'
+    expect: {rows: 1, contains: "tab:"}
+
+  - name: "Turtle 1.1 language-tagged literal"
+    noncritical: true
+    ttl_data: '<http://spec11-turtle-lang.example/s> <http://spec11-turtle-lang.example/label> "colour"@en-GB .'
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'SELECT ?label WHERE { <http://spec11-turtle-lang.example/s> <http://spec11-turtle-lang.example/label> ?label }'
+    expect: {rows: 1, contains: '"xml:lang":"en-gb"'}
+
+  - name: "Turtle 1.1 explicitly typed literal"
+    noncritical: true
+    ttl_data: |
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+      <http://spec11-turtle-typed.example/s> <http://spec11-turtle-typed.example/p> "42"^^xsd:integer .
+    headers: {Accept: "application/sparql-results+json"}
+    sparql: 'SELECT ?o WHERE { <http://spec11-turtle-typed.example/s> <http://spec11-turtle-typed.example/p> ?o }'
+    expect: {rows: 1, contains: "http://www.w3.org/2001/XMLSchema#integer"}
+
+  - name: "Turtle 1.1 integer literal has xsd integer datatype"
+    noncritical: true
+    ttl_data: '<http://spec11-turtle-numeric.example/integer> <http://spec11-turtle-numeric.example/p> -42 .'
+    sparql: 'SELECT ?o WHERE { <http://spec11-turtle-numeric.example/integer> <http://spec11-turtle-numeric.example/p> ?o FILTER(?o = -42) }'
+    expect: {rows: 1}
+
+  - name: "Turtle 1.1 decimal literal has xsd decimal datatype"
+    noncritical: true
+    ttl_data: '<http://spec11-turtle-numeric.example/decimal> <http://spec11-turtle-numeric.example/p> 12.50 .'
+    sparql: 'SELECT ?o WHERE { <http://spec11-turtle-numeric.example/decimal> <http://spec11-turtle-numeric.example/p> ?o FILTER(?o = 12.50) }'
+    expect: {rows: 1}
+
+  - name: "Turtle 1.1 double literal supports exponent notation"
+    noncritical: true
+    ttl_data: '<http://spec11-turtle-numeric.example/double> <http://spec11-turtle-numeric.example/p> 1.25e2 .'
+    sparql: 'SELECT ?o WHERE { <http://spec11-turtle-numeric.example/double> <http://spec11-turtle-numeric.example/p> ?o FILTER(?o = 125) }'
+    expect: {rows: 1}
+
+  - name: "Turtle 1.1 boolean literals are typed values"
+    noncritical: true
+    ttl_data: '<http://spec11-turtle-boolean.example/s> <http://spec11-turtle-boolean.example/p> true .'
+    sparql: 'SELECT ?o WHERE { <http://spec11-turtle-boolean.example/s> <http://spec11-turtle-boolean.example/p> ?o FILTER(?o = true) }'
+    expect: {rows: 1, data: [{"?o": true}]}
+
+  - name: "Turtle 1.1 object lists expand to multiple triples"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-turtle-object-list.example/> . ex:s ex:p "A", "B", "C" .
+    sparql: 'PREFIX ex: <http://spec11-turtle-object-list.example/> SELECT ?o WHERE { ex:s ex:p ?o }'
+    expect: {rows: 3}
+
+  - name: "Turtle 1.1 predicate lists share one subject"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-turtle-predicate-list.example/> . ex:s ex:p "A" ; ex:q "B" .
+    sparql: 'PREFIX ex: <http://spec11-turtle-predicate-list.example/> SELECT ?p ?o WHERE { ex:s ?p ?o }'
+    expect: {rows: 2}
+
+  - name: "Turtle 1.1 blank-node property lists nest"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-turtle-bnode-list.example/> . ex:s ex:address [ ex:city "Berlin" ; ex:country [ ex:code "DE" ] ] .
+    sparql: |
+      PREFIX ex: <http://spec11-turtle-bnode-list.example/>
+      SELECT ?city ?code WHERE { ex:s ex:address ?a . ?a ex:city ?city ; ex:country ?c . ?c ex:code ?code }
+    expect: {rows: 1, data: [{"?city": "Berlin", "?code": "DE"}]}
+
+  - name: "Turtle 1.1 anonymous blank-node labels allocate distinct nodes"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-turtle-anon.example/> . ex:s ex:item [] , [] .
+    sparql: 'PREFIX ex: <http://spec11-turtle-anon.example/> SELECT (COUNT(DISTINCT ?node) AS ?count) WHERE { ex:s ex:item ?node }'
+    expect: {rows: 1, data: [{"?count": 2}]}
+
+  - name: "Turtle 1.1 collections expand first and rest chains"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-turtle-collection.example/> . ex:s ex:items ("A" "B" "C") .
+    sparql: |
+      PREFIX ex: <http://spec11-turtle-collection.example/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      SELECT ?item WHERE { ex:s ex:items/rdf:rest*/rdf:first ?item }
+    expect: {rows: 3}
+
+  - name: "Turtle 1.1 empty collection denotes rdf nil"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-turtle-empty-list.example/> . ex:s ex:items () .
+    sparql: |
+      PREFIX ex: <http://spec11-turtle-empty-list.example/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      ASK WHERE { ex:s ex:items rdf:nil }
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "Turtle 1.1 a abbreviation denotes rdf type"
+    noncritical: true
+    ttl_data: |
+      @prefix ex: <http://spec11-turtle-type.example/> . ex:s a ex:Type .
+    sparql: |
+      PREFIX ex: <http://spec11-turtle-type.example/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      ASK WHERE { ex:s rdf:type ex:Type }
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+cleanup: []

--- a/tests/rdf/rdf-spec11-update-complete.yaml
+++ b/tests/rdf/rdf-spec11-update-complete.yaml
@@ -1,0 +1,213 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Executable inventory for every SPARQL 1.1 Update operation family.
+
+metadata:
+  version: "1.0"
+  description: "Complete SPARQL 1.1 Update and graph-management feature matrix"
+  isolated: true
+
+setup: []
+
+test_cases:
+  - name: "SPARQL 1.1 Update 3.1.1 INSERT DATA accepts the default graph"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-insert.example/> INSERT DATA { ex:s ex:p "value" }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.1 INSERT DATA default graph is visible"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-insert.example/> SELECT ?o WHERE { ex:s ex:p ?o }'
+    expect: {rows: 1, data: [{"?o": "value"}]}
+
+  - name: "SPARQL 1.1 Update 3.1.2 DELETE DATA is an absent-triple no-op"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-delete.example/> DELETE DATA { ex:absent ex:p "value" }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 DELETE WHERE shorthand"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-delete-where.example/> INSERT DATA { ex:a ex:p 1 . ex:b ex:p 2 }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 DELETE WHERE removes every matching solution"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-delete-where.example/> DELETE WHERE { ?s ex:p ?o }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 DELETE WHERE result is empty"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-delete-where.example/> SELECT ?s WHERE { ?s ex:p ?o }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 INSERT-only modify"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-insert-where.example/> INSERT DATA { ex:a ex:source "x" }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 INSERT WHERE instantiates its template"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-update-insert-where.example/>
+      INSERT { ?s ex:target ?value } WHERE { ?s ex:source ?value }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 INSERT WHERE result is visible"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-insert-where.example/> SELECT ?value WHERE { ex:a ex:target ?value }'
+    expect: {rows: 1, data: [{"?value": "x"}]}
+
+  - name: "SPARQL 1.1 Update 3.1.3 DELETE-only modify"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-delete-only.example/> INSERT DATA { ex:a ex:state "old" }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 DELETE template without INSERT"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-delete-only.example/> DELETE { ?s ex:state ?state } WHERE { ?s ex:state ?state }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 WITH selects the modify graph"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-with.example/> INSERT DATA { GRAPH ex:g { ex:a ex:state "old" } }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 WITH applies DELETE INSERT to one graph"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-update-with.example/>
+      WITH ex:g
+      DELETE { ?s ex:state ?old }
+      INSERT { ?s ex:state "new" }
+      WHERE { ?s ex:state ?old }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 USING supplies the default query dataset"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-update-using.example/>
+      INSERT DATA { GRAPH ex:source { ex:a ex:value "x" } }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 USING reads one graph into a default target"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-update-using.example/>
+      INSERT { ?s ex:copied ?value }
+      USING ex:source
+      WHERE { ?s ex:value ?value }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.1.3 USING NAMED supplies named query graphs"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-update-using.example/>
+      INSERT { ?s ex:namedCopy ?value }
+      USING NAMED ex:source
+      WHERE { GRAPH ex:source { ?s ex:value ?value } }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.1 LOAD SILENT suppresses retrieval failure"
+    noncritical: true
+    sparql: 'LOAD SILENT <http://127.0.0.1:1/spec11-unreachable.ttl>'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.2 CLEAR DEFAULT"
+    noncritical: true
+    sparql: 'CLEAR DEFAULT'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.2 CLEAR NAMED"
+    noncritical: true
+    sparql: 'CLEAR NAMED'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.2 CLEAR ALL"
+    noncritical: true
+    sparql: 'CLEAR ALL'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.3 CREATE records an empty graph"
+    noncritical: true
+    sparql: 'CREATE GRAPH <http://spec11-update-create.example/empty>'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.3 duplicate CREATE reports an error"
+    noncritical: true
+    sparql: 'CREATE GRAPH <http://spec11-update-create.example/empty>'
+    expect: {error: true}
+
+  - name: "SPARQL 1.1 Update 3.2.3 CREATE SILENT suppresses duplicate error"
+    noncritical: true
+    sparql: 'CREATE SILENT GRAPH <http://spec11-update-create.example/empty>'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.4 DROP DEFAULT"
+    noncritical: true
+    sparql: 'DROP DEFAULT'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.4 DROP NAMED"
+    noncritical: true
+    sparql: 'DROP NAMED'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.4 DROP ALL"
+    noncritical: true
+    sparql: 'DROP ALL'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.5 COPY graph setup"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-copy.example/> INSERT DATA { GRAPH ex:source { ex:s ex:p ex:o } }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.5 COPY replaces destination graph"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-copy.example/> COPY GRAPH ex:source TO GRAPH ex:copy'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.5 MOVE transfers and clears source graph"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-copy.example/> MOVE GRAPH ex:copy TO GRAPH ex:moved'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.5 ADD merges source into destination"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-copy.example/> ADD GRAPH ex:moved TO DEFAULT'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update 3.2.5 graph transfer result is visible"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-copy.example/> ASK WHERE { ex:s ex:p ex:o }'
+    expect: {rows: 1, data: [{"?ask": true}]}
+
+  - name: "SPARQL 1.1 Update 3.2 update request executes operations in order"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-update-sequence.example/>
+      INSERT DATA { ex:s ex:p "old" } ;
+      DELETE DATA { ex:s ex:p "old" } ;
+      INSERT DATA { ex:s ex:p "new" }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update blank nodes in INSERT templates are fresh per solution"
+    noncritical: true
+    sparql: 'PREFIX ex: <http://spec11-update-bnode.example/> INSERT DATA { ex:a ex:value "A" . ex:b ex:value "B" }'
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update allocates one template blank node per solution"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-update-bnode.example/>
+      INSERT { ?s ex:generated [ ex:copy ?value ] } WHERE { ?s ex:value ?value }
+    expect: {rows: 0}
+
+  - name: "SPARQL 1.1 Update template blank nodes remain distinct"
+    noncritical: true
+    sparql: |
+      PREFIX ex: <http://spec11-update-bnode.example/>
+      SELECT (COUNT(DISTINCT ?node) AS ?count) WHERE { ?s ex:generated ?node }
+    expect: {rows: 1, data: [{"?count": 2}]}
+
+cleanup: []


### PR DESCRIPTION
## Summary

- add 176 explicitly noncritical RDF/SPARQL conformance cases without changing production code
- cover SPARQL 1.1 terms and expressions, graph algebra, property paths, query forms, datasets, federation, updates, result media types, entailment, and normative rejection rules
- cover the positive Turtle 1.1 syntax and RDF 1.1 term forms needed by the SPARQL frontend
- document the complete recommendation-to-suite mapping and the protocol surfaces the current YAML harness cannot yet exercise honestly

## Test-driven workflow

All new cases use `noncritical: true`. Passing cases inventory existing support; failures remain visible without blocking CI. When a feature is selected for implementation, its cases can be promoted to critical in that feature PR.

## Validation

- parsed all new YAML suites
- verified 176/176 cases are explicitly noncritical, executable, uniquely named, and have expectation mappings
- SQL regression guard passes against `origin/master`
- full suite intentionally left to CI as requested

## Deliberate harness gaps

The coverage inventory records GET/form-POST protocol variants, Graph Store HTTP methods, Service Description discovery, successful remote SERVICE fixtures, and negative Turtle loader assertions as requiring a separate runner-capability change. No placeholder test claims coverage for an HTTP interaction the current runner cannot perform.