### PR TITLE
Test S3 compatibility against latest MinIO

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,11 +122,13 @@ jobs:
 
       - name: Start S3-compatible storage
         run: |
+          docker pull minio/minio:latest
+          docker image inspect --format='Testing {{index .RepoDigests 0}}' minio/minio:latest
           docker run --detach --name memcp-minio \
             --publish 9000:9000 \
             --env MINIO_ROOT_USER \
             --env MINIO_ROOT_PASSWORD \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+            minio/minio:latest server /data
           for attempt in $(seq 1 60); do
             if curl --fail --silent http://127.0.0.1:9000/minio/health/ready >/dev/null; then
               exit 0

--- a/tools/reliability-drill.md
+++ b/tools/reliability-drill.md
@@ -37,10 +37,12 @@ python3 tools/reliability_drill.py --mode atomicity \
   --database-config-json '{"backend":"s3","access_key_id":"minioadmin","secret_access_key":"minioadmin","region":"us-east-1","endpoint":"http://127.0.0.1:9000","bucket":"memcp","prefix":"reliability","force_path_style":true}'
 ```
 
-The regular GitHub Actions test workflow runs this bounded S3 drill against a
-pinned MinIO image after the main test job, in parallel with packaging. It also
-exercises the complete persistence interface directly, including paginated
-blob listings and WAL replacement/replay.
+The regular GitHub Actions test workflow runs this bounded S3 drill against the
+latest published MinIO image after the main test job, in parallel with
+packaging. The resolved image digest is printed in the job log so failures can
+be reproduced while normal CI runs continue to detect upstream compatibility
+changes. The job also exercises the complete persistence interface directly,
+including paginated blob listings and WAL replacement/replay.
 
 The server-side injector is enabled only when
 `MEMCP_IO_FAULT_PROBABILITY` is set. Tests can scope it with


### PR DESCRIPTION
## Summary

- pull and run the latest published MinIO image in the alternative-storage CI job
- print the resolved image digest so upstream compatibility failures remain reproducible
- document that the job intentionally tracks upstream MinIO changes

## Validation

- parsed `.github/workflows/test.yml` with PyYAML
- ran `git diff --check`
- local container startup was unavailable because this environment cannot access the Docker daemon; the alternative-storage CI job performs the end-to-end validation