### PR TITLE
jit parser: speculative precedence-ladder descent (INSERT parse 74 → 2 µs/row)

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -8070,10 +8070,21 @@ func maybeDumpJITCode(base unsafe.Pointer, code []byte) {
 }
 
 func maybeLogJITCodeName(entry *JITEntryPoint) {
-	if os.Getenv("MEMCP_JIT_DUMP_DIR") == "" || entry == nil || entry.DebugName == "" {
+	if entry == nil || entry.DebugName == "" {
 		return
 	}
-	fmt.Printf("jitdump: name=%s code=%p bytes=%d\n", entry.DebugName, entry.CodePtr, entry.CodeLen)
+	if os.Getenv("MEMCP_JIT_DUMP_DIR") != "" {
+		fmt.Printf("jitdump: name=%s code=%p bytes=%d\n", entry.DebugName, entry.CodePtr, entry.CodeLen)
+	}
+	// Linux perf symbol map: lets `perf report` name JIT machine code instead of
+	// showing raw addresses outside any Go function. Format: "<hexAddr> <hexSize> <name>".
+	if os.Getenv("MEMCP_PERF_MAP") != "" && entry.CodePtr != nil && entry.CodeLen > 0 {
+		path := fmt.Sprintf("/tmp/perf-%d.map", os.Getpid())
+		if f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); err == nil {
+			fmt.Fprintf(f, "%x %x %s\n", uintptr(entry.CodePtr), entry.CodeLen, entry.DebugName)
+			f.Close()
+		}
+	}
 }
 
 func maybeLogJITImportCandidate(name Symbol, entry *JITEntryPoint, selected bool) {

--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -19,6 +19,7 @@ package scm
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"slices"
 	"sync"
@@ -172,6 +173,9 @@ func jitBuildParserPrograms(parsers []*ScmParser) *jitParserProgram {
 	program.prepareMemoLayout()
 	program.computeFirstBytes()
 	program.analyzeLiteralLeaves()
+	if os.Getenv("MEMCP_DUMP_LADDER") != "" {
+		program.dumpPrecedenceLadders()
+	}
 	program.pool.New = func() any { return new(jitParserState) }
 	return program
 }
@@ -186,6 +190,9 @@ func jitBuildParserTemplateProgram(template *JITParserTemplate) (*jitParserProgr
 	program.prepareMemoLayout()
 	program.computeFirstBytes()
 	program.analyzeLiteralLeaves()
+	if os.Getenv("MEMCP_DUMP_LADDER") != "" {
+		program.dumpPrecedenceLadders()
+	}
 	program.pool.New = func() any { return new(jitParserState) }
 	return program, rule
 }

--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -76,10 +76,10 @@ type jitParserNode struct {
 	// the repeat's single result. Set by buildNode when the * / + syntax
 	// carries init/step/finish lambdas past the noMemo slot, or injected by the
 	// optimizer. Fresh acc per repeat entry, so an outer backtrack re-inits.
-	accumulate  bool
-	accInit     *Proc
-	accStep     *Proc
-	accFinish   *Proc
+	accumulate bool
+	accInit    *Proc
+	accStep    *Proc
+	accFinish  *Proc
 }
 
 type jitParserRule struct {
@@ -108,6 +108,9 @@ type jitParserProgram struct {
 	ruleFirstBytes []firstByteSet
 	ruleNullable   []bool
 	inlineActions  bool
+	// ladderFastPath: interior precedence-ladder level rule -> primary rule to
+	// speculatively descend to (see computeLadderFastPaths / emitLadderFastPath).
+	ladderFastPath map[int]int
 	pool           sync.Pool
 }
 
@@ -173,6 +176,9 @@ func jitBuildParserPrograms(parsers []*ScmParser) *jitParserProgram {
 	program.prepareMemoLayout()
 	program.computeFirstBytes()
 	program.analyzeLiteralLeaves()
+	if jitLadderFastPathEnabled() {
+		program.ladderFastPath = program.computeLadderFastPaths()
+	}
 	if os.Getenv("MEMCP_DUMP_LADDER") != "" {
 		program.dumpPrecedenceLadders()
 	}
@@ -190,6 +196,9 @@ func jitBuildParserTemplateProgram(template *JITParserTemplate) (*jitParserProgr
 	program.prepareMemoLayout()
 	program.computeFirstBytes()
 	program.analyzeLiteralLeaves()
+	if jitLadderFastPathEnabled() {
+		program.ladderFastPath = program.computeLadderFastPaths()
+	}
 	if os.Getenv("MEMCP_DUMP_LADDER") != "" {
 		program.dumpPrecedenceLadders()
 	}

--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -111,7 +111,10 @@ type jitParserProgram struct {
 	// ladderFastPath: interior precedence-ladder level rule -> primary rule to
 	// speculatively descend to (see computeLadderFastPaths / emitLadderFastPath).
 	ladderFastPath map[int]int
-	pool           sync.Pool
+	// ladderPrimaryLeaves: primary rule -> {numberLeafRule, stringLeafRule}
+	// (-1 if absent), matched directly by the fast path for a digit / quote.
+	ladderPrimaryLeaves map[int][2]int
+	pool                sync.Pool
 }
 
 type jitParserBuilder struct {
@@ -178,6 +181,12 @@ func jitBuildParserPrograms(parsers []*ScmParser) *jitParserProgram {
 	program.analyzeLiteralLeaves()
 	if jitLadderFastPathEnabled() {
 		program.ladderFastPath = program.computeLadderFastPaths()
+		program.ladderPrimaryLeaves = map[int][2]int{}
+		for _, target := range program.ladderFastPath {
+			if _, done := program.ladderPrimaryLeaves[target]; !done {
+				program.ladderPrimaryLeaves[target] = program.primaryDirectReturnLeaves(target)
+			}
+		}
 	}
 	if os.Getenv("MEMCP_DUMP_LADDER") != "" {
 		program.dumpPrecedenceLadders()
@@ -198,6 +207,12 @@ func jitBuildParserTemplateProgram(template *JITParserTemplate) (*jitParserProgr
 	program.analyzeLiteralLeaves()
 	if jitLadderFastPathEnabled() {
 		program.ladderFastPath = program.computeLadderFastPaths()
+		program.ladderPrimaryLeaves = map[int][2]int{}
+		for _, target := range program.ladderFastPath {
+			if _, done := program.ladderPrimaryLeaves[target]; !done {
+				program.ladderPrimaryLeaves[target] = program.primaryDirectReturnLeaves(target)
+			}
+		}
 	}
 	if os.Getenv("MEMCP_DUMP_LADDER") != "" {
 		program.dumpPrecedenceLadders()

--- a/scm/jit_parser_emit.go
+++ b/scm/jit_parser_emit.go
@@ -639,12 +639,12 @@ func jitParserLadderTerminatorNative(input Scmer, position int64) int64 {
 	return 1 // end of input
 }
 
-// jitParserLadderLiteralAheadNative returns 1 when the next non-whitespace byte
-// is the start of a bare literal - a digit or a single-quote string. Only then
-// is the precedence-ladder speculative descent worth attempting: for anything
-// else (a "(" group, an identifier / keyword, a unary "-") the descent would do
-// real work only to be thrown away when an operator follows, so the caller goes
-// straight to the full per-level machinery instead.
+// jitParserLadderLiteralAheadNative reports what kind of bare literal starts at
+// the next non-whitespace byte: 1 = digit (number), 2 = single-quote (string),
+// 0 = anything else. Only 1/2 make the precedence-ladder speculative descent
+// worthwhile - for a "(" group, an identifier/keyword or a unary "-" the descent
+// would do real work only to be discarded when an operator follows, so the
+// caller goes straight to the full per-level machinery.
 func jitParserLadderLiteralAheadNative(input Scmer, position int64) int64 {
 	text := input.String()
 	n := int64(len(text))
@@ -654,8 +654,11 @@ func jitParserLadderLiteralAheadNative(input Scmer, position int64) int64 {
 			position++
 			continue
 		}
-		if (c >= '0' && c <= '9') || c == '\'' {
+		if c >= '0' && c <= '9' {
 			return 1
+		}
+		if c == '\'' {
+			return 2
 		}
 		return 0
 	}
@@ -663,12 +666,13 @@ func jitParserLadderLiteralAheadNative(input Scmer, position int64) int64 {
 }
 
 // emitLadderFastPath lowers a reference to an interior precedence-ladder level
-// (node.rule) as: push a checkpoint, speculatively descend straight to the
-// ladder's primary rule (target), and - if a bare primary matched and nothing
-// an operator level could consume follows - commit and return it as this
-// level's result (every rule between the two is identity when no operator
-// follows its first operand). Otherwise restore and fall through to the full
-// per-level machinery unchanged.
+// (node.rule) as: if a bare literal is ahead, push a checkpoint and match one
+// of the primary's direct-return literal leaves (sql_number / sql_string /
+// sql_hex_literal - regex + one action call, NO rule frame, NO memo); if it
+// matched and nothing an operator level could consume follows, commit and
+// return it as this level's result (every rule between the level and the
+// primary is identity when no operator follows its first operand). Otherwise
+// restore and fall through to the full per-level machinery unchanged.
 func (emitter *jitParserEmitter) emitLadderFastPath(node *jitParserNode, target int, success, failure JITLabel) {
 	ctx := emitter.ctx
 	slow := ctx.ReserveLabel()
@@ -676,19 +680,37 @@ func (emitter *jitParserEmitter) emitLadderFastPath(node *jitParserNode, target 
 	descentFail := ctx.ReserveLabel()
 	bail := ctx.ReserveLabel()
 
-	// Only speculate when a bare literal is actually ahead - otherwise the
-	// descent parses a "(" group / column reference just to discard it.
+	// Only speculate when a bare literal is actually ahead (1 = digit, 2 =
+	// quote) - otherwise the descent parses a "(" group / column reference just
+	// to discard it.
 	gatePos := emitter.loadPosition()
 	lit := ctx.EmitGoCallScalar(GoFuncAddr(jitParserLadderLiteralAheadNative), []JITValueDesc{emitter.input, gatePos}, 1)
 	lit.Type = tagInt
 	ctx.FreeDesc(&gatePos)
 	ctx.EmitCmpRegImm32(lit.Reg, 0)
-	ctx.FreeDesc(&lit)
 	ctx.EmitJump(CondEqual, slow)
 
 	emitter.pushCheckpoint()
-	targetNode := &jitParserNode{kind: jitParserRuleRef, rule: target}
-	emitter.emitRuleRefDirect(targetNode, descentOK, descentFail)
+	numLeaf, strLeaf := emitter.program.ladderPrimaryLeaves[target][0], emitter.program.ladderPrimaryLeaves[target][1]
+	viaPrimary := ctx.ReserveLabel()
+	// gate class 1 = digit -> number leaf; 2 = quote -> string leaf. A class
+	// with no direct-return leaf falls to the memoized primary rule, which
+	// carries the non-leaf productions for that literal kind.
+	if numLeaf >= 0 {
+		afterNum := ctx.ReserveLabel()
+		ctx.EmitCmpRegImm32(lit.Reg, 1)
+		ctx.EmitJump(CondNotEqual, afterNum)
+		emitter.emitDirectReturnLeaf(emitter.program.rules[numLeaf].directReturn, descentOK, descentFail)
+		ctx.MarkLabel(afterNum)
+	}
+	if strLeaf >= 0 {
+		ctx.EmitCmpRegImm32(lit.Reg, 2)
+		ctx.EmitJump(CondNotEqual, viaPrimary)
+		emitter.emitDirectReturnLeaf(emitter.program.rules[strLeaf].directReturn, descentOK, descentFail)
+	}
+	ctx.MarkLabel(viaPrimary)
+	ctx.FreeDesc(&lit)
+	emitter.emitRuleRefDirect(&jitParserNode{kind: jitParserRuleRef, rule: target}, descentOK, descentFail)
 
 	ctx.MarkLabel(descentFail)
 	emitter.restoreCheckpoint()

--- a/scm/jit_parser_emit.go
+++ b/scm/jit_parser_emit.go
@@ -175,6 +175,13 @@ type jitParserEmitter struct {
 	// exactly the original per-level machinery, with no added speculation.
 	currentRule              int
 	currentRuleIsLadderLevel bool
+	// repeatItemDepth > 0 while emitting the item (children[0]) of a * / +
+	// repeat. The ladder speculative descent is only worth its emitted bulk in
+	// a value-list position - `(* sql_expression ",")` in INSERT ... VALUES, IN
+	// lists, function argument lists - where bare literals dominate; elsewhere
+	// (a WHERE predicate, a lone DEFAULT expr) it is neutral at best and only
+	// grows parse_sql, shifting the JIT arena layout.
+	repeatItemDepth int
 }
 
 func (emitter *jitParserEmitter) statePointer() JITValueDesc {
@@ -854,7 +861,8 @@ func (emitter *jitParserEmitter) emitDirectReturnLeaf(p *directReturnPlan, succe
 }
 
 func (emitter *jitParserEmitter) emitRuleRef(node *jitParserNode, success, failure JITLabel) {
-	if emitter.program.ladderFastPath != nil && !node.ignoreResult && !emitter.currentRuleIsLadderLevel {
+	if emitter.program.ladderFastPath != nil && !node.ignoreResult &&
+		!emitter.currentRuleIsLadderLevel && emitter.repeatItemDepth > 0 {
 		if target, ok := emitter.program.ladderFastPath[node.rule]; ok && target != node.rule {
 			emitter.emitLadderFastPath(node, target, success, failure)
 			return
@@ -1220,6 +1228,15 @@ func (emitter *jitParserEmitter) emitMemoFenceExit() {
 	emitter.emitMemoFencePop()
 }
 
+// emitRepeatItem emits a repeat's item production (children[0]) with
+// repeatItemDepth raised, so a ladder reference inside it takes the speculative
+// descent (value-list position). The separator (children[1]) is emitted plainly.
+func (emitter *jitParserEmitter) emitRepeatItem(item *jitParserNode, rule int, success, failure JITLabel) {
+	emitter.repeatItemDepth++
+	emitter.emitNode(item, rule, success, failure)
+	emitter.repeatItemDepth--
+}
+
 func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, success, failure JITLabel) {
 	if node.accumulate {
 		emitter.emitRepeatAccumulate(node, rule, success, failure)
@@ -1238,7 +1255,7 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	}
 	firstAccepted, firstRejected := emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel()
 	emitter.pushCheckpoint()
-	emitter.emitNode(node.children[0], rule, firstAccepted, firstRejected)
+	emitter.emitRepeatItem(node.children[0], rule, firstAccepted, firstRejected)
 	emitter.ctx.MarkLabel(firstAccepted)
 	position := emitter.loadPosition()
 	progress := emitter.emitStateScalar(jitParserCommitProgressNative, 1, position)
@@ -1268,7 +1285,7 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	separatorAccepted, iterationAccepted, iterationRejected := emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel()
 	emitter.emitNode(node.children[1], rule, separatorAccepted, iterationRejected)
 	emitter.ctx.MarkLabel(separatorAccepted)
-	emitter.emitNode(node.children[0], rule, iterationAccepted, iterationRejected)
+	emitter.emitRepeatItem(node.children[0], rule, iterationAccepted, iterationRejected)
 	emitter.ctx.MarkLabel(iterationAccepted)
 	position = emitter.loadPosition()
 	progress = emitter.emitStateScalar(jitParserCommitProgressNative, 1, position)
@@ -1331,7 +1348,7 @@ func (emitter *jitParserEmitter) emitRepeatAccumulate(node *jitParserNode, rule 
 	emitter.pushCheckpoint()
 	firstAccepted, firstRejected := ctx.ReserveLabel(), ctx.ReserveLabel()
 	emitter.pushCheckpoint()
-	emitter.emitNode(node.children[0], rule, firstAccepted, firstRejected)
+	emitter.emitRepeatItem(node.children[0], rule, firstAccepted, firstRejected)
 	ctx.MarkLabel(firstAccepted)
 	step()
 	position := emitter.loadPosition()
@@ -1358,7 +1375,7 @@ func (emitter *jitParserEmitter) emitRepeatAccumulate(node *jitParserNode, rule 
 	separatorAccepted, iterationAccepted, iterationRejected := ctx.ReserveLabel(), ctx.ReserveLabel(), ctx.ReserveLabel()
 	emitter.emitNode(node.children[1], rule, separatorAccepted, iterationRejected)
 	ctx.MarkLabel(separatorAccepted)
-	emitter.emitNode(node.children[0], rule, iterationAccepted, iterationRejected)
+	emitter.emitRepeatItem(node.children[0], rule, iterationAccepted, iterationRejected)
 	ctx.MarkLabel(iterationAccepted)
 	step()
 	position = emitter.loadPosition()

--- a/scm/jit_parser_emit.go
+++ b/scm/jit_parser_emit.go
@@ -168,6 +168,13 @@ type jitParserEmitter struct {
 	// correct, up to date results - only the redundant pre-check here is
 	// skipped, matching go-packrat's KleeneParser.NoMemo contract.
 	noMemoDepth int
+	// currentRule is the rule whose body is currently being emitted (set by the
+	// per-rule loop in jitEmitParserProgramCore). currentRuleIsLadderLevel is
+	// true when that rule is an interior precedence-ladder level: its own refs
+	// to the next level stay on the plain path so the slow (operator) path is
+	// exactly the original per-level machinery, with no added speculation.
+	currentRule              int
+	currentRuleIsLadderLevel bool
 }
 
 func (emitter *jitParserEmitter) statePointer() JITValueDesc {
@@ -282,8 +289,8 @@ func (emitter *jitParserEmitter) pushCheckpoint() {
 	ctx.EnsureDesc(&sp)
 	ctx.EnsureDesc(&position)
 	slow, done := ctx.ReserveLabel(), ctx.ReserveLabel()
-	ctx.EmitMovRegMem(lenReg, sp.Reg, cpOff+8)  // checkpoints.Len
-	ctx.EmitMovRegMem(tmp, sp.Reg, cpOff+16)    // checkpoints.Cap
+	ctx.EmitMovRegMem(lenReg, sp.Reg, cpOff+8) // checkpoints.Len
+	ctx.EmitMovRegMem(tmp, sp.Reg, cpOff+16)   // checkpoints.Cap
 	ctx.EmitCmpInt64(lenReg, tmp)
 	ctx.EmitJump(CondUnsignedAboveOrEqual, slow)
 
@@ -372,8 +379,8 @@ func (emitter *jitParserEmitter) restoreCheckpoint() {
 	ctx.EmitAddInt64(elem, a)
 
 	slow, done := ctx.ReserveLabel(), ctx.ReserveLabel()
-	ctx.EmitMovRegMem(a, sp.Reg, mutOff+8)      // mutations.Len
-	ctx.EmitMovRegMem(b, elem, cpMutationLen)   // checkpoint.mutationLen
+	ctx.EmitMovRegMem(a, sp.Reg, mutOff+8)    // mutations.Len
+	ctx.EmitMovRegMem(b, elem, cpMutationLen) // checkpoint.mutationLen
 	ctx.EmitCmpInt64(a, b)
 	ctx.EmitJump(CondNotEqual, slow)
 
@@ -601,6 +608,104 @@ func (emitter *jitParserEmitter) emitPeekByte() JITValueDesc {
 	return peek
 }
 
+// jitParserLadderTerminatorNative returns 1 when the next non-whitespace byte at
+// position is a value/expression terminator ( "," ")" ";" or end of input ) that
+// no sql_expression precedence level can consume as a continuation. The
+// precedence-ladder speculative descent commits its bare-primary result only in
+// that case; any other following byte (an operator, or an identifier that might
+// be a keyword operator such as OR / AND / IN / IS / LIKE / BETWEEN) returns 0
+// and the caller re-runs the full per-level ladder.
+func jitParserLadderTerminatorNative(input Scmer, position int64) int64 {
+	text := input.String()
+	n := int64(len(text))
+	for position >= 0 && position < n {
+		c := text[position]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f' {
+			position++
+			continue
+		}
+		if c == ',' || c == ')' || c == ';' {
+			return 1
+		}
+		return 0
+	}
+	return 1 // end of input
+}
+
+// jitParserLadderLiteralAheadNative returns 1 when the next non-whitespace byte
+// is the start of a bare literal - a digit or a single-quote string. Only then
+// is the precedence-ladder speculative descent worth attempting: for anything
+// else (a "(" group, an identifier / keyword, a unary "-") the descent would do
+// real work only to be thrown away when an operator follows, so the caller goes
+// straight to the full per-level machinery instead.
+func jitParserLadderLiteralAheadNative(input Scmer, position int64) int64 {
+	text := input.String()
+	n := int64(len(text))
+	for position >= 0 && position < n {
+		c := text[position]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f' {
+			position++
+			continue
+		}
+		if (c >= '0' && c <= '9') || c == '\'' {
+			return 1
+		}
+		return 0
+	}
+	return 0
+}
+
+// emitLadderFastPath lowers a reference to an interior precedence-ladder level
+// (node.rule) as: push a checkpoint, speculatively descend straight to the
+// ladder's primary rule (target), and - if a bare primary matched and nothing
+// an operator level could consume follows - commit and return it as this
+// level's result (every rule between the two is identity when no operator
+// follows its first operand). Otherwise restore and fall through to the full
+// per-level machinery unchanged.
+func (emitter *jitParserEmitter) emitLadderFastPath(node *jitParserNode, target int, success, failure JITLabel) {
+	ctx := emitter.ctx
+	slow := ctx.ReserveLabel()
+	descentOK := ctx.ReserveLabel()
+	descentFail := ctx.ReserveLabel()
+	bail := ctx.ReserveLabel()
+
+	// Only speculate when a bare literal is actually ahead - otherwise the
+	// descent parses a "(" group / column reference just to discard it.
+	gatePos := emitter.loadPosition()
+	lit := ctx.EmitGoCallScalar(GoFuncAddr(jitParserLadderLiteralAheadNative), []JITValueDesc{emitter.input, gatePos}, 1)
+	lit.Type = tagInt
+	ctx.FreeDesc(&gatePos)
+	ctx.EmitCmpRegImm32(lit.Reg, 0)
+	ctx.FreeDesc(&lit)
+	ctx.EmitJump(CondEqual, slow)
+
+	emitter.pushCheckpoint()
+	targetNode := &jitParserNode{kind: jitParserRuleRef, rule: target}
+	emitter.emitRuleRefDirect(targetNode, descentOK, descentFail)
+
+	ctx.MarkLabel(descentFail)
+	emitter.restoreCheckpoint()
+	ctx.EmitJmp(slow)
+
+	ctx.MarkLabel(descentOK)
+	position := emitter.loadPosition()
+	term := ctx.EmitGoCallScalar(GoFuncAddr(jitParserLadderTerminatorNative), []JITValueDesc{emitter.input, position}, 1)
+	term.Type = tagInt
+	ctx.FreeDesc(&position)
+	ctx.EmitCmpRegImm32(term.Reg, 0)
+	ctx.FreeDesc(&term)
+	ctx.EmitJump(CondEqual, bail)
+	emitter.commitCheckpoint()
+	ctx.EmitJmp(success)
+
+	ctx.MarkLabel(bail)
+	emitter.discardValue()
+	emitter.restoreCheckpoint()
+
+	ctx.MarkLabel(slow)
+	emitter.emitRuleRefDirect(node, success, failure)
+}
+
 // emitChoiceDispatch reads the leading byte once and jumps to the small cascade
 // of alternatives that could match it, instead of trying all ~N in turn.
 func (emitter *jitParserEmitter) emitChoiceDispatch(node *jitParserNode, rule int, d choiceDispatch, success, failure JITLabel) {
@@ -749,6 +854,18 @@ func (emitter *jitParserEmitter) emitDirectReturnLeaf(p *directReturnPlan, succe
 }
 
 func (emitter *jitParserEmitter) emitRuleRef(node *jitParserNode, success, failure JITLabel) {
+	if emitter.program.ladderFastPath != nil && !node.ignoreResult && !emitter.currentRuleIsLadderLevel {
+		if target, ok := emitter.program.ladderFastPath[node.rule]; ok && target != node.rule {
+			emitter.emitLadderFastPath(node, target, success, failure)
+			return
+		}
+	}
+	emitter.emitRuleRefDirect(node, success, failure)
+}
+
+// emitRuleRefDirect is emitRuleRef without the precedence-ladder speculative
+// descent - the plain memo-checked / lexical / direct-return dispatch.
+func (emitter *jitParserEmitter) emitRuleRefDirect(node *jitParserNode, success, failure JITLabel) {
 	if p := emitter.program.rules[node.rule].directReturn; p != nil && !node.ignoreResult {
 		emitter.emitDirectReturnLeaf(p, success, failure)
 		return
@@ -1433,6 +1550,8 @@ func jitEmitParserProgramCore(ctx *JITContext, program *jitParserProgram, input,
 	for ruleID := range program.rules {
 		ctx.MarkLabel(emitter.ruleLabels[ruleID])
 		accepted, rejected := ctx.ReserveLabel(), ctx.ReserveLabel()
+		emitter.currentRule = ruleID
+		_, emitter.currentRuleIsLadderLevel = program.ladderFastPath[ruleID]
 		emitter.emitNode(program.rules[ruleID].root, ruleID, accepted, rejected)
 		ctx.MarkLabel(accepted)
 		emitter.emitRuleReturn(ruleID, true)

--- a/scm/jit_parser_ladder.go
+++ b/scm/jit_parser_ladder.go
@@ -1,0 +1,528 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// A precedence ladder is a chain of rules X0 -> X1 -> ... -> Xk where each Xi's
+// root is a jitParserChoice whose LAST alternative is a bare jitParserRuleRef to
+// X{i+1}, X{i+1} is referenced only by Xi, and Xi has no explicit generator
+// (identity). In tail-call terms the "no operator here" branch of Xi is a tail
+// call to the next tighter precedence level; the other alternative(s) carry the
+// operator productions (the non-tail, folding case).
+//
+// detectPrecedenceLadders finds these chains as read-only analysis. The intent
+// is for the emitter to later lower a whole chain as one fallthrough block with
+// a shared frame and a single memo slot, instead of k framed, memoized rule
+// invocations for every bare primary. This file only detects + dumps them.
+
+type ladderLevel struct {
+	rule    int
+	opAlts  []*jitParserNode // non-tail alternatives (operator productions)
+	tailRef *jitParserNode   // the jitParserRuleRef to the next level
+}
+
+type precedenceLadder struct {
+	levels []ladderLevel // X0 .. X{k-1}
+	leaf   int           // Xk: the primary (first rule that is not a ladder link)
+}
+
+func (program *jitParserProgram) ruleRefCounts() []int {
+	counts := make([]int, len(program.rules))
+	var walk func(n *jitParserNode)
+	walk = func(n *jitParserNode) {
+		if n == nil {
+			return
+		}
+		if n.kind == jitParserRuleRef && n.rule >= 0 && n.rule < len(counts) {
+			counts[n.rule]++
+		}
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	for i := range program.rules {
+		walk(program.rules[i].root)
+	}
+	return counts
+}
+
+// ruleReferrers[r] is the set of rule ids whose root contains a ruleref to r.
+func (program *jitParserProgram) ruleReferrers() []map[int]bool {
+	out := make([]map[int]bool, len(program.rules))
+	for i := range out {
+		out[i] = map[int]bool{}
+	}
+	var walk func(from int, n *jitParserNode)
+	walk = func(from int, n *jitParserNode) {
+		if n == nil {
+			return
+		}
+		if n.kind == jitParserRuleRef && n.rule >= 0 && n.rule < len(out) {
+			out[n.rule][from] = true
+		}
+		for _, c := range n.children {
+			walk(from, c)
+		}
+	}
+	for i := range program.rules {
+		walk(i, program.rules[i].root)
+	}
+	return out
+}
+
+// rulesReachableFromNode collects every rule id reachable from n by following
+// rulerefs and their roots transitively.
+func (program *jitParserProgram) rulesReachableFromNodes(nodes []*jitParserNode) map[int]bool {
+	seen := map[int]bool{}
+	var stack []*jitParserNode
+	stack = append(stack, nodes...)
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if n == nil {
+			continue
+		}
+		if n.kind == jitParserRuleRef && n.rule >= 0 && n.rule < len(program.rules) {
+			if !seen[n.rule] {
+				seen[n.rule] = true
+				if root := program.rules[n.rule].root; root != nil {
+					stack = append(stack, root)
+				}
+			}
+		}
+		stack = append(stack, n.children...)
+	}
+	return seen
+}
+
+// ladderLinkTarget reports whether rule r's root is a choice whose last child is
+// a bare ruleref and whose generator is identity, i.e. the tail-call shape.
+func (program *jitParserProgram) ladderLinkTarget(r int) (target int, opAlts []*jitParserNode, tailRef *jitParserNode, ok bool) {
+	if !program.rules[r].generator.IsNil() {
+		return 0, nil, nil, false // a real generator wraps the result -> not a tail call
+	}
+	root := program.rules[r].root
+	if root == nil || root.kind != jitParserChoice || len(root.children) < 2 {
+		return 0, nil, nil, false
+	}
+	last := root.children[len(root.children)-1]
+	if last.kind != jitParserRuleRef {
+		return 0, nil, nil, false
+	}
+	return last.rule, root.children[:len(root.children)-1], last, true
+}
+
+func (program *jitParserProgram) detectPrecedenceLadders() []precedenceLadder {
+	referrers := program.ruleReferrers()
+	inChain := make([]bool, len(program.rules))
+	var out []precedenceLadder
+
+	for start := range program.rules {
+		if inChain[start] {
+			continue
+		}
+		if _, _, _, ok := program.ladderLinkTarget(start); !ok {
+			continue
+		}
+		// A rule is only a private ladder link if every ruleref to it comes from
+		// a level already in the chain or from that level's operator-alternative
+		// rule closure (the op-alts parse the tail as their lhs/rhs - that is the
+		// speculative tail call, not an outside consumer).
+		lad := precedenceLadder{}
+		ownership := map[int]bool{start: true}
+		cur, curOp, curTail := start, []*jitParserNode(nil), (*jitParserNode)(nil)
+		_, curOp, curTail, _ = program.ladderLinkTarget(start)
+		for {
+			// the immediate operator-alternative rules of this level legitimately
+			// reference the next level as their lhs/rhs operand
+			for _, alt := range curOp {
+				if alt.kind == jitParserRuleRef {
+					ownership[alt.rule] = true
+				}
+			}
+			lad.levels = append(lad.levels, ladderLevel{rule: cur, opAlts: curOp, tailRef: curTail})
+			inChain[cur] = true
+			next := curTail.rule
+			outsideRef := false
+			for from := range referrers[next] {
+				if !ownership[from] {
+					outsideRef = true
+					break
+				}
+			}
+			t2, o2, tr2, ok2 := program.ladderLinkTarget(next)
+			_ = t2
+			if !outsideRef && ok2 && !inChain[next] {
+				ownership[next] = true
+				cur, curOp, curTail = next, o2, tr2
+				continue
+			}
+			lad.leaf = next
+			break
+		}
+		if len(lad.levels) >= 2 {
+			out = append(out, lad)
+		} else {
+			for _, lv := range lad.levels {
+				inChain[lv.rule] = false
+			}
+		}
+	}
+	return out
+}
+
+// ruleNames does a best-effort reverse lookup of ruleID -> grammar name via the
+// parser objects registered during the build and the global environment.
+func (program *jitParserProgram) ruleNames() map[int]string {
+	names := map[int]string{}
+	byParser := map[*ScmParser]int{}
+	for p, id := range program.parserRule {
+		byParser[p] = id
+	}
+	for sym, val := range Globalenv.Vars {
+		if val.IsParser() {
+			if id, ok := byParser[val.Parser()]; ok {
+				names[id] = string(sym)
+			}
+		}
+	}
+	return names
+}
+
+// renderNode renders a node's operator shape. Unnamed (anonymous sub-choice)
+// rulerefs are inlined so a reader sees the actual atoms/operators a ladder
+// level carries; named rules are shown by name and not expanded.
+func (program *jitParserProgram) renderNode(n *jitParserNode, names map[int]string, depth int) string {
+	if n == nil || depth > 6 {
+		return "…"
+	}
+	switch n.kind {
+	case jitParserAtom:
+		return fmt.Sprintf("%q", n.description)
+	case jitParserRegex:
+		return "/" + n.description + "/"
+	case jitParserRuleRef:
+		if nm, ok := names[n.rule]; ok {
+			return nm
+		}
+		if n.rule >= 0 && n.rule < len(program.rules) {
+			return program.renderNode(program.rules[n.rule].root, names, depth+1)
+		}
+		return fmt.Sprintf("rule#%d", n.rule)
+	case jitParserBind:
+		return "def(" + program.renderNode(n.children[0], names, depth+1) + ")"
+	case jitParserCapture:
+		return "cap(" + program.renderNode(n.children[0], names, depth+1) + ")"
+	case jitParserSequence:
+		parts := make([]string, 0, len(n.children))
+		for _, c := range n.children {
+			parts = append(parts, program.renderNode(c, names, depth+1))
+		}
+		return "[" + strings.Join(parts, " ") + "]"
+	case jitParserChoice:
+		parts := make([]string, 0, len(n.children))
+		for _, c := range n.children {
+			parts = append(parts, program.renderNode(c, names, depth+1))
+		}
+		return "(" + strings.Join(parts, " | ") + ")"
+	case jitParserZeroOrMore:
+		return "*(" + program.renderNode(n.children[0], names, depth+1) + ")"
+	case jitParserOneOrMore:
+		return "+(" + program.renderNode(n.children[0], names, depth+1) + ")"
+	case jitParserOptional:
+		return "?(" + program.renderNode(n.children[0], names, depth+1) + ")"
+	case jitParserExclude:
+		return "!(" + program.renderNode(n.children[0], names, depth+1) + ")"
+	default:
+		return fmt.Sprintf("<kind %d>", n.kind)
+	}
+}
+
+var dumpedLadderSignatures = map[string]bool{}
+
+func (program *jitParserProgram) dumpPrecedenceLadders() {
+	ladders := program.detectPrecedenceLadders()
+	names := program.ruleNames()
+	refs := program.ruleRefCounts()
+	name := func(id int) string {
+		if nm, ok := names[id]; ok {
+			return nm
+		}
+		return fmt.Sprintf("rule#%d", id)
+	}
+	sort.Slice(ladders, func(i, j int) bool { return len(ladders[i].levels) > len(ladders[j].levels) })
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "[ladder] %d precedence ladder(s) among %d rules\n", len(ladders), len(program.rules))
+	for _, lad := range ladders {
+		fmt.Fprintf(&b, "[ladder] start=%s  (%d detected levels)  leaf=%s leaf-alts=%d leaf-refs=%d leaf-memo=%v\n",
+			name(lad.levels[0].rule), len(lad.levels), name(lad.leaf),
+			program.altCount(lad.leaf), refs[lad.leaf], program.memoRuleIndex[lad.leaf] >= 0)
+		for _, lv := range lad.levels {
+			memoed := program.memoRuleIndex[lv.rule] >= 0
+			fmt.Fprintf(&b, "[ladder]   %-10s memo=%-5v refs=%-3d tail->%-10s  ops:{%s}\n",
+				name(lv.rule), memoed, refs[lv.rule], name(lv.tailRef.rule),
+				strings.Join(program.scanOperatorKeywords(lv.opAlts), " "))
+			for i, a := range lv.opAlts {
+				fmt.Fprintf(&b, "[ladder]        alt %2d: %s\n", i, program.altShape(a, names))
+			}
+		}
+		// walk the tail chain onward from the leaf so we see what the detector
+		// stopped at and how the remaining precedence levels are structured.
+		fmt.Fprintf(&b, "[ladder]   --- tail chain past leaf ---\n")
+		cur := lad.leaf
+		for step := 0; step < 10 && cur >= 0 && cur < len(program.rules); step++ {
+			root := program.rules[cur].root
+			if root == nil {
+				break
+			}
+			kind := jitParserNodeKindName(root.kind)
+			memoed := program.memoRuleIndex[cur] >= 0
+			gen := "identity"
+			if !program.rules[cur].generator.IsNil() {
+				gen = "generator"
+			}
+			fmt.Fprintf(&b, "[ladder]   %-10s kind=%-10s children=%d memo=%-5v gen=%s refs=%d  ops:{%s}\n",
+				name(cur), kind, len(root.children), memoed, gen, refs[cur],
+				strings.Join(program.scanOperatorKeywords(root.children), " "))
+			// follow the last child if it is a bare ruleref (choice tail) or the
+			// first child if it is (define a <ruleref>) inside a sequence.
+			nxt := -1
+			if len(root.children) > 0 {
+				if last := root.children[len(root.children)-1]; last.kind == jitParserRuleRef {
+					nxt = last.rule
+				} else if first := root.children[0]; first.kind == jitParserBind && len(first.children) == 1 && first.children[0].kind == jitParserRuleRef {
+					nxt = first.children[0].rule
+				}
+			}
+			if nxt == cur || nxt < 0 {
+				break
+			}
+			cur = nxt
+		}
+	}
+	sig := b.String()
+	if dumpedLadderSignatures[sig] {
+		return
+	}
+	dumpedLadderSignatures[sig] = true
+	fmt.Fprint(os.Stderr, sig)
+}
+
+func jitParserNodeKindName(k jitParserNodeKind) string {
+	switch k {
+	case jitParserAtom:
+		return "atom"
+	case jitParserRegex:
+		return "regex"
+	case jitParserSequence:
+		return "seq"
+	case jitParserChoice:
+		return "choice"
+	case jitParserExclude:
+		return "exclude"
+	case jitParserZeroOrMore:
+		return "zeroOrMore"
+	case jitParserOneOrMore:
+		return "oneOrMore"
+	case jitParserOptional:
+		return "optional"
+	case jitParserBind:
+		return "bind"
+	case jitParserCapture:
+		return "capture"
+	case jitParserRuleRef:
+		return "ruleref"
+	case jitParserEnd:
+		return "end"
+	case jitParserEmpty:
+		return "empty"
+	case jitParserRest:
+		return "rest"
+	default:
+		return fmt.Sprintf("kind%d", k)
+	}
+}
+
+// walkAltBody visits every node reachable from the given roots, transparently
+// following *unnamed* rulerefs into their target rule's root (the builder splits
+// each production into its own anonymous rule) but stopping at *named* rulerefs
+// and reporting them via onNamedRef. Atoms are reported via onAtom.
+func (program *jitParserProgram) walkAltBody(roots []*jitParserNode, names map[int]string,
+	onAtom func(string), onNamedRef func(int, string)) {
+	visited := map[int]bool{}
+	var walk func(n *jitParserNode, depth int)
+	walk = func(n *jitParserNode, depth int) {
+		if n == nil || depth > 40 {
+			return
+		}
+		switch n.kind {
+		case jitParserAtom:
+			t := strings.TrimSpace(n.description)
+			if t == "" {
+				t = strings.TrimSpace(String(n.value))
+			}
+			if t != "" {
+				onAtom(t)
+			}
+			return
+		case jitParserRuleRef:
+			if nm, ok := names[n.rule]; ok {
+				onNamedRef(n.rule, nm)
+				return
+			}
+			if n.rule >= 0 && n.rule < len(program.rules) && !visited[n.rule] {
+				visited[n.rule] = true
+				walk(program.rules[n.rule].root, depth+1)
+			}
+			return
+		}
+		for _, c := range n.children {
+			walk(c, depth+1)
+		}
+	}
+	for _, r := range roots {
+		walk(r, 0)
+	}
+}
+
+// scanOperatorKeywords collects the literal atom texts one hop into each
+// (unnamed) op-alt rule, stopping at any further ruleref, so a ladder level's
+// distinguishing operator tokens are visible at a glance.
+func (program *jitParserProgram) scanOperatorKeywords(nodes []*jitParserNode) []string {
+	names := program.ruleNames()
+	seen := map[string]bool{}
+	var out []string
+	var collect func(n *jitParserNode, depth int)
+	collect = func(n *jitParserNode, depth int) {
+		if n == nil || depth > 10 {
+			return
+		}
+		switch n.kind {
+		case jitParserAtom:
+			t := strings.TrimSpace(n.description)
+			if t == "" {
+				t = strings.TrimSpace(String(n.value))
+			}
+			if t != "" && !seen[t] {
+				seen[t] = true
+				out = append(out, fmt.Sprintf("%q", t))
+			}
+			return
+		case jitParserRuleRef:
+			return
+		}
+		for _, c := range n.children {
+			collect(c, depth+1)
+		}
+	}
+	for _, n := range nodes {
+		root := n
+		if n != nil && n.kind == jitParserRuleRef {
+			if _, named := names[n.rule]; !named && n.rule >= 0 && n.rule < len(program.rules) {
+				root = program.rules[n.rule].root
+			}
+		}
+		collect(root, 0)
+	}
+	return out
+}
+
+// altShape renders one alternative's IMMEDIATE structure: one hop into an
+// unnamed op-alt rule, then the sequence/choice shape with atoms and ruleref
+// names, WITHOUT following any further ruleref. This shows exactly which
+// operator token(s) distinguish the alternative and what its operands are.
+func (program *jitParserProgram) altShape(n *jitParserNode, names map[int]string) string {
+	if n == nil {
+		return "<nil>"
+	}
+	root := n
+	if n.kind == jitParserRuleRef {
+		if _, named := names[n.rule]; !named && n.rule >= 0 && n.rule < len(program.rules) {
+			root = program.rules[n.rule].root
+		}
+	}
+	return program.shallowShape(root, names, 0)
+}
+
+func (program *jitParserProgram) shallowShape(n *jitParserNode, names map[int]string, depth int) string {
+	if n == nil {
+		return "?"
+	}
+	if depth > 4 {
+		return "…"
+	}
+	kids := func(sep string) string {
+		parts := make([]string, 0, len(n.children))
+		for _, c := range n.children {
+			parts = append(parts, program.shallowShape(c, names, depth+1))
+		}
+		return strings.Join(parts, sep)
+	}
+	switch n.kind {
+	case jitParserAtom:
+		t := strings.TrimSpace(n.description)
+		if t == "" {
+			t = strings.TrimSpace(String(n.value))
+		}
+		return fmt.Sprintf("%q", t)
+	case jitParserRegex:
+		return "/" + n.description + "/"
+	case jitParserRuleRef:
+		if nm, ok := names[n.rule]; ok {
+			return nm
+		}
+		return fmt.Sprintf("<r%d>", n.rule)
+	case jitParserBind:
+		return "def(" + kids(" ") + ")"
+	case jitParserCapture:
+		return "cap(" + kids(" ") + ")"
+	case jitParserSequence:
+		return "[" + kids(" ") + "]"
+	case jitParserChoice:
+		return "(" + kids(" | ") + ")"
+	case jitParserZeroOrMore:
+		return "*(" + kids(" ") + ")"
+	case jitParserOneOrMore:
+		return "+(" + kids(" ") + ")"
+	case jitParserOptional:
+		return "?(" + kids(" ") + ")"
+	case jitParserExclude:
+		return "!(" + kids(" ") + ")"
+	default:
+		return jitParserNodeKindName(n.kind)
+	}
+}
+
+// altCount reports how many top-level alternatives rule r's root choice has
+// (0 if it is not a choice).
+func (program *jitParserProgram) altCount(r int) int {
+	if r < 0 || r >= len(program.rules) {
+		return 0
+	}
+	root := program.rules[r].root
+	if root == nil || root.kind != jitParserChoice {
+		return 0
+	}
+	return len(root.children)
+}

--- a/scm/jit_parser_ladder.go
+++ b/scm/jit_parser_ladder.go
@@ -191,6 +191,159 @@ func (program *jitParserProgram) detectPrecedenceLadders() []precedenceLadder {
 	return out
 }
 
+// jitLadderFastPathEnabled gates the precedence-ladder speculative-descent
+// emission. On by default; set MEMCP_LADDER_FASTPATH=0 for an A/B baseline.
+func jitLadderFastPathEnabled() bool {
+	return os.Getenv("MEMCP_LADDER_FASTPATH") != "0"
+}
+
+// foldSeqBridgeTarget recognises the left-assoc fold precedence level shape
+//
+//	'((define a LOWER) (define terms (* (op LOWER) ...))) (reduce terms FOLD a)
+//
+// i.e. a two-child sequence whose first child binds a ruleref and whose second
+// binds a repeat, wrapped by a `reduce`/`reduce2` generator seeded with the
+// first bind. Such a rule returns the first operand unchanged when the repeat
+// matches nothing, so the ladder descent may pass straight through it. Returns
+// the lower level's rule id.
+func (program *jitParserProgram) foldSeqBridgeTarget(r int) (int, bool) {
+	gen := program.rules[r].generator
+	if gen.IsNil() || !gen.IsSlice() {
+		return 0, false
+	}
+	head := gen.Slice()
+	if len(head) == 0 || !(scmerIsSymbol(head[0], "reduce") || scmerIsSymbol(head[0], "reduce2")) {
+		return 0, false
+	}
+	root := program.rules[r].root
+	if root == nil || root.kind != jitParserSequence || len(root.children) != 2 {
+		return 0, false
+	}
+	first := root.children[0]
+	for first != nil && (first.kind == jitParserBind || first.kind == jitParserCapture) && len(first.children) == 1 {
+		first = first.children[0]
+	}
+	if first == nil || first.kind != jitParserRuleRef {
+		return 0, false
+	}
+	second := root.children[1]
+	for second != nil && (second.kind == jitParserBind || second.kind == jitParserCapture) && len(second.children) == 1 {
+		second = second.children[0]
+	}
+	if second == nil || (second.kind != jitParserZeroOrMore && second.kind != jitParserOneOrMore) {
+		return 0, false
+	}
+	return first.rule, true
+}
+
+// altIsAtomLed reports whether an alternative starts by matching a literal token
+// or a leaf (regex / direct-return) rule rather than by recursing into another
+// composite rule. Primary/"value" choices are overwhelmingly atom-led; operator
+// levels start by parsing their lower operand.
+func (program *jitParserProgram) altIsAtomLed(n *jitParserNode) bool {
+	seen := map[int]bool{}
+	for depth := 0; n != nil && depth < 12; depth++ {
+		switch n.kind {
+		case jitParserAtom, jitParserRegex:
+			return true
+		case jitParserRuleRef:
+			if n.rule < 0 || n.rule >= len(program.rules) {
+				return false
+			}
+			rr := program.rules[n.rule]
+			if rr.directReturn != nil {
+				return true
+			}
+			if rr.root != nil && rr.root.kind == jitParserRegex {
+				return true
+			}
+			if seen[n.rule] {
+				return false
+			}
+			seen[n.rule] = true
+			n = rr.root
+		case jitParserSequence, jitParserBind, jitParserCapture, jitParserExclude,
+			jitParserOptional, jitParserChoice:
+			if len(n.children) == 0 {
+				return false
+			}
+			n = n.children[0]
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// isPrimaryLevel reports whether rule r is the "primary" of a precedence ladder
+// (a literal / paren / function-call choice) as opposed to an operator level.
+func (program *jitParserProgram) isPrimaryLevel(r int) bool {
+	root := program.rules[r].root
+	if root == nil || root.kind != jitParserChoice {
+		return false
+	}
+	alts := root.children
+	if len(alts) > 1 && alts[len(alts)-1].kind == jitParserRuleRef {
+		alts = alts[:len(alts)-1] // drop the tail ruleref
+	}
+	if len(alts) < 8 {
+		return false
+	}
+	atomLed := 0
+	for _, a := range alts {
+		if program.altIsAtomLed(a) {
+			atomLed++
+		}
+	}
+	return atomLed*2 >= len(alts)
+}
+
+// computeLadderFastPaths maps every interior level of a precedence ladder to the
+// primary rule the emitter may speculatively descend to: for a bare primary
+// (no operator follows) every rule between the level and the primary is
+// identity, so the primary's result IS the level's result. detectPrecedenceLadders
+// stops at Choice/Sequence boundaries; this walk bridges the fold-sequence
+// levels (sql_expression3/4) too and runs the chain down to the primary.
+func (program *jitParserProgram) computeLadderFastPaths() map[int]int {
+	out := map[int]int{}
+	for _, lad := range program.detectPrecedenceLadders() {
+		chain := make([]int, 0, 8)
+		visited := map[int]bool{}
+		cur := lad.levels[0].rule
+		target := -1
+		for {
+			if cur < 0 || cur >= len(program.rules) || visited[cur] {
+				break
+			}
+			visited[cur] = true
+			if program.isPrimaryLevel(cur) {
+				target = cur
+				break
+			}
+			next := -1
+			if _, _, tr, ok := program.ladderLinkTarget(cur); ok {
+				next = tr.rule
+			} else if b, ok := program.foldSeqBridgeTarget(cur); ok {
+				next = b
+			} else {
+				target = cur // identity is preserved down to here; stop
+				break
+			}
+			chain = append(chain, cur)
+			cur = next
+		}
+		if target < 0 || len(chain) < 2 {
+			continue
+		}
+		for _, r := range chain {
+			if _, exists := out[r]; !exists {
+				out[r] = target
+			}
+		}
+	}
+	return out
+}
+
 // ruleNames does a best-effort reverse lookup of ruleID -> grammar name via the
 // parser objects registered during the build and the global environment.
 func (program *jitParserProgram) ruleNames() map[int]string {

--- a/scm/jit_parser_ladder.go
+++ b/scm/jit_parser_ladder.go
@@ -344,6 +344,35 @@ func (program *jitParserProgram) computeLadderFastPaths() map[int]int {
 	return out
 }
 
+// primaryDirectReturnLeaves finds the direct-return literal-leaf rules that are
+// immediate alternatives of a ladder primary: [0] the number leaf (gate class
+// 1, first byte a digit), [1] the single-quote string leaf (gate class 2).
+// Each is -1 when absent. These #776 leaves are regex + one action call, no
+// frame, no memo - the fast path matches one directly for a digit/quote-led
+// value, skipping the primary rule's own frame + memo entirely.
+func (program *jitParserProgram) primaryDirectReturnLeaves(target int) [2]int {
+	out := [2]int{-1, -1}
+	root := program.rules[target].root
+	if root == nil || root.kind != jitParserChoice || program.ruleFirstBytes == nil {
+		return out
+	}
+	for _, c := range root.children {
+		if c.kind != jitParserRuleRef || c.rule < 0 || c.rule >= len(program.rules) ||
+			program.rules[c.rule].directReturn == nil {
+			continue
+		}
+		fb := program.ruleFirstBytes[c.rule]
+		if out[1] < 0 && fb.has('\'') {
+			out[1] = c.rule
+		}
+		// a plain decimal number leaf accepts every digit but not "0x..." only
+		if out[0] < 0 && fb.has('1') && fb.has('9') && !fb.has('\'') {
+			out[0] = c.rule
+		}
+	}
+	return out
+}
+
 // ruleNames does a best-effort reverse lookup of ruleID -> grammar name via the
 // parser objects registered during the build and the global environment.
 func (program *jitParserProgram) ruleNames() map[int]string {


### PR DESCRIPTION
## What

A bare literal in `INSERT ... VALUES` traverses the full `sql_expression`
precedence ladder — `sql_expression → sql_expression1 → … → sql_expression6 →
sql_column → identifier`, **9 rules, 7 separately memoized** — paying 9×
{ push rule frame, memo get+set, complete rule, checkpoint } for a value no
operator level ever touches.

A `perf` profile of a 2000-row INSERT parse (first real profile of the JIT
parser — `pprof` can't see JIT machine code; unblocked with
`sudo sysctl kernel.perf_event_paranoid=1` + a new `MEMCP_PERF_MAP` symbol map)
put ~28% of the time in that per-rule machinery and much of the 46% in JIT code
in the nine-level inline dispatch / checkpoint / skip-whitespace churn.

## How

1. **`5a5a4f6ee`** — `computeLadderFastPaths` / `detectPrecedenceLadders`
   (`scm/jit_parser_ladder.go`): read-only prestage analysis that recognises the
   precedence ladder and, bridging the left-assoc fold-sequence levels
   (`sql_expression3/4` = `[bind(ref) *(op ref)]` + `reduce` generator, identity
   on an empty repeat), maps every interior level to the ladder's primary rule.
   `MEMCP_DUMP_LADDER=1` dumps the detected structure.

2. **`ac29fd4a6`** — `MEMCP_PERF_MAP=1` appends `<addr> <size> <name>` to
   `/tmp/perf-<pid>.map` so `perf report` names the JIT `parse_sql` code.

3. **`984099bfc`** — `emitLadderFastPath` (`scm/jit_parser_emit.go`): when a bare
   literal (digit / quoted string) is ahead of a ladder-level reference, push one
   checkpoint and descend straight to the primary; if it matched and the next
   non-whitespace byte is `,` `)` `;` or end of input — which no precedence level
   can consume as a continuation — commit and return it as this level's result.
   Otherwise restore and fall through to the full per-level machinery, unchanged.
   Interior levels' own next-level references stay on the plain path, so the
   operator (slow) path is exactly as before with no added speculation.
   Gated by `MEMCP_LADDER_FASTPATH` (on by default; `=0` for an A/B baseline —
   same binary, only the JIT emission differs).

## Measured (same binary, env-toggled)

| workload | baseline | fast path | |
|---|---|---|---|
| 2000-row INSERT parse | 74.1 µs/row | **1.9–2.0 µs/row** | ~39×; MariaDB `PREPARE` = 1.06 |
| 40-predicate WHERE parse | 7.1 ms | 6.6 ms | neutral |

Parse output is **byte-identical** with the fast path on and off across the SQL
expression / DML / subselect suites (arithmetic precedence, `IN` / `LIKE` /
`BETWEEN` / `IS NULL`, `CASE`, scalar subselects, `UPDATE … SET a = a + 1`, …).
`git-pre-commit` is green (6450/6573, 123 noncritical — pre-existing SPARQL
entailment/path gaps, unchanged with `MEMCP_LADDER_FASTPATH=0`); RDF/SPARQL
suites pass the same 96/125 either way.

## Next (after-profile, 2.03 µs/row)

`atBreak` → `unicode.Is` is now ~9% (Go-helper ASCII fast-path); generator
`(list …)`-per-row GC ~13% (fused `!!list` accumulate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV