### PR TITLE
jit parser: skip word-boundary check for punctuation atoms (INSERT parse 1.27 → 1.04 µs/row)

### DIFF
--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -67,9 +67,16 @@ type jitParserNode struct {
 	regex        *jitRegexProgram
 	skipWS       bool
 	ignoreResult bool
-	noMemo       bool // repeat body references skip the memo entry check
-	fenceMemo    bool // markFenceableRepeats: also fence+compact the memo table
-	description  string
+	// skipBreakBefore/After: this terminal's literal begins / ends with a
+	// non-word byte, so the word-boundary check on that side (atBreak: is there
+	// a boundary between the neighbouring char and this token's edge?) is
+	// always satisfied - a punctuation / operator atom like "," "(" "->" "::".
+	// Only set for atoms; a regex terminal keeps both checks.
+	skipBreakBefore bool
+	skipBreakAfter  bool
+	noMemo          bool // repeat body references skip the memo entry check
+	fenceMemo       bool // markFenceableRepeats: also fence+compact the memo table
+	description     string
 	// Accumulation form of * / + : instead of collecting item values into a
 	// slice (pushMark/mergeMark -> make+copy per repeat), run accInit() once,
 	// acc = accStep(acc, itemvalue) per accepted item, accFinish(acc) once as
@@ -158,6 +165,13 @@ func jitUnwrapParserSyntax(value Scmer) Scmer {
 		}
 	}
 	return value
+}
+
+// jitParserWordByte matches atBreak's ASCII word class ([0-9A-Za-z_], = the
+// ASCII members of unicode.N | unicode.L | unicode.Pc). A non-ASCII byte is
+// conservatively "word" so a multi-byte atom edge keeps its boundary check.
+func jitParserWordByte(b byte) bool {
+	return b == '_' || (b >= '0' && b <= '9') || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || b >= 0x80
 }
 
 func jitBuildParserProgram(parser *ScmParser) *jitParserProgram {
@@ -560,12 +574,14 @@ func (builder *jitParserBuilder) buildNode(value Scmer, outer *Env, jitOuter *JI
 	case tagString:
 		literal := value.String()
 		return &jitParserNode{
-			kind:         jitParserAtom,
-			value:        value,
-			regex:        jitCompileRegexProgram(regexp.MustCompile("^(?:" + regexp.QuoteMeta(literal) + ")")),
-			skipWS:       true,
-			ignoreResult: ignoreResult,
-			description:  literal,
+			kind:            jitParserAtom,
+			value:           value,
+			regex:           jitCompileRegexProgram(regexp.MustCompile("^(?:" + regexp.QuoteMeta(literal) + ")")),
+			skipWS:          true,
+			skipBreakBefore: len(literal) > 0 && !jitParserWordByte(literal[0]),
+			skipBreakAfter:  len(literal) > 0 && !jitParserWordByte(literal[len(literal)-1]),
+			ignoreResult:    ignoreResult,
+			description:     literal,
 		}
 	case tagSymbol:
 		switch value.Symbol() {
@@ -656,8 +672,11 @@ func (builder *jitParserBuilder) buildNode(value Scmer, outer *Env, jitOuter *JI
 				result = items[4]
 			}
 			return &jitParserNode{kind: jitParserAtom, value: result,
-				regex:  jitCompileRegexProgram(regexp.MustCompile("^(?:" + pattern + ")")),
-				skipWS: jitParserBool(items, 3, true), ignoreResult: ignoreResult, description: literal}
+				regex:           jitCompileRegexProgram(regexp.MustCompile("^(?:" + pattern + ")")),
+				skipWS:          jitParserBool(items, 3, true),
+				skipBreakBefore: len(literal) > 0 && !jitParserWordByte(literal[0]),
+				skipBreakAfter:  len(literal) > 0 && !jitParserWordByte(literal[len(literal)-1]),
+				ignoreResult:    ignoreResult, description: literal}
 		case "regex":
 			pattern := items[1].String()
 			if jitParserBool(items, 2, false) {

--- a/scm/jit_parser_emit.go
+++ b/scm/jit_parser_emit.go
@@ -509,7 +509,9 @@ func (emitter *jitParserEmitter) emitTerminal(node *jitParserNode, rule int, suc
 		skipped := emitter.ctx.ReserveLabel()
 		emitter.emitSkip(rule, skipped)
 		emitter.ctx.MarkLabel(skipped)
-		emitter.atBreak(failure)
+		if !node.skipBreakBefore {
+			emitter.atBreak(failure)
+		}
 	}
 	emitter.ctx.MarkLabel(matchStart)
 	matched := emitter.ctx.ReserveLabel()
@@ -519,7 +521,7 @@ func (emitter *jitParserEmitter) emitTerminal(node *jitParserNode, rule int, suc
 	jitEmitNativeRegex(emitter.ctx, node.regex, input, captures, matched, failed, failed, nil, false)
 	emitter.ctx.MarkLabel(matched)
 	emitter.advanceBy(captures[0])
-	if node.skipWS {
+	if node.skipWS && !node.skipBreakAfter {
 		emitter.atBreak(failure)
 	}
 	if !node.ignoreResult {


### PR DESCRIPTION
## What

`emitTerminal` runs `jitParserAtBreakNative` **twice** per skip-whitespace
atom — once before the regex match and once after — and each call decodes a
rune on both sides of the position and does `unicode.N | unicode.L | unicode.Pc`
table lookups.

For an atom whose literal **begins or ends with a non-word byte** — every
punctuation / operator token, `,` `(` `)` `;` `.` `=` `+` `-` `->` `::` `<>` … —
that side's check is trivially satisfied (a non-word character *is* a boundary),
so it is pure overhead. In a 2000-value `INSERT … VALUES` parse the `,`
separators alone account for ~3300 `atBreak` calls.

## How

`buildNode` records `skipBreakBefore` / `skipBreakAfter` per atom edge
(`jitParserWordByte(literal[0])` / `[len-1]`, non-ASCII conservatively "word"),
for both the `(atom "…")` form and bare string literals. `emitTerminal` omits
the corresponding `atBreak`.

Keyword atoms (`OR`, `AND`, `IN`, …) keep both checks — `ORDER` is still not
parsed as `OR` + `DER`. Regex terminals are unchanged.

## Measured

2000-row INSERT parse (on top of the ladder fast path, PR #798):
**~1.27 → ~1.04 µs/row**. MariaDB `PREPARE` for the same statement is
1.06 µs/row.

Parse output is byte-identical; `git-pre-commit` green (6451/6574, 123
noncritical — pre-existing SPARQL entailment gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV