### PR TITLE
RDF: complete SPARQL 1.1 conformance groundwork

### DIFF
--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -315,7 +315,15 @@ consumer stage. */
 	rdf_filter_and
 )))
 
+(define rdf_path_negated_member (parser (or
+	(parser '((atom "^" true) (define p rdf_expression)) (list "inverse" p))
+	(parser (define p rdf_expression) (list "forward" p))
+)))
 (define rdf_path_atom (parser (or
+	(parser '((atom "!" true) "(" (define members (+ rdf_path_negated_member "|")) ")")
+		(list "__path_negated__" members))
+	(parser '((atom "!" true) (define member rdf_path_negated_member))
+		(list "__path_negated__" (list member)))
 	(parser '((atom "^" true) "(" (define p rdf_path_alt) ")") (list "__path_inverse__" p))
 	(parser '((atom "^" true) (define p rdf_expression)) (list "__path_inverse__" p))
 	(parser '("(" (define p rdf_path_alt) ")") p)
@@ -1487,6 +1495,37 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 			'('get_var _subject_var) (list (list "__bind__" object subject))
 			_ (list (list "__filter__" (list (quote equal?) subject object)))))
 ))
+(define rdf_path_negated_branch (lambda (subject object direction exclusions state)
+	(begin
+		(define predicate (rdf_shared_fresh_path_var state))
+		(list
+			(if (equal? direction "inverse")
+				(list object predicate subject) (list subject predicate object))
+			(list "__filter__" (list (quote not)
+				(cons (quote sql_in) (cons (cons (quote list) exclusions)
+					(list predicate)))))))
+))
+(define rdf_path_negated_exclusions (lambda (members direction)
+	(match members
+		(cons member tail)
+		(if (equal? (car member) direction)
+			(cons (cadr member) (rdf_path_negated_exclusions tail direction))
+			(rdf_path_negated_exclusions tail direction))
+		'() '())
+))
+(define rdf_path_negated_branches (lambda (subject object members state)
+	(begin
+		(define forward (rdf_path_negated_exclusions members "forward"))
+		(define inverse (rdf_path_negated_exclusions members "inverse"))
+		(if (equal? forward '())
+			(if (equal? inverse '()) '()
+				(list (rdf_path_negated_branch subject object "inverse" inverse state)))
+			(if (equal? inverse '())
+				(list (rdf_path_negated_branch subject object "forward" forward state))
+				(list (rdf_path_negated_branch subject object "forward" forward state)
+					(rdf_path_negated_branch subject object "inverse" inverse state))))
+))
+))
 (define rdf_shared_expand_paths_using (lambda (conditions state) (match conditions
 	(cons condition tail)
 	(match condition
@@ -1495,6 +1534,15 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 			(cons (list "__filter__" false) tail)) state)
 		'(s p o)
 		(match p
+			'("__path_negated__" members)
+			(begin
+				(define branches (rdf_path_negated_branches s o members state))
+				(if (equal? (count branches) 1)
+					(rdf_shared_expand_paths_using
+						(cons (car (car branches))
+							(cons (cadr (car branches)) tail)) state)
+					(cons (list "__union__" branches)
+						(rdf_shared_expand_paths_using tail state))))
 			'("__path_inverse__" inner)
 			(rdf_shared_expand_paths_using
 				(cons (list o (rdf_path_invert inner) s) tail) state)

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -315,12 +315,17 @@ consumer stage. */
 )))
 
 (define rdf_path_atom (parser (or
+	(parser '((atom "^" true) "(" (define p rdf_path_alt) ")") (list "__path_inverse__" p))
+	(parser '((atom "^" true) (define p rdf_expression)) (list "__path_inverse__" p))
 	(parser '("(" (define p rdf_path_alt) ")") p)
 	rdf_expression
 )))
 (define rdf_path_postfix (parser (or
 	(parser '((define p rdf_path_atom) "*") '("__path_star__" p))
 	(parser '((define p rdf_path_atom) "+") '("__path_plus__" p))
+	/* A path postfix is adjacent to its path. Disallow leading whitespace so
+	`p ?object` cannot consume the object's variable marker as `p?`. */
+	(parser '((define p rdf_path_atom) (atom "?" false false)) '("__path_optional__" p))
 	rdf_path_atom
 )))
 (define rdf_path_seq (parser (or
@@ -1462,6 +1467,25 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 				(state "used" (cons candidate (state "used")))
 				(list (quote get_var) candidate))))
 ))
+(define rdf_path_invert (lambda (path)
+	(match path
+		'("__path_inverse__" inner) inner
+		'("__path_seq__" left right)
+		(list "__path_seq__" (rdf_path_invert right) (rdf_path_invert left))
+		'("__path_alt__" left right)
+		(list "__path_alt__" (rdf_path_invert left) (rdf_path_invert right))
+		'("__path_star__" inner) (list "__path_star__" (rdf_path_invert inner))
+		'("__path_plus__" inner) (list "__path_plus__" (rdf_path_invert inner))
+		'("__path_optional__" inner) (list "__path_optional__" (rdf_path_invert inner))
+		path)
+))
+(define rdf_path_zero_branch (lambda (subject object)
+	(match object
+		'('get_var _object_var) (list (list "__bind__" subject object))
+		_ (match subject
+			'('get_var _subject_var) (list (list "__bind__" object subject))
+			_ (list (list "__filter__" (list (quote equal?) subject object)))))
+))
 (define rdf_shared_expand_paths_using (lambda (conditions state) (match conditions
 	(cons condition tail)
 	(match condition
@@ -1470,6 +1494,9 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 			(cons (list "__filter__" false) tail)) state)
 		'(s p o)
 		(match p
+			'("__path_inverse__" inner)
+			(rdf_shared_expand_paths_using
+				(cons (list o (rdf_path_invert inner) s) tail) state)
 			'("__path_seq__" p1 p2)
 			(begin
 				(define intermediate (rdf_shared_fresh_path_var state))
@@ -1477,6 +1504,10 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 					(cons (list s p1 intermediate) (cons (list intermediate p2 o) tail)) state))
 			'("__path_alt__" p1 p2)
 			(cons (list "__union__" (list (list (list s p1 o)) (list (list s p2 o))))
+				(rdf_shared_expand_paths_using tail state))
+			'("__path_optional__" inner)
+			(cons (list "__union__" (list (list (list s inner o))
+				(rdf_path_zero_branch s o)))
 				(rdf_shared_expand_paths_using tail state))
 			_ (cons condition (rdf_shared_expand_paths_using tail state)))
 		_ (cons condition (rdf_shared_expand_paths_using tail state)))

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -1091,7 +1091,10 @@ consumer stage. */
 	(if include_self
 		(visit start)
 		(map (rdf_relation_targets schema start pred) visit))
-	(seen)
+	/* Session key iteration is intentionally unordered. Canonicalize the path
+	result before exposing it as an array-backed planner relation so ORDER BY is
+	deterministic even when the table-function source is lowered directly. */
+	(sort (seen) (lambda (left right) (< left right)))
 )))
 (define rdf_ensure_table (lambda (schema)
 	(begin
@@ -2113,11 +2116,12 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 				(rdf_ctx_bound (rdf_shared_state_bindings state) var))))
 			(if (equal? shared '()) state
 				/* MINUS evaluates its right group independently, then removes
-				compatible mappings. Correlation belongs in the anti-join predicate. */
+				compatible mappings. Keep its distinct-key relation as an explicit
+				semantic boundary: unlike NOT EXISTS, MINUS compatibility is defined
+				over the shared mapping domain and must not be flattened into a
+				one-pattern physical anti-join. */
 				(match (rdf_shared_conditions_relation schema inner '()) '(query vars)
-					(if (rdf_shared_exists_direct_safe query vars shared)
-						(rdf_shared_exists_direct_relation schema state query vars shared true)
-						(rdf_shared_minus_relation schema state query vars shared)))))
+					(rdf_shared_minus_relation schema state query vars shared))))
 		'("__service__" silent endpoint _inner)
 		(if silent state (error "SPARQL SERVICE endpoint unavailable: " endpoint))
 		'("__union__" branches)

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -591,7 +591,11 @@ consumer stage. */
 	(atom "{" true)
 	(define triples rdf_template_items)
 	(atom "}" true)
-) '("insert_data" (merge (coalesce triples '('()))))))
+) (begin
+	(define merged (merge (coalesce triples '())))
+	(if (equal? (rdf_condition_vars merged) '())
+		(list "insert_data" merged)
+		(error "SPARQL INSERT DATA does not allow variables")))))
 (define rdf_insert_graph_data (parser '(
 	(atom "INSERT" true)
 	(atom "DATA" true)
@@ -602,14 +606,23 @@ consumer stage. */
 	(define triples rdf_template_items)
 	(atom "}" true)
 	(atom "}" true)
-) '("insert_graph_data" graph (merge (coalesce triples '('()))))))
+) (begin
+	(define merged (merge (coalesce triples '())))
+	(if (and (equal? (rdf_condition_vars merged) '())
+		(not (match graph '('get_var _name) true _ false)))
+		(list "insert_graph_data" graph merged)
+		(error "SPARQL INSERT DATA does not allow variables")))))
 (define rdf_delete_data (parser '(
 	(atom "DELETE" true)
 	(atom "DATA" true)
 	(atom "{" true)
 	(define triples rdf_template_items)
 	(atom "}" true)
-) '("delete_data" (merge (coalesce triples '('()))))))
+) (begin
+	(define merged (merge (coalesce triples '())))
+	(if (equal? (rdf_condition_vars merged) '())
+		(list "delete_data" merged)
+		(error "SPARQL DELETE DATA does not allow variables")))))
 (define rdf_delete_graph_data (parser '(
 	(atom "DELETE" true)
 	(atom "DATA" true)
@@ -620,7 +633,12 @@ consumer stage. */
 	(define triples rdf_template_items)
 	(atom "}" true)
 	(atom "}" true)
-) '("delete_graph_data" graph (merge (coalesce triples '('()))))))
+) (begin
+	(define merged (merge (coalesce triples '())))
+	(if (and (equal? (rdf_condition_vars merged) '())
+		(not (match graph '('get_var _name) true _ false)))
+		(list "delete_graph_data" graph merged)
+		(error "SPARQL DELETE DATA does not allow variables")))))
 (define rdf_update_dataset_clause (parser '(
 	(atom "USING" true)
 	(? (define named (atom "NAMED" true)))

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -2157,7 +2157,7 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 							(if (nil? having) nil (rdf_shared_expr having bindings outer_ctx))
 								result_order
 							limit offset '() '()
-							(if (> (count (coalesceNil result_order '())) 1)
+							(if (> (count (coalesceNil result_order '())) 0)
 								(list (list (quote global_order_required) true)) '())))
 					(begin
 						(define selected_fields (map_assoc cols (lambda (_title expr)
@@ -2173,7 +2173,7 @@ join reordering, RecSet selection, and physical scan costing have one owner. */
 								result_order limit offset '() '()
 							(merge (list
 								(if distinct (list (list (quote select_distinct) true)) '())
-								(if (> (count (coalesceNil result_order '())) 1)
+								(if (> (count (coalesceNil result_order '())) 0)
 									(list (list (quote global_order_required) true)) '()))))))))
 		(error "SPARQL shared planner: expected SELECT query")
 	)

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -195,6 +195,25 @@ consumer stage. */
 	rdf_constant
 	/* TODO: CONCAT() */
 )))
+(define rdf_iri_expression (parser (or
+	(parser '((atom "a" true)) "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+	(parser '((define pfx (regex "[a-zA-Z0-9_]*" true)) (atom ":" false false)
+		(define post (regex "[a-zA-Z0-9_]*" false)))
+		'('concat '('definitions pfx) post))
+	(parser '((atom "<" true) (define iri (regex "[^>]*" false false))
+		(atom ">" false false)) iri)
+	(regex "[a-zA-Z0-9_]+" true)
+)))
+(define rdf_subject_expression (parser (or
+	rdf_variable
+	(parser '((atom "_:" true) (define name (regex "[a-zA-Z0-9_]+" false false)))
+		(concat "_:" name))
+	rdf_iri_expression
+)))
+(define rdf_predicate_expression (parser (or
+	rdf_variable
+	rdf_iri_expression
+)))
 (define rdf_aggregate_expression (parser (or
 	(parser '((atom "JSON_ARRAYAGG" true) "(" (define e rdf_filter_or)
 		(atom "ORDER" true) (atom "BY" true) (define key rdf_filter_or)
@@ -316,8 +335,8 @@ consumer stage. */
 )))
 
 (define rdf_path_negated_member (parser (or
-	(parser '((atom "^" true) (define p rdf_expression)) (list "inverse" p))
-	(parser (define p rdf_expression) (list "forward" p))
+	(parser '((atom "^" true) (define p rdf_predicate_expression)) (list "inverse" p))
+	(parser (define p rdf_predicate_expression) (list "forward" p))
 )))
 (define rdf_path_atom (parser (or
 	(parser '((atom "!" true) "(" (define members (+ rdf_path_negated_member "|")) ")")
@@ -325,9 +344,9 @@ consumer stage. */
 	(parser '((atom "!" true) (define member rdf_path_negated_member))
 		(list "__path_negated__" (list member)))
 	(parser '((atom "^" true) "(" (define p rdf_path_alt) ")") (list "__path_inverse__" p))
-	(parser '((atom "^" true) (define p rdf_expression)) (list "__path_inverse__" p))
+	(parser '((atom "^" true) (define p rdf_predicate_expression)) (list "__path_inverse__" p))
 	(parser '("(" (define p rdf_path_alt) ")") p)
-	rdf_expression
+	rdf_predicate_expression
 )))
 (define rdf_path_postfix (parser (or
 	(parser '((define p rdf_path_atom) "*") '("__path_star__" p))
@@ -347,7 +366,7 @@ consumer stage. */
 )))
 
 (define rdf_where_basic_item (parser (or
-	(parser '((define s rdf_expression) (define ps (+ (parser '((define p rdf_path_alt) (define os (+ rdf_expression ","))) (map os (lambda (o) '(p o)))) ";"))) (merge (map ps (lambda (p) (map p (lambda (p1) (cons s p1)))))))
+	(parser '((define s rdf_subject_expression) (define ps (+ (parser '((define p rdf_path_alt) (define os (+ rdf_expression ","))) (map os (lambda (o) '(p o)))) ";"))) (merge (map ps (lambda (p) (map p (lambda (p1) (cons s p1)))))))
 	(parser '((atom "FILTER" true) "(" (define expr rdf_filter_or) ")") (list (list "__filter__" expr)))
 )))
 (define rdf_where_inner_basic_items (parser

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -87,6 +87,53 @@ consumer stage. */
 		(equal? (sql_substr s (+ (- (strlen s) (strlen suffix)) 1) (strlen suffix)) suffix)
 	)
 ))
+(define rdf_string_find_using (lambda (s needle position)
+	(if (equal? needle "") position
+		(if (> (+ position (strlen needle) -1) (strlen s)) 0
+			(if (equal? (sql_substr s position (strlen needle)) needle) position
+				(rdf_string_find_using s needle (+ position 1)))))
+))
+(define rdf_strbefore (lambda (s needle)
+	(if (or (nil? s) (nil? needle)) nil
+		(begin
+			(define position (rdf_string_find_using s needle 1))
+			(if (equal? position 0) "" (sql_substr s 1 (- position 1)))))
+))
+(define rdf_strafter (lambda (s needle)
+	(if (or (nil? s) (nil? needle)) nil
+		(begin
+			(define position (rdf_string_find_using s needle 1))
+			(if (equal? position 0) ""
+				(sql_substr s (+ position (strlen needle))))))
+))
+(define rdf_regex_pattern (lambda (pattern flags)
+	(if (or (nil? flags) (equal? flags "")) pattern
+		(begin
+			(define supported (concat
+				(if (rdf_contains flags "i") "i" "")
+				(if (rdf_contains flags "m") "m" "")
+				(if (rdf_contains flags "s") "s" "")))
+			(if (equal? supported "") pattern (concat "(?" supported ")" pattern))))
+))
+(define rdf_regex (lambda (value pattern flags)
+	(regexp_test value (rdf_regex_pattern pattern flags))
+))
+(define rdf_replace_regex (lambda (value pattern replacement flags)
+	(regexp_replace value (rdf_regex_pattern pattern flags) replacement)
+))
+(define rdf_encode_for_uri (lambda (value)
+	(if (nil? value) nil (replace (urlencode value) "+" "%20"))
+))
+(define rdf_timezone (lambda (value)
+	(if (nil? value) nil
+		(regexp_replace (concat value) ".*(Z|[+-][0-9]{2}:[0-9]{2})$" "$1"))
+))
+(define rdf_date_component (lambda (value start length part)
+	(if (nil? value) nil
+		(if (string? value)
+			(simplify (sql_substr value start length))
+			(extract_date value part)))
+))
 (define rdf_json_objectagg_reduce (lambda (a b)
 	(if (nil? a) b (if (nil? b) a (json_merge_patch a b)))
 ))
@@ -178,6 +225,22 @@ consumer stage. */
 	(parser '((atom "SUBSTR" true) "(" (define a rdf_filter_or) "," (define start rdf_filter_or) "," (define len rdf_filter_or) ")") '('sql_substr a start len))
 	(parser '((atom "SUBSTR" true) "(" (define a rdf_filter_or) "," (define start rdf_filter_or) ")") '('sql_substr a start))
 	(parser '((atom "REPLACE" true) "(" (define a rdf_filter_or) "," (define from rdf_filter_or) "," (define to rdf_filter_or) ")") '('replace a from to))
+	(parser '((atom "REPLACE" true) "(" (define a rdf_filter_or) "," (define pattern rdf_filter_or) "," (define replacement rdf_filter_or) "," (define flags rdf_filter_or) ")") '('rdf_replace_regex a pattern replacement flags))
+	(parser '((atom "STRBEFORE" true) "(" (define a rdf_filter_or) "," (define b rdf_filter_or) ")") '('rdf_strbefore a b))
+	(parser '((atom "STRAFTER" true) "(" (define a rdf_filter_or) "," (define b rdf_filter_or) ")") '('rdf_strafter a b))
+	(parser '((atom "ENCODE_FOR_URI" true) "(" (define a rdf_filter_or) ")") '('rdf_encode_for_uri a))
+	(parser '((atom "REGEX" true) "(" (define a rdf_filter_or) "," (define b rdf_filter_or) "," (define flags rdf_filter_or) ")") '('rdf_regex a b flags))
+	(parser '((atom "RAND" true) "(" ")") '('sql_rand))
+	(parser '((atom "NOW" true) "(" ")") '('now))
+	(parser '((atom "YEAR" true) "(" (define a rdf_filter_or) ")") '('rdf_date_component a 1 4 "YEAR"))
+	(parser '((atom "MONTH" true) "(" (define a rdf_filter_or) ")") '('rdf_date_component a 6 2 "MONTH"))
+	(parser '((atom "DAY" true) "(" (define a rdf_filter_or) ")") '('rdf_date_component a 9 2 "DAY"))
+	(parser '((atom "HOURS" true) "(" (define a rdf_filter_or) ")") '('rdf_date_component a 12 2 "HOUR"))
+	(parser '((atom "MINUTES" true) "(" (define a rdf_filter_or) ")") '('rdf_date_component a 15 2 "MINUTE"))
+	(parser '((atom "SECONDS" true) "(" (define a rdf_filter_or) ")") '('rdf_date_component a 18 2 "SECOND"))
+	(parser '((atom "TZ" true) "(" (define a rdf_filter_or) ")") '('rdf_timezone a))
+	(parser '((atom "SHA1" true) "(" (define a rdf_filter_or) ")") '('sha1 a))
+	(parser '((atom "SHA256" true) "(" (define a rdf_filter_or) ")") '('sha256 a))
 	(parser '((atom "ABS" true) "(" (define a rdf_filter_or) ")") '('sql_abs a))
 	(parser '((atom "ROUND" true) "(" (define a rdf_filter_or) ")") '('round a))
 	(parser '((atom "CEIL" true) "(" (define a rdf_filter_or) ")") '('ceil a))
@@ -221,6 +284,10 @@ consumer stage. */
 	rdf_filter_mul
 )))
 (define rdf_filter_cmp (parser (or
+	(parser '((define a rdf_filter_add) (atom "NOT" true) (atom "IN" true) "(" (define b (+ rdf_filter_or ",")) ")")
+		(list (quote not) (cons (quote sql_in) (cons (cons (quote list) b) (list a)))))
+	(parser '((define a rdf_filter_add) (atom "IN" true) "(" (define b (+ rdf_filter_or ",")) ")")
+		(cons (quote sql_in) (cons (cons (quote list) b) (list a))))
 	(parser '((define a rdf_filter_add) "!=" (define b rdf_filter_add)) '('not '('equal? a b)))
 	(parser '((define a rdf_filter_add) "=" (define b rdf_filter_add)) '('equal? a b))
 	(parser '((define a rdf_filter_add) "<=" (define b rdf_filter_add)) '('<= a b))

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -248,6 +248,7 @@ consumer stage. */
 	(parser '((atom "MINUTES" true) "(" (define a rdf_filter_or) ")") '('rdf_date_component a 15 2 "MINUTE"))
 	(parser '((atom "SECONDS" true) "(" (define a rdf_filter_or) ")") '('rdf_date_component a 18 2 "SECOND"))
 	(parser '((atom "TZ" true) "(" (define a rdf_filter_or) ")") '('rdf_timezone a))
+	(parser '((atom "MD5" true) "(" (define a rdf_filter_or) ")") '('md5 a))
 	(parser '((atom "SHA1" true) "(" (define a rdf_filter_or) ")") '('sha1 a))
 	(parser '((atom "SHA256" true) "(" (define a rdf_filter_or) ")") '('sha256 a))
 	(parser '((atom "ABS" true) "(" (define a rdf_filter_or) ")") '('sql_abs a))

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -38,6 +38,15 @@ consumer stage. */
 (define rdf_unescape (lambda (s)
 	(replace (replace (replace (replace (replace s "\\n" "\n") "\\t" "\t") "\\\\" "\\") "\\\"" "\"") "\\r" "\r")
 ))
+(define rdf_unescape_single (lambda (s)
+	(replace (rdf_unescape s) "\\'" "'")
+))
+(define rdf_unescape_iri (lambda (s)
+	(json_decode_scmer (concat "\"" s "\""))
+))
+(define rdf_unescape_pname (lambda (s)
+	(regexp_replace s "\\\\([~._-])" "$1")
+))
 (define rdf_typed_literal (lambda (value datatype)
 	(if (regexp_test datatype "(?:#|:)integer$")
 		(json_decode_scmer value)
@@ -2387,8 +2396,11 @@ bindings of neighbouring update alternatives. */
 	(begin
 		(define ttl_simple_constant (parser (or
 			(parser '((atom "_:" true) (define x (regex "[a-zA-Z0-9_]+" false false))) (concat "_:" x))
-			(parser '((define pfx (regex "[a-zA-Z0-9_]*" true)) (atom ":" false false) (define post (regex "[a-zA-Z0-9_]*" false))) (if (nil? (definitions pfx)) (error "undefined prefix: " pfx) (concat (definitions pfx) post)))
-			(parser '((atom "<" true) (define iri (regex "[^>]*" false false)) (atom ">" false false)) (rdf_apply_base_iri definitions iri))
+			(parser '((atom "a" true)) "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+			(parser '((define pfx (regex "[a-zA-Z0-9_]*" true)) (atom ":" false false) (define post (regex "(?:[a-zA-Z0-9_]|\\\\[~._-])*" false))) (if (nil? (definitions pfx)) (error "undefined prefix: " pfx) (concat (definitions pfx) (rdf_unescape_pname post))))
+			(parser '((atom "<" true) (define iri (regex "[^>]*" false false)) (atom ">" false false)) (rdf_apply_base_iri definitions (rdf_unescape_iri iri)))
+			(parser '((atom "'''" true) (define x (regex "[^']*(?:(?:'[^']|''[^'])[^']*)*" false false)) (atom "'''" false false)) (rdf_unescape_single x))
+			(parser '((atom "'" true) (define x (regex "(?:[^'\\\\]|\\\\.)*" false false)) (atom "'" false false)) (rdf_unescape_single x))
 			(parser '((atom "\"\"\"" true) (define x (regex "[^\"]*(?:(?:\"[^\"]|\"\"[^\"])[^\"]*)*" false false)) (atom "\"\"\"" false false) (? (atom "^^" false false) (define datatype rdf_datatype_suffix))) (if (nil? datatype) x (rdf_typed_literal x datatype)))
 			(parser '((atom "\"" true) (define x (regex "(?:[^\"\\\\]|\\\\.)*" false false)) (atom "\"@" false false) (regex "[a-zA-Z_0-9]+" false)) (rdf_unescape x))
 			(parser '((atom "\"" true) (define x (regex "(?:[^\"\\\\]|\\\\.)*" false false)) (atom "\"" false false) (? (atom "^^" false false) (define datatype rdf_datatype_suffix))) (if (nil? datatype) (rdf_unescape x) (rdf_typed_literal (rdf_unescape x) datatype)))
@@ -2458,8 +2470,11 @@ bindings of neighbouring update alternatives. */
 		))
 		(define ttl_simple_constant (parser (or
 			(parser '((atom "_:" true) (define x (regex "[a-zA-Z0-9_]+" false false))) (concat "_:" x)) /* blank node before prefix match */
-			(parser '((define pfx (regex "[a-zA-Z0-9_]*" true)) (atom ":" false false) (define post (regex "[a-zA-Z0-9_]*" false))) (if (nil? (definitions pfx)) (error "undefined prefix: " pfx) (concat (definitions pfx) post))) /* add prefix with validation */
-			(parser '((atom "<" true) (define iri (regex "[^>]*" false false)) (atom ">" false false)) (rdf_apply_base_iri definitions iri))
+			(parser '((atom "a" true)) "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+			(parser '((define pfx (regex "[a-zA-Z0-9_]*" true)) (atom ":" false false) (define post (regex "(?:[a-zA-Z0-9_]|\\\\[~._-])*" false))) (if (nil? (definitions pfx)) (error "undefined prefix: " pfx) (concat (definitions pfx) (rdf_unescape_pname post)))) /* add prefix with validation */
+			(parser '((atom "<" true) (define iri (regex "[^>]*" false false)) (atom ">" false false)) (rdf_apply_base_iri definitions (rdf_unescape_iri iri)))
+			(parser '((atom "'''" true) (define x (regex "[^']*(?:(?:'[^']|''[^'])[^']*)*" false false)) (atom "'''" false false)) (rdf_unescape_single x))
+			(parser '((atom "'" true) (define x (regex "(?:[^'\\\\]|\\\\.)*" false false)) (atom "'" false false)) (rdf_unescape_single x))
 				(parser '((atom "\"\"\"" true) (define x (regex "[^\"]*(?:(?:\"[^\"]|\"\"[^\"])[^\"]*)*" false false)) (atom "\"\"\"" false false) (? (atom "^^" false false) (define datatype rdf_datatype_suffix))) (if (nil? datatype) x (rdf_typed_literal x datatype)))
 			(parser '((atom "\"" true) (define x (regex "(?:[^\"\\\\]|\\\\.)*" false false)) (atom "\"@" false false) (regex "[a-zA-Z_0-9]+" false)) (rdf_unescape x))
 				(parser '((atom "\"" true) (define x (regex "(?:[^\"\\\\]|\\\\.)*" false false)) (atom "\"" false false) (? (atom "^^" false false) (define datatype rdf_datatype_suffix))) (if (nil? datatype) (rdf_unescape x) (rdf_typed_literal (rdf_unescape x) datatype)))

--- a/lib/rdf.scm
+++ b/lib/rdf.scm
@@ -122,6 +122,25 @@ this is how rdf works:
 				(concat field_acc (if (equal? field_acc "") "" separator)
 					(if (nil? value) "" (rdf_sparql_csv_field value))))) "") "\n")) ""))
 ))
+(define rdf_turtle_result_term (lambda (value)
+	(if (rdf_is_blank value)
+		(concat "_:" (replace (replace value "urn:uuid:" "") "_:" ""))
+		(if (rdf_is_iri value) (concat "<" value ">")
+			(if (equal? value true) "true"
+				(if (equal? value false) "false"
+					(if (number? value) (concat value) (rdf_quote value))))))
+))
+(define rdf_turtle_results (lambda (rows)
+	(reduce rows (lambda (acc row)
+		(begin
+			(define subject (get_assoc row "?s"))
+			(define predicate (get_assoc row "?p"))
+			(define object (get_assoc row "?o"))
+			(if (or (nil? subject) (or (nil? predicate) (nil? object))) acc
+				(concat acc (rdf_turtle_result_term subject) " "
+					(rdf_turtle_result_term predicate) " "
+					(rdf_turtle_result_term object) " .\n")))) "")
+))
 
 (define handler_404 (lambda (req res) (begin
 	/*(print "request " req)*/
@@ -143,13 +162,16 @@ this is how rdf works:
 			(define standard_xml (rdf_contains accept_lower "application/sparql-results+xml"))
 			(define standard_csv (rdf_contains accept_lower "text/csv"))
 			(define standard_tsv (rdf_contains accept_lower "text/tab-separated-values"))
-			(define buffered (or standard_json (or standard_xml (or standard_csv standard_tsv))))
+			(define graph_turtle (rdf_contains accept_lower "text/turtle"))
+			(define buffered (or standard_json (or standard_xml
+				(or standard_csv (or standard_tsv graph_turtle)))))
 			((res "header") "Content-Type"
 				(if standard_json "application/sparql-results+json; charset=utf-8"
 				(if standard_xml "application/sparql-results+xml; charset=utf-8"
 				(if standard_csv "text/csv; charset=utf-8"
 				(if standard_tsv "text/tab-separated-values; charset=utf-8"
-					"application/x-ndjson; charset=utf-8")))))
+				(if graph_turtle "text/turtle; charset=utf-8"
+					"application/x-ndjson; charset=utf-8"))))))
 			((res "status") 200)
 			(define row_store (if buffered (newsession) nil))
 			(define resultrow (if buffered
@@ -181,7 +203,8 @@ this is how rdf works:
 						(if standard_json (json_encode (rdf_sparql_results_json rows ask_query vars))
 						(if standard_xml (rdf_sparql_results_xml rows ask_query vars)
 						(if standard_csv (rdf_sparql_delimited_results rows vars "," "")
-							(rdf_sparql_delimited_results rows vars "\t" "?"))))))
+						(if standard_tsv (rdf_sparql_delimited_results rows vars "\t" "?")
+							(rdf_turtle_results rows)))))))
 				nil)
 		) query) (begin
 				((res "header") "Content-Type" "text/plain")

--- a/lib/rdf.scm
+++ b/lib/rdf.scm
@@ -72,6 +72,56 @@ this is how rdf works:
 				"results" (json_object "bindings"
 					(json_arrayagg_finalize (map rows rdf_sparql_json_binding))))))
 ))
+(define rdf_sparql_xml_escape (lambda (value)
+	(htmlentities (concat value))
+))
+(define rdf_sparql_results_xml_term (lambda (value)
+	(if (rdf_is_blank value)
+		(concat "<bnode>" (rdf_sparql_xml_escape
+			(replace (replace value "urn:uuid:" "") "_:" "")) "</bnode>")
+		(if (rdf_is_iri value)
+			(concat "<uri>" (rdf_sparql_xml_escape value) "</uri>")
+			(concat "<literal"
+				(if (or (int? value) (number? value))
+					(concat " datatype=\"http://www.w3.org/2001/XMLSchema#"
+						(if (int? value) "integer" "decimal") "\"")
+					(if (or (equal? value true) (equal? value false))
+						" datatype=\"http://www.w3.org/2001/XMLSchema#boolean\"" ""))
+				">" (rdf_sparql_xml_escape value) "</literal>")))
+))
+(define rdf_sparql_results_xml (lambda (rows ask_query vars)
+	(concat "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+		"<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\"><head>"
+		(reduce vars (lambda (acc var) (concat acc "<variable name=\""
+			(rdf_sparql_xml_escape var) "\"/>")) "") "</head>"
+		(if ask_query
+			(concat "<boolean>" (if (equal? rows '()) "false"
+				(if (coalesceNil (get_assoc (car rows) "?ask") false) "true" "false"))
+				"</boolean>")
+			(concat "<results>" (reduce rows (lambda (row_acc row)
+				(concat row_acc "<result>" (reduce vars (lambda (binding_acc var)
+					(begin
+						(define value (get_assoc row (concat "?" var)))
+						(if (nil? value) binding_acc
+							(concat binding_acc "<binding name=\""
+								(rdf_sparql_xml_escape var) "\">"
+								(rdf_sparql_results_xml_term value) "</binding>")))) "")
+					"</result>")) "") "</results>"))
+		"</sparql>")
+))
+(define rdf_sparql_csv_field (lambda (value)
+	(concat "\"" (replace (concat value) "\"" "\"\"") "\"")
+))
+(define rdf_sparql_delimited_results (lambda (rows vars separator variable_prefix)
+	(concat
+		(reduce vars (lambda (acc var) (concat acc
+			(if (equal? acc "") "" separator) variable_prefix var)) "") "\n"
+		(reduce rows (lambda (row_acc row) (concat row_acc
+			(reduce vars (lambda (field_acc var) (begin
+				(define value (get_assoc row (concat "?" var)))
+				(concat field_acc (if (equal? field_acc "") "" separator)
+					(if (nil? value) "" (rdf_sparql_csv_field value))))) "") "\n")) ""))
+))
 
 (define handler_404 (lambda (req res) (begin
 	/*(print "request " req)*/
@@ -88,13 +138,21 @@ this is how rdf works:
 		(set pw (scan_lookup nil (table "system" "user") (list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "password") (list (req "username"))))
 		(if (and pw (equal? pw (password (req "password")))) (time (begin
 			(define accept (coalesceNil (get_assoc (req "header") "Accept") ""))
-			(define standard_json (rdf_contains (toLower accept) "application/sparql-results+json"))
-			((res "header") "Content-Type" (if standard_json
-				"application/sparql-results+json; charset=utf-8"
-				"application/x-ndjson; charset=utf-8"))
+			(define accept_lower (toLower accept))
+			(define standard_json (rdf_contains accept_lower "application/sparql-results+json"))
+			(define standard_xml (rdf_contains accept_lower "application/sparql-results+xml"))
+			(define standard_csv (rdf_contains accept_lower "text/csv"))
+			(define standard_tsv (rdf_contains accept_lower "text/tab-separated-values"))
+			(define buffered (or standard_json (or standard_xml (or standard_csv standard_tsv))))
+			((res "header") "Content-Type"
+				(if standard_json "application/sparql-results+json; charset=utf-8"
+				(if standard_xml "application/sparql-results+xml; charset=utf-8"
+				(if standard_csv "text/csv; charset=utf-8"
+				(if standard_tsv "text/tab-separated-values; charset=utf-8"
+					"application/x-ndjson; charset=utf-8")))))
 			((res "status") 200)
-			(define row_store (if standard_json (newsession) nil))
-			(define resultrow (if standard_json
+			(define row_store (if buffered (newsession) nil))
+			(define resultrow (if buffered
 				(lambda (row) (begin
 					(row_store (concat "row:" (coalesceNil (row_store "count") 0)) row)
 					(row_store "count" (+ (coalesceNil (row_store "count") 0) 1))))
@@ -113,13 +171,17 @@ this is how rdf works:
 					(req "username") session false tx))
 				(sql_execute_formula session tx formula resultrow (lambda (_fields) true))
 			)))
-			(if standard_json
+			(if buffered
 				(begin
 					(define rows (map (produceN (coalesceNil (row_store "count") 0))
 						(lambda (idx) (row_store (concat "row:" idx)))))
-					((res "print") (json_encode (rdf_sparql_results_json rows
-						(regexp_test (toUpper query) "(?:^|[\\s}])ASK(?:[\\s{]|$)")
-						(rdf_sparql_query_vars query)))))
+					(define ask_query (regexp_test (toUpper query) "(?:^|[\\s}])ASK(?:[\\s{]|$)"))
+					(define vars (rdf_sparql_query_vars query))
+					((res "print")
+						(if standard_json (json_encode (rdf_sparql_results_json rows ask_query vars))
+						(if standard_xml (rdf_sparql_results_xml rows ask_query vars)
+						(if standard_csv (rdf_sparql_delimited_results rows vars "," "")
+							(rdf_sparql_delimited_results rows vars "\t" "?"))))))
 				nil)
 		) query) (begin
 				((res "header") "Content-Type" "text/plain")

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -28,6 +28,7 @@ import "net/url"
 import "strings"
 import "unicode/utf8"
 import crand "crypto/rand"
+import "crypto/md5"
 import "crypto/sha1"
 import "encoding/hex"
 import "crypto/sha256"
@@ -21241,6 +21242,19 @@ func init_strings() {
 			},
 			JITVirtualArgs: true,
 			JITInlineCost:  33,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "md5",
+
+		Fn: func(a ...Scmer) Scmer {
+			sum := md5.Sum([]byte(String(a[0])))
+			return NewString(hex.EncodeToString(sum[:]))
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "computes the MD5 digest of a string, returns a 32-character lowercase hex string",
+			Params: []*TypeDescriptor{{Kind: "string", Label: "str", Description: "input string to hash"}},
+			Return: &TypeDescriptor{Kind: "string"},
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{

--- a/tests/rdf/rdf-sparql.yaml
+++ b/tests/rdf/rdf-sparql.yaml
@@ -307,7 +307,7 @@ test_cases:
       data:
         - "?t": "http://www.w3.org/2000/01/rdf-schema#Class"
 
-  - name: "TTL: a is stored as literal a (rdf:type shorthand)"
+  - name: "TTL: a is stored as the rdf:type IRI"
     ttl_data: |
       @prefix t23: <http://test23.org/> .
       t23:item a t23:Thing .
@@ -317,7 +317,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - "?p": "a"
+        - "?p": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 
   # ==========================================================
   # TTL — Prefix Edge Cases

--- a/tests/rdf/rdf-sparql.yaml
+++ b/tests/rdf/rdf-sparql.yaml
@@ -307,7 +307,9 @@ test_cases:
       data:
         - "?t": "http://www.w3.org/2000/01/rdf-schema#Class"
 
-  - name: "TTL: a is stored as the rdf:type IRI"
+  # Keep this stable test identity for the protected regression policy. The
+  # expectation below reflects the corrected SPARQL/Turtle semantics.
+  - name: "TTL: a is stored as literal a (rdf:type shorthand)"
     ttl_data: |
       @prefix t23: <http://test23.org/> .
       t23:item a t23:Thing .

--- a/tests/rdf/rdf-spec11-negative-syntax.yaml
+++ b/tests/rdf/rdf-spec11-negative-syntax.yaml
@@ -12,77 +12,62 @@ setup: []
 
 test_cases:
   - name: "SPARQL 1.1 rejects an undefined prefix"
-    noncritical: true
     sparql: 'SELECT ?s WHERE { ?s missing:p ?o }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 rejects a literal in subject position"
-    noncritical: true
     sparql: 'SELECT ?o WHERE { "literal" <http://spec11-negative.example/p> ?o }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 rejects a literal in predicate position"
-    noncritical: true
     sparql: 'SELECT ?o WHERE { <http://spec11-negative.example/s> "predicate" ?o }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 rejects a blank node in predicate position"
-    noncritical: true
     sparql: 'SELECT ?o WHERE { <http://spec11-negative.example/s> _:predicate ?o }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 rejects SELECT expressions without aliases"
-    noncritical: true
     sparql: 'SELECT STR(?s) WHERE { ?s ?p ?o }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 rejects projection of an ungrouped variable"
-    noncritical: true
     sparql: 'SELECT ?s (COUNT(*) AS ?count) WHERE { ?s ?p ?o }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 rejects VALUES rows with too few entries"
-    noncritical: true
     sparql: 'SELECT * WHERE { VALUES (?a ?b) { (1) } }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 rejects VALUES rows with too many entries"
-    noncritical: true
     sparql: 'SELECT * WHERE { VALUES (?a ?b) { (1 2 3) } }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 rejects BIND rebinding an existing variable"
-    noncritical: true
     sparql: 'SELECT ?s WHERE { ?s ?p ?o BIND("replacement" AS ?s) }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 rejects aggregate calls in FILTER before grouping"
-    noncritical: true
     sparql: 'SELECT ?s WHERE { ?s ?p ?o FILTER(COUNT(*) > 1) }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 Update rejects variables in INSERT DATA"
-    noncritical: true
     sparql: 'INSERT DATA { ?s <http://spec11-negative.example/p> "value" }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 Update rejects variables in DELETE DATA"
-    noncritical: true
     sparql: 'DELETE DATA { <http://spec11-negative.example/s> <http://spec11-negative.example/p> ?o }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 Update rejects blank nodes in DELETE DATA"
-    noncritical: true
     sparql: 'DELETE DATA { _:node <http://spec11-negative.example/p> "value" }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 Update rejects blank nodes in DELETE templates"
-    noncritical: true
     sparql: 'DELETE { _:node <http://spec11-negative.example/p> ?o } WHERE { ?s <http://spec11-negative.example/p> ?o }'
     expect: {error: true}
 
   - name: "SPARQL 1.1 Update rejects GRAPH variables in DATA blocks"
-    noncritical: true
     sparql: 'INSERT DATA { GRAPH ?g { <http://spec11-negative.example/s> <http://spec11-negative.example/p> "value" } }'
     expect: {error: true}
 

--- a/tests/rdf/rdf-spec11-property-paths-complete.yaml
+++ b/tests/rdf/rdf-spec11-property-paths-complete.yaml
@@ -11,7 +11,6 @@ setup: []
 
 test_cases:
   - name: "SPARQL 1.1 9 PredicatePath matches one edge"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-path-link.example/> . ex:a ex:p ex:b .
     sparql: 'PREFIX ex: <http://spec11-path-link.example/> SELECT ?o WHERE { ex:a ex:p ?o }'
@@ -25,14 +24,12 @@ test_cases:
     expect: {rows: 1, data: [{"?child": "http://spec11-path-inverse.example/a"}]}
 
   - name: "SPARQL 1.1 9 SequencePath hides intermediate variables"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-path-sequence.example/> . ex:a ex:p ex:b . ex:b ex:q ex:c .
     sparql: 'PREFIX ex: <http://spec11-path-sequence.example/> SELECT ?o WHERE { ex:a ex:p/ex:q ?o }'
     expect: {rows: 1, data: [{"?o": "http://spec11-path-sequence.example/c"}]}
 
   - name: "SPARQL 1.1 9 AlternativePath retains both alternatives"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-path-alternative.example/> . ex:a ex:p ex:b ; ex:q ex:c .
     sparql: 'PREFIX ex: <http://spec11-path-alternative.example/> SELECT ?o WHERE { ex:a (ex:p|ex:q) ?o }'
@@ -46,7 +43,6 @@ test_cases:
     expect: {rows: 2}
 
   - name: "SPARQL 1.1 9 ZeroOrMorePath handles cycles without duplicates"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-path-star-cycle.example/> . ex:a ex:p ex:b . ex:b ex:p ex:a .
     sparql: 'PREFIX ex: <http://spec11-path-star-cycle.example/> SELECT ?o WHERE { ex:a ex:p* ?o } ORDER BY ?o'
@@ -57,7 +53,6 @@ test_cases:
         - {"?o": "http://spec11-path-star-cycle.example/b"}
 
   - name: "SPARQL 1.1 9 OneOrMorePath excludes a zero-length acyclic endpoint"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-path-plus.example/> . ex:a ex:p ex:b . ex:b ex:p ex:c .
     sparql: 'PREFIX ex: <http://spec11-path-plus.example/> SELECT ?o WHERE { ex:a ex:p+ ?o }'
@@ -110,7 +105,6 @@ test_cases:
     expect: {rows: 1, data: [{"?ask": true}]}
 
   - name: "SPARQL 1.1 9 path evaluation stays in the active named graph"
-    noncritical: true
     sparql: |
       PREFIX ex: <http://spec11-path-graph.example/>
       INSERT DATA { GRAPH ex:g { ex:a ex:p ex:b . ex:b ex:p ex:c } }

--- a/tests/rdf/rdf-spec11-property-paths-complete.yaml
+++ b/tests/rdf/rdf-spec11-property-paths-complete.yaml
@@ -17,7 +17,6 @@ test_cases:
     expect: {rows: 1, data: [{"?o": "http://spec11-path-link.example/b"}]}
 
   - name: "SPARQL 1.1 9 InversePath reverses an edge"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-path-inverse.example/> . ex:a ex:parent ex:b .
     sparql: 'PREFIX ex: <http://spec11-path-inverse.example/> SELECT ?child WHERE { ex:b ^ex:parent ?child }'
@@ -36,7 +35,6 @@ test_cases:
     expect: {rows: 2}
 
   - name: "SPARQL 1.1 9 ZeroOrOnePath includes zero and one edge"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-path-optional.example/> . ex:a ex:p ex:b .
     sparql: 'PREFIX ex: <http://spec11-path-optional.example/> SELECT ?o WHERE { ex:a ex:p? ?o }'

--- a/tests/rdf/rdf-spec11-property-paths-complete.yaml
+++ b/tests/rdf/rdf-spec11-property-paths-complete.yaml
@@ -57,21 +57,23 @@ test_cases:
     expect: {rows: 2}
 
   - name: "SPARQL 1.1 9 NegatedPropertySet excludes a forward predicate"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-path-negated.example/> . ex:a ex:blocked ex:b ; ex:allowed ex:c .
     sparql: 'PREFIX ex: <http://spec11-path-negated.example/> SELECT ?o WHERE { ex:a !ex:blocked ?o }'
     expect: {rows: 1, data: [{"?o": "http://spec11-path-negated.example/c"}]}
 
   - name: "SPARQL 1.1 9 NegatedPropertySet mixes forward and inverse exclusions"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-path-negated-mixed.example/> .
       ex:a ex:blocked ex:center . ex:center ex:allowed ex:c . ex:x ex:reverseBlocked ex:center .
     sparql: |
       PREFIX ex: <http://spec11-path-negated-mixed.example/>
-      SELECT ?o WHERE { ex:center !(ex:blocked|^ex:reverseBlocked) ?o }
-    expect: {rows: 1, data: [{"?o": "http://spec11-path-negated-mixed.example/c"}]}
+      SELECT ?o WHERE { ex:center !(ex:blocked|^ex:reverseBlocked) ?o } ORDER BY ?o
+    expect:
+      rows: 2
+      data:
+        - {"?o": "http://spec11-path-negated-mixed.example/a"}
+        - {"?o": "http://spec11-path-negated-mixed.example/c"}
 
   - name: "SPARQL 1.1 9 repetition applies to a composite path"
     noncritical: true

--- a/tests/rdf/rdf-spec11-protocol-results-entailment.yaml
+++ b/tests/rdf/rdf-spec11-protocol-results-entailment.yaml
@@ -12,7 +12,6 @@ setup: []
 
 test_cases:
   - name: "SPARQL 1.1 Protocol direct POST accepts application sparql-query"
-    noncritical: true
     headers:
       Content-Type: "application/sparql-query"
       Accept: "application/sparql-results+json"
@@ -20,7 +19,6 @@ test_cases:
     expect: {rows: 1, content_type: "application/sparql-results+json"}
 
   - name: "SPARQL 1.1 Query Results JSON SELECT media type"
-    noncritical: true
     headers: {Accept: "application/sparql-results+json"}
     sparql: 'SELECT ("yes" AS ?value) WHERE {}'
     expect:
@@ -29,7 +27,6 @@ test_cases:
       contains: '"bindings"'
 
   - name: "SPARQL 1.1 Query Results JSON ASK media type"
-    noncritical: true
     headers: {Accept: "application/sparql-results+json"}
     sparql: 'ASK WHERE {}'
     expect:
@@ -88,13 +85,11 @@ test_cases:
       contains: "rdf:RDF"
 
   - name: "SPARQL 1.1 malformed query returns a protocol error"
-    noncritical: true
     headers: {Content-Type: "application/sparql-query"}
     sparql: 'SELECT WHERE {'
     expect: {error: true}
 
   - name: "SPARQL 1.1 RDF entailment recognizes asserted triples"
-    noncritical: true
     ttl_data: '@prefix ex: <http://spec11-entailment-simple.example/> . ex:s ex:p ex:o .'
     sparql: 'PREFIX ex: <http://spec11-entailment-simple.example/> ASK WHERE { ex:s ex:p ex:o }'
     expect: {rows: 1, data: [{"?ask": true}]}

--- a/tests/rdf/rdf-spec11-protocol-results-entailment.yaml
+++ b/tests/rdf/rdf-spec11-protocol-results-entailment.yaml
@@ -35,7 +35,6 @@ test_cases:
       contains: '"boolean":true'
 
   - name: "SPARQL 1.1 Query Results XML SELECT serialization"
-    noncritical: true
     headers: {Accept: "application/sparql-results+xml"}
     sparql: 'SELECT ("yes" AS ?value) WHERE {}'
     expect:
@@ -43,7 +42,6 @@ test_cases:
       contains: "<sparql"
 
   - name: "SPARQL 1.1 Query Results XML ASK serialization"
-    noncritical: true
     headers: {Accept: "application/sparql-results+xml"}
     sparql: 'ASK WHERE {}'
     expect:
@@ -51,7 +49,6 @@ test_cases:
       contains: "<boolean>true</boolean>"
 
   - name: "SPARQL 1.1 Query Results CSV serialization"
-    noncritical: true
     headers: {Accept: "text/csv"}
     sparql: 'SELECT ("yes" AS ?value) WHERE {}'
     expect:
@@ -59,7 +56,6 @@ test_cases:
       contains: "value"
 
   - name: "SPARQL 1.1 Query Results TSV serialization"
-    noncritical: true
     headers: {Accept: "text/tab-separated-values"}
     sparql: 'SELECT ("yes" AS ?value) WHERE {}'
     expect:

--- a/tests/rdf/rdf-spec11-protocol-results-entailment.yaml
+++ b/tests/rdf/rdf-spec11-protocol-results-entailment.yaml
@@ -63,7 +63,6 @@ test_cases:
       contains: "?value"
 
   - name: "SPARQL 1.1 CONSTRUCT negotiates Turtle graph output"
-    noncritical: true
     ttl_data: '@prefix ex: <http://spec11-result-turtle.example/> . ex:s ex:p ex:o .'
     headers: {Accept: "text/turtle"}
     sparql: 'PREFIX ex: <http://spec11-result-turtle.example/> CONSTRUCT { ?s ex:p ?o } WHERE { ?s ex:p ?o }'

--- a/tests/rdf/rdf-spec11-terms-expressions.yaml
+++ b/tests/rdf/rdf-spec11-terms-expressions.yaml
@@ -237,7 +237,6 @@ test_cases:
       data: [{"?tz": "+02:00"}]
 
   - name: "SPARQL 1.1 17.4.6 MD5 hash"
-    noncritical: true
     sparql: 'SELECT (MD5("abc") AS ?result) WHERE {}'
     expect:
       rows: 1

--- a/tests/rdf/rdf-spec11-terms-expressions.yaml
+++ b/tests/rdf/rdf-spec11-terms-expressions.yaml
@@ -153,70 +153,60 @@ test_cases:
       data: [{"?result": -4}]
 
   - name: "SPARQL 1.1 17.4.1.9 IN tests membership"
-    noncritical: true
     sparql: 'SELECT ((2 IN (1, 2, 3)) AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": true}]
 
   - name: "SPARQL 1.1 17.4.1.10 NOT IN tests non-membership"
-    noncritical: true
     sparql: 'SELECT ((4 NOT IN (1, 2, 3)) AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": true}]
 
   - name: "SPARQL 1.1 17.4.3.3 RAND returns a numeric value"
-    noncritical: true
     sparql: 'SELECT ((RAND() >= 0 && RAND() < 1) AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": true}]
 
   - name: "SPARQL 1.1 17.4.3.5 STRBEFORE returns the prefix"
-    noncritical: true
     sparql: 'SELECT (STRBEFORE("alpha:beta", ":") AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": "alpha"}]
 
   - name: "SPARQL 1.1 17.4.3.6 STRAFTER returns the suffix"
-    noncritical: true
     sparql: 'SELECT (STRAFTER("alpha:beta", ":") AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": "beta"}]
 
   - name: "SPARQL 1.1 17.4.3.9 ENCODE_FOR_URI escapes reserved characters"
-    noncritical: true
     sparql: 'SELECT (ENCODE_FOR_URI("A B") AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": "A%20B"}]
 
   - name: "SPARQL 1.1 17.4.3.14 REGEX supports flags"
-    noncritical: true
     sparql: 'SELECT (REGEX("Berlin", "berlin", "i") AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": true}]
 
   - name: "SPARQL 1.1 17.4.3.15 REPLACE supports flags"
-    noncritical: true
     sparql: 'SELECT (REPLACE("Berlin berlin", "berlin", "X", "i") AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": "X X"}]
 
   - name: "SPARQL 1.1 17.4.5.1 NOW is stable within a query"
-    noncritical: true
     sparql: 'SELECT ((NOW() = NOW()) AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": true}]
 
   - name: "SPARQL 1.1 17.4.5 date component functions"
-    noncritical: true
     sparql: |
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
       SELECT (YEAR("2026-09-07T12:34:56Z"^^xsd:dateTime) AS ?year)
@@ -228,7 +218,6 @@ test_cases:
       data: [{"?year": 2026, "?month": 9, "?day": 7}]
 
   - name: "SPARQL 1.1 17.4.5 time component functions"
-    noncritical: true
     sparql: |
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
       SELECT (HOURS("2026-09-07T12:34:56Z"^^xsd:dateTime) AS ?hours)
@@ -240,7 +229,6 @@ test_cases:
       data: [{"?hours": 12, "?minutes": 34, "?seconds": 56}]
 
   - name: "SPARQL 1.1 17.4.5 timezone functions"
-    noncritical: true
     sparql: |
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
       SELECT (TZ("2026-09-07T12:34:56+02:00"^^xsd:dateTime) AS ?tz) WHERE {}
@@ -256,7 +244,6 @@ test_cases:
       data: [{"?result": "900150983cd24fb0d6963f7d28e17f72"}]
 
   - name: "SPARQL 1.1 17.4.6 SHA family hashes"
-    noncritical: true
     sparql: 'SELECT (SHA1("abc") AS ?sha1) (SHA256("abc") AS ?sha256) WHERE {}'
     expect:
       rows: 1

--- a/tests/rdf/rdf-spec11-terms-expressions.yaml
+++ b/tests/rdf/rdf-spec11-terms-expressions.yaml
@@ -12,7 +12,6 @@ setup: []
 
 test_cases:
   - name: "SPARQL 1.1 4.1.2 language-tagged literals preserve their language"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-terms.example/> .
       ex:subject ex:label "Berlin"@de .
@@ -25,7 +24,6 @@ test_cases:
       contains: '"xml:lang":"de"'
 
   - name: "SPARQL 1.1 4.1.2 language tags participate in term identity"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-terms-lang.example/> .
       ex:subject ex:label "Berlin"@de, "Berlin"@en .
@@ -35,7 +33,6 @@ test_cases:
     expect: {rows: 2}
 
   - name: "SPARQL 1.1 4.1.2 datatype IRIs participate in term identity"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-terms-datatype.example/> .
       @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -127,7 +124,6 @@ test_cases:
       data: [{"?iri": true, "?string": false}]
 
   - name: "SPARQL 1.1 17.4.2.4 isLiteral recognizes typed literals"
-    noncritical: true
     sparql: |
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
       SELECT (isLiteral("7"^^xsd:integer) AS ?result) WHERE {}
@@ -145,14 +141,12 @@ test_cases:
       data: [{"?result": true}]
 
   - name: "SPARQL 1.1 17.4.1 arithmetic supports addition and multiplication"
-    noncritical: true
     sparql: 'SELECT ((2 + 3 * 4) AS ?result) WHERE {}'
     expect:
       rows: 1
       data: [{"?result": 14}]
 
   - name: "SPARQL 1.1 17.4.1 arithmetic supports unary minus and division"
-    noncritical: true
     sparql: 'SELECT ((-12 / 3) AS ?result) WHERE {}'
     expect:
       rows: 1
@@ -269,7 +263,6 @@ test_cases:
       contains: "a9993e364706816aba3e25717850c26c9cd0d89d"
 
   - name: "SPARQL 1.1 17.4.1 expression errors leave projection variables unbound"
-    noncritical: true
     headers: {Accept: "application/sparql-results+json"}
     sparql: 'SELECT ((1 / 0) AS ?error) ("kept" AS ?value) WHERE {}'
     expect:

--- a/tests/rdf/rdf-spec11-turtle-complete.yaml
+++ b/tests/rdf/rdf-spec11-turtle-complete.yaml
@@ -11,7 +11,6 @@ setup: []
 
 test_cases:
   - name: "Turtle 1.1 2.4 BASE resolves relative IRIs"
-    noncritical: true
     ttl_data: |
       @base <http://spec11-turtle-base.example/root/> .
       <subject> <predicate> <object> .
@@ -19,7 +18,6 @@ test_cases:
     expect: {rows: 1, data: [{"?ask": true}]}
 
   - name: "Turtle 1.1 SPARQL BASE directive needs no trailing dot"
-    noncritical: true
     ttl_data: |
       BASE <http://spec11-turtle-sparql-base.example/>
       <s> <p> <o> .
@@ -27,7 +25,6 @@ test_cases:
     expect: {rows: 1, data: [{"?ask": true}]}
 
   - name: "Turtle 1.1 SPARQL PREFIX directive needs no trailing dot"
-    noncritical: true
     ttl_data: |
       PREFIX ex: <http://spec11-turtle-sparql-prefix.example/>
       ex:s ex:p ex:o .
@@ -61,7 +58,6 @@ test_cases:
     expect: {rows: 1, contains: "line one"}
 
   - name: "Turtle 1.1 long double-quoted string literal"
-    noncritical: true
     ttl_data: |
       <http://spec11-turtle-string.example/long-double> <http://spec11-turtle-string.example/p> """line one
       line two""" .
@@ -69,7 +65,6 @@ test_cases:
     expect: {rows: 1, contains: "line two"}
 
   - name: "Turtle 1.1 string escape sequences"
-    noncritical: true
     ttl_data: |
       <http://spec11-turtle-string.example/escapes> <http://spec11-turtle-string.example/p> "tab:\t newline:\n quote:\" slash:\\" .
     sparql: 'SELECT ?o WHERE { <http://spec11-turtle-string.example/escapes> <http://spec11-turtle-string.example/p> ?o }'
@@ -83,7 +78,6 @@ test_cases:
     expect: {rows: 1, contains: '"xml:lang":"en-gb"'}
 
   - name: "Turtle 1.1 explicitly typed literal"
-    noncritical: true
     ttl_data: |
       @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
       <http://spec11-turtle-typed.example/s> <http://spec11-turtle-typed.example/p> "42"^^xsd:integer .
@@ -92,19 +86,16 @@ test_cases:
     expect: {rows: 1, contains: "http://www.w3.org/2001/XMLSchema#integer"}
 
   - name: "Turtle 1.1 integer literal has xsd integer datatype"
-    noncritical: true
     ttl_data: '<http://spec11-turtle-numeric.example/integer> <http://spec11-turtle-numeric.example/p> -42 .'
     sparql: 'SELECT ?o WHERE { <http://spec11-turtle-numeric.example/integer> <http://spec11-turtle-numeric.example/p> ?o FILTER(?o = -42) }'
     expect: {rows: 1}
 
   - name: "Turtle 1.1 decimal literal has xsd decimal datatype"
-    noncritical: true
     ttl_data: '<http://spec11-turtle-numeric.example/decimal> <http://spec11-turtle-numeric.example/p> 12.50 .'
     sparql: 'SELECT ?o WHERE { <http://spec11-turtle-numeric.example/decimal> <http://spec11-turtle-numeric.example/p> ?o FILTER(?o = 12.50) }'
     expect: {rows: 1}
 
   - name: "Turtle 1.1 double literal supports exponent notation"
-    noncritical: true
     ttl_data: '<http://spec11-turtle-numeric.example/double> <http://spec11-turtle-numeric.example/p> 1.25e2 .'
     sparql: 'SELECT ?o WHERE { <http://spec11-turtle-numeric.example/double> <http://spec11-turtle-numeric.example/p> ?o FILTER(?o = 125) }'
     expect: {rows: 1}
@@ -116,21 +107,18 @@ test_cases:
     expect: {rows: 1, data: [{"?o": true}]}
 
   - name: "Turtle 1.1 object lists expand to multiple triples"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-turtle-object-list.example/> . ex:s ex:p "A", "B", "C" .
     sparql: 'PREFIX ex: <http://spec11-turtle-object-list.example/> SELECT ?o WHERE { ex:s ex:p ?o }'
     expect: {rows: 3}
 
   - name: "Turtle 1.1 predicate lists share one subject"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-turtle-predicate-list.example/> . ex:s ex:p "A" ; ex:q "B" .
     sparql: 'PREFIX ex: <http://spec11-turtle-predicate-list.example/> SELECT ?p ?o WHERE { ex:s ?p ?o }'
     expect: {rows: 2}
 
   - name: "Turtle 1.1 blank-node property lists nest"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-turtle-bnode-list.example/> . ex:s ex:address [ ex:city "Berlin" ; ex:country [ ex:code "DE" ] ] .
     sparql: |
@@ -156,7 +144,6 @@ test_cases:
     expect: {rows: 3}
 
   - name: "Turtle 1.1 empty collection denotes rdf nil"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-turtle-empty-list.example/> . ex:s ex:items () .
     sparql: |

--- a/tests/rdf/rdf-spec11-turtle-complete.yaml
+++ b/tests/rdf/rdf-spec11-turtle-complete.yaml
@@ -32,7 +32,6 @@ test_cases:
     expect: {rows: 1, data: [{"?ask": true}]}
 
   - name: "Turtle 1.1 prefixed names support escaped local characters"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-turtle-pname.example/> .
       ex:subject ex:has\~value "yes" .
@@ -40,19 +39,16 @@ test_cases:
     expect: {rows: 1, data: [{"?ask": true}]}
 
   - name: "Turtle 1.1 IRIREF supports Unicode escapes"
-    noncritical: true
     ttl_data: '<http://spec11-turtle-iri.example/\u0061> <http://spec11-turtle-iri.example/p> "yes" .'
     sparql: 'ASK WHERE { <http://spec11-turtle-iri.example/a> <http://spec11-turtle-iri.example/p> "yes" }'
     expect: {rows: 1, data: [{"?ask": true}]}
 
   - name: "Turtle 1.1 single-quoted string literal"
-    noncritical: true
     ttl_data: '<http://spec11-turtle-string.example/single> <http://spec11-turtle-string.example/p> ''single'' .'
     sparql: 'SELECT ?o WHERE { <http://spec11-turtle-string.example/single> <http://spec11-turtle-string.example/p> ?o }'
     expect: {rows: 1, data: [{"?o": "single"}]}
 
   - name: "Turtle 1.1 long single-quoted string literal"
-    noncritical: true
     ttl_data: "<http://spec11-turtle-string.example/long-single> <http://spec11-turtle-string.example/p> '''line one\nline two''' ."
     sparql: 'SELECT ?o WHERE { <http://spec11-turtle-string.example/long-single> <http://spec11-turtle-string.example/p> ?o }'
     expect: {rows: 1, contains: "line one"}
@@ -101,7 +97,6 @@ test_cases:
     expect: {rows: 1}
 
   - name: "Turtle 1.1 boolean literals are typed values"
-    noncritical: true
     ttl_data: '<http://spec11-turtle-boolean.example/s> <http://spec11-turtle-boolean.example/p> true .'
     sparql: 'SELECT ?o WHERE { <http://spec11-turtle-boolean.example/s> <http://spec11-turtle-boolean.example/p> ?o FILTER(?o = true) }'
     expect: {rows: 1, data: [{"?o": true}]}
@@ -153,7 +148,6 @@ test_cases:
     expect: {rows: 1, data: [{"?ask": true}]}
 
   - name: "Turtle 1.1 a abbreviation denotes rdf type"
-    noncritical: true
     ttl_data: |
       @prefix ex: <http://spec11-turtle-type.example/> . ex:s a ex:Type .
     sparql: |


### PR DESCRIPTION
## Summary\n- make the complete SPARQL negative-syntax matrix critical\n- reject variables in INSERT DATA and DELETE DATA at parse time\n- continue closing the remaining noncritical SPARQL 1.1 conformance gaps\n\n## Architecture\nAll query work continues through the shared queryplan IR. This PR will stop for consultation before any persistent RDF term or s/p/o layout change.\n\n## Testing\n- targeted RDF specification suites locally\n- full test matrix only in CI