### PR TITLE
JIT: keep pointer-free scalar payloads in typed register lanes

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -2290,6 +2290,10 @@ func (ctx *JITContext) FreeDesc(desc *JITValueDesc) {
 	if desc.ID == 0 {
 		return
 	}
+	// Allocation can move the canonical owner to a stack or cross-class
+	// overflow home while generated code still holds descriptor aliases. Free
+	// the current placement, never the stale register named by such an alias.
+	ctx.SyncDesc(desc)
 	switch desc.Loc {
 	case LocReg:
 		if desc.Reg <= RegR15 {

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -1836,10 +1836,12 @@ func (ctx *JITContext) AllocReg() Reg {
 // jitScalarCanUseFPOverflow recognizes values whose sole machine word is data,
 // never a Go pointer. Type knowledge is intentionally not used as a blanket
 // permission: string/slice/procedure scalar views may carry addresses. Numeric,
-// boolean and internal ordinal payloads are safe, while RelocatablePointer is
-// an explicit veto even when such an address is represented as a Scheme int.
+// boolean and internal ordinal payloads are safe only when the producer also
+// proves NoHeapPointer. RelocatablePointer is an explicit veto: internal
+// runtime addresses may be represented as Scheme ints, but their register
+// homes remain part of the Go pointer/lifetime contract.
 func jitScalarCanUseFPOverflow(value *JITValueDesc) bool {
-	if value == nil || value.Loc != LocReg || value.RelocatablePointer {
+	if value == nil || value.Loc != LocReg || !value.NoHeapPointer || value.RelocatablePointer {
 		return false
 	}
 	switch value.Type {

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -81,6 +81,9 @@ Input arguments (args):
                 The emitter SHOULD constant-fold when all inputs are LocImm.
   - LocReg:     unboxed primitive in args[i].Reg.
   - LocFPReg:   unboxed float in the backend's floating-point register file.
+                The allocator may use the same physical bank as a temporary
+                overflow home for another proven pointer-free scalar, but
+                EnsureDesc restores that value before an emitter sees it.
   - LocRegPair: boxed Scmer in args[i].Reg (ptr) + args[i].Reg2 (aux).
   - LocStack:   value on the stack at args[i].StackOff.
   - LocStackPair:
@@ -579,7 +582,7 @@ const (
 	LocParserTemplate
 	LocClosurePair // One Scmer in the current Go funcval's typed closure environment
 	LocFlags       // Ephemeral comparison result consumed immediately by a branch
-	LocFPReg       // Unboxed scalar in a native floating-point register
+	LocFPReg       // Native FP value, or a pointer-free scalar payload in an FP overflow home
 )
 
 // JITRegisterClass separates values which share liveness but cannot share a
@@ -1740,6 +1743,33 @@ func (ctx *JITContext) AllocReg() Reg {
 	}
 
 	owner := ctx.RegOwners[r]
+	// A scalar register is only a payload while it remains inside generated
+	// code.  When its type is known and it is not a relocatable Go pointer, an
+	// unused FP register is a cheaper spill home than memory.  The original
+	// register class remains attached to the descriptor so a later FP spill is
+	// restored to the register file required by its consumer.  Full Scmer pairs
+	// are deliberately excluded: their pointer word must remain visible to the
+	// Go stack map unless NoHeapPointer proves otherwise, and splitting pairs
+	// here would make their ownership non-atomic.
+	if !pairSpill && !tripleSpill && jitScalarCanUseFPOverflow(owner) {
+		availableFP := ctx.FreeFPRegs &^ ctx.ProtectedRegs
+		if availableFP != 0 {
+			fp := Reg(bits.TrailingZeros64(availableFP))
+			ctx.FreeFPRegs &^= 1 << uint(fp)
+			ctx.EmitMovGPRToFP(fp, r)
+			owner.Loc = LocFPReg
+			owner.Reg = fp
+			ctx.RegOwners[r] = nil
+			ctx.RegOwners[fp] = owner
+			if owner.ID != 0 {
+				if ctx.descSpills == nil {
+					ctx.descSpills = make(map[uint32]descSpillMeta)
+				}
+				ctx.descSpills[owner.ID] = descSpillMeta{loc: LocFPReg, reg: fp}
+			}
+			return r
+		}
+	}
 	if pairSpill {
 		stackOff := ctx.AllocSpill(16)
 		ctx.EmitStoreRegMem(spillR1, RegRBP, stackOff)
@@ -1803,6 +1833,23 @@ func (ctx *JITContext) AllocReg() Reg {
 	return r
 }
 
+// jitScalarCanUseFPOverflow recognizes values whose sole machine word is data,
+// never a Go pointer. Type knowledge is intentionally not used as a blanket
+// permission: string/slice/procedure scalar views may carry addresses. Numeric,
+// boolean and internal ordinal payloads are safe, while RelocatablePointer is
+// an explicit veto even when such an address is represented as a Scheme int.
+func jitScalarCanUseFPOverflow(value *JITValueDesc) bool {
+	if value == nil || value.Loc != LocReg || value.RelocatablePointer {
+		return false
+	}
+	switch value.Type {
+	case tagInt, tagFloat, tagBool, tagDate, tagNthLocalVar:
+		return true
+	default:
+		return false
+	}
+}
+
 // AllocFPReg allocates a scalar floating-point register independently from the
 // GPR allocator. FP values cannot consume pointer-bearing GPR homes, and vice
 // versa; keeping the files separate also maps directly to non-amd64 backends.
@@ -1828,7 +1875,6 @@ func (ctx *JITContext) AllocFPReg() Reg {
 		owner.Loc = LocStack
 		owner.StackOff = off
 		owner.Reg = 0
-		owner.RegClass = JITRegisterClassFP
 		if owner.ID != 0 {
 			if ctx.descSpills == nil {
 				ctx.descSpills = make(map[uint32]descSpillMeta)
@@ -1899,6 +1945,13 @@ func (ctx *JITContext) EnsureDesc(desc *JITValueDesc) {
 		if desc.RegClass == JITRegisterClassFP {
 			ctx.EnsureFPReg(desc)
 		} else {
+			ctx.EnsureReg(desc)
+		}
+	case LocFPReg:
+		// LocFPReg is also an overflow home for pointer-free scalar payloads.
+		// Only native float values are consumed there directly; integer and
+		// boolean consumers get their original GPR representation back.
+		if desc.RegClass != JITRegisterClassFP {
 			ctx.EnsureReg(desc)
 		}
 	case LocStackPair:
@@ -2088,6 +2141,18 @@ func (ctx *JITContext) AllocRegExcept(excluded ...Reg) Reg {
 // If the value is still in a register, this is a no-op.
 // If spilled, allocates a new register, emits a load, and updates the desc.
 func (ctx *JITContext) EnsureReg(desc *JITValueDesc) {
+	if desc.Loc == LocFPReg {
+		fp := desc.Reg
+		r := ctx.AllocReg()
+		ctx.EmitMovFPToGPR(r, fp)
+		ctx.FreeReg(fp)
+		desc.Loc = LocReg
+		desc.Reg = r
+		desc.MemPtr = 0
+		desc.StackOff = 0
+		ctx.BindReg(r, desc)
+		return
+	}
 	if desc.Loc != LocStack {
 		return
 	}

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -232,7 +232,7 @@ func jitPlaceIntoPair(ctx *JITContext, src *JITValueDesc, target JITValueDesc) J
 			ctx.FreeDesc(src)
 		}
 		return target
-	case LocReg:
+	case LocReg, LocFPReg:
 		switch src.Type {
 		case tagBool:
 			ctx.EmitMakeBool(target, *src)
@@ -305,7 +305,7 @@ func JITPrepareScmerGoArg(ctx *JITContext, src JITValueDesc) JITValueDesc {
 	switch src.Loc {
 	case LocRegPair, LocStackPair, LocInputPair:
 		return src
-	case LocImm, LocReg, LocStack:
+	case LocImm, LocReg, LocFPReg, LocStack:
 		return jitCopyScmerToPair(ctx, src)
 	default:
 		panic("jit: Go call expects a Scmer argument")
@@ -937,7 +937,7 @@ func (ctx *JITContext) EmitStoreScmerAt(address, value *JITValueDesc) {
 			ctx.EmitStoreRegMem(value.Reg2, address.Reg, 8)
 			return
 		}
-		if value.Loc == LocReg {
+		if value.Loc == LocReg || value.Loc == LocFPReg {
 			ctx.ProtectReg(address.Reg)
 			ctx.ProtectReg(value.Reg)
 			pair := jitAllocTrackedPair(ctx, value.Type)
@@ -1110,7 +1110,7 @@ func (ctx *JITContext) emitDirectScmerSliceElement(slice, index, value *JITValue
 	if index.Loc != LocImm && index.Loc != LocReg {
 		return false
 	}
-	if value.Loc != LocImm && value.Loc != LocReg && value.Loc != LocRegPair {
+	if value.Loc != LocImm && value.Loc != LocReg && value.Loc != LocFPReg && value.Loc != LocRegPair {
 		return false
 	}
 
@@ -1218,6 +1218,22 @@ func (ctx *JITContext) emitDirectScmerSliceElement(slice, index, value *JITValue
 		ctx.EmitMovRegImm64(temporary, uint64(tagWord))
 		ctx.EmitStoreRegMem(temporary, ctx.ScratchReg, 0)
 		ctx.EmitStoreRegMem(value.Reg, ctx.ScratchReg, 8)
+	case LocFPReg:
+		var tagWord uintptr
+		switch value.Type {
+		case tagInt:
+			tagWord, _ = NewInt(0).RawWords()
+		case tagFloat:
+			tagWord, _ = NewFloat(0).RawWords()
+		case tagNil, tagBool:
+			tagWord = 0
+		default:
+			ctx.FreeReg(temporary)
+			return false
+		}
+		ctx.EmitMovRegImm64(temporary, uint64(tagWord))
+		ctx.EmitStoreRegMem(temporary, ctx.ScratchReg, 0)
+		ctx.EmitStoreFPRegMem(value.Reg, ctx.ScratchReg, 8)
 	}
 	if value.Loc != LocRegPair && !immediateStore {
 		ctx.FreeReg(temporary)

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -143,6 +143,31 @@ func TestJITPointerFreeScalarUsesFPOverflowHome(t *testing.T) {
 	}
 }
 
+func TestJITFreeDescReleasesScalarFPOverflowHome(t *testing.T) {
+	code := make([]byte, 128)
+	start := unsafe.Pointer(&code[0])
+	ctx := &JITContext{
+		Start:      start,
+		Ptr:        start,
+		End:        unsafe.Add(start, len(code)-1),
+		AllRegs:    1 << uint(RegRAX),
+		AllFPRegs:  1 << uint(RegX2),
+		FreeFPRegs: 1 << uint(RegX2),
+		FrameReg:   RegRBP,
+		StackReg:   RegRSP,
+		ScratchReg: RegR11,
+	}
+	value := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: RegRAX, NoHeapPointer: true}
+	ctx.BindReg(RegRAX, &value)
+	staleAlias := value
+	_ = ctx.AllocReg()
+
+	ctx.FreeDesc(&staleAlias)
+	if ctx.FreeFPRegs&(1<<uint(RegX2)) == 0 || ctx.RegOwners[RegX2] != nil {
+		t.Fatal("freeing a stale descriptor alias leaked its FP overflow home")
+	}
+}
+
 func newJITStackMapTestContext(code []byte) *JITContext {
 	start := unsafe.Pointer(&code[0])
 	return &JITContext{

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -106,6 +106,35 @@ func TestJITScalarPointerSpillRemainsInStackMap(t *testing.T) {
 	}
 }
 
+func TestJITUnprovenScalarDoesNotUseFPOverflowHome(t *testing.T) {
+	code := make([]byte, 128)
+	start := unsafe.Pointer(&code[0])
+	ctx := &JITContext{
+		Start:      start,
+		Ptr:        start,
+		End:        unsafe.Add(start, len(code)-1),
+		AllRegs:    1 << uint(RegRAX),
+		AllFPRegs:  1 << uint(RegX2),
+		FreeFPRegs: 1 << uint(RegX2),
+		FrameReg:   RegRBP,
+		StackReg:   RegRSP,
+		ScratchReg: RegR11,
+	}
+	value := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: RegRAX}
+	ctx.BindReg(RegRAX, &value)
+
+	if got := ctx.AllocReg(); got != RegRAX {
+		t.Fatalf("reclaimed register %d, want %d", got, RegRAX)
+	}
+	ctx.SyncDesc(&value)
+	if value.Loc != LocStack {
+		t.Fatalf("unproven scalar spilled to loc %d, want stack", value.Loc)
+	}
+	if ctx.FreeFPRegs&(1<<uint(RegX2)) == 0 {
+		t.Fatal("unproven scalar consumed an FP overflow home")
+	}
+}
+
 func TestJITPointerFreeScalarUsesFPOverflowHome(t *testing.T) {
 	code := make([]byte, 128)
 	start := unsafe.Pointer(&code[0])

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -88,6 +88,8 @@ func TestJITScalarPointerSpillRemainsInStackMap(t *testing.T) {
 		Ptr:        start,
 		End:        unsafe.Add(start, len(code)-1),
 		AllRegs:    1 << uint(RegRAX),
+		AllFPRegs:  1 << uint(RegX2),
+		FreeFPRegs: 1 << uint(RegX2),
 		FrameReg:   RegRBP,
 		StackReg:   RegRSP,
 		ScratchReg: RegR11,
@@ -101,6 +103,43 @@ func TestJITScalarPointerSpillRemainsInStackMap(t *testing.T) {
 	root := jitStackRoot{base: jitStackRootFrameBP, offset: -8}
 	if _, ok := ctx.StackRoots[root]; !ok {
 		t.Fatal("relocatable scalar spill is missing from the stack map")
+	}
+}
+
+func TestJITPointerFreeScalarUsesFPOverflowHome(t *testing.T) {
+	code := make([]byte, 128)
+	start := unsafe.Pointer(&code[0])
+	ctx := &JITContext{
+		Start:      start,
+		Ptr:        start,
+		End:        unsafe.Add(start, len(code)-1),
+		AllRegs:    1 << uint(RegRAX),
+		AllFPRegs:  1 << uint(RegX2),
+		FreeFPRegs: 1 << uint(RegX2),
+		FrameReg:   RegRBP,
+		StackReg:   RegRSP,
+		ScratchReg: RegR11,
+	}
+	value := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: RegRAX, NoHeapPointer: true}
+	ctx.BindReg(RegRAX, &value)
+
+	if got := ctx.AllocReg(); got != RegRAX {
+		t.Fatalf("reclaimed register %d, want %d", got, RegRAX)
+	}
+	ctx.SyncDesc(&value)
+	if value.Loc != LocFPReg || value.Reg != RegX2 {
+		t.Fatalf("scalar overflow home = loc %d reg %d, want XMM register %d", value.Loc, value.Reg, RegX2)
+	}
+	if ctx.MaxSpillOffset != 0 || len(ctx.StackRoots) != 0 {
+		t.Fatalf("register overflow used stack: spill=%d roots=%v", ctx.MaxSpillOffset, ctx.StackRoots)
+	}
+
+	// The allocator returned RAX to its caller. Once that temporary dies, an
+	// integer consumer must recover the original payload without boxing it.
+	ctx.FreeReg(RegRAX)
+	ctx.EnsureDesc(&value)
+	if value.Loc != LocReg || value.Reg != RegRAX {
+		t.Fatalf("restored scalar = loc %d reg %d, want GPR %d", value.Loc, value.Reg, RegRAX)
 	}
 }
 

--- a/scm/jit_vector_gojit_test.go
+++ b/scm/jit_vector_gojit_test.go
@@ -1,0 +1,82 @@
+//go:build goexperiment.jit && amd64
+
+/*
+Copyright (C) 2026  MemCP Contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package scm
+
+import (
+	"math"
+	"testing"
+)
+
+var jitDotBenchmarkSink Scmer
+
+func TestJITDotKeepsNativeFloatAccumulators(t *testing.T) {
+	left := NewSlice([]Scmer{NewFloat(3), NewFloat(4)})
+	right := NewSlice([]Scmer{NewFloat(3), NewFloat(4)})
+	for _, test := range []struct {
+		name   string
+		source string
+		want   float64
+	}{
+		{name: "dot", source: `(lambda (left right) (dot left right))`, want: 25},
+		{name: "cosine", source: `(lambda (left right) (dot left right "COSINE"))`, want: 1},
+		{name: "euclidean", source: `(lambda (left right) (dot left right "EUCLIDEAN"))`, want: 5},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compiled := jitCompile(Eval(Read(t.Name(), test.source), &Globalenv))
+			if compiled.GetTag() != tagProc || compiled.Proc().Compiled == nil {
+				t.Fatal("dot expression did not compile")
+			}
+			got := Apply(compiled, left, right).Float()
+			if math.Abs(got-test.want) > 1e-12 {
+				t.Fatalf("dot result = %g, want %g", got, test.want)
+			}
+		})
+	}
+}
+
+func BenchmarkJITDotNativeFP(b *testing.B) {
+	const count = 4096
+	left := make([]Scmer, count)
+	right := make([]Scmer, count)
+	for index := range left {
+		left[index] = NewFloat(float64(index%31) + 0.25)
+		right[index] = NewFloat(float64(index%17) + 0.75)
+	}
+	args := []Scmer{NewSlice(left), NewSlice(right)}
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{"dot", `(lambda (left right) (dot left right))`},
+		{"cosine", `(lambda (left right) (dot left right "COSINE"))`},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			compiled := jitCompile(Eval(Read(b.Name(), test.source), &Globalenv))
+			if compiled.GetTag() != tagProc || compiled.Proc().Compiled == nil {
+				b.Fatal("dot benchmark did not compile")
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iteration := 0; iteration < b.N; iteration++ {
+				jitDotBenchmarkSink = Apply(compiled, args...)
+			}
+		})
+	}
+}

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -388,7 +388,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 		switch desc.Loc {
 		case LocRegPair:
 			ctx.EmitMovPairToResult(&desc, &result)
-		case LocReg:
+		case LocReg, LocFPReg:
 			ret := JITValueDesc{Loc: LocRegPair, Reg: RegRAX, Reg2: RegRBX}
 			switch desc.Type {
 			case tagBool:
@@ -549,6 +549,8 @@ func (ctx *JITContext) EmitReturnInt(src JITValueDesc) {
 	ctx.emitBytes(0x48, 0xB8)
 	ctx.emitU64(uint64(uintptr(unsafe.Pointer(&scmerIntSentinel))))
 	switch src.Loc {
+	case LocFPReg:
+		ctx.emitMovqXmmToGpr(RegRBX, src.Reg)
 	case LocReg:
 		if src.Reg != RegRBX {
 			// MOV RBX, src.Reg
@@ -616,6 +618,14 @@ func (ctx *JITContext) EmitReturnBool(src JITValueDesc) {
 		ctx.emitU64(uint64(tagBool))
 		// OR RBX, RCX
 		ctx.emitBytes(0x48, 0x09, 0xCB)
+	case LocFPReg:
+		ctx.emitMovqXmmToGpr(RegRBX, src.Reg)
+		ctx.emitBytes(0x48, 0x81, 0xE3)
+		ctx.emitU32(1)
+		ctx.EmitShlRegImm8(RegRBX, 8)
+		ctx.emitBytes(0x48, 0xB9)
+		ctx.emitU64(uint64(tagBool))
+		ctx.emitBytes(0x48, 0x09, 0xCB)
 	}
 	ctx.emitByte(0xC3) // RET
 }
@@ -655,6 +665,7 @@ func (ctx *JITContext) EmitMakeInt(dst JITValueDesc, src JITValueDesc) {
 	switch src.Loc {
 	case LocFPReg:
 		ctx.emitMovqXmmToGpr(dst.Reg2, src.Reg)
+		ctx.EmitMovRegImm64(dst.Reg, uint64(uintptr(unsafe.Pointer(&scmerIntSentinel))))
 	case LocReg:
 		if dst.Reg2 != src.Reg {
 			ctx.emitMovRegReg(dst.Reg2, src.Reg)
@@ -670,6 +681,9 @@ func (ctx *JITContext) EmitMakeInt(dst JITValueDesc, src JITValueDesc) {
 // src.Reg holds the float64 bits as uint64.
 func (ctx *JITContext) EmitMakeFloat(dst JITValueDesc, src JITValueDesc) {
 	switch src.Loc {
+	case LocFPReg:
+		ctx.emitMovqXmmToGpr(dst.Reg2, src.Reg)
+		ctx.EmitMovRegImm64(dst.Reg, uint64(uintptr(unsafe.Pointer(&scmerFloatSentinel))))
 	case LocReg:
 		if dst.Reg2 != src.Reg {
 			ctx.emitMovRegReg(dst.Reg2, src.Reg)

--- a/scm/vector.go
+++ b/scm/vector.go
@@ -63,6 +63,9 @@ func init_vector() {
 			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", Label: "v1", Description: "vector1"}, &TypeDescriptor{Kind: "list", Label: "v2", Description: "vector2"}, &TypeDescriptor{Kind: "string", Label: "mode", Description: "DOT, COSINE, EUCLIDEAN, default is DOT", Optional: true}},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
+			// All loop accumulators are native float64 values until the final
+			// NewFloat boundary. Keep them in the backend FP register class.
+			JITNativeFP: true,
 
 			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
 				declaration := declarations["dot"]
@@ -70,36 +73,24 @@ func init_vector() {
 					ctx.Coverage.NativeCalls++
 					return jitEmitGeneratedCallBoundary(ctx, declaration, sourceArgs, args, result)
 				}
-				var d9 JITValueDesc
-				_ = d9
-				var d10 JITValueDesc
-				_ = d10
-				var d11 JITValueDesc
-				_ = d11
-				var d12 JITValueDesc
-				_ = d12
-				var d13 JITValueDesc
-				_ = d13
-				var d14 JITValueDesc
-				_ = d14
-				var d15 JITValueDesc
-				_ = d15
+				var d16 JITValueDesc
+				_ = d16
+				var d17 JITValueDesc
+				_ = d17
 				var d18 JITValueDesc
 				_ = d18
-				var d38 JITValueDesc
-				_ = d38
-				var d57 JITValueDesc
-				_ = d57
-				var d58 JITValueDesc
-				_ = d58
-				var d59 JITValueDesc
-				_ = d59
-				var d60 JITValueDesc
-				_ = d60
-				var d61 JITValueDesc
-				_ = d61
-				var d63 JITValueDesc
-				_ = d63
+				var d19 JITValueDesc
+				_ = d19
+				var d20 JITValueDesc
+				_ = d20
+				var d21 JITValueDesc
+				_ = d21
+				var d22 JITValueDesc
+				_ = d22
+				var d25 JITValueDesc
+				_ = d25
+				var d45 JITValueDesc
+				_ = d45
 				var d64 JITValueDesc
 				_ = d64
 				var d65 JITValueDesc
@@ -110,22 +101,22 @@ func init_vector() {
 				_ = d67
 				var d68 JITValueDesc
 				_ = d68
-				var d69 JITValueDesc
-				_ = d69
+				var d70 JITValueDesc
+				_ = d70
+				var d71 JITValueDesc
+				_ = d71
 				var d72 JITValueDesc
 				_ = d72
-				var d138 JITValueDesc
-				_ = d138
-				var d139 JITValueDesc
-				_ = d139
-				var d140 JITValueDesc
-				_ = d140
-				var d141 JITValueDesc
-				_ = d141
-				var d142 JITValueDesc
-				_ = d142
-				var d143 JITValueDesc
-				_ = d143
+				var d73 JITValueDesc
+				_ = d73
+				var d74 JITValueDesc
+				_ = d74
+				var d75 JITValueDesc
+				_ = d75
+				var d76 JITValueDesc
+				_ = d76
+				var d79 JITValueDesc
+				_ = d79
 				var d145 JITValueDesc
 				_ = d145
 				var d146 JITValueDesc
@@ -138,12 +129,14 @@ func init_vector() {
 				_ = d149
 				var d150 JITValueDesc
 				_ = d150
-				var d151 JITValueDesc
-				_ = d151
 				var d152 JITValueDesc
 				_ = d152
 				var d153 JITValueDesc
 				_ = d153
+				var d154 JITValueDesc
+				_ = d154
+				var d155 JITValueDesc
+				_ = d155
 				var d156 JITValueDesc
 				_ = d156
 				var d157 JITValueDesc
@@ -152,20 +145,16 @@ func init_vector() {
 				_ = d158
 				var d159 JITValueDesc
 				_ = d159
-				var d262 JITValueDesc
-				_ = d262
-				var d263 JITValueDesc
-				_ = d263
-				var d264 JITValueDesc
-				_ = d264
-				var d265 JITValueDesc
-				_ = d265
-				var d266 JITValueDesc
-				_ = d266
-				var d267 JITValueDesc
-				_ = d267
-				var d268 JITValueDesc
-				_ = d268
+				var d160 JITValueDesc
+				_ = d160
+				var d163 JITValueDesc
+				_ = d163
+				var d164 JITValueDesc
+				_ = d164
+				var d165 JITValueDesc
+				_ = d165
+				var d166 JITValueDesc
+				_ = d166
 				var d269 JITValueDesc
 				_ = d269
 				var d270 JITValueDesc
@@ -182,6 +171,8 @@ func init_vector() {
 				_ = d275
 				var d276 JITValueDesc
 				_ = d276
+				var d277 JITValueDesc
+				_ = d277
 				var d278 JITValueDesc
 				_ = d278
 				var d279 JITValueDesc
@@ -190,80 +181,116 @@ func init_vector() {
 				_ = d280
 				var d281 JITValueDesc
 				_ = d281
+				var d282 JITValueDesc
+				_ = d282
 				var d283 JITValueDesc
 				_ = d283
 				var d284 JITValueDesc
 				_ = d284
 				var d285 JITValueDesc
 				_ = d285
-				var d434 JITValueDesc
-				_ = d434
-				var d435 JITValueDesc
-				_ = d435
-				var d436 JITValueDesc
-				_ = d436
-				var d437 JITValueDesc
-				_ = d437
-				var d438 JITValueDesc
-				_ = d438
-				var d441 JITValueDesc
-				_ = d441
-				var d442 JITValueDesc
-				_ = d442
-				var d603 JITValueDesc
-				_ = d603
-				var d604 JITValueDesc
-				_ = d604
-				var d605 JITValueDesc
-				_ = d605
-				var d606 JITValueDesc
-				_ = d606
-				var d607 JITValueDesc
-				_ = d607
-				var d608 JITValueDesc
-				_ = d608
-				var d609 JITValueDesc
-				_ = d609
-				var d610 JITValueDesc
-				_ = d610
-				var d611 JITValueDesc
-				_ = d611
-				var d612 JITValueDesc
-				_ = d612
-				var d613 JITValueDesc
-				_ = d613
-				var d615 JITValueDesc
-				_ = d615
-				var d616 JITValueDesc
-				_ = d616
-				var d617 JITValueDesc
-				_ = d617
-				var d618 JITValueDesc
-				_ = d618
-				var d619 JITValueDesc
-				_ = d619
-				var d621 JITValueDesc
-				_ = d621
-				var d623 JITValueDesc
-				_ = d623
-				var d721 JITValueDesc
-				_ = d721
-				var d724 JITValueDesc
-				_ = d724
-				var d824 JITValueDesc
-				_ = d824
-				var d825 JITValueDesc
-				_ = d825
-				var d826 JITValueDesc
-				_ = d826
-				var d1035 JITValueDesc
-				_ = d1035
-				var d1036 JITValueDesc
-				_ = d1036
-				var d1037 JITValueDesc
-				_ = d1037
-				var d1039 JITValueDesc
-				_ = d1039
+				var d286 JITValueDesc
+				_ = d286
+				var d287 JITValueDesc
+				_ = d287
+				var d289 JITValueDesc
+				_ = d289
+				var d290 JITValueDesc
+				_ = d290
+				var d291 JITValueDesc
+				_ = d291
+				var d292 JITValueDesc
+				_ = d292
+				var d293 JITValueDesc
+				_ = d293
+				var d294 JITValueDesc
+				_ = d294
+				var d295 JITValueDesc
+				_ = d295
+				var d296 JITValueDesc
+				_ = d296
+				var d298 JITValueDesc
+				_ = d298
+				var d299 JITValueDesc
+				_ = d299
+				var d300 JITValueDesc
+				_ = d300
+				var d465 JITValueDesc
+				_ = d465
+				var d466 JITValueDesc
+				_ = d466
+				var d467 JITValueDesc
+				_ = d467
+				var d468 JITValueDesc
+				_ = d468
+				var d469 JITValueDesc
+				_ = d469
+				var d472 JITValueDesc
+				_ = d472
+				var d473 JITValueDesc
+				_ = d473
+				var d650 JITValueDesc
+				_ = d650
+				var d651 JITValueDesc
+				_ = d651
+				var d652 JITValueDesc
+				_ = d652
+				var d653 JITValueDesc
+				_ = d653
+				var d654 JITValueDesc
+				_ = d654
+				var d655 JITValueDesc
+				_ = d655
+				var d656 JITValueDesc
+				_ = d656
+				var d657 JITValueDesc
+				_ = d657
+				var d658 JITValueDesc
+				_ = d658
+				var d659 JITValueDesc
+				_ = d659
+				var d660 JITValueDesc
+				_ = d660
+				var d661 JITValueDesc
+				_ = d661
+				var d662 JITValueDesc
+				_ = d662
+				var d664 JITValueDesc
+				_ = d664
+				var d665 JITValueDesc
+				_ = d665
+				var d666 JITValueDesc
+				_ = d666
+				var d667 JITValueDesc
+				_ = d667
+				var d668 JITValueDesc
+				_ = d668
+				var d669 JITValueDesc
+				_ = d669
+				var d670 JITValueDesc
+				_ = d670
+				var d672 JITValueDesc
+				_ = d672
+				var d674 JITValueDesc
+				_ = d674
+				var d784 JITValueDesc
+				_ = d784
+				var d787 JITValueDesc
+				_ = d787
+				var d899 JITValueDesc
+				_ = d899
+				var d900 JITValueDesc
+				_ = d900
+				var d901 JITValueDesc
+				_ = d901
+				var d1134 JITValueDesc
+				_ = d1134
+				var d1135 JITValueDesc
+				_ = d1135
+				var d1136 JITValueDesc
+				_ = d1136
+				var d1138 JITValueDesc
+				_ = d1138
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				phiBase0 := ctx.AllocStack(int32(128))
 				var bbs [15]BBDescriptor
@@ -278,23 +305,85 @@ func init_vector() {
 				for i := range args {
 					ctx.StabilizeDescForControlFlow(&args[i])
 				}
-				d1 := JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+				registerHomes1 := ctx.AllocRegisterHomes(JITRegisterPlan{Slots: [16]JITRegisterSlot{{Color: 0, Width: 1, Cost: 64}, {Color: 1, Width: 1, Class: JITRegisterClassFP, Cost: 35}, {Color: 2, Width: 1, Class: JITRegisterClassFP, Cost: 17}, {Color: 3, Width: 1, Class: JITRegisterClassFP, Cost: 17}}, Count: 4})
+				defer ctx.ReleaseRegisterHomes(registerHomes1)
+				var r0 Reg
+				phiHomeOK2 := registerHomes1.Available&(uint16(1)<<1) == uint16(1)<<1
+				if phiHomeOK2 {
+					r0 = registerHomes1.Registers[1]
+				}
+				var r1 Reg
+				phiHomeOK3 := registerHomes1.Available&(uint16(1)<<2) == uint16(1)<<2
+				if phiHomeOK3 {
+					r1 = registerHomes1.Registers[2]
+				}
+				var r2 Reg
+				phiHomeOK4 := registerHomes1.Available&(uint16(1)<<3) == uint16(1)<<3
+				if phiHomeOK4 {
+					r2 = registerHomes1.Registers[3]
+				}
+				var r3 Reg
+				phiHomeOK5 := registerHomes1.Available&(uint16(1)<<0) == uint16(1)<<0
+				if phiHomeOK5 {
+					r3 = registerHomes1.Registers[0]
+				}
+				var r4 Reg
+				phiHomeOK6 := registerHomes1.Available&(uint16(1)<<1) == uint16(1)<<1
+				if phiHomeOK6 {
+					r4 = registerHomes1.Registers[1]
+				}
+				var r5 Reg
+				phiHomeOK7 := registerHomes1.Available&(uint16(1)<<0) == uint16(1)<<0
+				if phiHomeOK7 {
+					r5 = registerHomes1.Registers[0]
+				}
+				d8 := JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
 				ctx.PrepareScmerStackTarget(int32(phiBase0) + int32(0))
-				_ = d1
-				d2 := JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-				_ = d2
-				d3 := JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-				_ = d3
-				d4 := JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-				_ = d4
-				d5 := JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-				_ = d5
-				d6 := JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-				_ = d6
-				d7 := JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-				_ = d7
-				d8 := JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 				_ = d8
+				d9 := JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+				_ = d9
+				var d10 JITValueDesc
+				if phiHomeOK2 {
+					d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+				} else {
+					d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
+				}
+				_ = d10
+				var d11 JITValueDesc
+				if phiHomeOK3 {
+					d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+				} else {
+					d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
+				}
+				_ = d11
+				var d12 JITValueDesc
+				if phiHomeOK4 {
+					d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+				} else {
+					d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
+				}
+				_ = d12
+				var d13 JITValueDesc
+				if phiHomeOK5 {
+					d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+				} else {
+					d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
+				}
+				_ = d13
+				var d14 JITValueDesc
+				if phiHomeOK6 {
+					d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+				} else {
+					d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
+				}
+				_ = d14
+				var d15 JITValueDesc
+				if phiHomeOK7 {
+					d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+				} else {
+					d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
+				}
+				_ = d15
 				if result.Loc == LocAny {
 					result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
 					ctx.BindReg(result.Reg, &result)
@@ -385,145 +474,162 @@ func init_vector() {
 						ctx.MarkLabel(lbl1)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+						d11 = ps.OverlayValues[11]
+					}
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+						d12 = ps.OverlayValues[12]
+					}
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+						d13 = ps.OverlayValues[13]
+					}
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+						d14 = ps.OverlayValues[14]
+					}
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+						d15 = ps.OverlayValues[15]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d9 = args[0]
-					d9.ID = 0
-					var d10 JITValueDesc
-					if d9.Type == tagSlice {
-						d10 = jitKnownSliceHeader(ctx, &d9)
+					d16 = args[0]
+					d16.ID = 0
+					var d17 JITValueDesc
+					if d16.Type == tagSlice {
+						d17 = jitKnownSliceHeader(ctx, &d16)
 					} else {
-						d10 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d9}, 3)
+						d17 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d16}, 3)
 					}
-					ctx.BindReg(d10.Reg, &d10)
-					ctx.BindReg(d10.Reg2, &d10)
-					ctx.BindReg(d10.Reg3, &d10)
-					ctx.StabilizeDescForControlFlow(&d10)
-					ctx.FreeDesc(&d9)
-					d11 = args[1]
-					d11.ID = 0
-					var d12 JITValueDesc
-					if d11.Type == tagSlice {
-						d12 = jitKnownSliceHeader(ctx, &d11)
+					ctx.BindReg(d17.Reg, &d17)
+					ctx.BindReg(d17.Reg2, &d17)
+					ctx.BindReg(d17.Reg3, &d17)
+					ctx.StabilizeDescForControlFlow(&d17)
+					ctx.FreeDesc(&d16)
+					d18 = args[1]
+					d18.ID = 0
+					var d19 JITValueDesc
+					if d18.Type == tagSlice {
+						d19 = jitKnownSliceHeader(ctx, &d18)
 					} else {
-						d12 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d11}, 3)
+						d19 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d18}, 3)
 					}
-					ctx.BindReg(d12.Reg, &d12)
-					ctx.BindReg(d12.Reg2, &d12)
-					ctx.BindReg(d12.Reg3, &d12)
-					ctx.StabilizeDescForControlFlow(&d12)
-					ctx.FreeDesc(&d11)
-					d13 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
-					ctx.EnsureDesc(&d13)
-					var d14 JITValueDesc
-					if d13.Loc == LocImm {
-						d14 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d13.Imm.Int() > 2)}
+					ctx.BindReg(d19.Reg, &d19)
+					ctx.BindReg(d19.Reg2, &d19)
+					ctx.BindReg(d19.Reg3, &d19)
+					ctx.StabilizeDescForControlFlow(&d19)
+					ctx.FreeDesc(&d18)
+					d20 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
+					ctx.EnsureDesc(&d20)
+					var d21 JITValueDesc
+					if d20.Loc == LocImm {
+						d21 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d20.Imm.Int() > 2)}
 					} else {
-						r0 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d13.Reg, 2)
-						d14 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondSignedGreater}
-						ctx.BindReg(r0, &d14)
+						r6 := ctx.AllocReg()
+						ctx.EmitCmpRegImm32(d20.Reg, 2)
+						d21 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r6, Condition: CondSignedGreater}
+						ctx.BindReg(r6, &d21)
 					}
-					ctx.FreeDesc(&d13)
-					d15 = d14
-					ctx.EnsureDesc(&d15)
-					if d15.Loc != LocImm && d15.Loc != LocFlags {
+					ctx.FreeDesc(&d20)
+					d22 = d21
+					ctx.EnsureDesc(&d22)
+					if d22.Loc != LocImm && d22.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d15.Loc == LocImm {
-						if d15.Imm.Bool() {
+					if d22.Loc == LocImm {
+						if d22.Imm.Bool() {
 							if ps.General {
 							}
-							ps16 := PhiState{General: ps.General}
-							ps16.OverlayValues = make([]JITValueDesc, 16)
-							ps16.OverlayValues[1] = d1
-							ps16.OverlayValues[2] = d2
-							ps16.OverlayValues[3] = d3
-							ps16.OverlayValues[4] = d4
-							ps16.OverlayValues[5] = d5
-							ps16.OverlayValues[6] = d6
-							ps16.OverlayValues[7] = d7
-							ps16.OverlayValues[8] = d8
-							ps16.OverlayValues[9] = d9
-							ps16.OverlayValues[10] = d10
-							ps16.OverlayValues[11] = d11
-							ps16.OverlayValues[12] = d12
-							ps16.OverlayValues[13] = d13
-							ps16.OverlayValues[14] = d14
-							ps16.OverlayValues[15] = d15
-							return bbs[1].RenderPS(ps16)
+							ps23 := PhiState{General: ps.General}
+							ps23.OverlayValues = make([]JITValueDesc, 23)
+							ps23.OverlayValues[8] = d8
+							ps23.OverlayValues[9] = d9
+							ps23.OverlayValues[10] = d10
+							ps23.OverlayValues[11] = d11
+							ps23.OverlayValues[12] = d12
+							ps23.OverlayValues[13] = d13
+							ps23.OverlayValues[14] = d14
+							ps23.OverlayValues[15] = d15
+							ps23.OverlayValues[16] = d16
+							ps23.OverlayValues[17] = d17
+							ps23.OverlayValues[18] = d18
+							ps23.OverlayValues[19] = d19
+							ps23.OverlayValues[20] = d20
+							ps23.OverlayValues[21] = d21
+							ps23.OverlayValues[22] = d22
+							return bbs[1].RenderPS(ps23)
 						}
 						if ps.General {
 							ctx.EmitStoreScmerToStack(JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("DOT")}, int32(bbs[2].PhiBase)+int32(0))
 						}
-						ps17 := PhiState{General: ps.General}
-						ps17.OverlayValues = make([]JITValueDesc, 16)
-						ps17.OverlayValues[1] = d1
-						ps17.OverlayValues[2] = d2
-						ps17.OverlayValues[3] = d3
-						ps17.OverlayValues[4] = d4
-						ps17.OverlayValues[5] = d5
-						ps17.OverlayValues[6] = d6
-						ps17.OverlayValues[7] = d7
-						ps17.OverlayValues[8] = d8
-						ps17.OverlayValues[9] = d9
-						ps17.OverlayValues[10] = d10
-						ps17.OverlayValues[11] = d11
-						ps17.OverlayValues[12] = d12
-						ps17.OverlayValues[13] = d13
-						ps17.OverlayValues[14] = d14
-						ps17.OverlayValues[15] = d15
-						ps17.PhiValues = make([]JITValueDesc, 1)
-						d18 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("DOT")}
-						ps17.PhiValues[0] = d18
-						return bbs[2].RenderPS(ps17)
+						ps24 := PhiState{General: ps.General}
+						ps24.OverlayValues = make([]JITValueDesc, 23)
+						ps24.OverlayValues[8] = d8
+						ps24.OverlayValues[9] = d9
+						ps24.OverlayValues[10] = d10
+						ps24.OverlayValues[11] = d11
+						ps24.OverlayValues[12] = d12
+						ps24.OverlayValues[13] = d13
+						ps24.OverlayValues[14] = d14
+						ps24.OverlayValues[15] = d15
+						ps24.OverlayValues[16] = d16
+						ps24.OverlayValues[17] = d17
+						ps24.OverlayValues[18] = d18
+						ps24.OverlayValues[19] = d19
+						ps24.OverlayValues[20] = d20
+						ps24.OverlayValues[21] = d21
+						ps24.OverlayValues[22] = d22
+						ps24.PhiValues = make([]JITValueDesc, 1)
+						d25 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("DOT")}
+						ps24.PhiValues[0] = d25
+						return bbs[2].RenderPS(ps24)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[0].RenderPS(ps)
 					}
 					lbl16 := ctx.ReserveLabel()
-					ctx.EmitJump(d15.Condition, lbl2)
+					ctx.EmitJump(d22.Condition, lbl2)
 					ctx.EmitJmp(lbl16)
-					ctx.FreeDesc(&d14)
-					snap19 := d1
-					snap20 := d2
-					snap21 := d3
-					snap22 := d4
-					snap23 := d5
-					snap24 := d6
-					snap25 := d7
+					ctx.FreeDesc(&d21)
 					snap26 := d8
 					snap27 := d9
 					snap28 := d10
@@ -532,16 +638,16 @@ func init_vector() {
 					snap31 := d13
 					snap32 := d14
 					snap33 := d15
-					snap34 := d18
-					alloc35 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc35)
-					d1 = snap19
-					d2 = snap20
-					d3 = snap21
-					d4 = snap22
-					d5 = snap23
-					d6 = snap24
-					d7 = snap25
+					snap34 := d16
+					snap35 := d17
+					snap36 := d18
+					snap37 := d19
+					snap38 := d20
+					snap39 := d21
+					snap40 := d22
+					snap41 := d25
+					alloc42 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc42)
 					d8 = snap26
 					d9 = snap27
 					d10 = snap28
@@ -550,18 +656,18 @@ func init_vector() {
 					d13 = snap31
 					d14 = snap32
 					d15 = snap33
-					d18 = snap34
+					d16 = snap34
+					d17 = snap35
+					d18 = snap36
+					d19 = snap37
+					d20 = snap38
+					d21 = snap39
+					d22 = snap40
+					d25 = snap41
 					ctx.MarkLabel(lbl16)
 					ctx.EmitStoreScmerToStack(JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("DOT")}, int32(bbs[2].PhiBase)+int32(0))
 					ctx.EmitJmp(lbl3)
-					ctx.RestoreAllocState(alloc35)
-					d1 = snap19
-					d2 = snap20
-					d3 = snap21
-					d4 = snap22
-					d5 = snap23
-					d6 = snap24
-					d7 = snap25
+					ctx.RestoreAllocState(alloc42)
 					d8 = snap26
 					d9 = snap27
 					d10 = snap28
@@ -570,53 +676,53 @@ func init_vector() {
 					d13 = snap31
 					d14 = snap32
 					d15 = snap33
-					d18 = snap34
-					ps36 := PhiState{General: true}
-					ps36.OverlayValues = make([]JITValueDesc, 19)
-					ps36.OverlayValues[1] = d1
-					ps36.OverlayValues[2] = d2
-					ps36.OverlayValues[3] = d3
-					ps36.OverlayValues[4] = d4
-					ps36.OverlayValues[5] = d5
-					ps36.OverlayValues[6] = d6
-					ps36.OverlayValues[7] = d7
-					ps36.OverlayValues[8] = d8
-					ps36.OverlayValues[9] = d9
-					ps36.OverlayValues[10] = d10
-					ps36.OverlayValues[11] = d11
-					ps36.OverlayValues[12] = d12
-					ps36.OverlayValues[13] = d13
-					ps36.OverlayValues[14] = d14
-					ps36.OverlayValues[15] = d15
-					ps36.OverlayValues[18] = d18
-					ps37 := PhiState{General: true}
-					ps37.OverlayValues = make([]JITValueDesc, 19)
-					ps37.OverlayValues[1] = d1
-					ps37.OverlayValues[2] = d2
-					ps37.OverlayValues[3] = d3
-					ps37.OverlayValues[4] = d4
-					ps37.OverlayValues[5] = d5
-					ps37.OverlayValues[6] = d6
-					ps37.OverlayValues[7] = d7
-					ps37.OverlayValues[8] = d8
-					ps37.OverlayValues[9] = d9
-					ps37.OverlayValues[10] = d10
-					ps37.OverlayValues[11] = d11
-					ps37.OverlayValues[12] = d12
-					ps37.OverlayValues[13] = d13
-					ps37.OverlayValues[14] = d14
-					ps37.OverlayValues[15] = d15
-					ps37.OverlayValues[18] = d18
-					ps37.PhiValues = make([]JITValueDesc, 1)
-					d38 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("DOT")}
-					ps37.PhiValues[0] = d38
-					snap39 := d1
-					snap40 := d2
-					snap41 := d3
-					snap42 := d4
-					snap43 := d5
-					snap44 := d6
-					snap45 := d7
+					d16 = snap34
+					d17 = snap35
+					d18 = snap36
+					d19 = snap37
+					d20 = snap38
+					d21 = snap39
+					d22 = snap40
+					d25 = snap41
+					ps43 := PhiState{General: true}
+					ps43.OverlayValues = make([]JITValueDesc, 26)
+					ps43.OverlayValues[8] = d8
+					ps43.OverlayValues[9] = d9
+					ps43.OverlayValues[10] = d10
+					ps43.OverlayValues[11] = d11
+					ps43.OverlayValues[12] = d12
+					ps43.OverlayValues[13] = d13
+					ps43.OverlayValues[14] = d14
+					ps43.OverlayValues[15] = d15
+					ps43.OverlayValues[16] = d16
+					ps43.OverlayValues[17] = d17
+					ps43.OverlayValues[18] = d18
+					ps43.OverlayValues[19] = d19
+					ps43.OverlayValues[20] = d20
+					ps43.OverlayValues[21] = d21
+					ps43.OverlayValues[22] = d22
+					ps43.OverlayValues[25] = d25
+					ps44 := PhiState{General: true}
+					ps44.OverlayValues = make([]JITValueDesc, 26)
+					ps44.OverlayValues[8] = d8
+					ps44.OverlayValues[9] = d9
+					ps44.OverlayValues[10] = d10
+					ps44.OverlayValues[11] = d11
+					ps44.OverlayValues[12] = d12
+					ps44.OverlayValues[13] = d13
+					ps44.OverlayValues[14] = d14
+					ps44.OverlayValues[15] = d15
+					ps44.OverlayValues[16] = d16
+					ps44.OverlayValues[17] = d17
+					ps44.OverlayValues[18] = d18
+					ps44.OverlayValues[19] = d19
+					ps44.OverlayValues[20] = d20
+					ps44.OverlayValues[21] = d21
+					ps44.OverlayValues[22] = d22
+					ps44.OverlayValues[25] = d25
+					ps44.PhiValues = make([]JITValueDesc, 1)
+					d45 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("DOT")}
+					ps44.PhiValues[0] = d45
 					snap46 := d8
 					snap47 := d9
 					snap48 := d10
@@ -625,20 +731,20 @@ func init_vector() {
 					snap51 := d13
 					snap52 := d14
 					snap53 := d15
-					snap54 := d18
-					snap55 := d38
-					alloc56 := ctx.SnapshotAllocState()
+					snap54 := d16
+					snap55 := d17
+					snap56 := d18
+					snap57 := d19
+					snap58 := d20
+					snap59 := d21
+					snap60 := d22
+					snap61 := d25
+					snap62 := d45
+					alloc63 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps37)
+						bbs[2].RenderPS(ps44)
 					}
-					ctx.RestoreAllocState(alloc56)
-					d1 = snap39
-					d2 = snap40
-					d3 = snap41
-					d4 = snap42
-					d5 = snap43
-					d6 = snap44
-					d7 = snap45
+					ctx.RestoreAllocState(alloc63)
 					d8 = snap46
 					d9 = snap47
 					d10 = snap48
@@ -647,10 +753,17 @@ func init_vector() {
 					d13 = snap51
 					d14 = snap52
 					d15 = snap53
-					d18 = snap54
-					d38 = snap55
+					d16 = snap54
+					d17 = snap55
+					d18 = snap56
+					d19 = snap57
+					d20 = snap58
+					d21 = snap59
+					d22 = snap60
+					d25 = snap61
+					d45 = snap62
 					if !bbs[1].Rendered {
-						return bbs[1].RenderPS(ps36)
+						return bbs[1].RenderPS(ps43)
 					}
 					return result
 					return result
@@ -674,189 +787,213 @@ func init_vector() {
 						ctx.MarkLabel(lbl2)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
+					}
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
+					}
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
+					}
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
+					}
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
+					}
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d57 = args[2]
-					d57.ID = 0
-					d59 = d57
-					ctx.SyncDesc(&d59)
-					if d59.Loc == LocMem {
-						tmpScalar := JITValueDesc{Loc: LocReg, Type: d59.Type, Reg: ctx.AllocReg()}
+					d64 = args[2]
+					d64.ID = 0
+					d66 = d64
+					ctx.SyncDesc(&d66)
+					if d66.Loc == LocMem {
+						tmpScalar := JITValueDesc{Loc: LocReg, Type: d66.Type, Reg: ctx.AllocReg()}
 						scratch := ctx.AllocRegExcept(tmpScalar.Reg)
-						ctx.EmitMovRegImm64(scratch, uint64(d59.MemPtr))
+						ctx.EmitMovRegImm64(scratch, uint64(d66.MemPtr))
 						ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
 						ctx.FreeReg(scratch)
 						ctx.BindReg(tmpScalar.Reg, &tmpScalar)
-						d59 = tmpScalar
+						d66 = tmpScalar
 					}
-					d59 = JITPrepareScmerGoArg(ctx, d59)
-					if d59.Loc != LocRegPair && d59.Loc != LocStackPair && d59.Loc != LocInputPair {
+					d66 = JITPrepareScmerGoArg(ctx, d66)
+					if d66.Loc != LocRegPair && d66.Loc != LocStackPair && d66.Loc != LocInputPair {
 						panic("jit: Scmer.String receiver not materialized as pair")
 					}
-					d58 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d59}, 2)
-					ctx.FreeDesc(&d57)
-					ctx.EnsureDesc(&d58)
-					if d58.Loc == LocImm {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d58.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.TrackImm(d58.Imm)
-						ptrWord, _ := d58.Imm.RawWords()
+					d65 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d66}, 2)
+					ctx.FreeDesc(&d64)
+					ctx.EnsureDesc(&d65)
+					if d65.Loc == LocImm {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d65.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.TrackImm(d65.Imm)
+						ptrWord, _ := d65.Imm.RawWords()
 						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d58.Imm.String())))
-						d58 = tmpPair
-					} else if d58.Loc == LocReg {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d58.Type, Reg: ctx.AllocRegExcept(d58.Reg), Reg2: ctx.AllocRegExcept(d58.Reg)}
-						switch d58.Type {
+						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d65.Imm.String())))
+						d65 = tmpPair
+					} else if d65.Loc == LocReg {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d65.Type, Reg: ctx.AllocRegExcept(d65.Reg), Reg2: ctx.AllocRegExcept(d65.Reg)}
+						switch d65.Type {
 						case tagBool:
-							ctx.EmitMakeBool(tmpPair, d58)
+							ctx.EmitMakeBool(tmpPair, d65)
 						case tagInt:
-							ctx.EmitMakeInt(tmpPair, d58)
+							ctx.EmitMakeInt(tmpPair, d65)
 						case tagFloat:
-							ctx.EmitMakeFloat(tmpPair, d58)
+							ctx.EmitMakeFloat(tmpPair, d65)
 						default:
 							panic("jit: generic call arg scalar type unknown for 2-word value")
 						}
-						ctx.FreeDesc(&d58)
-						d58 = tmpPair
+						ctx.FreeDesc(&d65)
+						d65 = tmpPair
 					}
-					if d58.Loc != LocRegPair && d58.Loc != LocStackPair && d58.Loc != LocInputPair {
+					if d65.Loc != LocRegPair && d65.Loc != LocStackPair && d65.Loc != LocInputPair {
 						panic("jit: generic call arg expects 2-word value (strings.ToUpper arg0)")
 					}
-					ctx.SyncDesc(&d58)
-					d60 = ctx.EmitGoCallScalar(GoFuncAddr(strings.ToUpper), []JITValueDesc{d58}, 2)
-					d60.NoHeapPointer = false
-					ctx.BindReg(d60.Reg, &d60)
-					ctx.BindReg(d60.Reg2, &d60)
-					ctx.StabilizeDescForControlFlow(&d60)
+					ctx.SyncDesc(&d65)
+					d67 = ctx.EmitGoCallScalar(GoFuncAddr(strings.ToUpper), []JITValueDesc{d65}, 2)
+					d67.NoHeapPointer = false
+					ctx.BindReg(d67.Reg, &d67)
+					ctx.BindReg(d67.Reg2, &d67)
+					ctx.StabilizeDescForControlFlow(&d67)
 					if ps.General {
-						ctx.SyncDesc(&d60)
-						if d60.Loc == LocReg {
-							ctx.ProtectReg(d60.Reg)
-						} else if d60.Loc == LocRegPair {
-							ctx.ProtectReg(d60.Reg)
-							ctx.ProtectReg(d60.Reg2)
+						ctx.SyncDesc(&d67)
+						if d67.Loc == LocReg || d67.Loc == LocFPReg {
+							ctx.ProtectReg(d67.Reg)
+						} else if d67.Loc == LocRegPair {
+							ctx.ProtectReg(d67.Reg)
+							ctx.ProtectReg(d67.Reg2)
 						}
-						d61 = d60
-						if d61.Loc == LocNone {
+						d68 = d67
+						if d68.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.SyncDesc(&d61)
-						if d61.Loc == LocStackPair {
-							ctx.EmitCopyStackWords(d61, int32(bbs[2].PhiBase)+int32(0), 2)
-						} else if d61.Loc == LocInputPair {
-							ctx.EnsureDesc(&d61)
-							ctx.EmitStoreScmerToStack(d61, int32(bbs[2].PhiBase)+int32(0))
-						} else if d61.Loc == LocRegPair || d61.Loc == LocImm {
-							ctx.EmitStoreScmerToStack(d61, int32(bbs[2].PhiBase)+int32(0))
+						ctx.SyncDesc(&d68)
+						if d68.Loc == LocStackPair {
+							ctx.EmitCopyStackWords(d68, int32(bbs[2].PhiBase)+int32(0), 2)
+						} else if d68.Loc == LocInputPair {
+							ctx.EnsureDesc(&d68)
+							ctx.EmitStoreScmerToStack(d68, int32(bbs[2].PhiBase)+int32(0))
+						} else if d68.Loc == LocRegPair || d68.Loc == LocImm {
+							ctx.EmitStoreScmerToStack(d68, int32(bbs[2].PhiBase)+int32(0))
 						} else {
-							ctx.EnsureDesc(&d61)
-							ctx.EmitStoreToStack(d61, int32(bbs[2].PhiBase)+int32(0))
+							ctx.EnsureDesc(&d68)
+							ctx.EmitStoreToStack(d68, int32(bbs[2].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 						}
-						if d60.Loc == LocReg {
-							ctx.UnprotectReg(d60.Reg)
-						} else if d60.Loc == LocRegPair {
-							ctx.UnprotectReg(d60.Reg)
-							ctx.UnprotectReg(d60.Reg2)
+						if d67.Loc == LocReg || d67.Loc == LocFPReg {
+							ctx.UnprotectReg(d67.Reg)
+						} else if d67.Loc == LocRegPair {
+							ctx.UnprotectReg(d67.Reg)
+							ctx.UnprotectReg(d67.Reg2)
 						}
 					}
-					ps62 := PhiState{General: ps.General}
-					ps62.OverlayValues = make([]JITValueDesc, 62)
-					ps62.OverlayValues[1] = d1
-					ps62.OverlayValues[2] = d2
-					ps62.OverlayValues[3] = d3
-					ps62.OverlayValues[4] = d4
-					ps62.OverlayValues[5] = d5
-					ps62.OverlayValues[6] = d6
-					ps62.OverlayValues[7] = d7
-					ps62.OverlayValues[8] = d8
-					ps62.OverlayValues[9] = d9
-					ps62.OverlayValues[10] = d10
-					ps62.OverlayValues[11] = d11
-					ps62.OverlayValues[12] = d12
-					ps62.OverlayValues[13] = d13
-					ps62.OverlayValues[14] = d14
-					ps62.OverlayValues[15] = d15
-					ps62.OverlayValues[18] = d18
-					ps62.OverlayValues[38] = d38
-					ps62.OverlayValues[57] = d57
-					ps62.OverlayValues[58] = d58
-					ps62.OverlayValues[59] = d59
-					ps62.OverlayValues[60] = d60
-					ps62.OverlayValues[61] = d61
-					ps62.PhiValues = make([]JITValueDesc, 1)
-					d63 = d60
-					ps62.PhiValues[0] = d63
-					if ps62.General && bbs[2].Rendered {
+					ps69 := PhiState{General: ps.General}
+					ps69.OverlayValues = make([]JITValueDesc, 69)
+					ps69.OverlayValues[8] = d8
+					ps69.OverlayValues[9] = d9
+					ps69.OverlayValues[10] = d10
+					ps69.OverlayValues[11] = d11
+					ps69.OverlayValues[12] = d12
+					ps69.OverlayValues[13] = d13
+					ps69.OverlayValues[14] = d14
+					ps69.OverlayValues[15] = d15
+					ps69.OverlayValues[16] = d16
+					ps69.OverlayValues[17] = d17
+					ps69.OverlayValues[18] = d18
+					ps69.OverlayValues[19] = d19
+					ps69.OverlayValues[20] = d20
+					ps69.OverlayValues[21] = d21
+					ps69.OverlayValues[22] = d22
+					ps69.OverlayValues[25] = d25
+					ps69.OverlayValues[45] = d45
+					ps69.OverlayValues[64] = d64
+					ps69.OverlayValues[65] = d65
+					ps69.OverlayValues[66] = d66
+					ps69.OverlayValues[67] = d67
+					ps69.OverlayValues[68] = d68
+					ps69.PhiValues = make([]JITValueDesc, 1)
+					d70 = d67
+					ps69.PhiValues[0] = d70
+					if ps69.General && bbs[2].Rendered {
 						ctx.EmitJmp(lbl3)
 						return result
 					}
-					return bbs[2].RenderPS(ps62)
+					return bbs[2].RenderPS(ps69)
 					return result
 				}
 				bbs[2].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d64 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d64)
-							ctx.EmitStoreScmerToStack(d64, int32(bbs[2].PhiBase)+int32(0))
+							d71 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d71)
+							ctx.EmitStoreScmerToStack(d71, int32(bbs[2].PhiBase)+int32(0))
 						}
 						if bbs[2].VisitCount >= 0 {
 							ps.General = true
@@ -875,219 +1012,236 @@ func init_vector() {
 						ctx.MarkLabel(lbl3)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
 					}
+					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
+						d65 = ps.OverlayValues[65]
+					}
+					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
+						d66 = ps.OverlayValues[66]
+					}
+					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
+						d67 = ps.OverlayValues[67]
+					}
+					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
+						d68 = ps.OverlayValues[68]
+					}
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
+					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-						d1 = ps.PhiValues[0]
+						d8 = ps.PhiValues[0]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.StabilizeDescForControlFlow(&d1)
-					ctx.EnsureDesc(&d1)
-					var d65 JITValueDesc
-					if d1.Loc == LocImm {
-						ctx.TrackImm(d1.Imm)
-						ptrWord, _ := d1.Imm.RawWords()
-						d65 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.EmitMovRegImm64(d65.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(d65.Reg2, uint64(len(d1.Imm.String())))
-						ctx.BindReg(d65.Reg, &d65)
-						ctx.BindReg(d65.Reg2, &d65)
+					ctx.StabilizeDescForControlFlow(&d8)
+					ctx.EnsureDesc(&d8)
+					var d72 JITValueDesc
+					if d8.Loc == LocImm {
+						ctx.TrackImm(d8.Imm)
+						ptrWord, _ := d8.Imm.RawWords()
+						d72 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.EmitMovRegImm64(d72.Reg, uint64(ptrWord))
+						ctx.EmitMovRegImm64(d72.Reg2, uint64(len(d8.Imm.String())))
+						ctx.BindReg(d72.Reg, &d72)
+						ctx.BindReg(d72.Reg2, &d72)
 					} else {
-						d65 = d1
+						d72 = d8
 					}
-					d66 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("COSINE")}
-					var d67 JITValueDesc
-					if d66.Loc == LocImm {
-						ctx.TrackImm(d66.Imm)
-						ptrWord, _ := d66.Imm.RawWords()
-						d67 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.EmitMovRegImm64(d67.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(d67.Reg2, uint64(len(d66.Imm.String())))
-						ctx.BindReg(d67.Reg, &d67)
-						ctx.BindReg(d67.Reg2, &d67)
+					d73 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("COSINE")}
+					var d74 JITValueDesc
+					if d73.Loc == LocImm {
+						ctx.TrackImm(d73.Imm)
+						ptrWord, _ := d73.Imm.RawWords()
+						d74 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.EmitMovRegImm64(d74.Reg, uint64(ptrWord))
+						ctx.EmitMovRegImm64(d74.Reg2, uint64(len(d73.Imm.String())))
+						ctx.BindReg(d74.Reg, &d74)
+						ctx.BindReg(d74.Reg2, &d74)
 					} else {
-						d67 = d66
+						d74 = d73
 					}
-					d68 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d65, d67}, 1)
-					ctx.EmitAndRegImm32(d68.Reg, 1)
-					d68.Type = tagBool
-					ctx.BindReg(d68.Reg, &d68)
-					d69 = d68
-					ctx.EnsureDesc(&d69)
-					if d69.Loc != LocImm && d69.Loc != LocReg {
+					d75 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d72, d74}, 1)
+					ctx.EmitAndRegImm32(d75.Reg, 1)
+					d75.Type = tagBool
+					ctx.BindReg(d75.Reg, &d75)
+					d76 = d75
+					ctx.EnsureDesc(&d76)
+					if d76.Loc != LocImm && d76.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d69.Loc == LocImm {
-						if d69.Imm.Bool() {
+					if d76.Loc == LocImm {
+						if d76.Imm.Bool() {
 							if ps.General {
 							}
-							ps70 := PhiState{General: ps.General}
-							ps70.OverlayValues = make([]JITValueDesc, 70)
-							ps70.OverlayValues[1] = d1
-							ps70.OverlayValues[2] = d2
-							ps70.OverlayValues[3] = d3
-							ps70.OverlayValues[4] = d4
-							ps70.OverlayValues[5] = d5
-							ps70.OverlayValues[6] = d6
-							ps70.OverlayValues[7] = d7
-							ps70.OverlayValues[8] = d8
-							ps70.OverlayValues[9] = d9
-							ps70.OverlayValues[10] = d10
-							ps70.OverlayValues[11] = d11
-							ps70.OverlayValues[12] = d12
-							ps70.OverlayValues[13] = d13
-							ps70.OverlayValues[14] = d14
-							ps70.OverlayValues[15] = d15
-							ps70.OverlayValues[18] = d18
-							ps70.OverlayValues[38] = d38
-							ps70.OverlayValues[57] = d57
-							ps70.OverlayValues[58] = d58
-							ps70.OverlayValues[59] = d59
-							ps70.OverlayValues[60] = d60
-							ps70.OverlayValues[61] = d61
-							ps70.OverlayValues[63] = d63
-							ps70.OverlayValues[64] = d64
-							ps70.OverlayValues[65] = d65
-							ps70.OverlayValues[66] = d66
-							ps70.OverlayValues[67] = d67
-							ps70.OverlayValues[68] = d68
-							ps70.OverlayValues[69] = d69
-							return bbs[3].RenderPS(ps70)
+							ps77 := PhiState{General: ps.General}
+							ps77.OverlayValues = make([]JITValueDesc, 77)
+							ps77.OverlayValues[8] = d8
+							ps77.OverlayValues[9] = d9
+							ps77.OverlayValues[10] = d10
+							ps77.OverlayValues[11] = d11
+							ps77.OverlayValues[12] = d12
+							ps77.OverlayValues[13] = d13
+							ps77.OverlayValues[14] = d14
+							ps77.OverlayValues[15] = d15
+							ps77.OverlayValues[16] = d16
+							ps77.OverlayValues[17] = d17
+							ps77.OverlayValues[18] = d18
+							ps77.OverlayValues[19] = d19
+							ps77.OverlayValues[20] = d20
+							ps77.OverlayValues[21] = d21
+							ps77.OverlayValues[22] = d22
+							ps77.OverlayValues[25] = d25
+							ps77.OverlayValues[45] = d45
+							ps77.OverlayValues[64] = d64
+							ps77.OverlayValues[65] = d65
+							ps77.OverlayValues[66] = d66
+							ps77.OverlayValues[67] = d67
+							ps77.OverlayValues[68] = d68
+							ps77.OverlayValues[70] = d70
+							ps77.OverlayValues[71] = d71
+							ps77.OverlayValues[72] = d72
+							ps77.OverlayValues[73] = d73
+							ps77.OverlayValues[74] = d74
+							ps77.OverlayValues[75] = d75
+							ps77.OverlayValues[76] = d76
+							return bbs[3].RenderPS(ps77)
 						}
 						if ps.General {
 						}
-						ps71 := PhiState{General: ps.General}
-						ps71.OverlayValues = make([]JITValueDesc, 70)
-						ps71.OverlayValues[1] = d1
-						ps71.OverlayValues[2] = d2
-						ps71.OverlayValues[3] = d3
-						ps71.OverlayValues[4] = d4
-						ps71.OverlayValues[5] = d5
-						ps71.OverlayValues[6] = d6
-						ps71.OverlayValues[7] = d7
-						ps71.OverlayValues[8] = d8
-						ps71.OverlayValues[9] = d9
-						ps71.OverlayValues[10] = d10
-						ps71.OverlayValues[11] = d11
-						ps71.OverlayValues[12] = d12
-						ps71.OverlayValues[13] = d13
-						ps71.OverlayValues[14] = d14
-						ps71.OverlayValues[15] = d15
-						ps71.OverlayValues[18] = d18
-						ps71.OverlayValues[38] = d38
-						ps71.OverlayValues[57] = d57
-						ps71.OverlayValues[58] = d58
-						ps71.OverlayValues[59] = d59
-						ps71.OverlayValues[60] = d60
-						ps71.OverlayValues[61] = d61
-						ps71.OverlayValues[63] = d63
-						ps71.OverlayValues[64] = d64
-						ps71.OverlayValues[65] = d65
-						ps71.OverlayValues[66] = d66
-						ps71.OverlayValues[67] = d67
-						ps71.OverlayValues[68] = d68
-						ps71.OverlayValues[69] = d69
-						return bbs[5].RenderPS(ps71)
+						ps78 := PhiState{General: ps.General}
+						ps78.OverlayValues = make([]JITValueDesc, 77)
+						ps78.OverlayValues[8] = d8
+						ps78.OverlayValues[9] = d9
+						ps78.OverlayValues[10] = d10
+						ps78.OverlayValues[11] = d11
+						ps78.OverlayValues[12] = d12
+						ps78.OverlayValues[13] = d13
+						ps78.OverlayValues[14] = d14
+						ps78.OverlayValues[15] = d15
+						ps78.OverlayValues[16] = d16
+						ps78.OverlayValues[17] = d17
+						ps78.OverlayValues[18] = d18
+						ps78.OverlayValues[19] = d19
+						ps78.OverlayValues[20] = d20
+						ps78.OverlayValues[21] = d21
+						ps78.OverlayValues[22] = d22
+						ps78.OverlayValues[25] = d25
+						ps78.OverlayValues[45] = d45
+						ps78.OverlayValues[64] = d64
+						ps78.OverlayValues[65] = d65
+						ps78.OverlayValues[66] = d66
+						ps78.OverlayValues[67] = d67
+						ps78.OverlayValues[68] = d68
+						ps78.OverlayValues[70] = d70
+						ps78.OverlayValues[71] = d71
+						ps78.OverlayValues[72] = d72
+						ps78.OverlayValues[73] = d73
+						ps78.OverlayValues[74] = d74
+						ps78.OverlayValues[75] = d75
+						ps78.OverlayValues[76] = d76
+						return bbs[5].RenderPS(ps78)
 					}
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d72 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d72)
-							ctx.EmitStoreScmerToStack(d72, int32(bbs[2].PhiBase)+int32(0))
+							d79 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d79)
+							ctx.EmitStoreScmerToStack(d79, int32(bbs[2].PhiBase)+int32(0))
 						}
 						ps.General = true
 						return bbs[2].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d69.Reg, 0)
+					ctx.EmitCmpRegImm32(d76.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl4)
 					if bbs[5].Rendered {
 						ctx.EmitJmp(lbl6)
 					}
-					snap73 := d1
-					snap74 := d2
-					snap75 := d3
-					snap76 := d4
-					snap77 := d5
-					snap78 := d6
-					snap79 := d7
 					snap80 := d8
 					snap81 := d9
 					snap82 := d10
@@ -1096,30 +1250,30 @@ func init_vector() {
 					snap85 := d13
 					snap86 := d14
 					snap87 := d15
-					snap88 := d18
-					snap89 := d38
-					snap90 := d57
-					snap91 := d58
-					snap92 := d59
-					snap93 := d60
-					snap94 := d61
-					snap95 := d63
-					snap96 := d64
-					snap97 := d65
-					snap98 := d66
-					snap99 := d67
-					snap100 := d68
-					snap101 := d69
-					snap102 := d72
-					alloc103 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc103)
-					d1 = snap73
-					d2 = snap74
-					d3 = snap75
-					d4 = snap76
-					d5 = snap77
-					d6 = snap78
-					d7 = snap79
+					snap88 := d16
+					snap89 := d17
+					snap90 := d18
+					snap91 := d19
+					snap92 := d20
+					snap93 := d21
+					snap94 := d22
+					snap95 := d25
+					snap96 := d45
+					snap97 := d64
+					snap98 := d65
+					snap99 := d66
+					snap100 := d67
+					snap101 := d68
+					snap102 := d70
+					snap103 := d71
+					snap104 := d72
+					snap105 := d73
+					snap106 := d74
+					snap107 := d75
+					snap108 := d76
+					snap109 := d79
+					alloc110 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc110)
 					d8 = snap80
 					d9 = snap81
 					d10 = snap82
@@ -1128,29 +1282,29 @@ func init_vector() {
 					d13 = snap85
 					d14 = snap86
 					d15 = snap87
-					d18 = snap88
-					d38 = snap89
-					d57 = snap90
-					d58 = snap91
-					d59 = snap92
-					d60 = snap93
-					d61 = snap94
-					d63 = snap95
-					d64 = snap96
-					d65 = snap97
-					d66 = snap98
-					d67 = snap99
-					d68 = snap100
-					d69 = snap101
-					d72 = snap102
-					ctx.RestoreAllocState(alloc103)
-					d1 = snap73
-					d2 = snap74
-					d3 = snap75
-					d4 = snap76
-					d5 = snap77
-					d6 = snap78
-					d7 = snap79
+					d16 = snap88
+					d17 = snap89
+					d18 = snap90
+					d19 = snap91
+					d20 = snap92
+					d21 = snap93
+					d22 = snap94
+					d25 = snap95
+					d45 = snap96
+					d64 = snap97
+					d65 = snap98
+					d66 = snap99
+					d67 = snap100
+					d68 = snap101
+					d70 = snap102
+					d71 = snap103
+					d72 = snap104
+					d73 = snap105
+					d74 = snap106
+					d75 = snap107
+					d76 = snap108
+					d79 = snap109
+					ctx.RestoreAllocState(alloc110)
 					d8 = snap80
 					d9 = snap81
 					d10 = snap82
@@ -1159,92 +1313,92 @@ func init_vector() {
 					d13 = snap85
 					d14 = snap86
 					d15 = snap87
-					d18 = snap88
-					d38 = snap89
-					d57 = snap90
-					d58 = snap91
-					d59 = snap92
-					d60 = snap93
-					d61 = snap94
-					d63 = snap95
-					d64 = snap96
-					d65 = snap97
-					d66 = snap98
-					d67 = snap99
-					d68 = snap100
-					d69 = snap101
-					d72 = snap102
-					ps104 := PhiState{General: true}
-					ps104.OverlayValues = make([]JITValueDesc, 73)
-					ps104.OverlayValues[1] = d1
-					ps104.OverlayValues[2] = d2
-					ps104.OverlayValues[3] = d3
-					ps104.OverlayValues[4] = d4
-					ps104.OverlayValues[5] = d5
-					ps104.OverlayValues[6] = d6
-					ps104.OverlayValues[7] = d7
-					ps104.OverlayValues[8] = d8
-					ps104.OverlayValues[9] = d9
-					ps104.OverlayValues[10] = d10
-					ps104.OverlayValues[11] = d11
-					ps104.OverlayValues[12] = d12
-					ps104.OverlayValues[13] = d13
-					ps104.OverlayValues[14] = d14
-					ps104.OverlayValues[15] = d15
-					ps104.OverlayValues[18] = d18
-					ps104.OverlayValues[38] = d38
-					ps104.OverlayValues[57] = d57
-					ps104.OverlayValues[58] = d58
-					ps104.OverlayValues[59] = d59
-					ps104.OverlayValues[60] = d60
-					ps104.OverlayValues[61] = d61
-					ps104.OverlayValues[63] = d63
-					ps104.OverlayValues[64] = d64
-					ps104.OverlayValues[65] = d65
-					ps104.OverlayValues[66] = d66
-					ps104.OverlayValues[67] = d67
-					ps104.OverlayValues[68] = d68
-					ps104.OverlayValues[69] = d69
-					ps104.OverlayValues[72] = d72
-					ps105 := PhiState{General: true}
-					ps105.OverlayValues = make([]JITValueDesc, 73)
-					ps105.OverlayValues[1] = d1
-					ps105.OverlayValues[2] = d2
-					ps105.OverlayValues[3] = d3
-					ps105.OverlayValues[4] = d4
-					ps105.OverlayValues[5] = d5
-					ps105.OverlayValues[6] = d6
-					ps105.OverlayValues[7] = d7
-					ps105.OverlayValues[8] = d8
-					ps105.OverlayValues[9] = d9
-					ps105.OverlayValues[10] = d10
-					ps105.OverlayValues[11] = d11
-					ps105.OverlayValues[12] = d12
-					ps105.OverlayValues[13] = d13
-					ps105.OverlayValues[14] = d14
-					ps105.OverlayValues[15] = d15
-					ps105.OverlayValues[18] = d18
-					ps105.OverlayValues[38] = d38
-					ps105.OverlayValues[57] = d57
-					ps105.OverlayValues[58] = d58
-					ps105.OverlayValues[59] = d59
-					ps105.OverlayValues[60] = d60
-					ps105.OverlayValues[61] = d61
-					ps105.OverlayValues[63] = d63
-					ps105.OverlayValues[64] = d64
-					ps105.OverlayValues[65] = d65
-					ps105.OverlayValues[66] = d66
-					ps105.OverlayValues[67] = d67
-					ps105.OverlayValues[68] = d68
-					ps105.OverlayValues[69] = d69
-					ps105.OverlayValues[72] = d72
-					snap106 := d1
-					snap107 := d2
-					snap108 := d3
-					snap109 := d4
-					snap110 := d5
-					snap111 := d6
-					snap112 := d7
+					d16 = snap88
+					d17 = snap89
+					d18 = snap90
+					d19 = snap91
+					d20 = snap92
+					d21 = snap93
+					d22 = snap94
+					d25 = snap95
+					d45 = snap96
+					d64 = snap97
+					d65 = snap98
+					d66 = snap99
+					d67 = snap100
+					d68 = snap101
+					d70 = snap102
+					d71 = snap103
+					d72 = snap104
+					d73 = snap105
+					d74 = snap106
+					d75 = snap107
+					d76 = snap108
+					d79 = snap109
+					ps111 := PhiState{General: true}
+					ps111.OverlayValues = make([]JITValueDesc, 80)
+					ps111.OverlayValues[8] = d8
+					ps111.OverlayValues[9] = d9
+					ps111.OverlayValues[10] = d10
+					ps111.OverlayValues[11] = d11
+					ps111.OverlayValues[12] = d12
+					ps111.OverlayValues[13] = d13
+					ps111.OverlayValues[14] = d14
+					ps111.OverlayValues[15] = d15
+					ps111.OverlayValues[16] = d16
+					ps111.OverlayValues[17] = d17
+					ps111.OverlayValues[18] = d18
+					ps111.OverlayValues[19] = d19
+					ps111.OverlayValues[20] = d20
+					ps111.OverlayValues[21] = d21
+					ps111.OverlayValues[22] = d22
+					ps111.OverlayValues[25] = d25
+					ps111.OverlayValues[45] = d45
+					ps111.OverlayValues[64] = d64
+					ps111.OverlayValues[65] = d65
+					ps111.OverlayValues[66] = d66
+					ps111.OverlayValues[67] = d67
+					ps111.OverlayValues[68] = d68
+					ps111.OverlayValues[70] = d70
+					ps111.OverlayValues[71] = d71
+					ps111.OverlayValues[72] = d72
+					ps111.OverlayValues[73] = d73
+					ps111.OverlayValues[74] = d74
+					ps111.OverlayValues[75] = d75
+					ps111.OverlayValues[76] = d76
+					ps111.OverlayValues[79] = d79
+					ps112 := PhiState{General: true}
+					ps112.OverlayValues = make([]JITValueDesc, 80)
+					ps112.OverlayValues[8] = d8
+					ps112.OverlayValues[9] = d9
+					ps112.OverlayValues[10] = d10
+					ps112.OverlayValues[11] = d11
+					ps112.OverlayValues[12] = d12
+					ps112.OverlayValues[13] = d13
+					ps112.OverlayValues[14] = d14
+					ps112.OverlayValues[15] = d15
+					ps112.OverlayValues[16] = d16
+					ps112.OverlayValues[17] = d17
+					ps112.OverlayValues[18] = d18
+					ps112.OverlayValues[19] = d19
+					ps112.OverlayValues[20] = d20
+					ps112.OverlayValues[21] = d21
+					ps112.OverlayValues[22] = d22
+					ps112.OverlayValues[25] = d25
+					ps112.OverlayValues[45] = d45
+					ps112.OverlayValues[64] = d64
+					ps112.OverlayValues[65] = d65
+					ps112.OverlayValues[66] = d66
+					ps112.OverlayValues[67] = d67
+					ps112.OverlayValues[68] = d68
+					ps112.OverlayValues[70] = d70
+					ps112.OverlayValues[71] = d71
+					ps112.OverlayValues[72] = d72
+					ps112.OverlayValues[73] = d73
+					ps112.OverlayValues[74] = d74
+					ps112.OverlayValues[75] = d75
+					ps112.OverlayValues[76] = d76
+					ps112.OverlayValues[79] = d79
 					snap113 := d8
 					snap114 := d9
 					snap115 := d10
@@ -1253,33 +1407,33 @@ func init_vector() {
 					snap118 := d13
 					snap119 := d14
 					snap120 := d15
-					snap121 := d18
-					snap122 := d38
-					snap123 := d57
-					snap124 := d58
-					snap125 := d59
-					snap126 := d60
-					snap127 := d61
-					snap128 := d63
-					snap129 := d64
-					snap130 := d65
-					snap131 := d66
-					snap132 := d67
-					snap133 := d68
-					snap134 := d69
-					snap135 := d72
-					alloc136 := ctx.SnapshotAllocState()
+					snap121 := d16
+					snap122 := d17
+					snap123 := d18
+					snap124 := d19
+					snap125 := d20
+					snap126 := d21
+					snap127 := d22
+					snap128 := d25
+					snap129 := d45
+					snap130 := d64
+					snap131 := d65
+					snap132 := d66
+					snap133 := d67
+					snap134 := d68
+					snap135 := d70
+					snap136 := d71
+					snap137 := d72
+					snap138 := d73
+					snap139 := d74
+					snap140 := d75
+					snap141 := d76
+					snap142 := d79
+					alloc143 := ctx.SnapshotAllocState()
 					if !bbs[5].Rendered {
-						bbs[5].RenderPS(ps105)
+						bbs[5].RenderPS(ps112)
 					}
-					ctx.RestoreAllocState(alloc136)
-					d1 = snap106
-					d2 = snap107
-					d3 = snap108
-					d4 = snap109
-					d5 = snap110
-					d6 = snap111
-					d7 = snap112
+					ctx.RestoreAllocState(alloc143)
 					d8 = snap113
 					d9 = snap114
 					d10 = snap115
@@ -1288,26 +1442,33 @@ func init_vector() {
 					d13 = snap118
 					d14 = snap119
 					d15 = snap120
-					d18 = snap121
-					d38 = snap122
-					d57 = snap123
-					d58 = snap124
-					d59 = snap125
-					d60 = snap126
-					d61 = snap127
-					d63 = snap128
-					d64 = snap129
-					d65 = snap130
-					d66 = snap131
-					d67 = snap132
-					d68 = snap133
-					d69 = snap134
-					d72 = snap135
+					d16 = snap121
+					d17 = snap122
+					d18 = snap123
+					d19 = snap124
+					d20 = snap125
+					d21 = snap126
+					d22 = snap127
+					d25 = snap128
+					d45 = snap129
+					d64 = snap130
+					d65 = snap131
+					d66 = snap132
+					d67 = snap133
+					d68 = snap134
+					d70 = snap135
+					d71 = snap136
+					d72 = snap137
+					d73 = snap138
+					d74 = snap139
+					d75 = snap140
+					d76 = snap141
+					d79 = snap142
 					if !bbs[3].Rendered {
-						return bbs[3].RenderPS(ps104)
+						return bbs[3].RenderPS(ps111)
 					}
 					return result
-					ctx.FreeDesc(&d68)
+					ctx.FreeDesc(&d75)
 					return result
 				}
 				bbs[3].RenderPS = func(ps PhiState) JITValueDesc {
@@ -1329,82 +1490,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl4)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -1421,73 +1588,107 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
+					}
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
+					}
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
+					}
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
+					}
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
+					}
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
-						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(0))
-						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)}, int32(bbs[6].PhiBase)+int32(16))
-						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)}, int32(bbs[6].PhiBase)+int32(32))
-						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(48))
+						if phiHomeOK2 {
+							ctx.EmitMovToReg(r0, JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)})
+						} else {
+							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(0))
+						}
+						if phiHomeOK3 {
+							ctx.EmitMovToReg(r1, JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)})
+						} else {
+							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)}, int32(bbs[6].PhiBase)+int32(16))
+						}
+						if phiHomeOK4 {
+							ctx.EmitMovToReg(r2, JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)})
+						} else {
+							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)}, int32(bbs[6].PhiBase)+int32(32))
+						}
+						if phiHomeOK5 {
+							ctx.EmitMovToReg(r3, JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)})
+						} else {
+							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(48))
+						}
 					}
-					ps137 := PhiState{General: ps.General}
-					ps137.OverlayValues = make([]JITValueDesc, 73)
-					ps137.OverlayValues[1] = d1
-					ps137.OverlayValues[2] = d2
-					ps137.OverlayValues[3] = d3
-					ps137.OverlayValues[4] = d4
-					ps137.OverlayValues[5] = d5
-					ps137.OverlayValues[6] = d6
-					ps137.OverlayValues[7] = d7
-					ps137.OverlayValues[8] = d8
-					ps137.OverlayValues[9] = d9
-					ps137.OverlayValues[10] = d10
-					ps137.OverlayValues[11] = d11
-					ps137.OverlayValues[12] = d12
-					ps137.OverlayValues[13] = d13
-					ps137.OverlayValues[14] = d14
-					ps137.OverlayValues[15] = d15
-					ps137.OverlayValues[18] = d18
-					ps137.OverlayValues[38] = d38
-					ps137.OverlayValues[57] = d57
-					ps137.OverlayValues[58] = d58
-					ps137.OverlayValues[59] = d59
-					ps137.OverlayValues[60] = d60
-					ps137.OverlayValues[61] = d61
-					ps137.OverlayValues[63] = d63
-					ps137.OverlayValues[64] = d64
-					ps137.OverlayValues[65] = d65
-					ps137.OverlayValues[66] = d66
-					ps137.OverlayValues[67] = d67
-					ps137.OverlayValues[68] = d68
-					ps137.OverlayValues[69] = d69
-					ps137.OverlayValues[72] = d72
-					ps137.PhiValues = make([]JITValueDesc, 4)
-					d138 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					ps137.PhiValues[0] = d138
-					d139 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)}
-					ps137.PhiValues[1] = d139
-					d140 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)}
-					ps137.PhiValues[2] = d140
-					d141 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					ps137.PhiValues[3] = d141
-					if ps137.General && bbs[6].Rendered {
+					ps144 := PhiState{General: ps.General}
+					ps144.OverlayValues = make([]JITValueDesc, 80)
+					ps144.OverlayValues[8] = d8
+					ps144.OverlayValues[9] = d9
+					ps144.OverlayValues[10] = d10
+					ps144.OverlayValues[11] = d11
+					ps144.OverlayValues[12] = d12
+					ps144.OverlayValues[13] = d13
+					ps144.OverlayValues[14] = d14
+					ps144.OverlayValues[15] = d15
+					ps144.OverlayValues[16] = d16
+					ps144.OverlayValues[17] = d17
+					ps144.OverlayValues[18] = d18
+					ps144.OverlayValues[19] = d19
+					ps144.OverlayValues[20] = d20
+					ps144.OverlayValues[21] = d21
+					ps144.OverlayValues[22] = d22
+					ps144.OverlayValues[25] = d25
+					ps144.OverlayValues[45] = d45
+					ps144.OverlayValues[64] = d64
+					ps144.OverlayValues[65] = d65
+					ps144.OverlayValues[66] = d66
+					ps144.OverlayValues[67] = d67
+					ps144.OverlayValues[68] = d68
+					ps144.OverlayValues[70] = d70
+					ps144.OverlayValues[71] = d71
+					ps144.OverlayValues[72] = d72
+					ps144.OverlayValues[73] = d73
+					ps144.OverlayValues[74] = d74
+					ps144.OverlayValues[75] = d75
+					ps144.OverlayValues[76] = d76
+					ps144.OverlayValues[79] = d79
+					ps144.PhiValues = make([]JITValueDesc, 4)
+					d145 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					ps144.PhiValues[0] = d145
+					d146 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)}
+					ps144.PhiValues[1] = d146
+					d147 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(0)}
+					ps144.PhiValues[2] = d147
+					d148 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					ps144.PhiValues[3] = d148
+					if ps144.General && bbs[6].Rendered {
 						ctx.EmitJmp(lbl7)
 						return result
 					}
-					return bbs[6].RenderPS(ps137)
+					return bbs[6].RenderPS(ps144)
 					return result
 				}
 				bbs[4].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d142 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d142)
-							ctx.EmitStoreToStack(d142, int32(bbs[4].PhiBase)+int32(0))
+							d149 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d149)
+							ctx.EmitStoreToStack(d149, int32(bbs[4].PhiBase)+int32(0))
 						}
 						if bbs[4].VisitCount >= 0 {
 							ps.General = true
@@ -1506,82 +1707,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl5)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -1598,40 +1805,58 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
+					}
+					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
+						d145 = ps.OverlayValues[145]
+					}
+					if len(ps.OverlayValues) > 146 && ps.OverlayValues[146].Loc != LocNone {
+						d146 = ps.OverlayValues[146]
+					}
+					if len(ps.OverlayValues) > 147 && ps.OverlayValues[147].Loc != LocNone {
+						d147 = ps.OverlayValues[147]
+					}
+					if len(ps.OverlayValues) > 148 && ps.OverlayValues[148].Loc != LocNone {
+						d148 = ps.OverlayValues[148]
+					}
+					if len(ps.OverlayValues) > 149 && ps.OverlayValues[149].Loc != LocNone {
+						d149 = ps.OverlayValues[149]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-						d2 = ps.PhiValues[0]
+						d9 = ps.PhiValues[0]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d2)
-					if d2.Loc == LocImm {
-						ctx.EmitMakeFloat(result, d2)
+					ctx.EnsureDesc(&d9)
+					if d9.Loc == LocImm {
+						ctx.EmitMakeFloat(result, d9)
 					} else {
-						ctx.EmitMovToReg(result.Reg2, d2)
-						d143 := JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeFloat(result, d143)
-						if d2.Loc == LocReg && d2.Reg != result.Reg2 {
-							ctx.FreeReg(d2.Reg)
+						ctx.EmitMovToReg(result.Reg2, d9)
+						d150 := JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeFloat(result, d150)
+						if d9.Loc == LocReg && d9.Reg != result.Reg2 {
+							ctx.FreeReg(d9.Reg)
 						}
 					}
 					result.Type = tagFloat
@@ -1657,82 +1882,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl6)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -1749,239 +1980,29 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
-					}
-					ctx.ReclaimUntrackedRegs()
-					if ps.General {
-						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[10].PhiBase)+int32(0))
-						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[10].PhiBase)+int32(16))
-					}
-					ps144 := PhiState{General: ps.General}
-					ps144.OverlayValues = make([]JITValueDesc, 144)
-					ps144.OverlayValues[1] = d1
-					ps144.OverlayValues[2] = d2
-					ps144.OverlayValues[3] = d3
-					ps144.OverlayValues[4] = d4
-					ps144.OverlayValues[5] = d5
-					ps144.OverlayValues[6] = d6
-					ps144.OverlayValues[7] = d7
-					ps144.OverlayValues[8] = d8
-					ps144.OverlayValues[9] = d9
-					ps144.OverlayValues[10] = d10
-					ps144.OverlayValues[11] = d11
-					ps144.OverlayValues[12] = d12
-					ps144.OverlayValues[13] = d13
-					ps144.OverlayValues[14] = d14
-					ps144.OverlayValues[15] = d15
-					ps144.OverlayValues[18] = d18
-					ps144.OverlayValues[38] = d38
-					ps144.OverlayValues[57] = d57
-					ps144.OverlayValues[58] = d58
-					ps144.OverlayValues[59] = d59
-					ps144.OverlayValues[60] = d60
-					ps144.OverlayValues[61] = d61
-					ps144.OverlayValues[63] = d63
-					ps144.OverlayValues[64] = d64
-					ps144.OverlayValues[65] = d65
-					ps144.OverlayValues[66] = d66
-					ps144.OverlayValues[67] = d67
-					ps144.OverlayValues[68] = d68
-					ps144.OverlayValues[69] = d69
-					ps144.OverlayValues[72] = d72
-					ps144.OverlayValues[138] = d138
-					ps144.OverlayValues[139] = d139
-					ps144.OverlayValues[140] = d140
-					ps144.OverlayValues[141] = d141
-					ps144.OverlayValues[142] = d142
-					ps144.OverlayValues[143] = d143
-					ps144.PhiValues = make([]JITValueDesc, 2)
-					d145 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					ps144.PhiValues[0] = d145
-					d146 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					ps144.PhiValues[1] = d146
-					if ps144.General && bbs[10].Rendered {
-						ctx.EmitJmp(lbl11)
-						return result
-					}
-					return bbs[10].RenderPS(ps144)
-					return result
-				}
-				bbs[6].RenderPS = func(ps PhiState) JITValueDesc {
-					if !ps.General {
-						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d147 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d147)
-							ctx.EmitStoreToStack(d147, int32(bbs[6].PhiBase)+int32(0))
-						}
-						if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
-							d148 := ps.PhiValues[1]
-							ctx.EnsureDesc(&d148)
-							ctx.EmitStoreToStack(d148, int32(bbs[6].PhiBase)+int32(16))
-						}
-						if len(ps.PhiValues) > 2 && ps.PhiValues[2].Loc != LocNone {
-							d149 := ps.PhiValues[2]
-							ctx.EnsureDesc(&d149)
-							ctx.EmitStoreToStack(d149, int32(bbs[6].PhiBase)+int32(32))
-						}
-						if len(ps.PhiValues) > 3 && ps.PhiValues[3].Loc != LocNone {
-							d150 := ps.PhiValues[3]
-							ctx.EnsureDesc(&d150)
-							ctx.EmitStoreToStack(d150, int32(bbs[6].PhiBase)+int32(48))
-						}
-						if bbs[6].VisitCount >= 0 {
-							ps.General = true
-							return bbs[6].RenderPS(ps)
-						}
-					}
-					bbs[6].VisitCount++
-					if ps.General {
-						if bbs[6].Rendered {
-							ctx.EmitJmp(lbl7)
-							return result
-						}
-						bbs[6].Rendered = true
-						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-						bbpos_0_6 = bbs[6].Address
-						ctx.MarkLabel(lbl7)
-						ctx.ResolveFixups()
-					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
-					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
-					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
-					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
-					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
-					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
-					}
-					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
-						d8 = ps.OverlayValues[8]
-					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
-					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
-						d10 = ps.OverlayValues[10]
-					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
-						d11 = ps.OverlayValues[11]
-					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
-						d12 = ps.OverlayValues[12]
-					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
-						d13 = ps.OverlayValues[13]
-					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
-						d14 = ps.OverlayValues[14]
-					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
-						d15 = ps.OverlayValues[15]
-					}
-					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
-						d18 = ps.OverlayValues[18]
-					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
-					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
-					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
-					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
-					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
-					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
-					}
-					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
-						d64 = ps.OverlayValues[64]
-					}
-					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
-						d65 = ps.OverlayValues[65]
-					}
-					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
-						d66 = ps.OverlayValues[66]
-					}
-					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
-						d67 = ps.OverlayValues[67]
-					}
-					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
-						d68 = ps.OverlayValues[68]
-					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
-					}
-					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
-						d72 = ps.OverlayValues[72]
-					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
-					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
-					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
-					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
-					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
 						d145 = ps.OverlayValues[145]
@@ -2001,214 +2022,507 @@ func init_vector() {
 					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
 						d150 = ps.OverlayValues[150]
 					}
+					ctx.ReclaimUntrackedRegs()
+					if ps.General {
+						if phiHomeOK6 {
+							ctx.EmitMovToReg(r4, JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)})
+						} else {
+							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[10].PhiBase)+int32(0))
+						}
+						if phiHomeOK7 {
+							ctx.EmitMovToReg(r5, JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)})
+						} else {
+							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[10].PhiBase)+int32(16))
+						}
+					}
+					ps151 := PhiState{General: ps.General}
+					ps151.OverlayValues = make([]JITValueDesc, 151)
+					ps151.OverlayValues[8] = d8
+					ps151.OverlayValues[9] = d9
+					ps151.OverlayValues[10] = d10
+					ps151.OverlayValues[11] = d11
+					ps151.OverlayValues[12] = d12
+					ps151.OverlayValues[13] = d13
+					ps151.OverlayValues[14] = d14
+					ps151.OverlayValues[15] = d15
+					ps151.OverlayValues[16] = d16
+					ps151.OverlayValues[17] = d17
+					ps151.OverlayValues[18] = d18
+					ps151.OverlayValues[19] = d19
+					ps151.OverlayValues[20] = d20
+					ps151.OverlayValues[21] = d21
+					ps151.OverlayValues[22] = d22
+					ps151.OverlayValues[25] = d25
+					ps151.OverlayValues[45] = d45
+					ps151.OverlayValues[64] = d64
+					ps151.OverlayValues[65] = d65
+					ps151.OverlayValues[66] = d66
+					ps151.OverlayValues[67] = d67
+					ps151.OverlayValues[68] = d68
+					ps151.OverlayValues[70] = d70
+					ps151.OverlayValues[71] = d71
+					ps151.OverlayValues[72] = d72
+					ps151.OverlayValues[73] = d73
+					ps151.OverlayValues[74] = d74
+					ps151.OverlayValues[75] = d75
+					ps151.OverlayValues[76] = d76
+					ps151.OverlayValues[79] = d79
+					ps151.OverlayValues[145] = d145
+					ps151.OverlayValues[146] = d146
+					ps151.OverlayValues[147] = d147
+					ps151.OverlayValues[148] = d148
+					ps151.OverlayValues[149] = d149
+					ps151.OverlayValues[150] = d150
+					ps151.PhiValues = make([]JITValueDesc, 2)
+					d152 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					ps151.PhiValues[0] = d152
+					d153 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					ps151.PhiValues[1] = d153
+					if ps151.General && bbs[10].Rendered {
+						ctx.EmitJmp(lbl11)
+						return result
+					}
+					return bbs[10].RenderPS(ps151)
+					return result
+				}
+				bbs[6].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+							d154 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d154)
+							if phiHomeOK2 {
+								ctx.EmitMovToReg(r0, d154)
+							} else {
+								ctx.EmitStoreToStack(d154, int32(bbs[6].PhiBase)+int32(0))
+							}
+						}
+						if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
+							d155 := ps.PhiValues[1]
+							ctx.EnsureDesc(&d155)
+							if phiHomeOK3 {
+								ctx.EmitMovToReg(r1, d155)
+							} else {
+								ctx.EmitStoreToStack(d155, int32(bbs[6].PhiBase)+int32(16))
+							}
+						}
+						if len(ps.PhiValues) > 2 && ps.PhiValues[2].Loc != LocNone {
+							d156 := ps.PhiValues[2]
+							ctx.EnsureDesc(&d156)
+							if phiHomeOK4 {
+								ctx.EmitMovToReg(r2, d156)
+							} else {
+								ctx.EmitStoreToStack(d156, int32(bbs[6].PhiBase)+int32(32))
+							}
+						}
+						if len(ps.PhiValues) > 3 && ps.PhiValues[3].Loc != LocNone {
+							d157 := ps.PhiValues[3]
+							ctx.EnsureDesc(&d157)
+							if phiHomeOK5 {
+								ctx.EmitMovToReg(r3, d157)
+							} else {
+								ctx.EmitStoreToStack(d157, int32(bbs[6].PhiBase)+int32(48))
+							}
+						}
+						if bbs[6].VisitCount >= 0 {
+							ps.General = true
+							return bbs[6].RenderPS(ps)
+						}
+					}
+					bbs[6].VisitCount++
+					if ps.General {
+						if bbs[6].Rendered {
+							ctx.EmitJmp(lbl7)
+							return result
+						}
+						bbs[6].Rendered = true
+						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_6 = bbs[6].Address
+						ctx.MarkLabel(lbl7)
+						ctx.ResolveFixups()
+					}
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
+					}
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
+					}
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
+					}
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
+					}
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
+					}
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
+					}
+					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+						d11 = ps.OverlayValues[11]
+					}
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+						d12 = ps.OverlayValues[12]
+					}
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+						d13 = ps.OverlayValues[13]
+					}
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+						d14 = ps.OverlayValues[14]
+					}
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
+					}
+					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
+						d18 = ps.OverlayValues[18]
+					}
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
+					}
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
+					}
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
+					}
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
+					}
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
+					}
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
+					}
+					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
+						d64 = ps.OverlayValues[64]
+					}
+					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
+						d65 = ps.OverlayValues[65]
+					}
+					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
+						d66 = ps.OverlayValues[66]
+					}
+					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
+						d67 = ps.OverlayValues[67]
+					}
+					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
+						d68 = ps.OverlayValues[68]
+					}
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
+					}
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
+					}
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
+					}
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
+					}
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
+					}
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
+					}
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
+					}
+					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
+						d145 = ps.OverlayValues[145]
+					}
+					if len(ps.OverlayValues) > 146 && ps.OverlayValues[146].Loc != LocNone {
+						d146 = ps.OverlayValues[146]
+					}
+					if len(ps.OverlayValues) > 147 && ps.OverlayValues[147].Loc != LocNone {
+						d147 = ps.OverlayValues[147]
+					}
+					if len(ps.OverlayValues) > 148 && ps.OverlayValues[148].Loc != LocNone {
+						d148 = ps.OverlayValues[148]
+					}
+					if len(ps.OverlayValues) > 149 && ps.OverlayValues[149].Loc != LocNone {
+						d149 = ps.OverlayValues[149]
+					}
+					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
+						d150 = ps.OverlayValues[150]
+					}
+					if len(ps.OverlayValues) > 152 && ps.OverlayValues[152].Loc != LocNone {
+						d152 = ps.OverlayValues[152]
+					}
+					if len(ps.OverlayValues) > 153 && ps.OverlayValues[153].Loc != LocNone {
+						d153 = ps.OverlayValues[153]
+					}
+					if len(ps.OverlayValues) > 154 && ps.OverlayValues[154].Loc != LocNone {
+						d154 = ps.OverlayValues[154]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
+					}
+					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
+						d156 = ps.OverlayValues[156]
+					}
+					if len(ps.OverlayValues) > 157 && ps.OverlayValues[157].Loc != LocNone {
+						d157 = ps.OverlayValues[157]
+					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-						d3 = ps.PhiValues[0]
+						d10 = ps.PhiValues[0]
 					}
 					if !ps.General && len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
-						d4 = ps.PhiValues[1]
+						d11 = ps.PhiValues[1]
 					}
 					if !ps.General && len(ps.PhiValues) > 2 && ps.PhiValues[2].Loc != LocNone {
-						d5 = ps.PhiValues[2]
+						d12 = ps.PhiValues[2]
 					}
 					if !ps.General && len(ps.PhiValues) > 3 && ps.PhiValues[3].Loc != LocNone {
-						d6 = ps.PhiValues[3]
+						d13 = ps.PhiValues[3]
+					}
+					if phiHomeOK2 && d10.Loc == LocReg {
+						ctx.BindReg(r0, &d10)
+					}
+					if phiHomeOK3 && d11.Loc == LocReg {
+						ctx.BindReg(r1, &d11)
+					}
+					if phiHomeOK4 && d12.Loc == LocReg {
+						ctx.BindReg(r2, &d12)
+					}
+					if phiHomeOK5 && d13.Loc == LocReg {
+						ctx.BindReg(r3, &d13)
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.StabilizeDescForControlFlow(&d3)
-					ctx.StabilizeDescForControlFlow(&d4)
-					ctx.StabilizeDescForControlFlow(&d5)
-					ctx.StabilizeDescForControlFlow(&d6)
-					var d151 JITValueDesc
-					if d10.SliceSizeKnown {
-						d151 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d10.KnownSliceLen))}
-					} else if d10.Loc == LocImm {
-						d151 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d10.StackOff))}
-					} else if d10.Loc == LocStackTriple {
-						d151 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d10.StackOff + 8, NoHeapPointer: true}
+					var d158 JITValueDesc
+					if d17.SliceSizeKnown {
+						d158 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d17.KnownSliceLen))}
+					} else if d17.Loc == LocImm {
+						d158 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d17.StackOff))}
+					} else if d17.Loc == LocStackTriple {
+						d158 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d17.StackOff + 8, NoHeapPointer: true}
 					} else {
-						ctx.EnsureDesc(&d10)
-						if d10.Loc == LocRegPair || d10.Loc == LocRegTriple {
-							d151 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d10.Reg2, ID: 0}
-						} else if d10.Loc == LocReg {
-							d151 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d10.Reg, ID: 0}
+						ctx.EnsureDesc(&d17)
+						if d17.Loc == LocRegPair || d17.Loc == LocRegTriple {
+							d158 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d17.Reg2, ID: 0}
+						} else if d17.Loc == LocReg {
+							d158 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d17.Reg, ID: 0}
 						} else {
 							panic("len on unsupported descriptor location")
 						}
 					}
-					ctx.EnsureDesc(&d6)
-					ctx.EnsureDesc(&d151)
-					ctx.EnsureDescsTogether(&d6, &d151)
-					var d152 JITValueDesc
-					if d6.Loc == LocImm && d151.Loc == LocImm {
-						d152 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d6.Imm.Int() < d151.Imm.Int())}
-					} else if d151.Loc == LocImm {
-						r1 := ctx.AllocRegExcept(d6.Reg)
-						if d151.Imm.Int() >= -2147483648 && d151.Imm.Int() <= 2147483647 {
-							ctx.EmitCmpRegImm32(d6.Reg, int32(d151.Imm.Int()))
+					ctx.EnsureDesc(&d13)
+					ctx.EnsureDesc(&d158)
+					ctx.EnsureDescsTogether(&d13, &d158)
+					var d159 JITValueDesc
+					if d13.Loc == LocImm && d158.Loc == LocImm {
+						d159 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d13.Imm.Int() < d158.Imm.Int())}
+					} else if d158.Loc == LocImm {
+						r7 := ctx.AllocRegExcept(d13.Reg)
+						if d158.Imm.Int() >= -2147483648 && d158.Imm.Int() <= 2147483647 {
+							ctx.EmitCmpRegImm32(d13.Reg, int32(d158.Imm.Int()))
 						} else {
-							ctx.EmitMovRegImm64(RegR11, uint64(d151.Imm.Int()))
-							ctx.EmitCmpInt64(d6.Reg, RegR11)
+							ctx.EmitMovRegImm64(RegR11, uint64(d158.Imm.Int()))
+							ctx.EmitCmpInt64(d13.Reg, RegR11)
 						}
-						d152 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondSignedLess}
-						ctx.BindReg(r1, &d152)
-					} else if d6.Loc == LocImm {
-						r2 := ctx.AllocReg()
-						ctx.EmitMovRegImm64(RegR11, uint64(d6.Imm.Int()))
-						ctx.EmitCmpInt64(RegR11, d151.Reg)
-						d152 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondSignedLess}
-						ctx.BindReg(r2, &d152)
+						d159 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r7, Condition: CondSignedLess}
+						ctx.BindReg(r7, &d159)
+					} else if d13.Loc == LocImm {
+						r8 := ctx.AllocReg()
+						ctx.EmitMovRegImm64(RegR11, uint64(d13.Imm.Int()))
+						ctx.EmitCmpInt64(RegR11, d158.Reg)
+						d159 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r8, Condition: CondSignedLess}
+						ctx.BindReg(r8, &d159)
 					} else {
-						r3 := ctx.AllocRegExcept(d6.Reg)
-						ctx.EmitCmpInt64(d6.Reg, d151.Reg)
-						d152 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r3, Condition: CondSignedLess}
-						ctx.BindReg(r3, &d152)
+						r9 := ctx.AllocRegExcept(d13.Reg)
+						ctx.EmitCmpInt64(d13.Reg, d158.Reg)
+						d159 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r9, Condition: CondSignedLess}
+						ctx.BindReg(r9, &d159)
 					}
-					ctx.FreeDesc(&d151)
-					d153 = d152
-					ctx.EnsureDesc(&d153)
-					if d153.Loc != LocImm && d153.Loc != LocFlags {
+					ctx.FreeDesc(&d158)
+					d160 = d159
+					ctx.EnsureDesc(&d160)
+					if d160.Loc != LocImm && d160.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d153.Loc == LocImm {
-						if d153.Imm.Bool() {
+					if d160.Loc == LocImm {
+						if d160.Imm.Bool() {
 							if ps.General {
 							}
-							ps154 := PhiState{General: ps.General}
-							ps154.OverlayValues = make([]JITValueDesc, 154)
-							ps154.OverlayValues[1] = d1
-							ps154.OverlayValues[2] = d2
-							ps154.OverlayValues[3] = d3
-							ps154.OverlayValues[4] = d4
-							ps154.OverlayValues[5] = d5
-							ps154.OverlayValues[6] = d6
-							ps154.OverlayValues[7] = d7
-							ps154.OverlayValues[8] = d8
-							ps154.OverlayValues[9] = d9
-							ps154.OverlayValues[10] = d10
-							ps154.OverlayValues[11] = d11
-							ps154.OverlayValues[12] = d12
-							ps154.OverlayValues[13] = d13
-							ps154.OverlayValues[14] = d14
-							ps154.OverlayValues[15] = d15
-							ps154.OverlayValues[18] = d18
-							ps154.OverlayValues[38] = d38
-							ps154.OverlayValues[57] = d57
-							ps154.OverlayValues[58] = d58
-							ps154.OverlayValues[59] = d59
-							ps154.OverlayValues[60] = d60
-							ps154.OverlayValues[61] = d61
-							ps154.OverlayValues[63] = d63
-							ps154.OverlayValues[64] = d64
-							ps154.OverlayValues[65] = d65
-							ps154.OverlayValues[66] = d66
-							ps154.OverlayValues[67] = d67
-							ps154.OverlayValues[68] = d68
-							ps154.OverlayValues[69] = d69
-							ps154.OverlayValues[72] = d72
-							ps154.OverlayValues[138] = d138
-							ps154.OverlayValues[139] = d139
-							ps154.OverlayValues[140] = d140
-							ps154.OverlayValues[141] = d141
-							ps154.OverlayValues[142] = d142
-							ps154.OverlayValues[143] = d143
-							ps154.OverlayValues[145] = d145
-							ps154.OverlayValues[146] = d146
-							ps154.OverlayValues[147] = d147
-							ps154.OverlayValues[148] = d148
-							ps154.OverlayValues[149] = d149
-							ps154.OverlayValues[150] = d150
-							ps154.OverlayValues[151] = d151
-							ps154.OverlayValues[152] = d152
-							ps154.OverlayValues[153] = d153
-							return bbs[9].RenderPS(ps154)
+							ps161 := PhiState{General: ps.General}
+							ps161.OverlayValues = make([]JITValueDesc, 161)
+							ps161.OverlayValues[8] = d8
+							ps161.OverlayValues[9] = d9
+							ps161.OverlayValues[10] = d10
+							ps161.OverlayValues[11] = d11
+							ps161.OverlayValues[12] = d12
+							ps161.OverlayValues[13] = d13
+							ps161.OverlayValues[14] = d14
+							ps161.OverlayValues[15] = d15
+							ps161.OverlayValues[16] = d16
+							ps161.OverlayValues[17] = d17
+							ps161.OverlayValues[18] = d18
+							ps161.OverlayValues[19] = d19
+							ps161.OverlayValues[20] = d20
+							ps161.OverlayValues[21] = d21
+							ps161.OverlayValues[22] = d22
+							ps161.OverlayValues[25] = d25
+							ps161.OverlayValues[45] = d45
+							ps161.OverlayValues[64] = d64
+							ps161.OverlayValues[65] = d65
+							ps161.OverlayValues[66] = d66
+							ps161.OverlayValues[67] = d67
+							ps161.OverlayValues[68] = d68
+							ps161.OverlayValues[70] = d70
+							ps161.OverlayValues[71] = d71
+							ps161.OverlayValues[72] = d72
+							ps161.OverlayValues[73] = d73
+							ps161.OverlayValues[74] = d74
+							ps161.OverlayValues[75] = d75
+							ps161.OverlayValues[76] = d76
+							ps161.OverlayValues[79] = d79
+							ps161.OverlayValues[145] = d145
+							ps161.OverlayValues[146] = d146
+							ps161.OverlayValues[147] = d147
+							ps161.OverlayValues[148] = d148
+							ps161.OverlayValues[149] = d149
+							ps161.OverlayValues[150] = d150
+							ps161.OverlayValues[152] = d152
+							ps161.OverlayValues[153] = d153
+							ps161.OverlayValues[154] = d154
+							ps161.OverlayValues[155] = d155
+							ps161.OverlayValues[156] = d156
+							ps161.OverlayValues[157] = d157
+							ps161.OverlayValues[158] = d158
+							ps161.OverlayValues[159] = d159
+							ps161.OverlayValues[160] = d160
+							return bbs[9].RenderPS(ps161)
 						}
 						if ps.General {
 						}
-						ps155 := PhiState{General: ps.General}
-						ps155.OverlayValues = make([]JITValueDesc, 154)
-						ps155.OverlayValues[1] = d1
-						ps155.OverlayValues[2] = d2
-						ps155.OverlayValues[3] = d3
-						ps155.OverlayValues[4] = d4
-						ps155.OverlayValues[5] = d5
-						ps155.OverlayValues[6] = d6
-						ps155.OverlayValues[7] = d7
-						ps155.OverlayValues[8] = d8
-						ps155.OverlayValues[9] = d9
-						ps155.OverlayValues[10] = d10
-						ps155.OverlayValues[11] = d11
-						ps155.OverlayValues[12] = d12
-						ps155.OverlayValues[13] = d13
-						ps155.OverlayValues[14] = d14
-						ps155.OverlayValues[15] = d15
-						ps155.OverlayValues[18] = d18
-						ps155.OverlayValues[38] = d38
-						ps155.OverlayValues[57] = d57
-						ps155.OverlayValues[58] = d58
-						ps155.OverlayValues[59] = d59
-						ps155.OverlayValues[60] = d60
-						ps155.OverlayValues[61] = d61
-						ps155.OverlayValues[63] = d63
-						ps155.OverlayValues[64] = d64
-						ps155.OverlayValues[65] = d65
-						ps155.OverlayValues[66] = d66
-						ps155.OverlayValues[67] = d67
-						ps155.OverlayValues[68] = d68
-						ps155.OverlayValues[69] = d69
-						ps155.OverlayValues[72] = d72
-						ps155.OverlayValues[138] = d138
-						ps155.OverlayValues[139] = d139
-						ps155.OverlayValues[140] = d140
-						ps155.OverlayValues[141] = d141
-						ps155.OverlayValues[142] = d142
-						ps155.OverlayValues[143] = d143
-						ps155.OverlayValues[145] = d145
-						ps155.OverlayValues[146] = d146
-						ps155.OverlayValues[147] = d147
-						ps155.OverlayValues[148] = d148
-						ps155.OverlayValues[149] = d149
-						ps155.OverlayValues[150] = d150
-						ps155.OverlayValues[151] = d151
-						ps155.OverlayValues[152] = d152
-						ps155.OverlayValues[153] = d153
-						return bbs[8].RenderPS(ps155)
+						ps162 := PhiState{General: ps.General}
+						ps162.OverlayValues = make([]JITValueDesc, 161)
+						ps162.OverlayValues[8] = d8
+						ps162.OverlayValues[9] = d9
+						ps162.OverlayValues[10] = d10
+						ps162.OverlayValues[11] = d11
+						ps162.OverlayValues[12] = d12
+						ps162.OverlayValues[13] = d13
+						ps162.OverlayValues[14] = d14
+						ps162.OverlayValues[15] = d15
+						ps162.OverlayValues[16] = d16
+						ps162.OverlayValues[17] = d17
+						ps162.OverlayValues[18] = d18
+						ps162.OverlayValues[19] = d19
+						ps162.OverlayValues[20] = d20
+						ps162.OverlayValues[21] = d21
+						ps162.OverlayValues[22] = d22
+						ps162.OverlayValues[25] = d25
+						ps162.OverlayValues[45] = d45
+						ps162.OverlayValues[64] = d64
+						ps162.OverlayValues[65] = d65
+						ps162.OverlayValues[66] = d66
+						ps162.OverlayValues[67] = d67
+						ps162.OverlayValues[68] = d68
+						ps162.OverlayValues[70] = d70
+						ps162.OverlayValues[71] = d71
+						ps162.OverlayValues[72] = d72
+						ps162.OverlayValues[73] = d73
+						ps162.OverlayValues[74] = d74
+						ps162.OverlayValues[75] = d75
+						ps162.OverlayValues[76] = d76
+						ps162.OverlayValues[79] = d79
+						ps162.OverlayValues[145] = d145
+						ps162.OverlayValues[146] = d146
+						ps162.OverlayValues[147] = d147
+						ps162.OverlayValues[148] = d148
+						ps162.OverlayValues[149] = d149
+						ps162.OverlayValues[150] = d150
+						ps162.OverlayValues[152] = d152
+						ps162.OverlayValues[153] = d153
+						ps162.OverlayValues[154] = d154
+						ps162.OverlayValues[155] = d155
+						ps162.OverlayValues[156] = d156
+						ps162.OverlayValues[157] = d157
+						ps162.OverlayValues[158] = d158
+						ps162.OverlayValues[159] = d159
+						ps162.OverlayValues[160] = d160
+						return bbs[8].RenderPS(ps162)
 					}
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d156 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d156)
-							ctx.EmitStoreToStack(d156, int32(bbs[6].PhiBase)+int32(0))
+							d163 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d163)
+							if phiHomeOK2 {
+								ctx.EmitMovToReg(r0, d163)
+							} else {
+								ctx.EmitStoreToStack(d163, int32(bbs[6].PhiBase)+int32(0))
+							}
 						}
 						if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
-							d157 := ps.PhiValues[1]
-							ctx.EnsureDesc(&d157)
-							ctx.EmitStoreToStack(d157, int32(bbs[6].PhiBase)+int32(16))
+							d164 := ps.PhiValues[1]
+							ctx.EnsureDesc(&d164)
+							if phiHomeOK3 {
+								ctx.EmitMovToReg(r1, d164)
+							} else {
+								ctx.EmitStoreToStack(d164, int32(bbs[6].PhiBase)+int32(16))
+							}
 						}
 						if len(ps.PhiValues) > 2 && ps.PhiValues[2].Loc != LocNone {
-							d158 := ps.PhiValues[2]
-							ctx.EnsureDesc(&d158)
-							ctx.EmitStoreToStack(d158, int32(bbs[6].PhiBase)+int32(32))
+							d165 := ps.PhiValues[2]
+							ctx.EnsureDesc(&d165)
+							if phiHomeOK4 {
+								ctx.EmitMovToReg(r2, d165)
+							} else {
+								ctx.EmitStoreToStack(d165, int32(bbs[6].PhiBase)+int32(32))
+							}
 						}
 						if len(ps.PhiValues) > 3 && ps.PhiValues[3].Loc != LocNone {
-							d159 := ps.PhiValues[3]
-							ctx.EnsureDesc(&d159)
-							ctx.EmitStoreToStack(d159, int32(bbs[6].PhiBase)+int32(48))
+							d166 := ps.PhiValues[3]
+							ctx.EnsureDesc(&d166)
+							if phiHomeOK5 {
+								ctx.EmitMovToReg(r3, d166)
+							} else {
+								ctx.EmitStoreToStack(d166, int32(bbs[6].PhiBase)+int32(48))
+							}
 						}
 						ps.General = true
 						return bbs[6].RenderPS(ps)
 					}
-					ctx.EmitJump(d153.Condition, lbl10)
+					ctx.EmitJump(d160.Condition, lbl10)
 					if bbs[8].Rendered {
 						ctx.EmitJmp(lbl9)
 					}
-					ctx.FreeDesc(&d152)
-					snap160 := d1
-					snap161 := d2
-					snap162 := d3
-					snap163 := d4
-					snap164 := d5
-					snap165 := d6
-					snap166 := d7
+					ctx.FreeDesc(&d159)
 					snap167 := d8
 					snap168 := d9
 					snap169 := d10
@@ -2217,49 +2531,49 @@ func init_vector() {
 					snap172 := d13
 					snap173 := d14
 					snap174 := d15
-					snap175 := d18
-					snap176 := d38
-					snap177 := d57
-					snap178 := d58
-					snap179 := d59
-					snap180 := d60
-					snap181 := d61
-					snap182 := d63
-					snap183 := d64
-					snap184 := d65
-					snap185 := d66
-					snap186 := d67
-					snap187 := d68
-					snap188 := d69
-					snap189 := d72
-					snap190 := d138
-					snap191 := d139
-					snap192 := d140
-					snap193 := d141
-					snap194 := d142
-					snap195 := d143
-					snap196 := d145
-					snap197 := d146
-					snap198 := d147
-					snap199 := d148
-					snap200 := d149
-					snap201 := d150
-					snap202 := d151
+					snap175 := d16
+					snap176 := d17
+					snap177 := d18
+					snap178 := d19
+					snap179 := d20
+					snap180 := d21
+					snap181 := d22
+					snap182 := d25
+					snap183 := d45
+					snap184 := d64
+					snap185 := d65
+					snap186 := d66
+					snap187 := d67
+					snap188 := d68
+					snap189 := d70
+					snap190 := d71
+					snap191 := d72
+					snap192 := d73
+					snap193 := d74
+					snap194 := d75
+					snap195 := d76
+					snap196 := d79
+					snap197 := d145
+					snap198 := d146
+					snap199 := d147
+					snap200 := d148
+					snap201 := d149
+					snap202 := d150
 					snap203 := d152
 					snap204 := d153
-					snap205 := d156
-					snap206 := d157
-					snap207 := d158
-					snap208 := d159
-					alloc209 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc209)
-					d1 = snap160
-					d2 = snap161
-					d3 = snap162
-					d4 = snap163
-					d5 = snap164
-					d6 = snap165
-					d7 = snap166
+					snap205 := d154
+					snap206 := d155
+					snap207 := d156
+					snap208 := d157
+					snap209 := d158
+					snap210 := d159
+					snap211 := d160
+					snap212 := d163
+					snap213 := d164
+					snap214 := d165
+					snap215 := d166
+					alloc216 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc216)
 					d8 = snap167
 					d9 = snap168
 					d10 = snap169
@@ -2268,48 +2582,48 @@ func init_vector() {
 					d13 = snap172
 					d14 = snap173
 					d15 = snap174
-					d18 = snap175
-					d38 = snap176
-					d57 = snap177
-					d58 = snap178
-					d59 = snap179
-					d60 = snap180
-					d61 = snap181
-					d63 = snap182
-					d64 = snap183
-					d65 = snap184
-					d66 = snap185
-					d67 = snap186
-					d68 = snap187
-					d69 = snap188
-					d72 = snap189
-					d138 = snap190
-					d139 = snap191
-					d140 = snap192
-					d141 = snap193
-					d142 = snap194
-					d143 = snap195
-					d145 = snap196
-					d146 = snap197
-					d147 = snap198
-					d148 = snap199
-					d149 = snap200
-					d150 = snap201
-					d151 = snap202
+					d16 = snap175
+					d17 = snap176
+					d18 = snap177
+					d19 = snap178
+					d20 = snap179
+					d21 = snap180
+					d22 = snap181
+					d25 = snap182
+					d45 = snap183
+					d64 = snap184
+					d65 = snap185
+					d66 = snap186
+					d67 = snap187
+					d68 = snap188
+					d70 = snap189
+					d71 = snap190
+					d72 = snap191
+					d73 = snap192
+					d74 = snap193
+					d75 = snap194
+					d76 = snap195
+					d79 = snap196
+					d145 = snap197
+					d146 = snap198
+					d147 = snap199
+					d148 = snap200
+					d149 = snap201
+					d150 = snap202
 					d152 = snap203
 					d153 = snap204
-					d156 = snap205
-					d157 = snap206
-					d158 = snap207
-					d159 = snap208
-					ctx.RestoreAllocState(alloc209)
-					d1 = snap160
-					d2 = snap161
-					d3 = snap162
-					d4 = snap163
-					d5 = snap164
-					d6 = snap165
-					d7 = snap166
+					d154 = snap205
+					d155 = snap206
+					d156 = snap207
+					d157 = snap208
+					d158 = snap209
+					d159 = snap210
+					d160 = snap211
+					d163 = snap212
+					d164 = snap213
+					d165 = snap214
+					d166 = snap215
+					ctx.RestoreAllocState(alloc216)
 					d8 = snap167
 					d9 = snap168
 					d10 = snap169
@@ -2318,149 +2632,149 @@ func init_vector() {
 					d13 = snap172
 					d14 = snap173
 					d15 = snap174
-					d18 = snap175
-					d38 = snap176
-					d57 = snap177
-					d58 = snap178
-					d59 = snap179
-					d60 = snap180
-					d61 = snap181
-					d63 = snap182
-					d64 = snap183
-					d65 = snap184
-					d66 = snap185
-					d67 = snap186
-					d68 = snap187
-					d69 = snap188
-					d72 = snap189
-					d138 = snap190
-					d139 = snap191
-					d140 = snap192
-					d141 = snap193
-					d142 = snap194
-					d143 = snap195
-					d145 = snap196
-					d146 = snap197
-					d147 = snap198
-					d148 = snap199
-					d149 = snap200
-					d150 = snap201
-					d151 = snap202
+					d16 = snap175
+					d17 = snap176
+					d18 = snap177
+					d19 = snap178
+					d20 = snap179
+					d21 = snap180
+					d22 = snap181
+					d25 = snap182
+					d45 = snap183
+					d64 = snap184
+					d65 = snap185
+					d66 = snap186
+					d67 = snap187
+					d68 = snap188
+					d70 = snap189
+					d71 = snap190
+					d72 = snap191
+					d73 = snap192
+					d74 = snap193
+					d75 = snap194
+					d76 = snap195
+					d79 = snap196
+					d145 = snap197
+					d146 = snap198
+					d147 = snap199
+					d148 = snap200
+					d149 = snap201
+					d150 = snap202
 					d152 = snap203
 					d153 = snap204
-					d156 = snap205
-					d157 = snap206
-					d158 = snap207
-					d159 = snap208
-					ps210 := PhiState{General: true}
-					ps210.OverlayValues = make([]JITValueDesc, 160)
-					ps210.OverlayValues[1] = d1
-					ps210.OverlayValues[2] = d2
-					ps210.OverlayValues[3] = d3
-					ps210.OverlayValues[4] = d4
-					ps210.OverlayValues[5] = d5
-					ps210.OverlayValues[6] = d6
-					ps210.OverlayValues[7] = d7
-					ps210.OverlayValues[8] = d8
-					ps210.OverlayValues[9] = d9
-					ps210.OverlayValues[10] = d10
-					ps210.OverlayValues[11] = d11
-					ps210.OverlayValues[12] = d12
-					ps210.OverlayValues[13] = d13
-					ps210.OverlayValues[14] = d14
-					ps210.OverlayValues[15] = d15
-					ps210.OverlayValues[18] = d18
-					ps210.OverlayValues[38] = d38
-					ps210.OverlayValues[57] = d57
-					ps210.OverlayValues[58] = d58
-					ps210.OverlayValues[59] = d59
-					ps210.OverlayValues[60] = d60
-					ps210.OverlayValues[61] = d61
-					ps210.OverlayValues[63] = d63
-					ps210.OverlayValues[64] = d64
-					ps210.OverlayValues[65] = d65
-					ps210.OverlayValues[66] = d66
-					ps210.OverlayValues[67] = d67
-					ps210.OverlayValues[68] = d68
-					ps210.OverlayValues[69] = d69
-					ps210.OverlayValues[72] = d72
-					ps210.OverlayValues[138] = d138
-					ps210.OverlayValues[139] = d139
-					ps210.OverlayValues[140] = d140
-					ps210.OverlayValues[141] = d141
-					ps210.OverlayValues[142] = d142
-					ps210.OverlayValues[143] = d143
-					ps210.OverlayValues[145] = d145
-					ps210.OverlayValues[146] = d146
-					ps210.OverlayValues[147] = d147
-					ps210.OverlayValues[148] = d148
-					ps210.OverlayValues[149] = d149
-					ps210.OverlayValues[150] = d150
-					ps210.OverlayValues[151] = d151
-					ps210.OverlayValues[152] = d152
-					ps210.OverlayValues[153] = d153
-					ps210.OverlayValues[156] = d156
-					ps210.OverlayValues[157] = d157
-					ps210.OverlayValues[158] = d158
-					ps210.OverlayValues[159] = d159
-					ps211 := PhiState{General: true}
-					ps211.OverlayValues = make([]JITValueDesc, 160)
-					ps211.OverlayValues[1] = d1
-					ps211.OverlayValues[2] = d2
-					ps211.OverlayValues[3] = d3
-					ps211.OverlayValues[4] = d4
-					ps211.OverlayValues[5] = d5
-					ps211.OverlayValues[6] = d6
-					ps211.OverlayValues[7] = d7
-					ps211.OverlayValues[8] = d8
-					ps211.OverlayValues[9] = d9
-					ps211.OverlayValues[10] = d10
-					ps211.OverlayValues[11] = d11
-					ps211.OverlayValues[12] = d12
-					ps211.OverlayValues[13] = d13
-					ps211.OverlayValues[14] = d14
-					ps211.OverlayValues[15] = d15
-					ps211.OverlayValues[18] = d18
-					ps211.OverlayValues[38] = d38
-					ps211.OverlayValues[57] = d57
-					ps211.OverlayValues[58] = d58
-					ps211.OverlayValues[59] = d59
-					ps211.OverlayValues[60] = d60
-					ps211.OverlayValues[61] = d61
-					ps211.OverlayValues[63] = d63
-					ps211.OverlayValues[64] = d64
-					ps211.OverlayValues[65] = d65
-					ps211.OverlayValues[66] = d66
-					ps211.OverlayValues[67] = d67
-					ps211.OverlayValues[68] = d68
-					ps211.OverlayValues[69] = d69
-					ps211.OverlayValues[72] = d72
-					ps211.OverlayValues[138] = d138
-					ps211.OverlayValues[139] = d139
-					ps211.OverlayValues[140] = d140
-					ps211.OverlayValues[141] = d141
-					ps211.OverlayValues[142] = d142
-					ps211.OverlayValues[143] = d143
-					ps211.OverlayValues[145] = d145
-					ps211.OverlayValues[146] = d146
-					ps211.OverlayValues[147] = d147
-					ps211.OverlayValues[148] = d148
-					ps211.OverlayValues[149] = d149
-					ps211.OverlayValues[150] = d150
-					ps211.OverlayValues[151] = d151
-					ps211.OverlayValues[152] = d152
-					ps211.OverlayValues[153] = d153
-					ps211.OverlayValues[156] = d156
-					ps211.OverlayValues[157] = d157
-					ps211.OverlayValues[158] = d158
-					ps211.OverlayValues[159] = d159
-					snap212 := d1
-					snap213 := d2
-					snap214 := d3
-					snap215 := d4
-					snap216 := d5
-					snap217 := d6
-					snap218 := d7
+					d154 = snap205
+					d155 = snap206
+					d156 = snap207
+					d157 = snap208
+					d158 = snap209
+					d159 = snap210
+					d160 = snap211
+					d163 = snap212
+					d164 = snap213
+					d165 = snap214
+					d166 = snap215
+					ps217 := PhiState{General: true}
+					ps217.OverlayValues = make([]JITValueDesc, 167)
+					ps217.OverlayValues[8] = d8
+					ps217.OverlayValues[9] = d9
+					ps217.OverlayValues[10] = d10
+					ps217.OverlayValues[11] = d11
+					ps217.OverlayValues[12] = d12
+					ps217.OverlayValues[13] = d13
+					ps217.OverlayValues[14] = d14
+					ps217.OverlayValues[15] = d15
+					ps217.OverlayValues[16] = d16
+					ps217.OverlayValues[17] = d17
+					ps217.OverlayValues[18] = d18
+					ps217.OverlayValues[19] = d19
+					ps217.OverlayValues[20] = d20
+					ps217.OverlayValues[21] = d21
+					ps217.OverlayValues[22] = d22
+					ps217.OverlayValues[25] = d25
+					ps217.OverlayValues[45] = d45
+					ps217.OverlayValues[64] = d64
+					ps217.OverlayValues[65] = d65
+					ps217.OverlayValues[66] = d66
+					ps217.OverlayValues[67] = d67
+					ps217.OverlayValues[68] = d68
+					ps217.OverlayValues[70] = d70
+					ps217.OverlayValues[71] = d71
+					ps217.OverlayValues[72] = d72
+					ps217.OverlayValues[73] = d73
+					ps217.OverlayValues[74] = d74
+					ps217.OverlayValues[75] = d75
+					ps217.OverlayValues[76] = d76
+					ps217.OverlayValues[79] = d79
+					ps217.OverlayValues[145] = d145
+					ps217.OverlayValues[146] = d146
+					ps217.OverlayValues[147] = d147
+					ps217.OverlayValues[148] = d148
+					ps217.OverlayValues[149] = d149
+					ps217.OverlayValues[150] = d150
+					ps217.OverlayValues[152] = d152
+					ps217.OverlayValues[153] = d153
+					ps217.OverlayValues[154] = d154
+					ps217.OverlayValues[155] = d155
+					ps217.OverlayValues[156] = d156
+					ps217.OverlayValues[157] = d157
+					ps217.OverlayValues[158] = d158
+					ps217.OverlayValues[159] = d159
+					ps217.OverlayValues[160] = d160
+					ps217.OverlayValues[163] = d163
+					ps217.OverlayValues[164] = d164
+					ps217.OverlayValues[165] = d165
+					ps217.OverlayValues[166] = d166
+					ps218 := PhiState{General: true}
+					ps218.OverlayValues = make([]JITValueDesc, 167)
+					ps218.OverlayValues[8] = d8
+					ps218.OverlayValues[9] = d9
+					ps218.OverlayValues[10] = d10
+					ps218.OverlayValues[11] = d11
+					ps218.OverlayValues[12] = d12
+					ps218.OverlayValues[13] = d13
+					ps218.OverlayValues[14] = d14
+					ps218.OverlayValues[15] = d15
+					ps218.OverlayValues[16] = d16
+					ps218.OverlayValues[17] = d17
+					ps218.OverlayValues[18] = d18
+					ps218.OverlayValues[19] = d19
+					ps218.OverlayValues[20] = d20
+					ps218.OverlayValues[21] = d21
+					ps218.OverlayValues[22] = d22
+					ps218.OverlayValues[25] = d25
+					ps218.OverlayValues[45] = d45
+					ps218.OverlayValues[64] = d64
+					ps218.OverlayValues[65] = d65
+					ps218.OverlayValues[66] = d66
+					ps218.OverlayValues[67] = d67
+					ps218.OverlayValues[68] = d68
+					ps218.OverlayValues[70] = d70
+					ps218.OverlayValues[71] = d71
+					ps218.OverlayValues[72] = d72
+					ps218.OverlayValues[73] = d73
+					ps218.OverlayValues[74] = d74
+					ps218.OverlayValues[75] = d75
+					ps218.OverlayValues[76] = d76
+					ps218.OverlayValues[79] = d79
+					ps218.OverlayValues[145] = d145
+					ps218.OverlayValues[146] = d146
+					ps218.OverlayValues[147] = d147
+					ps218.OverlayValues[148] = d148
+					ps218.OverlayValues[149] = d149
+					ps218.OverlayValues[150] = d150
+					ps218.OverlayValues[152] = d152
+					ps218.OverlayValues[153] = d153
+					ps218.OverlayValues[154] = d154
+					ps218.OverlayValues[155] = d155
+					ps218.OverlayValues[156] = d156
+					ps218.OverlayValues[157] = d157
+					ps218.OverlayValues[158] = d158
+					ps218.OverlayValues[159] = d159
+					ps218.OverlayValues[160] = d160
+					ps218.OverlayValues[163] = d163
+					ps218.OverlayValues[164] = d164
+					ps218.OverlayValues[165] = d165
+					ps218.OverlayValues[166] = d166
 					snap219 := d8
 					snap220 := d9
 					snap221 := d10
@@ -2469,52 +2783,52 @@ func init_vector() {
 					snap224 := d13
 					snap225 := d14
 					snap226 := d15
-					snap227 := d18
-					snap228 := d38
-					snap229 := d57
-					snap230 := d58
-					snap231 := d59
-					snap232 := d60
-					snap233 := d61
-					snap234 := d63
-					snap235 := d64
-					snap236 := d65
-					snap237 := d66
-					snap238 := d67
-					snap239 := d68
-					snap240 := d69
-					snap241 := d72
-					snap242 := d138
-					snap243 := d139
-					snap244 := d140
-					snap245 := d141
-					snap246 := d142
-					snap247 := d143
-					snap248 := d145
-					snap249 := d146
-					snap250 := d147
-					snap251 := d148
-					snap252 := d149
-					snap253 := d150
-					snap254 := d151
+					snap227 := d16
+					snap228 := d17
+					snap229 := d18
+					snap230 := d19
+					snap231 := d20
+					snap232 := d21
+					snap233 := d22
+					snap234 := d25
+					snap235 := d45
+					snap236 := d64
+					snap237 := d65
+					snap238 := d66
+					snap239 := d67
+					snap240 := d68
+					snap241 := d70
+					snap242 := d71
+					snap243 := d72
+					snap244 := d73
+					snap245 := d74
+					snap246 := d75
+					snap247 := d76
+					snap248 := d79
+					snap249 := d145
+					snap250 := d146
+					snap251 := d147
+					snap252 := d148
+					snap253 := d149
+					snap254 := d150
 					snap255 := d152
 					snap256 := d153
-					snap257 := d156
-					snap258 := d157
-					snap259 := d158
-					snap260 := d159
-					alloc261 := ctx.SnapshotAllocState()
+					snap257 := d154
+					snap258 := d155
+					snap259 := d156
+					snap260 := d157
+					snap261 := d158
+					snap262 := d159
+					snap263 := d160
+					snap264 := d163
+					snap265 := d164
+					snap266 := d165
+					snap267 := d166
+					alloc268 := ctx.SnapshotAllocState()
 					if !bbs[8].Rendered {
-						bbs[8].RenderPS(ps211)
+						bbs[8].RenderPS(ps218)
 					}
-					ctx.RestoreAllocState(alloc261)
-					d1 = snap212
-					d2 = snap213
-					d3 = snap214
-					d4 = snap215
-					d5 = snap216
-					d6 = snap217
-					d7 = snap218
+					ctx.RestoreAllocState(alloc268)
 					d8 = snap219
 					d9 = snap220
 					d10 = snap221
@@ -2523,42 +2837,49 @@ func init_vector() {
 					d13 = snap224
 					d14 = snap225
 					d15 = snap226
-					d18 = snap227
-					d38 = snap228
-					d57 = snap229
-					d58 = snap230
-					d59 = snap231
-					d60 = snap232
-					d61 = snap233
-					d63 = snap234
-					d64 = snap235
-					d65 = snap236
-					d66 = snap237
-					d67 = snap238
-					d68 = snap239
-					d69 = snap240
-					d72 = snap241
-					d138 = snap242
-					d139 = snap243
-					d140 = snap244
-					d141 = snap245
-					d142 = snap246
-					d143 = snap247
-					d145 = snap248
-					d146 = snap249
-					d147 = snap250
-					d148 = snap251
-					d149 = snap252
-					d150 = snap253
-					d151 = snap254
+					d16 = snap227
+					d17 = snap228
+					d18 = snap229
+					d19 = snap230
+					d20 = snap231
+					d21 = snap232
+					d22 = snap233
+					d25 = snap234
+					d45 = snap235
+					d64 = snap236
+					d65 = snap237
+					d66 = snap238
+					d67 = snap239
+					d68 = snap240
+					d70 = snap241
+					d71 = snap242
+					d72 = snap243
+					d73 = snap244
+					d74 = snap245
+					d75 = snap246
+					d76 = snap247
+					d79 = snap248
+					d145 = snap249
+					d146 = snap250
+					d147 = snap251
+					d148 = snap252
+					d149 = snap253
+					d150 = snap254
 					d152 = snap255
 					d153 = snap256
-					d156 = snap257
-					d157 = snap258
-					d158 = snap259
-					d159 = snap260
+					d154 = snap257
+					d155 = snap258
+					d156 = snap259
+					d157 = snap260
+					d158 = snap261
+					d159 = snap262
+					d160 = snap263
+					d163 = snap264
+					d164 = snap265
+					d165 = snap266
+					d166 = snap267
 					if !bbs[9].Rendered {
-						return bbs[9].RenderPS(ps210)
+						return bbs[9].RenderPS(ps217)
 					}
 					return result
 					return result
@@ -2582,82 +2903,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl8)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -2674,29 +3001,29 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
 						d145 = ps.OverlayValues[145]
@@ -2716,14 +3043,17 @@ func init_vector() {
 					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
 						d150 = ps.OverlayValues[150]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
-					}
 					if len(ps.OverlayValues) > 152 && ps.OverlayValues[152].Loc != LocNone {
 						d152 = ps.OverlayValues[152]
 					}
 					if len(ps.OverlayValues) > 153 && ps.OverlayValues[153].Loc != LocNone {
 						d153 = ps.OverlayValues[153]
+					}
+					if len(ps.OverlayValues) > 154 && ps.OverlayValues[154].Loc != LocNone {
+						d154 = ps.OverlayValues[154]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
 					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
 						d156 = ps.OverlayValues[156]
@@ -2737,19 +3067,34 @@ func init_vector() {
 					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
 						d159 = ps.OverlayValues[159]
 					}
+					if len(ps.OverlayValues) > 160 && ps.OverlayValues[160].Loc != LocNone {
+						d160 = ps.OverlayValues[160]
+					}
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
+					}
+					if len(ps.OverlayValues) > 164 && ps.OverlayValues[164].Loc != LocNone {
+						d164 = ps.OverlayValues[164]
+					}
+					if len(ps.OverlayValues) > 165 && ps.OverlayValues[165].Loc != LocNone {
+						d165 = ps.OverlayValues[165]
+					}
+					if len(ps.OverlayValues) > 166 && ps.OverlayValues[166].Loc != LocNone {
+						d166 = ps.OverlayValues[166]
+					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d6)
-					d263 = ctx.EmitSliceElementAddress(&d10, &d6, 16)
-					ctx.EnsureDesc(&d263)
-					r4 := ctx.AllocRegExcept(d263.Reg)
-					ctx.EmitMovRegMem(r4, d263.Reg, 8)
-					ctx.EmitMovRegMem(d263.Reg, d263.Reg, 0)
-					d262 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d263.Reg, Reg2: r4}
-					ctx.BindReg(d263.Reg, &d262)
-					ctx.BindReg(r4, &d262)
-					ctx.EnsureDesc(&d262)
-					d264 = d262
-					_ = d264
+					ctx.EnsureDesc(&d13)
+					d270 = ctx.EmitSliceElementAddress(&d17, &d13, 16)
+					ctx.EnsureDesc(&d270)
+					r10 := ctx.AllocRegExcept(d270.Reg)
+					ctx.EmitMovRegMem(r10, d270.Reg, 8)
+					ctx.EmitMovRegMem(d270.Reg, d270.Reg, 0)
+					d269 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d270.Reg, Reg2: r10}
+					ctx.BindReg(d270.Reg, &d269)
+					ctx.BindReg(r10, &d269)
+					ctx.EnsureDesc(&d269)
+					d271 = d269
+					_ = d271
 					bbpos_1_0 := int32(-1)
 					_ = bbpos_1_0
 					lbl17 := ctx.ReserveLabel()
@@ -2759,38 +3104,38 @@ func init_vector() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					var d265 JITValueDesc
-					if d264.Loc == LocImm {
-						d265 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d264.Imm.Float())}
-					} else if d264.Type == tagFloat && d264.Loc == LocReg {
-						d265 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d264.Reg}
-						ctx.BindReg(d264.Reg, &d265)
-						ctx.BindReg(d264.Reg, &d265)
-					} else if d264.Type == tagFloat && d264.Loc == LocRegPair {
-						ctx.FreeReg(d264.Reg)
-						d265 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d264.Reg2}
-						ctx.BindReg(d264.Reg2, &d265)
-						ctx.BindReg(d264.Reg2, &d265)
+					var d272 JITValueDesc
+					if d271.Loc == LocImm {
+						d272 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d271.Imm.Float())}
+					} else if d271.Type == tagFloat && d271.Loc == LocReg {
+						d272 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d271.Reg}
+						ctx.BindReg(d271.Reg, &d272)
+						ctx.BindReg(d271.Reg, &d272)
+					} else if d271.Type == tagFloat && d271.Loc == LocRegPair {
+						ctx.FreeReg(d271.Reg)
+						d272 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d271.Reg2}
+						ctx.BindReg(d271.Reg2, &d272)
+						ctx.BindReg(d271.Reg2, &d272)
 					} else {
-						d265 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d264}, 1)
-						d265.Type = tagFloat
-						ctx.BindReg(d265.Reg, &d265)
+						d272 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d271}, 1)
+						d272.Type = tagFloat
+						ctx.BindReg(d272.Reg, &d272)
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d265)
-					ctx.FreeDesc(&d262)
-					ctx.EnsureDesc(&d6)
-					d267 = ctx.EmitSliceElementAddress(&d12, &d6, 16)
-					ctx.EnsureDesc(&d267)
-					r5 := ctx.AllocRegExcept(d267.Reg)
-					ctx.EmitMovRegMem(r5, d267.Reg, 8)
-					ctx.EmitMovRegMem(d267.Reg, d267.Reg, 0)
-					d266 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d267.Reg, Reg2: r5}
-					ctx.BindReg(d267.Reg, &d266)
-					ctx.BindReg(r5, &d266)
-					ctx.EnsureDesc(&d266)
-					d268 = d266
-					_ = d268
+					ctx.EnsureDesc(&d272)
+					ctx.FreeDesc(&d269)
+					ctx.EnsureDesc(&d13)
+					d274 = ctx.EmitSliceElementAddress(&d19, &d13, 16)
+					ctx.EnsureDesc(&d274)
+					r11 := ctx.AllocRegExcept(d274.Reg)
+					ctx.EmitMovRegMem(r11, d274.Reg, 8)
+					ctx.EmitMovRegMem(d274.Reg, d274.Reg, 0)
+					d273 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d274.Reg, Reg2: r11}
+					ctx.BindReg(d274.Reg, &d273)
+					ctx.BindReg(r11, &d273)
+					ctx.EnsureDesc(&d273)
+					d275 = d273
+					_ = d275
 					bbpos_2_0 := int32(-1)
 					_ = bbpos_2_0
 					lbl18 := ctx.ReserveLabel()
@@ -2800,321 +3145,248 @@ func init_vector() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					var d269 JITValueDesc
-					if d268.Loc == LocImm {
-						d269 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d268.Imm.Float())}
-					} else if d268.Type == tagFloat && d268.Loc == LocReg {
-						d269 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d268.Reg}
-						ctx.BindReg(d268.Reg, &d269)
-						ctx.BindReg(d268.Reg, &d269)
-					} else if d268.Type == tagFloat && d268.Loc == LocRegPair {
-						ctx.FreeReg(d268.Reg)
-						d269 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d268.Reg2}
-						ctx.BindReg(d268.Reg2, &d269)
-						ctx.BindReg(d268.Reg2, &d269)
+					var d276 JITValueDesc
+					if d275.Loc == LocImm {
+						d276 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d275.Imm.Float())}
+					} else if d275.Type == tagFloat && d275.Loc == LocReg {
+						d276 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d275.Reg}
+						ctx.BindReg(d275.Reg, &d276)
+						ctx.BindReg(d275.Reg, &d276)
+					} else if d275.Type == tagFloat && d275.Loc == LocRegPair {
+						ctx.FreeReg(d275.Reg)
+						d276 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d275.Reg2}
+						ctx.BindReg(d275.Reg2, &d276)
+						ctx.BindReg(d275.Reg2, &d276)
 					} else {
-						d269 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d268}, 1)
-						d269.Type = tagFloat
-						ctx.BindReg(d269.Reg, &d269)
+						d276 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d275}, 1)
+						d276.Type = tagFloat
+						ctx.BindReg(d276.Reg, &d276)
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d269)
-					ctx.FreeDesc(&d266)
-					ctx.EnsureDesc(&d265)
-					ctx.EnsureDesc(&d265)
-					ctx.EnsureDescsTogether(&d265, &d265)
-					var d270 JITValueDesc
-					if d265.Loc == LocImm {
-						d270 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d265.Imm.Float() * d265.Imm.Float())}
-					} else if d265.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d265.Reg)
-						_, xBits := d265.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitMulFloat64(scratch, d265.Reg)
-						d270 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d270)
-					} else if d265.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d265.Reg)
-						ctx.EmitMovRegReg(scratch, d265.Reg)
-						_, yBits := d265.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitMulFloat64(scratch, RegR11)
-						d270 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d270)
-					} else {
-						r6 := ctx.AllocRegExcept(d265.Reg, d265.Reg)
-						ctx.EmitMovRegReg(r6, d265.Reg)
-						ctx.EmitMulFloat64(r6, d265.Reg)
-						d270 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r6}
-						ctx.BindReg(r6, &d270)
-					}
-					if d270.Loc == LocReg && d265.Loc == LocReg && d270.Reg == d265.Reg {
-						ctx.TransferReg(d265.Reg)
-						d265.Loc = LocNone
-					}
-					ctx.EnsureDesc(&d4)
-					ctx.EnsureDesc(&d270)
-					ctx.EnsureDescsTogether(&d4, &d270)
-					var d271 JITValueDesc
-					if d4.Loc == LocImm && d270.Loc == LocImm {
-						d271 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d4.Imm.Float() + d270.Imm.Float())}
-					} else if d4.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d270.Reg)
-						_, xBits := d4.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitAddFloat64(scratch, d270.Reg)
-						d271 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d271)
-					} else if d270.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d4.Reg)
-						ctx.EmitMovRegReg(scratch, d4.Reg)
-						_, yBits := d270.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitAddFloat64(scratch, RegR11)
-						d271 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d271)
-					} else {
-						r7 := ctx.AllocRegExcept(d4.Reg, d270.Reg)
-						ctx.EmitMovRegReg(r7, d4.Reg)
-						ctx.EmitAddFloat64(r7, d270.Reg)
-						d271 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r7}
-						ctx.BindReg(r7, &d271)
-					}
-					if d271.Loc == LocReg && d4.Loc == LocReg && d271.Reg == d4.Reg {
-						ctx.TransferReg(d4.Reg)
-						d4.Loc = LocNone
-					}
-					ctx.EnsureDesc(&d271)
-					ctx.EmitStoreToStack(d271, int32(bbs[6].PhiBase)+int32(16))
-					ctx.StabilizeDescForControlFlow(&d271)
-					ctx.FreeDesc(&d270)
-					ctx.EnsureDesc(&d269)
-					ctx.EnsureDesc(&d269)
-					ctx.EnsureDescsTogether(&d269, &d269)
-					var d272 JITValueDesc
-					if d269.Loc == LocImm {
-						d272 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d269.Imm.Float() * d269.Imm.Float())}
-					} else if d269.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d269.Reg)
-						_, xBits := d269.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitMulFloat64(scratch, d269.Reg)
-						d272 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d272)
-					} else if d269.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d269.Reg)
-						ctx.EmitMovRegReg(scratch, d269.Reg)
-						_, yBits := d269.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitMulFloat64(scratch, RegR11)
-						d272 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d272)
-					} else {
-						r8 := ctx.AllocRegExcept(d269.Reg, d269.Reg)
-						ctx.EmitMovRegReg(r8, d269.Reg)
-						ctx.EmitMulFloat64(r8, d269.Reg)
-						d272 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r8}
-						ctx.BindReg(r8, &d272)
-					}
-					if d272.Loc == LocReg && d269.Loc == LocReg && d272.Reg == d269.Reg {
-						ctx.TransferReg(d269.Reg)
-						d269.Loc = LocNone
-					}
-					ctx.EnsureDesc(&d5)
-					ctx.EnsureDesc(&d272)
-					ctx.EnsureDescsTogether(&d5, &d272)
-					var d273 JITValueDesc
-					if d5.Loc == LocImm && d272.Loc == LocImm {
-						d273 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d5.Imm.Float() + d272.Imm.Float())}
-					} else if d5.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d272.Reg)
-						_, xBits := d5.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitAddFloat64(scratch, d272.Reg)
-						d273 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d273)
-					} else if d272.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d5.Reg)
-						ctx.EmitMovRegReg(scratch, d5.Reg)
-						_, yBits := d272.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitAddFloat64(scratch, RegR11)
-						d273 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d273)
-					} else {
-						r9 := ctx.AllocRegExcept(d5.Reg, d272.Reg)
-						ctx.EmitMovRegReg(r9, d5.Reg)
-						ctx.EmitAddFloat64(r9, d272.Reg)
-						d273 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r9}
-						ctx.BindReg(r9, &d273)
-					}
-					if d273.Loc == LocReg && d5.Loc == LocReg && d273.Reg == d5.Reg {
-						ctx.TransferReg(d5.Reg)
-						d5.Loc = LocNone
-					}
-					ctx.EnsureDesc(&d273)
-					ctx.EmitStoreToStack(d273, int32(bbs[6].PhiBase)+int32(32))
-					ctx.StabilizeDescForControlFlow(&d273)
-					ctx.FreeDesc(&d272)
-					ctx.EnsureDesc(&d265)
-					ctx.EnsureDesc(&d269)
-					ctx.EnsureDescsTogether(&d265, &d269)
-					var d274 JITValueDesc
-					if d265.Loc == LocImm && d269.Loc == LocImm {
-						d274 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d265.Imm.Float() * d269.Imm.Float())}
-					} else if d265.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d269.Reg)
-						_, xBits := d265.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitMulFloat64(scratch, d269.Reg)
-						d274 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d274)
-					} else if d269.Loc == LocImm {
-						_, yBits := d269.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitMulFloat64(d265.Reg, RegR11)
-						d274 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d265.Reg}
-						ctx.BindReg(d265.Reg, &d274)
-					} else {
-						ctx.EmitMulFloat64(d265.Reg, d269.Reg)
-						d274 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d265.Reg}
-						ctx.BindReg(d265.Reg, &d274)
-					}
-					if d274.Loc == LocReg && d265.Loc == LocReg && d274.Reg == d265.Reg {
-						ctx.TransferReg(d265.Reg)
-						d265.Loc = LocNone
-					}
-					ctx.FreeDesc(&d265)
-					ctx.FreeDesc(&d269)
-					ctx.EnsureDesc(&d3)
-					ctx.EnsureDesc(&d274)
-					ctx.EnsureDescsTogether(&d3, &d274)
-					var d275 JITValueDesc
-					if d3.Loc == LocImm && d274.Loc == LocImm {
-						d275 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d3.Imm.Float() + d274.Imm.Float())}
-					} else if d3.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d274.Reg)
-						_, xBits := d3.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitAddFloat64(scratch, d274.Reg)
-						d275 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d275)
-					} else if d274.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d3.Reg)
-						ctx.EmitMovRegReg(scratch, d3.Reg)
-						_, yBits := d274.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitAddFloat64(scratch, RegR11)
-						d275 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d275)
-					} else {
-						r10 := ctx.AllocRegExcept(d3.Reg, d274.Reg)
-						ctx.EmitMovRegReg(r10, d3.Reg)
-						ctx.EmitAddFloat64(r10, d274.Reg)
-						d275 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r10}
-						ctx.BindReg(r10, &d275)
-					}
-					if d275.Loc == LocReg && d3.Loc == LocReg && d275.Reg == d3.Reg {
-						ctx.TransferReg(d3.Reg)
-						d3.Loc = LocNone
-					}
-					ctx.EnsureDesc(&d275)
-					ctx.EmitStoreToStack(d275, int32(bbs[6].PhiBase)+int32(0))
-					ctx.StabilizeDescForControlFlow(&d275)
-					ctx.FreeDesc(&d274)
-					ctx.EnsureDesc(&d6)
-					ctx.EnsureDesc(&d6)
-					var d276 JITValueDesc
-					if d6.Loc == LocImm {
-						d276 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d6.Imm.Int() + 1)}
-					} else {
-						scratch := ctx.AllocRegExcept(d6.Reg)
-						ctx.EmitMovRegReg(scratch, d6.Reg)
-						ctx.EmitAddRegImm32(scratch, int32(1))
-						d276 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-						ctx.BindReg(scratch, &d276)
-					}
-					if d276.Loc == LocReg && d6.Loc == LocReg && d276.Reg == d6.Reg {
-						ctx.TransferReg(d6.Reg)
-						d6.Loc = LocNone
-					}
 					ctx.EnsureDesc(&d276)
-					ctx.EmitStoreToStack(d276, int32(bbs[6].PhiBase)+int32(48))
-					ctx.StabilizeDescForControlFlow(&d276)
-					if ps.General {
+					ctx.FreeDesc(&d273)
+					ctx.EnsureDesc(&d272)
+					ctx.EnsureDesc(&d272)
+					d277 = ctx.EmitFloatBinary(&d272, &d272, JITFloatMul)
+					ctx.EnsureDesc(&d11)
+					ctx.EnsureDesc(&d277)
+					d278 = ctx.EmitFloatBinary(&d11, &d277, JITFloatAdd)
+					ctx.FreeDesc(&d277)
+					ctx.EnsureDesc(&d276)
+					ctx.EnsureDesc(&d276)
+					d279 = ctx.EmitFloatBinary(&d276, &d276, JITFloatMul)
+					ctx.EnsureDesc(&d12)
+					ctx.EnsureDesc(&d279)
+					d280 = ctx.EmitFloatBinary(&d12, &d279, JITFloatAdd)
+					ctx.FreeDesc(&d279)
+					ctx.EnsureDesc(&d272)
+					ctx.EnsureDesc(&d276)
+					d281 = ctx.EmitFloatBinary(&d272, &d276, JITFloatMul)
+					ctx.FreeDesc(&d272)
+					ctx.FreeDesc(&d276)
+					ctx.EnsureDesc(&d10)
+					ctx.EnsureDesc(&d281)
+					d282 = ctx.EmitFloatBinary(&d10, &d281, JITFloatAdd)
+					ctx.FreeDesc(&d281)
+					ctx.EnsureDesc(&d13)
+					ctx.EnsureDesc(&d13)
+					var d283 JITValueDesc
+					if d13.Loc == LocImm {
+						d283 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d13.Imm.Int() + 1)}
+					} else {
+						var scratch Reg
+						if phiHomeOK5 {
+							scratch = r3
+						} else {
+							scratch = ctx.AllocRegExcept(d13.Reg)
+						}
+						ctx.EmitMovRegReg(scratch, d13.Reg)
+						ctx.EmitAddRegImm32(scratch, int32(1))
+						d283 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d283)
 					}
-					ps277 := PhiState{General: ps.General}
-					ps277.OverlayValues = make([]JITValueDesc, 277)
-					ps277.OverlayValues[1] = d1
-					ps277.OverlayValues[2] = d2
-					ps277.OverlayValues[3] = d3
-					ps277.OverlayValues[4] = d4
-					ps277.OverlayValues[5] = d5
-					ps277.OverlayValues[6] = d6
-					ps277.OverlayValues[7] = d7
-					ps277.OverlayValues[8] = d8
-					ps277.OverlayValues[9] = d9
-					ps277.OverlayValues[10] = d10
-					ps277.OverlayValues[11] = d11
-					ps277.OverlayValues[12] = d12
-					ps277.OverlayValues[13] = d13
-					ps277.OverlayValues[14] = d14
-					ps277.OverlayValues[15] = d15
-					ps277.OverlayValues[18] = d18
-					ps277.OverlayValues[38] = d38
-					ps277.OverlayValues[57] = d57
-					ps277.OverlayValues[58] = d58
-					ps277.OverlayValues[59] = d59
-					ps277.OverlayValues[60] = d60
-					ps277.OverlayValues[61] = d61
-					ps277.OverlayValues[63] = d63
-					ps277.OverlayValues[64] = d64
-					ps277.OverlayValues[65] = d65
-					ps277.OverlayValues[66] = d66
-					ps277.OverlayValues[67] = d67
-					ps277.OverlayValues[68] = d68
-					ps277.OverlayValues[69] = d69
-					ps277.OverlayValues[72] = d72
-					ps277.OverlayValues[138] = d138
-					ps277.OverlayValues[139] = d139
-					ps277.OverlayValues[140] = d140
-					ps277.OverlayValues[141] = d141
-					ps277.OverlayValues[142] = d142
-					ps277.OverlayValues[143] = d143
-					ps277.OverlayValues[145] = d145
-					ps277.OverlayValues[146] = d146
-					ps277.OverlayValues[147] = d147
-					ps277.OverlayValues[148] = d148
-					ps277.OverlayValues[149] = d149
-					ps277.OverlayValues[150] = d150
-					ps277.OverlayValues[151] = d151
-					ps277.OverlayValues[152] = d152
-					ps277.OverlayValues[153] = d153
-					ps277.OverlayValues[156] = d156
-					ps277.OverlayValues[157] = d157
-					ps277.OverlayValues[158] = d158
-					ps277.OverlayValues[159] = d159
-					ps277.OverlayValues[262] = d262
-					ps277.OverlayValues[263] = d263
-					ps277.OverlayValues[264] = d264
-					ps277.OverlayValues[265] = d265
-					ps277.OverlayValues[266] = d266
-					ps277.OverlayValues[267] = d267
-					ps277.OverlayValues[268] = d268
-					ps277.OverlayValues[269] = d269
-					ps277.OverlayValues[270] = d270
-					ps277.OverlayValues[271] = d271
-					ps277.OverlayValues[272] = d272
-					ps277.OverlayValues[273] = d273
-					ps277.OverlayValues[274] = d274
-					ps277.OverlayValues[275] = d275
-					ps277.OverlayValues[276] = d276
-					ps277.PhiValues = make([]JITValueDesc, 4)
-					if ps277.General && bbs[6].Rendered {
+					if d283.Loc == LocReg && d13.Loc == LocReg && d283.Reg == d13.Reg {
+						ctx.TransferReg(d13.Reg)
+						d13.Loc = LocNone
+					}
+					if ps.General {
+						ctx.SyncDesc(&d278)
+						if d278.Loc == LocReg || d278.Loc == LocFPReg {
+							ctx.ProtectReg(d278.Reg)
+						} else if d278.Loc == LocRegPair {
+							ctx.ProtectReg(d278.Reg)
+							ctx.ProtectReg(d278.Reg2)
+						}
+						ctx.SyncDesc(&d280)
+						if d280.Loc == LocReg || d280.Loc == LocFPReg {
+							ctx.ProtectReg(d280.Reg)
+						} else if d280.Loc == LocRegPair {
+							ctx.ProtectReg(d280.Reg)
+							ctx.ProtectReg(d280.Reg2)
+						}
+						ctx.SyncDesc(&d282)
+						if d282.Loc == LocReg || d282.Loc == LocFPReg {
+							ctx.ProtectReg(d282.Reg)
+						} else if d282.Loc == LocRegPair {
+							ctx.ProtectReg(d282.Reg)
+							ctx.ProtectReg(d282.Reg2)
+						}
+						d284 = d282
+						if d284.Loc == LocNone {
+							panic("jit: phi source has no location")
+						}
+						ctx.EnsureDesc(&d284)
+						if phiHomeOK2 {
+							ctx.EmitMovToReg(r0, d284)
+						} else {
+							ctx.EmitStoreToStack(d284, int32(bbs[6].PhiBase)+int32(0))
+						}
+						d285 = d278
+						if d285.Loc == LocNone {
+							panic("jit: phi source has no location")
+						}
+						ctx.EnsureDesc(&d285)
+						if phiHomeOK3 {
+							ctx.EmitMovToReg(r1, d285)
+						} else {
+							ctx.EmitStoreToStack(d285, int32(bbs[6].PhiBase)+int32(16))
+						}
+						d286 = d280
+						if d286.Loc == LocNone {
+							panic("jit: phi source has no location")
+						}
+						ctx.EnsureDesc(&d286)
+						if phiHomeOK4 {
+							ctx.EmitMovToReg(r2, d286)
+						} else {
+							ctx.EmitStoreToStack(d286, int32(bbs[6].PhiBase)+int32(32))
+						}
+						if d278.Loc == LocReg || d278.Loc == LocFPReg {
+							ctx.UnprotectReg(d278.Reg)
+						} else if d278.Loc == LocRegPair {
+							ctx.UnprotectReg(d278.Reg)
+							ctx.UnprotectReg(d278.Reg2)
+						}
+						if d280.Loc == LocReg || d280.Loc == LocFPReg {
+							ctx.UnprotectReg(d280.Reg)
+						} else if d280.Loc == LocRegPair {
+							ctx.UnprotectReg(d280.Reg)
+							ctx.UnprotectReg(d280.Reg2)
+						}
+						if d282.Loc == LocReg || d282.Loc == LocFPReg {
+							ctx.UnprotectReg(d282.Reg)
+						} else if d282.Loc == LocRegPair {
+							ctx.UnprotectReg(d282.Reg)
+							ctx.UnprotectReg(d282.Reg2)
+						}
+						ctx.SyncDesc(&d283)
+						if d283.Loc == LocReg || d283.Loc == LocFPReg {
+							ctx.ProtectReg(d283.Reg)
+						} else if d283.Loc == LocRegPair {
+							ctx.ProtectReg(d283.Reg)
+							ctx.ProtectReg(d283.Reg2)
+						}
+						d287 = d283
+						if d287.Loc == LocNone {
+							panic("jit: phi source has no location")
+						}
+						ctx.EnsureDesc(&d287)
+						if phiHomeOK5 {
+							ctx.EmitMovToReg(r3, d287)
+						} else {
+							ctx.EmitStoreToStack(d287, int32(bbs[6].PhiBase)+int32(48))
+						}
+						if d283.Loc == LocReg || d283.Loc == LocFPReg {
+							ctx.UnprotectReg(d283.Reg)
+						} else if d283.Loc == LocRegPair {
+							ctx.UnprotectReg(d283.Reg)
+							ctx.UnprotectReg(d283.Reg2)
+						}
+					}
+					ps288 := PhiState{General: ps.General}
+					ps288.OverlayValues = make([]JITValueDesc, 288)
+					ps288.OverlayValues[8] = d8
+					ps288.OverlayValues[9] = d9
+					ps288.OverlayValues[10] = d10
+					ps288.OverlayValues[11] = d11
+					ps288.OverlayValues[12] = d12
+					ps288.OverlayValues[13] = d13
+					ps288.OverlayValues[14] = d14
+					ps288.OverlayValues[15] = d15
+					ps288.OverlayValues[16] = d16
+					ps288.OverlayValues[17] = d17
+					ps288.OverlayValues[18] = d18
+					ps288.OverlayValues[19] = d19
+					ps288.OverlayValues[20] = d20
+					ps288.OverlayValues[21] = d21
+					ps288.OverlayValues[22] = d22
+					ps288.OverlayValues[25] = d25
+					ps288.OverlayValues[45] = d45
+					ps288.OverlayValues[64] = d64
+					ps288.OverlayValues[65] = d65
+					ps288.OverlayValues[66] = d66
+					ps288.OverlayValues[67] = d67
+					ps288.OverlayValues[68] = d68
+					ps288.OverlayValues[70] = d70
+					ps288.OverlayValues[71] = d71
+					ps288.OverlayValues[72] = d72
+					ps288.OverlayValues[73] = d73
+					ps288.OverlayValues[74] = d74
+					ps288.OverlayValues[75] = d75
+					ps288.OverlayValues[76] = d76
+					ps288.OverlayValues[79] = d79
+					ps288.OverlayValues[145] = d145
+					ps288.OverlayValues[146] = d146
+					ps288.OverlayValues[147] = d147
+					ps288.OverlayValues[148] = d148
+					ps288.OverlayValues[149] = d149
+					ps288.OverlayValues[150] = d150
+					ps288.OverlayValues[152] = d152
+					ps288.OverlayValues[153] = d153
+					ps288.OverlayValues[154] = d154
+					ps288.OverlayValues[155] = d155
+					ps288.OverlayValues[156] = d156
+					ps288.OverlayValues[157] = d157
+					ps288.OverlayValues[158] = d158
+					ps288.OverlayValues[159] = d159
+					ps288.OverlayValues[160] = d160
+					ps288.OverlayValues[163] = d163
+					ps288.OverlayValues[164] = d164
+					ps288.OverlayValues[165] = d165
+					ps288.OverlayValues[166] = d166
+					ps288.OverlayValues[269] = d269
+					ps288.OverlayValues[270] = d270
+					ps288.OverlayValues[271] = d271
+					ps288.OverlayValues[272] = d272
+					ps288.OverlayValues[273] = d273
+					ps288.OverlayValues[274] = d274
+					ps288.OverlayValues[275] = d275
+					ps288.OverlayValues[276] = d276
+					ps288.OverlayValues[277] = d277
+					ps288.OverlayValues[278] = d278
+					ps288.OverlayValues[279] = d279
+					ps288.OverlayValues[280] = d280
+					ps288.OverlayValues[281] = d281
+					ps288.OverlayValues[282] = d282
+					ps288.OverlayValues[283] = d283
+					ps288.OverlayValues[284] = d284
+					ps288.OverlayValues[285] = d285
+					ps288.OverlayValues[286] = d286
+					ps288.OverlayValues[287] = d287
+					ps288.PhiValues = make([]JITValueDesc, 4)
+					d289 = d282
+					ps288.PhiValues[0] = d289
+					d290 = d278
+					ps288.PhiValues[1] = d290
+					d291 = d280
+					ps288.PhiValues[2] = d291
+					d292 = d283
+					ps288.PhiValues[3] = d292
+					if ps288.General && bbs[6].Rendered {
 						ctx.EmitJmp(lbl7)
 						return result
 					}
-					return bbs[6].RenderPS(ps277)
+					return bbs[6].RenderPS(ps288)
 					return result
 				}
 				bbs[8].RenderPS = func(ps PhiState) JITValueDesc {
@@ -3136,82 +3408,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl9)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -3228,29 +3506,29 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
 						d145 = ps.OverlayValues[145]
@@ -3270,14 +3548,17 @@ func init_vector() {
 					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
 						d150 = ps.OverlayValues[150]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
-					}
 					if len(ps.OverlayValues) > 152 && ps.OverlayValues[152].Loc != LocNone {
 						d152 = ps.OverlayValues[152]
 					}
 					if len(ps.OverlayValues) > 153 && ps.OverlayValues[153].Loc != LocNone {
 						d153 = ps.OverlayValues[153]
+					}
+					if len(ps.OverlayValues) > 154 && ps.OverlayValues[154].Loc != LocNone {
+						d154 = ps.OverlayValues[154]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
 					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
 						d156 = ps.OverlayValues[156]
@@ -3291,26 +3572,20 @@ func init_vector() {
 					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
 						d159 = ps.OverlayValues[159]
 					}
-					if len(ps.OverlayValues) > 262 && ps.OverlayValues[262].Loc != LocNone {
-						d262 = ps.OverlayValues[262]
+					if len(ps.OverlayValues) > 160 && ps.OverlayValues[160].Loc != LocNone {
+						d160 = ps.OverlayValues[160]
 					}
-					if len(ps.OverlayValues) > 263 && ps.OverlayValues[263].Loc != LocNone {
-						d263 = ps.OverlayValues[263]
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
 					}
-					if len(ps.OverlayValues) > 264 && ps.OverlayValues[264].Loc != LocNone {
-						d264 = ps.OverlayValues[264]
+					if len(ps.OverlayValues) > 164 && ps.OverlayValues[164].Loc != LocNone {
+						d164 = ps.OverlayValues[164]
 					}
-					if len(ps.OverlayValues) > 265 && ps.OverlayValues[265].Loc != LocNone {
-						d265 = ps.OverlayValues[265]
+					if len(ps.OverlayValues) > 165 && ps.OverlayValues[165].Loc != LocNone {
+						d165 = ps.OverlayValues[165]
 					}
-					if len(ps.OverlayValues) > 266 && ps.OverlayValues[266].Loc != LocNone {
-						d266 = ps.OverlayValues[266]
-					}
-					if len(ps.OverlayValues) > 267 && ps.OverlayValues[267].Loc != LocNone {
-						d267 = ps.OverlayValues[267]
-					}
-					if len(ps.OverlayValues) > 268 && ps.OverlayValues[268].Loc != LocNone {
-						d268 = ps.OverlayValues[268]
+					if len(ps.OverlayValues) > 166 && ps.OverlayValues[166].Loc != LocNone {
+						d166 = ps.OverlayValues[166]
 					}
 					if len(ps.OverlayValues) > 269 && ps.OverlayValues[269].Loc != LocNone {
 						d269 = ps.OverlayValues[269]
@@ -3336,175 +3611,170 @@ func init_vector() {
 					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
 						d276 = ps.OverlayValues[276]
 					}
+					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
+						d277 = ps.OverlayValues[277]
+					}
+					if len(ps.OverlayValues) > 278 && ps.OverlayValues[278].Loc != LocNone {
+						d278 = ps.OverlayValues[278]
+					}
+					if len(ps.OverlayValues) > 279 && ps.OverlayValues[279].Loc != LocNone {
+						d279 = ps.OverlayValues[279]
+					}
+					if len(ps.OverlayValues) > 280 && ps.OverlayValues[280].Loc != LocNone {
+						d280 = ps.OverlayValues[280]
+					}
+					if len(ps.OverlayValues) > 281 && ps.OverlayValues[281].Loc != LocNone {
+						d281 = ps.OverlayValues[281]
+					}
+					if len(ps.OverlayValues) > 282 && ps.OverlayValues[282].Loc != LocNone {
+						d282 = ps.OverlayValues[282]
+					}
+					if len(ps.OverlayValues) > 283 && ps.OverlayValues[283].Loc != LocNone {
+						d283 = ps.OverlayValues[283]
+					}
+					if len(ps.OverlayValues) > 284 && ps.OverlayValues[284].Loc != LocNone {
+						d284 = ps.OverlayValues[284]
+					}
+					if len(ps.OverlayValues) > 285 && ps.OverlayValues[285].Loc != LocNone {
+						d285 = ps.OverlayValues[285]
+					}
+					if len(ps.OverlayValues) > 286 && ps.OverlayValues[286].Loc != LocNone {
+						d286 = ps.OverlayValues[286]
+					}
+					if len(ps.OverlayValues) > 287 && ps.OverlayValues[287].Loc != LocNone {
+						d287 = ps.OverlayValues[287]
+					}
+					if len(ps.OverlayValues) > 289 && ps.OverlayValues[289].Loc != LocNone {
+						d289 = ps.OverlayValues[289]
+					}
+					if len(ps.OverlayValues) > 290 && ps.OverlayValues[290].Loc != LocNone {
+						d290 = ps.OverlayValues[290]
+					}
+					if len(ps.OverlayValues) > 291 && ps.OverlayValues[291].Loc != LocNone {
+						d291 = ps.OverlayValues[291]
+					}
+					if len(ps.OverlayValues) > 292 && ps.OverlayValues[292].Loc != LocNone {
+						d292 = ps.OverlayValues[292]
+					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d4)
-					ctx.EnsureDesc(&d5)
-					ctx.EnsureDescsTogether(&d4, &d5)
-					var d278 JITValueDesc
-					if d4.Loc == LocImm && d5.Loc == LocImm {
-						d278 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d4.Imm.Float() * d5.Imm.Float())}
-					} else if d4.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d5.Reg)
-						_, xBits := d4.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitMulFloat64(scratch, d5.Reg)
-						d278 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d278)
-					} else if d5.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d4.Reg)
-						ctx.EmitMovRegReg(scratch, d4.Reg)
-						_, yBits := d5.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitMulFloat64(scratch, RegR11)
-						d278 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d278)
+					ctx.EnsureDesc(&d11)
+					ctx.EnsureDesc(&d12)
+					d293 = ctx.EmitFloatBinary(&d11, &d12, JITFloatMul)
+					ctx.EnsureDesc(&d293)
+					var d294 JITValueDesc
+					if d293.Loc == LocImm {
+						d294 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(math.Sqrt(d293.Imm.Float()))}
 					} else {
-						r11 := ctx.AllocRegExcept(d4.Reg, d5.Reg)
-						ctx.EmitMovRegReg(r11, d4.Reg)
-						ctx.EmitMulFloat64(r11, d5.Reg)
-						d278 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r11}
-						ctx.BindReg(r11, &d278)
-					}
-					if d278.Loc == LocReg && d4.Loc == LocReg && d278.Reg == d4.Reg {
-						ctx.TransferReg(d4.Reg)
-						d4.Loc = LocNone
-					}
-					ctx.EnsureDesc(&d278)
-					var d279 JITValueDesc
-					if d278.Loc == LocImm {
-						d279 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(math.Sqrt(d278.Imm.Float()))}
-					} else {
-						ctx.EnsureDesc(&d278)
-						var d280 JITValueDesc
-						if d278.Loc == LocRegPair {
-							ctx.FreeReg(d278.Reg)
-							d280 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d278.Reg2}
-							ctx.BindReg(d278.Reg2, &d280)
-							ctx.BindReg(d278.Reg2, &d280)
+						ctx.EnsureDesc(&d293)
+						var d295 JITValueDesc
+						if d293.Loc == LocRegPair {
+							ctx.FreeReg(d293.Reg)
+							d295 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d293.Reg2}
+							ctx.BindReg(d293.Reg2, &d295)
+							ctx.BindReg(d293.Reg2, &d295)
 						} else {
-							d280 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d278.Reg}
-							ctx.BindReg(d278.Reg, &d280)
-							ctx.BindReg(d278.Reg, &d280)
+							d295 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d293.Reg}
+							ctx.BindReg(d293.Reg, &d295)
+							ctx.BindReg(d293.Reg, &d295)
 						}
-						d279 = ctx.EmitGoCallScalar(GoFuncAddr(JITSqrtBits), []JITValueDesc{d280}, 1)
-						d279.Type = tagFloat
-						ctx.BindReg(d279.Reg, &d279)
+						d294 = ctx.EmitGoCallScalar(GoFuncAddr(JITSqrtBits), []JITValueDesc{d295}, 1)
+						d294.Type = tagFloat
+						ctx.BindReg(d294.Reg, &d294)
 					}
-					ctx.FreeDesc(&d278)
-					ctx.EnsureDesc(&d3)
-					ctx.EnsureDesc(&d279)
-					ctx.EnsureDescsTogether(&d3, &d279)
-					var d281 JITValueDesc
-					if d3.Loc == LocImm && d279.Loc == LocImm {
-						d281 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d3.Imm.Float() / d279.Imm.Float())}
-					} else if d3.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d279.Reg)
-						_, xBits := d3.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitDivFloat64(scratch, d279.Reg)
-						d281 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d281)
-					} else if d279.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d3.Reg)
-						ctx.EmitMovRegReg(scratch, d3.Reg)
-						_, yBits := d279.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitDivFloat64(scratch, RegR11)
-						d281 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d281)
-					} else {
-						r12 := ctx.AllocRegExcept(d3.Reg, d279.Reg)
-						ctx.EmitMovRegReg(r12, d3.Reg)
-						ctx.EmitDivFloat64(r12, d279.Reg)
-						d281 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r12}
-						ctx.BindReg(r12, &d281)
-					}
-					if d281.Loc == LocReg && d3.Loc == LocReg && d281.Reg == d3.Reg {
-						ctx.TransferReg(d3.Reg)
-						d3.Loc = LocNone
-					}
-					ctx.EnsureDesc(&d281)
-					ctx.EmitStoreToStack(d281, int32(bbs[4].PhiBase)+int32(0))
-					ctx.StabilizeDescForControlFlow(&d281)
-					ctx.FreeDesc(&d279)
+					ctx.FreeDesc(&d293)
+					ctx.EnsureDesc(&d10)
+					ctx.EnsureDesc(&d294)
+					d296 = ctx.EmitFloatBinary(&d10, &d294, JITFloatDiv)
+					ctx.EnsureDesc(&d296)
+					ctx.EmitStoreToStack(d296, int32(bbs[4].PhiBase)+int32(0))
+					ctx.StabilizeDescForControlFlow(&d296)
+					ctx.FreeDesc(&d294)
 					if ps.General {
 					}
-					ps282 := PhiState{General: ps.General}
-					ps282.OverlayValues = make([]JITValueDesc, 282)
-					ps282.OverlayValues[1] = d1
-					ps282.OverlayValues[2] = d2
-					ps282.OverlayValues[3] = d3
-					ps282.OverlayValues[4] = d4
-					ps282.OverlayValues[5] = d5
-					ps282.OverlayValues[6] = d6
-					ps282.OverlayValues[7] = d7
-					ps282.OverlayValues[8] = d8
-					ps282.OverlayValues[9] = d9
-					ps282.OverlayValues[10] = d10
-					ps282.OverlayValues[11] = d11
-					ps282.OverlayValues[12] = d12
-					ps282.OverlayValues[13] = d13
-					ps282.OverlayValues[14] = d14
-					ps282.OverlayValues[15] = d15
-					ps282.OverlayValues[18] = d18
-					ps282.OverlayValues[38] = d38
-					ps282.OverlayValues[57] = d57
-					ps282.OverlayValues[58] = d58
-					ps282.OverlayValues[59] = d59
-					ps282.OverlayValues[60] = d60
-					ps282.OverlayValues[61] = d61
-					ps282.OverlayValues[63] = d63
-					ps282.OverlayValues[64] = d64
-					ps282.OverlayValues[65] = d65
-					ps282.OverlayValues[66] = d66
-					ps282.OverlayValues[67] = d67
-					ps282.OverlayValues[68] = d68
-					ps282.OverlayValues[69] = d69
-					ps282.OverlayValues[72] = d72
-					ps282.OverlayValues[138] = d138
-					ps282.OverlayValues[139] = d139
-					ps282.OverlayValues[140] = d140
-					ps282.OverlayValues[141] = d141
-					ps282.OverlayValues[142] = d142
-					ps282.OverlayValues[143] = d143
-					ps282.OverlayValues[145] = d145
-					ps282.OverlayValues[146] = d146
-					ps282.OverlayValues[147] = d147
-					ps282.OverlayValues[148] = d148
-					ps282.OverlayValues[149] = d149
-					ps282.OverlayValues[150] = d150
-					ps282.OverlayValues[151] = d151
-					ps282.OverlayValues[152] = d152
-					ps282.OverlayValues[153] = d153
-					ps282.OverlayValues[156] = d156
-					ps282.OverlayValues[157] = d157
-					ps282.OverlayValues[158] = d158
-					ps282.OverlayValues[159] = d159
-					ps282.OverlayValues[262] = d262
-					ps282.OverlayValues[263] = d263
-					ps282.OverlayValues[264] = d264
-					ps282.OverlayValues[265] = d265
-					ps282.OverlayValues[266] = d266
-					ps282.OverlayValues[267] = d267
-					ps282.OverlayValues[268] = d268
-					ps282.OverlayValues[269] = d269
-					ps282.OverlayValues[270] = d270
-					ps282.OverlayValues[271] = d271
-					ps282.OverlayValues[272] = d272
-					ps282.OverlayValues[273] = d273
-					ps282.OverlayValues[274] = d274
-					ps282.OverlayValues[275] = d275
-					ps282.OverlayValues[276] = d276
-					ps282.OverlayValues[278] = d278
-					ps282.OverlayValues[279] = d279
-					ps282.OverlayValues[280] = d280
-					ps282.OverlayValues[281] = d281
-					ps282.PhiValues = make([]JITValueDesc, 1)
-					if ps282.General && bbs[4].Rendered {
+					ps297 := PhiState{General: ps.General}
+					ps297.OverlayValues = make([]JITValueDesc, 297)
+					ps297.OverlayValues[8] = d8
+					ps297.OverlayValues[9] = d9
+					ps297.OverlayValues[10] = d10
+					ps297.OverlayValues[11] = d11
+					ps297.OverlayValues[12] = d12
+					ps297.OverlayValues[13] = d13
+					ps297.OverlayValues[14] = d14
+					ps297.OverlayValues[15] = d15
+					ps297.OverlayValues[16] = d16
+					ps297.OverlayValues[17] = d17
+					ps297.OverlayValues[18] = d18
+					ps297.OverlayValues[19] = d19
+					ps297.OverlayValues[20] = d20
+					ps297.OverlayValues[21] = d21
+					ps297.OverlayValues[22] = d22
+					ps297.OverlayValues[25] = d25
+					ps297.OverlayValues[45] = d45
+					ps297.OverlayValues[64] = d64
+					ps297.OverlayValues[65] = d65
+					ps297.OverlayValues[66] = d66
+					ps297.OverlayValues[67] = d67
+					ps297.OverlayValues[68] = d68
+					ps297.OverlayValues[70] = d70
+					ps297.OverlayValues[71] = d71
+					ps297.OverlayValues[72] = d72
+					ps297.OverlayValues[73] = d73
+					ps297.OverlayValues[74] = d74
+					ps297.OverlayValues[75] = d75
+					ps297.OverlayValues[76] = d76
+					ps297.OverlayValues[79] = d79
+					ps297.OverlayValues[145] = d145
+					ps297.OverlayValues[146] = d146
+					ps297.OverlayValues[147] = d147
+					ps297.OverlayValues[148] = d148
+					ps297.OverlayValues[149] = d149
+					ps297.OverlayValues[150] = d150
+					ps297.OverlayValues[152] = d152
+					ps297.OverlayValues[153] = d153
+					ps297.OverlayValues[154] = d154
+					ps297.OverlayValues[155] = d155
+					ps297.OverlayValues[156] = d156
+					ps297.OverlayValues[157] = d157
+					ps297.OverlayValues[158] = d158
+					ps297.OverlayValues[159] = d159
+					ps297.OverlayValues[160] = d160
+					ps297.OverlayValues[163] = d163
+					ps297.OverlayValues[164] = d164
+					ps297.OverlayValues[165] = d165
+					ps297.OverlayValues[166] = d166
+					ps297.OverlayValues[269] = d269
+					ps297.OverlayValues[270] = d270
+					ps297.OverlayValues[271] = d271
+					ps297.OverlayValues[272] = d272
+					ps297.OverlayValues[273] = d273
+					ps297.OverlayValues[274] = d274
+					ps297.OverlayValues[275] = d275
+					ps297.OverlayValues[276] = d276
+					ps297.OverlayValues[277] = d277
+					ps297.OverlayValues[278] = d278
+					ps297.OverlayValues[279] = d279
+					ps297.OverlayValues[280] = d280
+					ps297.OverlayValues[281] = d281
+					ps297.OverlayValues[282] = d282
+					ps297.OverlayValues[283] = d283
+					ps297.OverlayValues[284] = d284
+					ps297.OverlayValues[285] = d285
+					ps297.OverlayValues[286] = d286
+					ps297.OverlayValues[287] = d287
+					ps297.OverlayValues[289] = d289
+					ps297.OverlayValues[290] = d290
+					ps297.OverlayValues[291] = d291
+					ps297.OverlayValues[292] = d292
+					ps297.OverlayValues[293] = d293
+					ps297.OverlayValues[294] = d294
+					ps297.OverlayValues[295] = d295
+					ps297.OverlayValues[296] = d296
+					ps297.PhiValues = make([]JITValueDesc, 1)
+					if ps297.General && bbs[4].Rendered {
 						ctx.EmitJmp(lbl5)
 						return result
 					}
-					return bbs[4].RenderPS(ps282)
+					return bbs[4].RenderPS(ps297)
 					return result
 				}
 				bbs[9].RenderPS = func(ps PhiState) JITValueDesc {
@@ -3526,82 +3796,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl10)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -3618,29 +3894,29 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
 						d145 = ps.OverlayValues[145]
@@ -3660,14 +3936,17 @@ func init_vector() {
 					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
 						d150 = ps.OverlayValues[150]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
-					}
 					if len(ps.OverlayValues) > 152 && ps.OverlayValues[152].Loc != LocNone {
 						d152 = ps.OverlayValues[152]
 					}
 					if len(ps.OverlayValues) > 153 && ps.OverlayValues[153].Loc != LocNone {
 						d153 = ps.OverlayValues[153]
+					}
+					if len(ps.OverlayValues) > 154 && ps.OverlayValues[154].Loc != LocNone {
+						d154 = ps.OverlayValues[154]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
 					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
 						d156 = ps.OverlayValues[156]
@@ -3681,26 +3960,20 @@ func init_vector() {
 					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
 						d159 = ps.OverlayValues[159]
 					}
-					if len(ps.OverlayValues) > 262 && ps.OverlayValues[262].Loc != LocNone {
-						d262 = ps.OverlayValues[262]
+					if len(ps.OverlayValues) > 160 && ps.OverlayValues[160].Loc != LocNone {
+						d160 = ps.OverlayValues[160]
 					}
-					if len(ps.OverlayValues) > 263 && ps.OverlayValues[263].Loc != LocNone {
-						d263 = ps.OverlayValues[263]
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
 					}
-					if len(ps.OverlayValues) > 264 && ps.OverlayValues[264].Loc != LocNone {
-						d264 = ps.OverlayValues[264]
+					if len(ps.OverlayValues) > 164 && ps.OverlayValues[164].Loc != LocNone {
+						d164 = ps.OverlayValues[164]
 					}
-					if len(ps.OverlayValues) > 265 && ps.OverlayValues[265].Loc != LocNone {
-						d265 = ps.OverlayValues[265]
+					if len(ps.OverlayValues) > 165 && ps.OverlayValues[165].Loc != LocNone {
+						d165 = ps.OverlayValues[165]
 					}
-					if len(ps.OverlayValues) > 266 && ps.OverlayValues[266].Loc != LocNone {
-						d266 = ps.OverlayValues[266]
-					}
-					if len(ps.OverlayValues) > 267 && ps.OverlayValues[267].Loc != LocNone {
-						d267 = ps.OverlayValues[267]
-					}
-					if len(ps.OverlayValues) > 268 && ps.OverlayValues[268].Loc != LocNone {
-						d268 = ps.OverlayValues[268]
+					if len(ps.OverlayValues) > 166 && ps.OverlayValues[166].Loc != LocNone {
+						d166 = ps.OverlayValues[166]
 					}
 					if len(ps.OverlayValues) > 269 && ps.OverlayValues[269].Loc != LocNone {
 						d269 = ps.OverlayValues[269]
@@ -3726,6 +3999,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
 						d276 = ps.OverlayValues[276]
 					}
+					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
+						d277 = ps.OverlayValues[277]
+					}
 					if len(ps.OverlayValues) > 278 && ps.OverlayValues[278].Loc != LocNone {
 						d278 = ps.OverlayValues[278]
 					}
@@ -3738,734 +4014,848 @@ func init_vector() {
 					if len(ps.OverlayValues) > 281 && ps.OverlayValues[281].Loc != LocNone {
 						d281 = ps.OverlayValues[281]
 					}
+					if len(ps.OverlayValues) > 282 && ps.OverlayValues[282].Loc != LocNone {
+						d282 = ps.OverlayValues[282]
+					}
+					if len(ps.OverlayValues) > 283 && ps.OverlayValues[283].Loc != LocNone {
+						d283 = ps.OverlayValues[283]
+					}
+					if len(ps.OverlayValues) > 284 && ps.OverlayValues[284].Loc != LocNone {
+						d284 = ps.OverlayValues[284]
+					}
+					if len(ps.OverlayValues) > 285 && ps.OverlayValues[285].Loc != LocNone {
+						d285 = ps.OverlayValues[285]
+					}
+					if len(ps.OverlayValues) > 286 && ps.OverlayValues[286].Loc != LocNone {
+						d286 = ps.OverlayValues[286]
+					}
+					if len(ps.OverlayValues) > 287 && ps.OverlayValues[287].Loc != LocNone {
+						d287 = ps.OverlayValues[287]
+					}
+					if len(ps.OverlayValues) > 289 && ps.OverlayValues[289].Loc != LocNone {
+						d289 = ps.OverlayValues[289]
+					}
+					if len(ps.OverlayValues) > 290 && ps.OverlayValues[290].Loc != LocNone {
+						d290 = ps.OverlayValues[290]
+					}
+					if len(ps.OverlayValues) > 291 && ps.OverlayValues[291].Loc != LocNone {
+						d291 = ps.OverlayValues[291]
+					}
+					if len(ps.OverlayValues) > 292 && ps.OverlayValues[292].Loc != LocNone {
+						d292 = ps.OverlayValues[292]
+					}
+					if len(ps.OverlayValues) > 293 && ps.OverlayValues[293].Loc != LocNone {
+						d293 = ps.OverlayValues[293]
+					}
+					if len(ps.OverlayValues) > 294 && ps.OverlayValues[294].Loc != LocNone {
+						d294 = ps.OverlayValues[294]
+					}
+					if len(ps.OverlayValues) > 295 && ps.OverlayValues[295].Loc != LocNone {
+						d295 = ps.OverlayValues[295]
+					}
+					if len(ps.OverlayValues) > 296 && ps.OverlayValues[296].Loc != LocNone {
+						d296 = ps.OverlayValues[296]
+					}
 					ctx.ReclaimUntrackedRegs()
-					var d283 JITValueDesc
-					if d12.SliceSizeKnown {
-						d283 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d12.KnownSliceLen))}
-					} else if d12.Loc == LocImm {
-						d283 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d12.StackOff))}
-					} else if d12.Loc == LocStackTriple {
-						d283 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d12.StackOff + 8, NoHeapPointer: true}
+					var d298 JITValueDesc
+					if d19.SliceSizeKnown {
+						d298 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.KnownSliceLen))}
+					} else if d19.Loc == LocImm {
+						d298 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.StackOff))}
+					} else if d19.Loc == LocStackTriple {
+						d298 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d19.StackOff + 8, NoHeapPointer: true}
 					} else {
-						ctx.EnsureDesc(&d12)
-						if d12.Loc == LocRegPair || d12.Loc == LocRegTriple {
-							d283 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d12.Reg2, ID: 0}
-						} else if d12.Loc == LocReg {
-							d283 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d12.Reg, ID: 0}
+						ctx.EnsureDesc(&d19)
+						if d19.Loc == LocRegPair || d19.Loc == LocRegTriple {
+							d298 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg2, ID: 0}
+						} else if d19.Loc == LocReg {
+							d298 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg, ID: 0}
 						} else {
 							panic("len on unsupported descriptor location")
 						}
 					}
-					ctx.EnsureDesc(&d6)
-					ctx.EnsureDesc(&d283)
-					ctx.EnsureDescsTogether(&d6, &d283)
-					var d284 JITValueDesc
-					if d6.Loc == LocImm && d283.Loc == LocImm {
-						d284 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d6.Imm.Int() < d283.Imm.Int())}
-					} else if d283.Loc == LocImm {
-						r13 := ctx.AllocRegExcept(d6.Reg)
-						if d283.Imm.Int() >= -2147483648 && d283.Imm.Int() <= 2147483647 {
-							ctx.EmitCmpRegImm32(d6.Reg, int32(d283.Imm.Int()))
+					ctx.EnsureDesc(&d13)
+					ctx.EnsureDesc(&d298)
+					ctx.EnsureDescsTogether(&d13, &d298)
+					var d299 JITValueDesc
+					if d13.Loc == LocImm && d298.Loc == LocImm {
+						d299 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d13.Imm.Int() < d298.Imm.Int())}
+					} else if d298.Loc == LocImm {
+						r12 := ctx.AllocRegExcept(d13.Reg)
+						if d298.Imm.Int() >= -2147483648 && d298.Imm.Int() <= 2147483647 {
+							ctx.EmitCmpRegImm32(d13.Reg, int32(d298.Imm.Int()))
 						} else {
-							ctx.EmitMovRegImm64(RegR11, uint64(d283.Imm.Int()))
-							ctx.EmitCmpInt64(d6.Reg, RegR11)
+							ctx.EmitMovRegImm64(RegR11, uint64(d298.Imm.Int()))
+							ctx.EmitCmpInt64(d13.Reg, RegR11)
 						}
-						d284 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r13, Condition: CondSignedLess}
-						ctx.BindReg(r13, &d284)
-					} else if d6.Loc == LocImm {
-						r14 := ctx.AllocReg()
-						ctx.EmitMovRegImm64(RegR11, uint64(d6.Imm.Int()))
-						ctx.EmitCmpInt64(RegR11, d283.Reg)
-						d284 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r14, Condition: CondSignedLess}
-						ctx.BindReg(r14, &d284)
+						d299 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r12, Condition: CondSignedLess}
+						ctx.BindReg(r12, &d299)
+					} else if d13.Loc == LocImm {
+						r13 := ctx.AllocReg()
+						ctx.EmitMovRegImm64(RegR11, uint64(d13.Imm.Int()))
+						ctx.EmitCmpInt64(RegR11, d298.Reg)
+						d299 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r13, Condition: CondSignedLess}
+						ctx.BindReg(r13, &d299)
 					} else {
-						r15 := ctx.AllocRegExcept(d6.Reg)
-						ctx.EmitCmpInt64(d6.Reg, d283.Reg)
-						d284 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r15, Condition: CondSignedLess}
-						ctx.BindReg(r15, &d284)
+						r14 := ctx.AllocRegExcept(d13.Reg)
+						ctx.EmitCmpInt64(d13.Reg, d298.Reg)
+						d299 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r14, Condition: CondSignedLess}
+						ctx.BindReg(r14, &d299)
 					}
-					ctx.FreeDesc(&d283)
-					d285 = d284
-					ctx.EnsureDesc(&d285)
-					if d285.Loc != LocImm && d285.Loc != LocFlags {
+					ctx.FreeDesc(&d298)
+					d300 = d299
+					ctx.EnsureDesc(&d300)
+					if d300.Loc != LocImm && d300.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d285.Loc == LocImm {
-						if d285.Imm.Bool() {
+					if d300.Loc == LocImm {
+						if d300.Imm.Bool() {
 							if ps.General {
 							}
-							ps286 := PhiState{General: ps.General}
-							ps286.OverlayValues = make([]JITValueDesc, 286)
-							ps286.OverlayValues[1] = d1
-							ps286.OverlayValues[2] = d2
-							ps286.OverlayValues[3] = d3
-							ps286.OverlayValues[4] = d4
-							ps286.OverlayValues[5] = d5
-							ps286.OverlayValues[6] = d6
-							ps286.OverlayValues[7] = d7
-							ps286.OverlayValues[8] = d8
-							ps286.OverlayValues[9] = d9
-							ps286.OverlayValues[10] = d10
-							ps286.OverlayValues[11] = d11
-							ps286.OverlayValues[12] = d12
-							ps286.OverlayValues[13] = d13
-							ps286.OverlayValues[14] = d14
-							ps286.OverlayValues[15] = d15
-							ps286.OverlayValues[18] = d18
-							ps286.OverlayValues[38] = d38
-							ps286.OverlayValues[57] = d57
-							ps286.OverlayValues[58] = d58
-							ps286.OverlayValues[59] = d59
-							ps286.OverlayValues[60] = d60
-							ps286.OverlayValues[61] = d61
-							ps286.OverlayValues[63] = d63
-							ps286.OverlayValues[64] = d64
-							ps286.OverlayValues[65] = d65
-							ps286.OverlayValues[66] = d66
-							ps286.OverlayValues[67] = d67
-							ps286.OverlayValues[68] = d68
-							ps286.OverlayValues[69] = d69
-							ps286.OverlayValues[72] = d72
-							ps286.OverlayValues[138] = d138
-							ps286.OverlayValues[139] = d139
-							ps286.OverlayValues[140] = d140
-							ps286.OverlayValues[141] = d141
-							ps286.OverlayValues[142] = d142
-							ps286.OverlayValues[143] = d143
-							ps286.OverlayValues[145] = d145
-							ps286.OverlayValues[146] = d146
-							ps286.OverlayValues[147] = d147
-							ps286.OverlayValues[148] = d148
-							ps286.OverlayValues[149] = d149
-							ps286.OverlayValues[150] = d150
-							ps286.OverlayValues[151] = d151
-							ps286.OverlayValues[152] = d152
-							ps286.OverlayValues[153] = d153
-							ps286.OverlayValues[156] = d156
-							ps286.OverlayValues[157] = d157
-							ps286.OverlayValues[158] = d158
-							ps286.OverlayValues[159] = d159
-							ps286.OverlayValues[262] = d262
-							ps286.OverlayValues[263] = d263
-							ps286.OverlayValues[264] = d264
-							ps286.OverlayValues[265] = d265
-							ps286.OverlayValues[266] = d266
-							ps286.OverlayValues[267] = d267
-							ps286.OverlayValues[268] = d268
-							ps286.OverlayValues[269] = d269
-							ps286.OverlayValues[270] = d270
-							ps286.OverlayValues[271] = d271
-							ps286.OverlayValues[272] = d272
-							ps286.OverlayValues[273] = d273
-							ps286.OverlayValues[274] = d274
-							ps286.OverlayValues[275] = d275
-							ps286.OverlayValues[276] = d276
-							ps286.OverlayValues[278] = d278
-							ps286.OverlayValues[279] = d279
-							ps286.OverlayValues[280] = d280
-							ps286.OverlayValues[281] = d281
-							ps286.OverlayValues[283] = d283
-							ps286.OverlayValues[284] = d284
-							ps286.OverlayValues[285] = d285
-							return bbs[7].RenderPS(ps286)
+							ps301 := PhiState{General: ps.General}
+							ps301.OverlayValues = make([]JITValueDesc, 301)
+							ps301.OverlayValues[8] = d8
+							ps301.OverlayValues[9] = d9
+							ps301.OverlayValues[10] = d10
+							ps301.OverlayValues[11] = d11
+							ps301.OverlayValues[12] = d12
+							ps301.OverlayValues[13] = d13
+							ps301.OverlayValues[14] = d14
+							ps301.OverlayValues[15] = d15
+							ps301.OverlayValues[16] = d16
+							ps301.OverlayValues[17] = d17
+							ps301.OverlayValues[18] = d18
+							ps301.OverlayValues[19] = d19
+							ps301.OverlayValues[20] = d20
+							ps301.OverlayValues[21] = d21
+							ps301.OverlayValues[22] = d22
+							ps301.OverlayValues[25] = d25
+							ps301.OverlayValues[45] = d45
+							ps301.OverlayValues[64] = d64
+							ps301.OverlayValues[65] = d65
+							ps301.OverlayValues[66] = d66
+							ps301.OverlayValues[67] = d67
+							ps301.OverlayValues[68] = d68
+							ps301.OverlayValues[70] = d70
+							ps301.OverlayValues[71] = d71
+							ps301.OverlayValues[72] = d72
+							ps301.OverlayValues[73] = d73
+							ps301.OverlayValues[74] = d74
+							ps301.OverlayValues[75] = d75
+							ps301.OverlayValues[76] = d76
+							ps301.OverlayValues[79] = d79
+							ps301.OverlayValues[145] = d145
+							ps301.OverlayValues[146] = d146
+							ps301.OverlayValues[147] = d147
+							ps301.OverlayValues[148] = d148
+							ps301.OverlayValues[149] = d149
+							ps301.OverlayValues[150] = d150
+							ps301.OverlayValues[152] = d152
+							ps301.OverlayValues[153] = d153
+							ps301.OverlayValues[154] = d154
+							ps301.OverlayValues[155] = d155
+							ps301.OverlayValues[156] = d156
+							ps301.OverlayValues[157] = d157
+							ps301.OverlayValues[158] = d158
+							ps301.OverlayValues[159] = d159
+							ps301.OverlayValues[160] = d160
+							ps301.OverlayValues[163] = d163
+							ps301.OverlayValues[164] = d164
+							ps301.OverlayValues[165] = d165
+							ps301.OverlayValues[166] = d166
+							ps301.OverlayValues[269] = d269
+							ps301.OverlayValues[270] = d270
+							ps301.OverlayValues[271] = d271
+							ps301.OverlayValues[272] = d272
+							ps301.OverlayValues[273] = d273
+							ps301.OverlayValues[274] = d274
+							ps301.OverlayValues[275] = d275
+							ps301.OverlayValues[276] = d276
+							ps301.OverlayValues[277] = d277
+							ps301.OverlayValues[278] = d278
+							ps301.OverlayValues[279] = d279
+							ps301.OverlayValues[280] = d280
+							ps301.OverlayValues[281] = d281
+							ps301.OverlayValues[282] = d282
+							ps301.OverlayValues[283] = d283
+							ps301.OverlayValues[284] = d284
+							ps301.OverlayValues[285] = d285
+							ps301.OverlayValues[286] = d286
+							ps301.OverlayValues[287] = d287
+							ps301.OverlayValues[289] = d289
+							ps301.OverlayValues[290] = d290
+							ps301.OverlayValues[291] = d291
+							ps301.OverlayValues[292] = d292
+							ps301.OverlayValues[293] = d293
+							ps301.OverlayValues[294] = d294
+							ps301.OverlayValues[295] = d295
+							ps301.OverlayValues[296] = d296
+							ps301.OverlayValues[298] = d298
+							ps301.OverlayValues[299] = d299
+							ps301.OverlayValues[300] = d300
+							return bbs[7].RenderPS(ps301)
 						}
 						if ps.General {
 						}
-						ps287 := PhiState{General: ps.General}
-						ps287.OverlayValues = make([]JITValueDesc, 286)
-						ps287.OverlayValues[1] = d1
-						ps287.OverlayValues[2] = d2
-						ps287.OverlayValues[3] = d3
-						ps287.OverlayValues[4] = d4
-						ps287.OverlayValues[5] = d5
-						ps287.OverlayValues[6] = d6
-						ps287.OverlayValues[7] = d7
-						ps287.OverlayValues[8] = d8
-						ps287.OverlayValues[9] = d9
-						ps287.OverlayValues[10] = d10
-						ps287.OverlayValues[11] = d11
-						ps287.OverlayValues[12] = d12
-						ps287.OverlayValues[13] = d13
-						ps287.OverlayValues[14] = d14
-						ps287.OverlayValues[15] = d15
-						ps287.OverlayValues[18] = d18
-						ps287.OverlayValues[38] = d38
-						ps287.OverlayValues[57] = d57
-						ps287.OverlayValues[58] = d58
-						ps287.OverlayValues[59] = d59
-						ps287.OverlayValues[60] = d60
-						ps287.OverlayValues[61] = d61
-						ps287.OverlayValues[63] = d63
-						ps287.OverlayValues[64] = d64
-						ps287.OverlayValues[65] = d65
-						ps287.OverlayValues[66] = d66
-						ps287.OverlayValues[67] = d67
-						ps287.OverlayValues[68] = d68
-						ps287.OverlayValues[69] = d69
-						ps287.OverlayValues[72] = d72
-						ps287.OverlayValues[138] = d138
-						ps287.OverlayValues[139] = d139
-						ps287.OverlayValues[140] = d140
-						ps287.OverlayValues[141] = d141
-						ps287.OverlayValues[142] = d142
-						ps287.OverlayValues[143] = d143
-						ps287.OverlayValues[145] = d145
-						ps287.OverlayValues[146] = d146
-						ps287.OverlayValues[147] = d147
-						ps287.OverlayValues[148] = d148
-						ps287.OverlayValues[149] = d149
-						ps287.OverlayValues[150] = d150
-						ps287.OverlayValues[151] = d151
-						ps287.OverlayValues[152] = d152
-						ps287.OverlayValues[153] = d153
-						ps287.OverlayValues[156] = d156
-						ps287.OverlayValues[157] = d157
-						ps287.OverlayValues[158] = d158
-						ps287.OverlayValues[159] = d159
-						ps287.OverlayValues[262] = d262
-						ps287.OverlayValues[263] = d263
-						ps287.OverlayValues[264] = d264
-						ps287.OverlayValues[265] = d265
-						ps287.OverlayValues[266] = d266
-						ps287.OverlayValues[267] = d267
-						ps287.OverlayValues[268] = d268
-						ps287.OverlayValues[269] = d269
-						ps287.OverlayValues[270] = d270
-						ps287.OverlayValues[271] = d271
-						ps287.OverlayValues[272] = d272
-						ps287.OverlayValues[273] = d273
-						ps287.OverlayValues[274] = d274
-						ps287.OverlayValues[275] = d275
-						ps287.OverlayValues[276] = d276
-						ps287.OverlayValues[278] = d278
-						ps287.OverlayValues[279] = d279
-						ps287.OverlayValues[280] = d280
-						ps287.OverlayValues[281] = d281
-						ps287.OverlayValues[283] = d283
-						ps287.OverlayValues[284] = d284
-						ps287.OverlayValues[285] = d285
-						return bbs[8].RenderPS(ps287)
+						ps302 := PhiState{General: ps.General}
+						ps302.OverlayValues = make([]JITValueDesc, 301)
+						ps302.OverlayValues[8] = d8
+						ps302.OverlayValues[9] = d9
+						ps302.OverlayValues[10] = d10
+						ps302.OverlayValues[11] = d11
+						ps302.OverlayValues[12] = d12
+						ps302.OverlayValues[13] = d13
+						ps302.OverlayValues[14] = d14
+						ps302.OverlayValues[15] = d15
+						ps302.OverlayValues[16] = d16
+						ps302.OverlayValues[17] = d17
+						ps302.OverlayValues[18] = d18
+						ps302.OverlayValues[19] = d19
+						ps302.OverlayValues[20] = d20
+						ps302.OverlayValues[21] = d21
+						ps302.OverlayValues[22] = d22
+						ps302.OverlayValues[25] = d25
+						ps302.OverlayValues[45] = d45
+						ps302.OverlayValues[64] = d64
+						ps302.OverlayValues[65] = d65
+						ps302.OverlayValues[66] = d66
+						ps302.OverlayValues[67] = d67
+						ps302.OverlayValues[68] = d68
+						ps302.OverlayValues[70] = d70
+						ps302.OverlayValues[71] = d71
+						ps302.OverlayValues[72] = d72
+						ps302.OverlayValues[73] = d73
+						ps302.OverlayValues[74] = d74
+						ps302.OverlayValues[75] = d75
+						ps302.OverlayValues[76] = d76
+						ps302.OverlayValues[79] = d79
+						ps302.OverlayValues[145] = d145
+						ps302.OverlayValues[146] = d146
+						ps302.OverlayValues[147] = d147
+						ps302.OverlayValues[148] = d148
+						ps302.OverlayValues[149] = d149
+						ps302.OverlayValues[150] = d150
+						ps302.OverlayValues[152] = d152
+						ps302.OverlayValues[153] = d153
+						ps302.OverlayValues[154] = d154
+						ps302.OverlayValues[155] = d155
+						ps302.OverlayValues[156] = d156
+						ps302.OverlayValues[157] = d157
+						ps302.OverlayValues[158] = d158
+						ps302.OverlayValues[159] = d159
+						ps302.OverlayValues[160] = d160
+						ps302.OverlayValues[163] = d163
+						ps302.OverlayValues[164] = d164
+						ps302.OverlayValues[165] = d165
+						ps302.OverlayValues[166] = d166
+						ps302.OverlayValues[269] = d269
+						ps302.OverlayValues[270] = d270
+						ps302.OverlayValues[271] = d271
+						ps302.OverlayValues[272] = d272
+						ps302.OverlayValues[273] = d273
+						ps302.OverlayValues[274] = d274
+						ps302.OverlayValues[275] = d275
+						ps302.OverlayValues[276] = d276
+						ps302.OverlayValues[277] = d277
+						ps302.OverlayValues[278] = d278
+						ps302.OverlayValues[279] = d279
+						ps302.OverlayValues[280] = d280
+						ps302.OverlayValues[281] = d281
+						ps302.OverlayValues[282] = d282
+						ps302.OverlayValues[283] = d283
+						ps302.OverlayValues[284] = d284
+						ps302.OverlayValues[285] = d285
+						ps302.OverlayValues[286] = d286
+						ps302.OverlayValues[287] = d287
+						ps302.OverlayValues[289] = d289
+						ps302.OverlayValues[290] = d290
+						ps302.OverlayValues[291] = d291
+						ps302.OverlayValues[292] = d292
+						ps302.OverlayValues[293] = d293
+						ps302.OverlayValues[294] = d294
+						ps302.OverlayValues[295] = d295
+						ps302.OverlayValues[296] = d296
+						ps302.OverlayValues[298] = d298
+						ps302.OverlayValues[299] = d299
+						ps302.OverlayValues[300] = d300
+						return bbs[8].RenderPS(ps302)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[9].RenderPS(ps)
 					}
-					ctx.EmitJump(d285.Condition, lbl8)
+					ctx.EmitJump(d300.Condition, lbl8)
 					if bbs[8].Rendered {
 						ctx.EmitJmp(lbl9)
 					}
-					ctx.FreeDesc(&d284)
-					snap288 := d1
-					snap289 := d2
-					snap290 := d3
-					snap291 := d4
-					snap292 := d5
-					snap293 := d6
-					snap294 := d7
-					snap295 := d8
-					snap296 := d9
-					snap297 := d10
-					snap298 := d11
-					snap299 := d12
-					snap300 := d13
-					snap301 := d14
-					snap302 := d15
-					snap303 := d18
-					snap304 := d38
-					snap305 := d57
-					snap306 := d58
-					snap307 := d59
-					snap308 := d60
-					snap309 := d61
-					snap310 := d63
-					snap311 := d64
-					snap312 := d65
-					snap313 := d66
-					snap314 := d67
-					snap315 := d68
-					snap316 := d69
-					snap317 := d72
-					snap318 := d138
-					snap319 := d139
-					snap320 := d140
-					snap321 := d141
-					snap322 := d142
-					snap323 := d143
-					snap324 := d145
-					snap325 := d146
-					snap326 := d147
-					snap327 := d148
-					snap328 := d149
-					snap329 := d150
-					snap330 := d151
-					snap331 := d152
-					snap332 := d153
-					snap333 := d156
-					snap334 := d157
-					snap335 := d158
-					snap336 := d159
-					snap337 := d262
-					snap338 := d263
-					snap339 := d264
-					snap340 := d265
-					snap341 := d266
-					snap342 := d267
-					snap343 := d268
-					snap344 := d269
-					snap345 := d270
-					snap346 := d271
-					snap347 := d272
-					snap348 := d273
-					snap349 := d274
-					snap350 := d275
-					snap351 := d276
-					snap352 := d278
-					snap353 := d279
-					snap354 := d280
-					snap355 := d281
-					snap356 := d283
-					snap357 := d284
-					snap358 := d285
-					alloc359 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc359)
-					d1 = snap288
-					d2 = snap289
-					d3 = snap290
-					d4 = snap291
-					d5 = snap292
-					d6 = snap293
-					d7 = snap294
-					d8 = snap295
-					d9 = snap296
-					d10 = snap297
-					d11 = snap298
-					d12 = snap299
-					d13 = snap300
-					d14 = snap301
-					d15 = snap302
-					d18 = snap303
-					d38 = snap304
-					d57 = snap305
-					d58 = snap306
-					d59 = snap307
-					d60 = snap308
-					d61 = snap309
-					d63 = snap310
-					d64 = snap311
-					d65 = snap312
-					d66 = snap313
-					d67 = snap314
-					d68 = snap315
-					d69 = snap316
-					d72 = snap317
-					d138 = snap318
-					d139 = snap319
-					d140 = snap320
-					d141 = snap321
-					d142 = snap322
-					d143 = snap323
-					d145 = snap324
-					d146 = snap325
-					d147 = snap326
-					d148 = snap327
-					d149 = snap328
-					d150 = snap329
-					d151 = snap330
-					d152 = snap331
-					d153 = snap332
-					d156 = snap333
-					d157 = snap334
-					d158 = snap335
-					d159 = snap336
-					d262 = snap337
-					d263 = snap338
-					d264 = snap339
-					d265 = snap340
-					d266 = snap341
-					d267 = snap342
-					d268 = snap343
-					d269 = snap344
-					d270 = snap345
-					d271 = snap346
-					d272 = snap347
-					d273 = snap348
-					d274 = snap349
-					d275 = snap350
-					d276 = snap351
-					d278 = snap352
-					d279 = snap353
-					d280 = snap354
-					d281 = snap355
-					d283 = snap356
-					d284 = snap357
-					d285 = snap358
-					ctx.RestoreAllocState(alloc359)
-					d1 = snap288
-					d2 = snap289
-					d3 = snap290
-					d4 = snap291
-					d5 = snap292
-					d6 = snap293
-					d7 = snap294
-					d8 = snap295
-					d9 = snap296
-					d10 = snap297
-					d11 = snap298
-					d12 = snap299
-					d13 = snap300
-					d14 = snap301
-					d15 = snap302
-					d18 = snap303
-					d38 = snap304
-					d57 = snap305
-					d58 = snap306
-					d59 = snap307
-					d60 = snap308
-					d61 = snap309
-					d63 = snap310
-					d64 = snap311
-					d65 = snap312
-					d66 = snap313
-					d67 = snap314
-					d68 = snap315
-					d69 = snap316
-					d72 = snap317
-					d138 = snap318
-					d139 = snap319
-					d140 = snap320
-					d141 = snap321
-					d142 = snap322
-					d143 = snap323
-					d145 = snap324
-					d146 = snap325
-					d147 = snap326
-					d148 = snap327
-					d149 = snap328
-					d150 = snap329
-					d151 = snap330
-					d152 = snap331
-					d153 = snap332
-					d156 = snap333
-					d157 = snap334
-					d158 = snap335
-					d159 = snap336
-					d262 = snap337
-					d263 = snap338
-					d264 = snap339
-					d265 = snap340
-					d266 = snap341
-					d267 = snap342
-					d268 = snap343
-					d269 = snap344
-					d270 = snap345
-					d271 = snap346
-					d272 = snap347
-					d273 = snap348
-					d274 = snap349
-					d275 = snap350
-					d276 = snap351
-					d278 = snap352
-					d279 = snap353
-					d280 = snap354
-					d281 = snap355
-					d283 = snap356
-					d284 = snap357
-					d285 = snap358
-					ps360 := PhiState{General: true}
-					ps360.OverlayValues = make([]JITValueDesc, 286)
-					ps360.OverlayValues[1] = d1
-					ps360.OverlayValues[2] = d2
-					ps360.OverlayValues[3] = d3
-					ps360.OverlayValues[4] = d4
-					ps360.OverlayValues[5] = d5
-					ps360.OverlayValues[6] = d6
-					ps360.OverlayValues[7] = d7
-					ps360.OverlayValues[8] = d8
-					ps360.OverlayValues[9] = d9
-					ps360.OverlayValues[10] = d10
-					ps360.OverlayValues[11] = d11
-					ps360.OverlayValues[12] = d12
-					ps360.OverlayValues[13] = d13
-					ps360.OverlayValues[14] = d14
-					ps360.OverlayValues[15] = d15
-					ps360.OverlayValues[18] = d18
-					ps360.OverlayValues[38] = d38
-					ps360.OverlayValues[57] = d57
-					ps360.OverlayValues[58] = d58
-					ps360.OverlayValues[59] = d59
-					ps360.OverlayValues[60] = d60
-					ps360.OverlayValues[61] = d61
-					ps360.OverlayValues[63] = d63
-					ps360.OverlayValues[64] = d64
-					ps360.OverlayValues[65] = d65
-					ps360.OverlayValues[66] = d66
-					ps360.OverlayValues[67] = d67
-					ps360.OverlayValues[68] = d68
-					ps360.OverlayValues[69] = d69
-					ps360.OverlayValues[72] = d72
-					ps360.OverlayValues[138] = d138
-					ps360.OverlayValues[139] = d139
-					ps360.OverlayValues[140] = d140
-					ps360.OverlayValues[141] = d141
-					ps360.OverlayValues[142] = d142
-					ps360.OverlayValues[143] = d143
-					ps360.OverlayValues[145] = d145
-					ps360.OverlayValues[146] = d146
-					ps360.OverlayValues[147] = d147
-					ps360.OverlayValues[148] = d148
-					ps360.OverlayValues[149] = d149
-					ps360.OverlayValues[150] = d150
-					ps360.OverlayValues[151] = d151
-					ps360.OverlayValues[152] = d152
-					ps360.OverlayValues[153] = d153
-					ps360.OverlayValues[156] = d156
-					ps360.OverlayValues[157] = d157
-					ps360.OverlayValues[158] = d158
-					ps360.OverlayValues[159] = d159
-					ps360.OverlayValues[262] = d262
-					ps360.OverlayValues[263] = d263
-					ps360.OverlayValues[264] = d264
-					ps360.OverlayValues[265] = d265
-					ps360.OverlayValues[266] = d266
-					ps360.OverlayValues[267] = d267
-					ps360.OverlayValues[268] = d268
-					ps360.OverlayValues[269] = d269
-					ps360.OverlayValues[270] = d270
-					ps360.OverlayValues[271] = d271
-					ps360.OverlayValues[272] = d272
-					ps360.OverlayValues[273] = d273
-					ps360.OverlayValues[274] = d274
-					ps360.OverlayValues[275] = d275
-					ps360.OverlayValues[276] = d276
-					ps360.OverlayValues[278] = d278
-					ps360.OverlayValues[279] = d279
-					ps360.OverlayValues[280] = d280
-					ps360.OverlayValues[281] = d281
-					ps360.OverlayValues[283] = d283
-					ps360.OverlayValues[284] = d284
-					ps360.OverlayValues[285] = d285
-					ps361 := PhiState{General: true}
-					ps361.OverlayValues = make([]JITValueDesc, 286)
-					ps361.OverlayValues[1] = d1
-					ps361.OverlayValues[2] = d2
-					ps361.OverlayValues[3] = d3
-					ps361.OverlayValues[4] = d4
-					ps361.OverlayValues[5] = d5
-					ps361.OverlayValues[6] = d6
-					ps361.OverlayValues[7] = d7
-					ps361.OverlayValues[8] = d8
-					ps361.OverlayValues[9] = d9
-					ps361.OverlayValues[10] = d10
-					ps361.OverlayValues[11] = d11
-					ps361.OverlayValues[12] = d12
-					ps361.OverlayValues[13] = d13
-					ps361.OverlayValues[14] = d14
-					ps361.OverlayValues[15] = d15
-					ps361.OverlayValues[18] = d18
-					ps361.OverlayValues[38] = d38
-					ps361.OverlayValues[57] = d57
-					ps361.OverlayValues[58] = d58
-					ps361.OverlayValues[59] = d59
-					ps361.OverlayValues[60] = d60
-					ps361.OverlayValues[61] = d61
-					ps361.OverlayValues[63] = d63
-					ps361.OverlayValues[64] = d64
-					ps361.OverlayValues[65] = d65
-					ps361.OverlayValues[66] = d66
-					ps361.OverlayValues[67] = d67
-					ps361.OverlayValues[68] = d68
-					ps361.OverlayValues[69] = d69
-					ps361.OverlayValues[72] = d72
-					ps361.OverlayValues[138] = d138
-					ps361.OverlayValues[139] = d139
-					ps361.OverlayValues[140] = d140
-					ps361.OverlayValues[141] = d141
-					ps361.OverlayValues[142] = d142
-					ps361.OverlayValues[143] = d143
-					ps361.OverlayValues[145] = d145
-					ps361.OverlayValues[146] = d146
-					ps361.OverlayValues[147] = d147
-					ps361.OverlayValues[148] = d148
-					ps361.OverlayValues[149] = d149
-					ps361.OverlayValues[150] = d150
-					ps361.OverlayValues[151] = d151
-					ps361.OverlayValues[152] = d152
-					ps361.OverlayValues[153] = d153
-					ps361.OverlayValues[156] = d156
-					ps361.OverlayValues[157] = d157
-					ps361.OverlayValues[158] = d158
-					ps361.OverlayValues[159] = d159
-					ps361.OverlayValues[262] = d262
-					ps361.OverlayValues[263] = d263
-					ps361.OverlayValues[264] = d264
-					ps361.OverlayValues[265] = d265
-					ps361.OverlayValues[266] = d266
-					ps361.OverlayValues[267] = d267
-					ps361.OverlayValues[268] = d268
-					ps361.OverlayValues[269] = d269
-					ps361.OverlayValues[270] = d270
-					ps361.OverlayValues[271] = d271
-					ps361.OverlayValues[272] = d272
-					ps361.OverlayValues[273] = d273
-					ps361.OverlayValues[274] = d274
-					ps361.OverlayValues[275] = d275
-					ps361.OverlayValues[276] = d276
-					ps361.OverlayValues[278] = d278
-					ps361.OverlayValues[279] = d279
-					ps361.OverlayValues[280] = d280
-					ps361.OverlayValues[281] = d281
-					ps361.OverlayValues[283] = d283
-					ps361.OverlayValues[284] = d284
-					ps361.OverlayValues[285] = d285
-					snap362 := d1
-					snap363 := d2
-					snap364 := d3
-					snap365 := d4
-					snap366 := d5
-					snap367 := d6
-					snap368 := d7
-					snap369 := d8
-					snap370 := d9
-					snap371 := d10
-					snap372 := d11
-					snap373 := d12
-					snap374 := d13
-					snap375 := d14
-					snap376 := d15
-					snap377 := d18
-					snap378 := d38
-					snap379 := d57
-					snap380 := d58
-					snap381 := d59
-					snap382 := d60
-					snap383 := d61
-					snap384 := d63
-					snap385 := d64
-					snap386 := d65
-					snap387 := d66
-					snap388 := d67
-					snap389 := d68
-					snap390 := d69
-					snap391 := d72
-					snap392 := d138
-					snap393 := d139
-					snap394 := d140
-					snap395 := d141
-					snap396 := d142
-					snap397 := d143
-					snap398 := d145
-					snap399 := d146
-					snap400 := d147
-					snap401 := d148
-					snap402 := d149
-					snap403 := d150
-					snap404 := d151
-					snap405 := d152
-					snap406 := d153
-					snap407 := d156
-					snap408 := d157
-					snap409 := d158
-					snap410 := d159
-					snap411 := d262
-					snap412 := d263
-					snap413 := d264
-					snap414 := d265
-					snap415 := d266
-					snap416 := d267
-					snap417 := d268
-					snap418 := d269
-					snap419 := d270
-					snap420 := d271
-					snap421 := d272
-					snap422 := d273
-					snap423 := d274
-					snap424 := d275
-					snap425 := d276
-					snap426 := d278
-					snap427 := d279
-					snap428 := d280
-					snap429 := d281
-					snap430 := d283
-					snap431 := d284
-					snap432 := d285
-					alloc433 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d299)
+					snap303 := d8
+					snap304 := d9
+					snap305 := d10
+					snap306 := d11
+					snap307 := d12
+					snap308 := d13
+					snap309 := d14
+					snap310 := d15
+					snap311 := d16
+					snap312 := d17
+					snap313 := d18
+					snap314 := d19
+					snap315 := d20
+					snap316 := d21
+					snap317 := d22
+					snap318 := d25
+					snap319 := d45
+					snap320 := d64
+					snap321 := d65
+					snap322 := d66
+					snap323 := d67
+					snap324 := d68
+					snap325 := d70
+					snap326 := d71
+					snap327 := d72
+					snap328 := d73
+					snap329 := d74
+					snap330 := d75
+					snap331 := d76
+					snap332 := d79
+					snap333 := d145
+					snap334 := d146
+					snap335 := d147
+					snap336 := d148
+					snap337 := d149
+					snap338 := d150
+					snap339 := d152
+					snap340 := d153
+					snap341 := d154
+					snap342 := d155
+					snap343 := d156
+					snap344 := d157
+					snap345 := d158
+					snap346 := d159
+					snap347 := d160
+					snap348 := d163
+					snap349 := d164
+					snap350 := d165
+					snap351 := d166
+					snap352 := d269
+					snap353 := d270
+					snap354 := d271
+					snap355 := d272
+					snap356 := d273
+					snap357 := d274
+					snap358 := d275
+					snap359 := d276
+					snap360 := d277
+					snap361 := d278
+					snap362 := d279
+					snap363 := d280
+					snap364 := d281
+					snap365 := d282
+					snap366 := d283
+					snap367 := d284
+					snap368 := d285
+					snap369 := d286
+					snap370 := d287
+					snap371 := d289
+					snap372 := d290
+					snap373 := d291
+					snap374 := d292
+					snap375 := d293
+					snap376 := d294
+					snap377 := d295
+					snap378 := d296
+					snap379 := d298
+					snap380 := d299
+					snap381 := d300
+					alloc382 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc382)
+					d8 = snap303
+					d9 = snap304
+					d10 = snap305
+					d11 = snap306
+					d12 = snap307
+					d13 = snap308
+					d14 = snap309
+					d15 = snap310
+					d16 = snap311
+					d17 = snap312
+					d18 = snap313
+					d19 = snap314
+					d20 = snap315
+					d21 = snap316
+					d22 = snap317
+					d25 = snap318
+					d45 = snap319
+					d64 = snap320
+					d65 = snap321
+					d66 = snap322
+					d67 = snap323
+					d68 = snap324
+					d70 = snap325
+					d71 = snap326
+					d72 = snap327
+					d73 = snap328
+					d74 = snap329
+					d75 = snap330
+					d76 = snap331
+					d79 = snap332
+					d145 = snap333
+					d146 = snap334
+					d147 = snap335
+					d148 = snap336
+					d149 = snap337
+					d150 = snap338
+					d152 = snap339
+					d153 = snap340
+					d154 = snap341
+					d155 = snap342
+					d156 = snap343
+					d157 = snap344
+					d158 = snap345
+					d159 = snap346
+					d160 = snap347
+					d163 = snap348
+					d164 = snap349
+					d165 = snap350
+					d166 = snap351
+					d269 = snap352
+					d270 = snap353
+					d271 = snap354
+					d272 = snap355
+					d273 = snap356
+					d274 = snap357
+					d275 = snap358
+					d276 = snap359
+					d277 = snap360
+					d278 = snap361
+					d279 = snap362
+					d280 = snap363
+					d281 = snap364
+					d282 = snap365
+					d283 = snap366
+					d284 = snap367
+					d285 = snap368
+					d286 = snap369
+					d287 = snap370
+					d289 = snap371
+					d290 = snap372
+					d291 = snap373
+					d292 = snap374
+					d293 = snap375
+					d294 = snap376
+					d295 = snap377
+					d296 = snap378
+					d298 = snap379
+					d299 = snap380
+					d300 = snap381
+					ctx.RestoreAllocState(alloc382)
+					d8 = snap303
+					d9 = snap304
+					d10 = snap305
+					d11 = snap306
+					d12 = snap307
+					d13 = snap308
+					d14 = snap309
+					d15 = snap310
+					d16 = snap311
+					d17 = snap312
+					d18 = snap313
+					d19 = snap314
+					d20 = snap315
+					d21 = snap316
+					d22 = snap317
+					d25 = snap318
+					d45 = snap319
+					d64 = snap320
+					d65 = snap321
+					d66 = snap322
+					d67 = snap323
+					d68 = snap324
+					d70 = snap325
+					d71 = snap326
+					d72 = snap327
+					d73 = snap328
+					d74 = snap329
+					d75 = snap330
+					d76 = snap331
+					d79 = snap332
+					d145 = snap333
+					d146 = snap334
+					d147 = snap335
+					d148 = snap336
+					d149 = snap337
+					d150 = snap338
+					d152 = snap339
+					d153 = snap340
+					d154 = snap341
+					d155 = snap342
+					d156 = snap343
+					d157 = snap344
+					d158 = snap345
+					d159 = snap346
+					d160 = snap347
+					d163 = snap348
+					d164 = snap349
+					d165 = snap350
+					d166 = snap351
+					d269 = snap352
+					d270 = snap353
+					d271 = snap354
+					d272 = snap355
+					d273 = snap356
+					d274 = snap357
+					d275 = snap358
+					d276 = snap359
+					d277 = snap360
+					d278 = snap361
+					d279 = snap362
+					d280 = snap363
+					d281 = snap364
+					d282 = snap365
+					d283 = snap366
+					d284 = snap367
+					d285 = snap368
+					d286 = snap369
+					d287 = snap370
+					d289 = snap371
+					d290 = snap372
+					d291 = snap373
+					d292 = snap374
+					d293 = snap375
+					d294 = snap376
+					d295 = snap377
+					d296 = snap378
+					d298 = snap379
+					d299 = snap380
+					d300 = snap381
+					ps383 := PhiState{General: true}
+					ps383.OverlayValues = make([]JITValueDesc, 301)
+					ps383.OverlayValues[8] = d8
+					ps383.OverlayValues[9] = d9
+					ps383.OverlayValues[10] = d10
+					ps383.OverlayValues[11] = d11
+					ps383.OverlayValues[12] = d12
+					ps383.OverlayValues[13] = d13
+					ps383.OverlayValues[14] = d14
+					ps383.OverlayValues[15] = d15
+					ps383.OverlayValues[16] = d16
+					ps383.OverlayValues[17] = d17
+					ps383.OverlayValues[18] = d18
+					ps383.OverlayValues[19] = d19
+					ps383.OverlayValues[20] = d20
+					ps383.OverlayValues[21] = d21
+					ps383.OverlayValues[22] = d22
+					ps383.OverlayValues[25] = d25
+					ps383.OverlayValues[45] = d45
+					ps383.OverlayValues[64] = d64
+					ps383.OverlayValues[65] = d65
+					ps383.OverlayValues[66] = d66
+					ps383.OverlayValues[67] = d67
+					ps383.OverlayValues[68] = d68
+					ps383.OverlayValues[70] = d70
+					ps383.OverlayValues[71] = d71
+					ps383.OverlayValues[72] = d72
+					ps383.OverlayValues[73] = d73
+					ps383.OverlayValues[74] = d74
+					ps383.OverlayValues[75] = d75
+					ps383.OverlayValues[76] = d76
+					ps383.OverlayValues[79] = d79
+					ps383.OverlayValues[145] = d145
+					ps383.OverlayValues[146] = d146
+					ps383.OverlayValues[147] = d147
+					ps383.OverlayValues[148] = d148
+					ps383.OverlayValues[149] = d149
+					ps383.OverlayValues[150] = d150
+					ps383.OverlayValues[152] = d152
+					ps383.OverlayValues[153] = d153
+					ps383.OverlayValues[154] = d154
+					ps383.OverlayValues[155] = d155
+					ps383.OverlayValues[156] = d156
+					ps383.OverlayValues[157] = d157
+					ps383.OverlayValues[158] = d158
+					ps383.OverlayValues[159] = d159
+					ps383.OverlayValues[160] = d160
+					ps383.OverlayValues[163] = d163
+					ps383.OverlayValues[164] = d164
+					ps383.OverlayValues[165] = d165
+					ps383.OverlayValues[166] = d166
+					ps383.OverlayValues[269] = d269
+					ps383.OverlayValues[270] = d270
+					ps383.OverlayValues[271] = d271
+					ps383.OverlayValues[272] = d272
+					ps383.OverlayValues[273] = d273
+					ps383.OverlayValues[274] = d274
+					ps383.OverlayValues[275] = d275
+					ps383.OverlayValues[276] = d276
+					ps383.OverlayValues[277] = d277
+					ps383.OverlayValues[278] = d278
+					ps383.OverlayValues[279] = d279
+					ps383.OverlayValues[280] = d280
+					ps383.OverlayValues[281] = d281
+					ps383.OverlayValues[282] = d282
+					ps383.OverlayValues[283] = d283
+					ps383.OverlayValues[284] = d284
+					ps383.OverlayValues[285] = d285
+					ps383.OverlayValues[286] = d286
+					ps383.OverlayValues[287] = d287
+					ps383.OverlayValues[289] = d289
+					ps383.OverlayValues[290] = d290
+					ps383.OverlayValues[291] = d291
+					ps383.OverlayValues[292] = d292
+					ps383.OverlayValues[293] = d293
+					ps383.OverlayValues[294] = d294
+					ps383.OverlayValues[295] = d295
+					ps383.OverlayValues[296] = d296
+					ps383.OverlayValues[298] = d298
+					ps383.OverlayValues[299] = d299
+					ps383.OverlayValues[300] = d300
+					ps384 := PhiState{General: true}
+					ps384.OverlayValues = make([]JITValueDesc, 301)
+					ps384.OverlayValues[8] = d8
+					ps384.OverlayValues[9] = d9
+					ps384.OverlayValues[10] = d10
+					ps384.OverlayValues[11] = d11
+					ps384.OverlayValues[12] = d12
+					ps384.OverlayValues[13] = d13
+					ps384.OverlayValues[14] = d14
+					ps384.OverlayValues[15] = d15
+					ps384.OverlayValues[16] = d16
+					ps384.OverlayValues[17] = d17
+					ps384.OverlayValues[18] = d18
+					ps384.OverlayValues[19] = d19
+					ps384.OverlayValues[20] = d20
+					ps384.OverlayValues[21] = d21
+					ps384.OverlayValues[22] = d22
+					ps384.OverlayValues[25] = d25
+					ps384.OverlayValues[45] = d45
+					ps384.OverlayValues[64] = d64
+					ps384.OverlayValues[65] = d65
+					ps384.OverlayValues[66] = d66
+					ps384.OverlayValues[67] = d67
+					ps384.OverlayValues[68] = d68
+					ps384.OverlayValues[70] = d70
+					ps384.OverlayValues[71] = d71
+					ps384.OverlayValues[72] = d72
+					ps384.OverlayValues[73] = d73
+					ps384.OverlayValues[74] = d74
+					ps384.OverlayValues[75] = d75
+					ps384.OverlayValues[76] = d76
+					ps384.OverlayValues[79] = d79
+					ps384.OverlayValues[145] = d145
+					ps384.OverlayValues[146] = d146
+					ps384.OverlayValues[147] = d147
+					ps384.OverlayValues[148] = d148
+					ps384.OverlayValues[149] = d149
+					ps384.OverlayValues[150] = d150
+					ps384.OverlayValues[152] = d152
+					ps384.OverlayValues[153] = d153
+					ps384.OverlayValues[154] = d154
+					ps384.OverlayValues[155] = d155
+					ps384.OverlayValues[156] = d156
+					ps384.OverlayValues[157] = d157
+					ps384.OverlayValues[158] = d158
+					ps384.OverlayValues[159] = d159
+					ps384.OverlayValues[160] = d160
+					ps384.OverlayValues[163] = d163
+					ps384.OverlayValues[164] = d164
+					ps384.OverlayValues[165] = d165
+					ps384.OverlayValues[166] = d166
+					ps384.OverlayValues[269] = d269
+					ps384.OverlayValues[270] = d270
+					ps384.OverlayValues[271] = d271
+					ps384.OverlayValues[272] = d272
+					ps384.OverlayValues[273] = d273
+					ps384.OverlayValues[274] = d274
+					ps384.OverlayValues[275] = d275
+					ps384.OverlayValues[276] = d276
+					ps384.OverlayValues[277] = d277
+					ps384.OverlayValues[278] = d278
+					ps384.OverlayValues[279] = d279
+					ps384.OverlayValues[280] = d280
+					ps384.OverlayValues[281] = d281
+					ps384.OverlayValues[282] = d282
+					ps384.OverlayValues[283] = d283
+					ps384.OverlayValues[284] = d284
+					ps384.OverlayValues[285] = d285
+					ps384.OverlayValues[286] = d286
+					ps384.OverlayValues[287] = d287
+					ps384.OverlayValues[289] = d289
+					ps384.OverlayValues[290] = d290
+					ps384.OverlayValues[291] = d291
+					ps384.OverlayValues[292] = d292
+					ps384.OverlayValues[293] = d293
+					ps384.OverlayValues[294] = d294
+					ps384.OverlayValues[295] = d295
+					ps384.OverlayValues[296] = d296
+					ps384.OverlayValues[298] = d298
+					ps384.OverlayValues[299] = d299
+					ps384.OverlayValues[300] = d300
+					snap385 := d8
+					snap386 := d9
+					snap387 := d10
+					snap388 := d11
+					snap389 := d12
+					snap390 := d13
+					snap391 := d14
+					snap392 := d15
+					snap393 := d16
+					snap394 := d17
+					snap395 := d18
+					snap396 := d19
+					snap397 := d20
+					snap398 := d21
+					snap399 := d22
+					snap400 := d25
+					snap401 := d45
+					snap402 := d64
+					snap403 := d65
+					snap404 := d66
+					snap405 := d67
+					snap406 := d68
+					snap407 := d70
+					snap408 := d71
+					snap409 := d72
+					snap410 := d73
+					snap411 := d74
+					snap412 := d75
+					snap413 := d76
+					snap414 := d79
+					snap415 := d145
+					snap416 := d146
+					snap417 := d147
+					snap418 := d148
+					snap419 := d149
+					snap420 := d150
+					snap421 := d152
+					snap422 := d153
+					snap423 := d154
+					snap424 := d155
+					snap425 := d156
+					snap426 := d157
+					snap427 := d158
+					snap428 := d159
+					snap429 := d160
+					snap430 := d163
+					snap431 := d164
+					snap432 := d165
+					snap433 := d166
+					snap434 := d269
+					snap435 := d270
+					snap436 := d271
+					snap437 := d272
+					snap438 := d273
+					snap439 := d274
+					snap440 := d275
+					snap441 := d276
+					snap442 := d277
+					snap443 := d278
+					snap444 := d279
+					snap445 := d280
+					snap446 := d281
+					snap447 := d282
+					snap448 := d283
+					snap449 := d284
+					snap450 := d285
+					snap451 := d286
+					snap452 := d287
+					snap453 := d289
+					snap454 := d290
+					snap455 := d291
+					snap456 := d292
+					snap457 := d293
+					snap458 := d294
+					snap459 := d295
+					snap460 := d296
+					snap461 := d298
+					snap462 := d299
+					snap463 := d300
+					alloc464 := ctx.SnapshotAllocState()
 					if !bbs[8].Rendered {
-						bbs[8].RenderPS(ps361)
+						bbs[8].RenderPS(ps384)
 					}
-					ctx.RestoreAllocState(alloc433)
-					d1 = snap362
-					d2 = snap363
-					d3 = snap364
-					d4 = snap365
-					d5 = snap366
-					d6 = snap367
-					d7 = snap368
-					d8 = snap369
-					d9 = snap370
-					d10 = snap371
-					d11 = snap372
-					d12 = snap373
-					d13 = snap374
-					d14 = snap375
-					d15 = snap376
-					d18 = snap377
-					d38 = snap378
-					d57 = snap379
-					d58 = snap380
-					d59 = snap381
-					d60 = snap382
-					d61 = snap383
-					d63 = snap384
-					d64 = snap385
-					d65 = snap386
-					d66 = snap387
-					d67 = snap388
-					d68 = snap389
-					d69 = snap390
-					d72 = snap391
-					d138 = snap392
-					d139 = snap393
-					d140 = snap394
-					d141 = snap395
-					d142 = snap396
-					d143 = snap397
-					d145 = snap398
-					d146 = snap399
-					d147 = snap400
-					d148 = snap401
-					d149 = snap402
-					d150 = snap403
-					d151 = snap404
-					d152 = snap405
-					d153 = snap406
-					d156 = snap407
-					d157 = snap408
-					d158 = snap409
-					d159 = snap410
-					d262 = snap411
-					d263 = snap412
-					d264 = snap413
-					d265 = snap414
-					d266 = snap415
-					d267 = snap416
-					d268 = snap417
-					d269 = snap418
-					d270 = snap419
-					d271 = snap420
-					d272 = snap421
-					d273 = snap422
-					d274 = snap423
-					d275 = snap424
-					d276 = snap425
-					d278 = snap426
-					d279 = snap427
-					d280 = snap428
-					d281 = snap429
-					d283 = snap430
-					d284 = snap431
-					d285 = snap432
+					ctx.RestoreAllocState(alloc464)
+					d8 = snap385
+					d9 = snap386
+					d10 = snap387
+					d11 = snap388
+					d12 = snap389
+					d13 = snap390
+					d14 = snap391
+					d15 = snap392
+					d16 = snap393
+					d17 = snap394
+					d18 = snap395
+					d19 = snap396
+					d20 = snap397
+					d21 = snap398
+					d22 = snap399
+					d25 = snap400
+					d45 = snap401
+					d64 = snap402
+					d65 = snap403
+					d66 = snap404
+					d67 = snap405
+					d68 = snap406
+					d70 = snap407
+					d71 = snap408
+					d72 = snap409
+					d73 = snap410
+					d74 = snap411
+					d75 = snap412
+					d76 = snap413
+					d79 = snap414
+					d145 = snap415
+					d146 = snap416
+					d147 = snap417
+					d148 = snap418
+					d149 = snap419
+					d150 = snap420
+					d152 = snap421
+					d153 = snap422
+					d154 = snap423
+					d155 = snap424
+					d156 = snap425
+					d157 = snap426
+					d158 = snap427
+					d159 = snap428
+					d160 = snap429
+					d163 = snap430
+					d164 = snap431
+					d165 = snap432
+					d166 = snap433
+					d269 = snap434
+					d270 = snap435
+					d271 = snap436
+					d272 = snap437
+					d273 = snap438
+					d274 = snap439
+					d275 = snap440
+					d276 = snap441
+					d277 = snap442
+					d278 = snap443
+					d279 = snap444
+					d280 = snap445
+					d281 = snap446
+					d282 = snap447
+					d283 = snap448
+					d284 = snap449
+					d285 = snap450
+					d286 = snap451
+					d287 = snap452
+					d289 = snap453
+					d290 = snap454
+					d291 = snap455
+					d292 = snap456
+					d293 = snap457
+					d294 = snap458
+					d295 = snap459
+					d296 = snap460
+					d298 = snap461
+					d299 = snap462
+					d300 = snap463
 					if !bbs[7].Rendered {
-						return bbs[7].RenderPS(ps360)
+						return bbs[7].RenderPS(ps383)
 					}
 					return result
 					return result
@@ -4473,14 +4863,22 @@ func init_vector() {
 				bbs[10].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d434 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d434)
-							ctx.EmitStoreToStack(d434, int32(bbs[10].PhiBase)+int32(0))
+							d465 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d465)
+							if phiHomeOK6 {
+								ctx.EmitMovToReg(r4, d465)
+							} else {
+								ctx.EmitStoreToStack(d465, int32(bbs[10].PhiBase)+int32(0))
+							}
 						}
 						if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
-							d435 := ps.PhiValues[1]
-							ctx.EnsureDesc(&d435)
-							ctx.EmitStoreToStack(d435, int32(bbs[10].PhiBase)+int32(16))
+							d466 := ps.PhiValues[1]
+							ctx.EnsureDesc(&d466)
+							if phiHomeOK7 {
+								ctx.EmitMovToReg(r5, d466)
+							} else {
+								ctx.EmitStoreToStack(d466, int32(bbs[10].PhiBase)+int32(16))
+							}
 						}
 						if bbs[10].VisitCount >= 0 {
 							ps.General = true
@@ -4499,82 +4897,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl11)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -4591,29 +4995,29 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
 						d145 = ps.OverlayValues[145]
@@ -4633,14 +5037,17 @@ func init_vector() {
 					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
 						d150 = ps.OverlayValues[150]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
-					}
 					if len(ps.OverlayValues) > 152 && ps.OverlayValues[152].Loc != LocNone {
 						d152 = ps.OverlayValues[152]
 					}
 					if len(ps.OverlayValues) > 153 && ps.OverlayValues[153].Loc != LocNone {
 						d153 = ps.OverlayValues[153]
+					}
+					if len(ps.OverlayValues) > 154 && ps.OverlayValues[154].Loc != LocNone {
+						d154 = ps.OverlayValues[154]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
 					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
 						d156 = ps.OverlayValues[156]
@@ -4654,26 +5061,20 @@ func init_vector() {
 					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
 						d159 = ps.OverlayValues[159]
 					}
-					if len(ps.OverlayValues) > 262 && ps.OverlayValues[262].Loc != LocNone {
-						d262 = ps.OverlayValues[262]
+					if len(ps.OverlayValues) > 160 && ps.OverlayValues[160].Loc != LocNone {
+						d160 = ps.OverlayValues[160]
 					}
-					if len(ps.OverlayValues) > 263 && ps.OverlayValues[263].Loc != LocNone {
-						d263 = ps.OverlayValues[263]
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
 					}
-					if len(ps.OverlayValues) > 264 && ps.OverlayValues[264].Loc != LocNone {
-						d264 = ps.OverlayValues[264]
+					if len(ps.OverlayValues) > 164 && ps.OverlayValues[164].Loc != LocNone {
+						d164 = ps.OverlayValues[164]
 					}
-					if len(ps.OverlayValues) > 265 && ps.OverlayValues[265].Loc != LocNone {
-						d265 = ps.OverlayValues[265]
+					if len(ps.OverlayValues) > 165 && ps.OverlayValues[165].Loc != LocNone {
+						d165 = ps.OverlayValues[165]
 					}
-					if len(ps.OverlayValues) > 266 && ps.OverlayValues[266].Loc != LocNone {
-						d266 = ps.OverlayValues[266]
-					}
-					if len(ps.OverlayValues) > 267 && ps.OverlayValues[267].Loc != LocNone {
-						d267 = ps.OverlayValues[267]
-					}
-					if len(ps.OverlayValues) > 268 && ps.OverlayValues[268].Loc != LocNone {
-						d268 = ps.OverlayValues[268]
+					if len(ps.OverlayValues) > 166 && ps.OverlayValues[166].Loc != LocNone {
+						d166 = ps.OverlayValues[166]
 					}
 					if len(ps.OverlayValues) > 269 && ps.OverlayValues[269].Loc != LocNone {
 						d269 = ps.OverlayValues[269]
@@ -4699,6 +5100,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
 						d276 = ps.OverlayValues[276]
 					}
+					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
+						d277 = ps.OverlayValues[277]
+					}
 					if len(ps.OverlayValues) > 278 && ps.OverlayValues[278].Loc != LocNone {
 						d278 = ps.OverlayValues[278]
 					}
@@ -4711,6 +5115,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 281 && ps.OverlayValues[281].Loc != LocNone {
 						d281 = ps.OverlayValues[281]
 					}
+					if len(ps.OverlayValues) > 282 && ps.OverlayValues[282].Loc != LocNone {
+						d282 = ps.OverlayValues[282]
+					}
 					if len(ps.OverlayValues) > 283 && ps.OverlayValues[283].Loc != LocNone {
 						d283 = ps.OverlayValues[283]
 					}
@@ -4720,817 +5127,940 @@ func init_vector() {
 					if len(ps.OverlayValues) > 285 && ps.OverlayValues[285].Loc != LocNone {
 						d285 = ps.OverlayValues[285]
 					}
-					if len(ps.OverlayValues) > 434 && ps.OverlayValues[434].Loc != LocNone {
-						d434 = ps.OverlayValues[434]
+					if len(ps.OverlayValues) > 286 && ps.OverlayValues[286].Loc != LocNone {
+						d286 = ps.OverlayValues[286]
 					}
-					if len(ps.OverlayValues) > 435 && ps.OverlayValues[435].Loc != LocNone {
-						d435 = ps.OverlayValues[435]
+					if len(ps.OverlayValues) > 287 && ps.OverlayValues[287].Loc != LocNone {
+						d287 = ps.OverlayValues[287]
+					}
+					if len(ps.OverlayValues) > 289 && ps.OverlayValues[289].Loc != LocNone {
+						d289 = ps.OverlayValues[289]
+					}
+					if len(ps.OverlayValues) > 290 && ps.OverlayValues[290].Loc != LocNone {
+						d290 = ps.OverlayValues[290]
+					}
+					if len(ps.OverlayValues) > 291 && ps.OverlayValues[291].Loc != LocNone {
+						d291 = ps.OverlayValues[291]
+					}
+					if len(ps.OverlayValues) > 292 && ps.OverlayValues[292].Loc != LocNone {
+						d292 = ps.OverlayValues[292]
+					}
+					if len(ps.OverlayValues) > 293 && ps.OverlayValues[293].Loc != LocNone {
+						d293 = ps.OverlayValues[293]
+					}
+					if len(ps.OverlayValues) > 294 && ps.OverlayValues[294].Loc != LocNone {
+						d294 = ps.OverlayValues[294]
+					}
+					if len(ps.OverlayValues) > 295 && ps.OverlayValues[295].Loc != LocNone {
+						d295 = ps.OverlayValues[295]
+					}
+					if len(ps.OverlayValues) > 296 && ps.OverlayValues[296].Loc != LocNone {
+						d296 = ps.OverlayValues[296]
+					}
+					if len(ps.OverlayValues) > 298 && ps.OverlayValues[298].Loc != LocNone {
+						d298 = ps.OverlayValues[298]
+					}
+					if len(ps.OverlayValues) > 299 && ps.OverlayValues[299].Loc != LocNone {
+						d299 = ps.OverlayValues[299]
+					}
+					if len(ps.OverlayValues) > 300 && ps.OverlayValues[300].Loc != LocNone {
+						d300 = ps.OverlayValues[300]
+					}
+					if len(ps.OverlayValues) > 465 && ps.OverlayValues[465].Loc != LocNone {
+						d465 = ps.OverlayValues[465]
+					}
+					if len(ps.OverlayValues) > 466 && ps.OverlayValues[466].Loc != LocNone {
+						d466 = ps.OverlayValues[466]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-						d7 = ps.PhiValues[0]
+						d14 = ps.PhiValues[0]
 					}
 					if !ps.General && len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
-						d8 = ps.PhiValues[1]
+						d15 = ps.PhiValues[1]
+					}
+					if phiHomeOK6 && d14.Loc == LocReg {
+						ctx.BindReg(r4, &d14)
+					}
+					if phiHomeOK7 && d15.Loc == LocReg {
+						ctx.BindReg(r5, &d15)
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.StabilizeDescForControlFlow(&d7)
-					ctx.StabilizeDescForControlFlow(&d8)
-					var d436 JITValueDesc
-					if d10.SliceSizeKnown {
-						d436 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d10.KnownSliceLen))}
-					} else if d10.Loc == LocImm {
-						d436 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d10.StackOff))}
-					} else if d10.Loc == LocStackTriple {
-						d436 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d10.StackOff + 8, NoHeapPointer: true}
+					var d467 JITValueDesc
+					if d17.SliceSizeKnown {
+						d467 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d17.KnownSliceLen))}
+					} else if d17.Loc == LocImm {
+						d467 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d17.StackOff))}
+					} else if d17.Loc == LocStackTriple {
+						d467 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d17.StackOff + 8, NoHeapPointer: true}
 					} else {
-						ctx.EnsureDesc(&d10)
-						if d10.Loc == LocRegPair || d10.Loc == LocRegTriple {
-							d436 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d10.Reg2, ID: 0}
-						} else if d10.Loc == LocReg {
-							d436 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d10.Reg, ID: 0}
+						ctx.EnsureDesc(&d17)
+						if d17.Loc == LocRegPair || d17.Loc == LocRegTriple {
+							d467 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d17.Reg2, ID: 0}
+						} else if d17.Loc == LocReg {
+							d467 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d17.Reg, ID: 0}
 						} else {
 							panic("len on unsupported descriptor location")
 						}
 					}
-					ctx.EnsureDesc(&d8)
-					ctx.EnsureDesc(&d436)
-					ctx.EnsureDescsTogether(&d8, &d436)
-					var d437 JITValueDesc
-					if d8.Loc == LocImm && d436.Loc == LocImm {
-						d437 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d8.Imm.Int() < d436.Imm.Int())}
-					} else if d436.Loc == LocImm {
-						r16 := ctx.AllocRegExcept(d8.Reg)
-						if d436.Imm.Int() >= -2147483648 && d436.Imm.Int() <= 2147483647 {
-							ctx.EmitCmpRegImm32(d8.Reg, int32(d436.Imm.Int()))
+					ctx.EnsureDesc(&d15)
+					ctx.EnsureDesc(&d467)
+					ctx.EnsureDescsTogether(&d15, &d467)
+					var d468 JITValueDesc
+					if d15.Loc == LocImm && d467.Loc == LocImm {
+						d468 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d15.Imm.Int() < d467.Imm.Int())}
+					} else if d467.Loc == LocImm {
+						r15 := ctx.AllocRegExcept(d15.Reg)
+						if d467.Imm.Int() >= -2147483648 && d467.Imm.Int() <= 2147483647 {
+							ctx.EmitCmpRegImm32(d15.Reg, int32(d467.Imm.Int()))
 						} else {
-							ctx.EmitMovRegImm64(RegR11, uint64(d436.Imm.Int()))
-							ctx.EmitCmpInt64(d8.Reg, RegR11)
+							ctx.EmitMovRegImm64(RegR11, uint64(d467.Imm.Int()))
+							ctx.EmitCmpInt64(d15.Reg, RegR11)
 						}
-						d437 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r16, Condition: CondSignedLess}
-						ctx.BindReg(r16, &d437)
-					} else if d8.Loc == LocImm {
-						r17 := ctx.AllocReg()
-						ctx.EmitMovRegImm64(RegR11, uint64(d8.Imm.Int()))
-						ctx.EmitCmpInt64(RegR11, d436.Reg)
-						d437 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r17, Condition: CondSignedLess}
-						ctx.BindReg(r17, &d437)
+						d468 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r15, Condition: CondSignedLess}
+						ctx.BindReg(r15, &d468)
+					} else if d15.Loc == LocImm {
+						r16 := ctx.AllocReg()
+						ctx.EmitMovRegImm64(RegR11, uint64(d15.Imm.Int()))
+						ctx.EmitCmpInt64(RegR11, d467.Reg)
+						d468 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r16, Condition: CondSignedLess}
+						ctx.BindReg(r16, &d468)
 					} else {
-						r18 := ctx.AllocRegExcept(d8.Reg)
-						ctx.EmitCmpInt64(d8.Reg, d436.Reg)
-						d437 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r18, Condition: CondSignedLess}
-						ctx.BindReg(r18, &d437)
+						r17 := ctx.AllocRegExcept(d15.Reg)
+						ctx.EmitCmpInt64(d15.Reg, d467.Reg)
+						d468 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r17, Condition: CondSignedLess}
+						ctx.BindReg(r17, &d468)
 					}
-					ctx.FreeDesc(&d436)
-					d438 = d437
-					ctx.EnsureDesc(&d438)
-					if d438.Loc != LocImm && d438.Loc != LocFlags {
+					ctx.FreeDesc(&d467)
+					d469 = d468
+					ctx.EnsureDesc(&d469)
+					if d469.Loc != LocImm && d469.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d438.Loc == LocImm {
-						if d438.Imm.Bool() {
+					if d469.Loc == LocImm {
+						if d469.Imm.Bool() {
 							if ps.General {
 							}
-							ps439 := PhiState{General: ps.General}
-							ps439.OverlayValues = make([]JITValueDesc, 439)
-							ps439.OverlayValues[1] = d1
-							ps439.OverlayValues[2] = d2
-							ps439.OverlayValues[3] = d3
-							ps439.OverlayValues[4] = d4
-							ps439.OverlayValues[5] = d5
-							ps439.OverlayValues[6] = d6
-							ps439.OverlayValues[7] = d7
-							ps439.OverlayValues[8] = d8
-							ps439.OverlayValues[9] = d9
-							ps439.OverlayValues[10] = d10
-							ps439.OverlayValues[11] = d11
-							ps439.OverlayValues[12] = d12
-							ps439.OverlayValues[13] = d13
-							ps439.OverlayValues[14] = d14
-							ps439.OverlayValues[15] = d15
-							ps439.OverlayValues[18] = d18
-							ps439.OverlayValues[38] = d38
-							ps439.OverlayValues[57] = d57
-							ps439.OverlayValues[58] = d58
-							ps439.OverlayValues[59] = d59
-							ps439.OverlayValues[60] = d60
-							ps439.OverlayValues[61] = d61
-							ps439.OverlayValues[63] = d63
-							ps439.OverlayValues[64] = d64
-							ps439.OverlayValues[65] = d65
-							ps439.OverlayValues[66] = d66
-							ps439.OverlayValues[67] = d67
-							ps439.OverlayValues[68] = d68
-							ps439.OverlayValues[69] = d69
-							ps439.OverlayValues[72] = d72
-							ps439.OverlayValues[138] = d138
-							ps439.OverlayValues[139] = d139
-							ps439.OverlayValues[140] = d140
-							ps439.OverlayValues[141] = d141
-							ps439.OverlayValues[142] = d142
-							ps439.OverlayValues[143] = d143
-							ps439.OverlayValues[145] = d145
-							ps439.OverlayValues[146] = d146
-							ps439.OverlayValues[147] = d147
-							ps439.OverlayValues[148] = d148
-							ps439.OverlayValues[149] = d149
-							ps439.OverlayValues[150] = d150
-							ps439.OverlayValues[151] = d151
-							ps439.OverlayValues[152] = d152
-							ps439.OverlayValues[153] = d153
-							ps439.OverlayValues[156] = d156
-							ps439.OverlayValues[157] = d157
-							ps439.OverlayValues[158] = d158
-							ps439.OverlayValues[159] = d159
-							ps439.OverlayValues[262] = d262
-							ps439.OverlayValues[263] = d263
-							ps439.OverlayValues[264] = d264
-							ps439.OverlayValues[265] = d265
-							ps439.OverlayValues[266] = d266
-							ps439.OverlayValues[267] = d267
-							ps439.OverlayValues[268] = d268
-							ps439.OverlayValues[269] = d269
-							ps439.OverlayValues[270] = d270
-							ps439.OverlayValues[271] = d271
-							ps439.OverlayValues[272] = d272
-							ps439.OverlayValues[273] = d273
-							ps439.OverlayValues[274] = d274
-							ps439.OverlayValues[275] = d275
-							ps439.OverlayValues[276] = d276
-							ps439.OverlayValues[278] = d278
-							ps439.OverlayValues[279] = d279
-							ps439.OverlayValues[280] = d280
-							ps439.OverlayValues[281] = d281
-							ps439.OverlayValues[283] = d283
-							ps439.OverlayValues[284] = d284
-							ps439.OverlayValues[285] = d285
-							ps439.OverlayValues[434] = d434
-							ps439.OverlayValues[435] = d435
-							ps439.OverlayValues[436] = d436
-							ps439.OverlayValues[437] = d437
-							ps439.OverlayValues[438] = d438
-							return bbs[13].RenderPS(ps439)
+							ps470 := PhiState{General: ps.General}
+							ps470.OverlayValues = make([]JITValueDesc, 470)
+							ps470.OverlayValues[8] = d8
+							ps470.OverlayValues[9] = d9
+							ps470.OverlayValues[10] = d10
+							ps470.OverlayValues[11] = d11
+							ps470.OverlayValues[12] = d12
+							ps470.OverlayValues[13] = d13
+							ps470.OverlayValues[14] = d14
+							ps470.OverlayValues[15] = d15
+							ps470.OverlayValues[16] = d16
+							ps470.OverlayValues[17] = d17
+							ps470.OverlayValues[18] = d18
+							ps470.OverlayValues[19] = d19
+							ps470.OverlayValues[20] = d20
+							ps470.OverlayValues[21] = d21
+							ps470.OverlayValues[22] = d22
+							ps470.OverlayValues[25] = d25
+							ps470.OverlayValues[45] = d45
+							ps470.OverlayValues[64] = d64
+							ps470.OverlayValues[65] = d65
+							ps470.OverlayValues[66] = d66
+							ps470.OverlayValues[67] = d67
+							ps470.OverlayValues[68] = d68
+							ps470.OverlayValues[70] = d70
+							ps470.OverlayValues[71] = d71
+							ps470.OverlayValues[72] = d72
+							ps470.OverlayValues[73] = d73
+							ps470.OverlayValues[74] = d74
+							ps470.OverlayValues[75] = d75
+							ps470.OverlayValues[76] = d76
+							ps470.OverlayValues[79] = d79
+							ps470.OverlayValues[145] = d145
+							ps470.OverlayValues[146] = d146
+							ps470.OverlayValues[147] = d147
+							ps470.OverlayValues[148] = d148
+							ps470.OverlayValues[149] = d149
+							ps470.OverlayValues[150] = d150
+							ps470.OverlayValues[152] = d152
+							ps470.OverlayValues[153] = d153
+							ps470.OverlayValues[154] = d154
+							ps470.OverlayValues[155] = d155
+							ps470.OverlayValues[156] = d156
+							ps470.OverlayValues[157] = d157
+							ps470.OverlayValues[158] = d158
+							ps470.OverlayValues[159] = d159
+							ps470.OverlayValues[160] = d160
+							ps470.OverlayValues[163] = d163
+							ps470.OverlayValues[164] = d164
+							ps470.OverlayValues[165] = d165
+							ps470.OverlayValues[166] = d166
+							ps470.OverlayValues[269] = d269
+							ps470.OverlayValues[270] = d270
+							ps470.OverlayValues[271] = d271
+							ps470.OverlayValues[272] = d272
+							ps470.OverlayValues[273] = d273
+							ps470.OverlayValues[274] = d274
+							ps470.OverlayValues[275] = d275
+							ps470.OverlayValues[276] = d276
+							ps470.OverlayValues[277] = d277
+							ps470.OverlayValues[278] = d278
+							ps470.OverlayValues[279] = d279
+							ps470.OverlayValues[280] = d280
+							ps470.OverlayValues[281] = d281
+							ps470.OverlayValues[282] = d282
+							ps470.OverlayValues[283] = d283
+							ps470.OverlayValues[284] = d284
+							ps470.OverlayValues[285] = d285
+							ps470.OverlayValues[286] = d286
+							ps470.OverlayValues[287] = d287
+							ps470.OverlayValues[289] = d289
+							ps470.OverlayValues[290] = d290
+							ps470.OverlayValues[291] = d291
+							ps470.OverlayValues[292] = d292
+							ps470.OverlayValues[293] = d293
+							ps470.OverlayValues[294] = d294
+							ps470.OverlayValues[295] = d295
+							ps470.OverlayValues[296] = d296
+							ps470.OverlayValues[298] = d298
+							ps470.OverlayValues[299] = d299
+							ps470.OverlayValues[300] = d300
+							ps470.OverlayValues[465] = d465
+							ps470.OverlayValues[466] = d466
+							ps470.OverlayValues[467] = d467
+							ps470.OverlayValues[468] = d468
+							ps470.OverlayValues[469] = d469
+							return bbs[13].RenderPS(ps470)
 						}
 						if ps.General {
 						}
-						ps440 := PhiState{General: ps.General}
-						ps440.OverlayValues = make([]JITValueDesc, 439)
-						ps440.OverlayValues[1] = d1
-						ps440.OverlayValues[2] = d2
-						ps440.OverlayValues[3] = d3
-						ps440.OverlayValues[4] = d4
-						ps440.OverlayValues[5] = d5
-						ps440.OverlayValues[6] = d6
-						ps440.OverlayValues[7] = d7
-						ps440.OverlayValues[8] = d8
-						ps440.OverlayValues[9] = d9
-						ps440.OverlayValues[10] = d10
-						ps440.OverlayValues[11] = d11
-						ps440.OverlayValues[12] = d12
-						ps440.OverlayValues[13] = d13
-						ps440.OverlayValues[14] = d14
-						ps440.OverlayValues[15] = d15
-						ps440.OverlayValues[18] = d18
-						ps440.OverlayValues[38] = d38
-						ps440.OverlayValues[57] = d57
-						ps440.OverlayValues[58] = d58
-						ps440.OverlayValues[59] = d59
-						ps440.OverlayValues[60] = d60
-						ps440.OverlayValues[61] = d61
-						ps440.OverlayValues[63] = d63
-						ps440.OverlayValues[64] = d64
-						ps440.OverlayValues[65] = d65
-						ps440.OverlayValues[66] = d66
-						ps440.OverlayValues[67] = d67
-						ps440.OverlayValues[68] = d68
-						ps440.OverlayValues[69] = d69
-						ps440.OverlayValues[72] = d72
-						ps440.OverlayValues[138] = d138
-						ps440.OverlayValues[139] = d139
-						ps440.OverlayValues[140] = d140
-						ps440.OverlayValues[141] = d141
-						ps440.OverlayValues[142] = d142
-						ps440.OverlayValues[143] = d143
-						ps440.OverlayValues[145] = d145
-						ps440.OverlayValues[146] = d146
-						ps440.OverlayValues[147] = d147
-						ps440.OverlayValues[148] = d148
-						ps440.OverlayValues[149] = d149
-						ps440.OverlayValues[150] = d150
-						ps440.OverlayValues[151] = d151
-						ps440.OverlayValues[152] = d152
-						ps440.OverlayValues[153] = d153
-						ps440.OverlayValues[156] = d156
-						ps440.OverlayValues[157] = d157
-						ps440.OverlayValues[158] = d158
-						ps440.OverlayValues[159] = d159
-						ps440.OverlayValues[262] = d262
-						ps440.OverlayValues[263] = d263
-						ps440.OverlayValues[264] = d264
-						ps440.OverlayValues[265] = d265
-						ps440.OverlayValues[266] = d266
-						ps440.OverlayValues[267] = d267
-						ps440.OverlayValues[268] = d268
-						ps440.OverlayValues[269] = d269
-						ps440.OverlayValues[270] = d270
-						ps440.OverlayValues[271] = d271
-						ps440.OverlayValues[272] = d272
-						ps440.OverlayValues[273] = d273
-						ps440.OverlayValues[274] = d274
-						ps440.OverlayValues[275] = d275
-						ps440.OverlayValues[276] = d276
-						ps440.OverlayValues[278] = d278
-						ps440.OverlayValues[279] = d279
-						ps440.OverlayValues[280] = d280
-						ps440.OverlayValues[281] = d281
-						ps440.OverlayValues[283] = d283
-						ps440.OverlayValues[284] = d284
-						ps440.OverlayValues[285] = d285
-						ps440.OverlayValues[434] = d434
-						ps440.OverlayValues[435] = d435
-						ps440.OverlayValues[436] = d436
-						ps440.OverlayValues[437] = d437
-						ps440.OverlayValues[438] = d438
-						return bbs[12].RenderPS(ps440)
+						ps471 := PhiState{General: ps.General}
+						ps471.OverlayValues = make([]JITValueDesc, 470)
+						ps471.OverlayValues[8] = d8
+						ps471.OverlayValues[9] = d9
+						ps471.OverlayValues[10] = d10
+						ps471.OverlayValues[11] = d11
+						ps471.OverlayValues[12] = d12
+						ps471.OverlayValues[13] = d13
+						ps471.OverlayValues[14] = d14
+						ps471.OverlayValues[15] = d15
+						ps471.OverlayValues[16] = d16
+						ps471.OverlayValues[17] = d17
+						ps471.OverlayValues[18] = d18
+						ps471.OverlayValues[19] = d19
+						ps471.OverlayValues[20] = d20
+						ps471.OverlayValues[21] = d21
+						ps471.OverlayValues[22] = d22
+						ps471.OverlayValues[25] = d25
+						ps471.OverlayValues[45] = d45
+						ps471.OverlayValues[64] = d64
+						ps471.OverlayValues[65] = d65
+						ps471.OverlayValues[66] = d66
+						ps471.OverlayValues[67] = d67
+						ps471.OverlayValues[68] = d68
+						ps471.OverlayValues[70] = d70
+						ps471.OverlayValues[71] = d71
+						ps471.OverlayValues[72] = d72
+						ps471.OverlayValues[73] = d73
+						ps471.OverlayValues[74] = d74
+						ps471.OverlayValues[75] = d75
+						ps471.OverlayValues[76] = d76
+						ps471.OverlayValues[79] = d79
+						ps471.OverlayValues[145] = d145
+						ps471.OverlayValues[146] = d146
+						ps471.OverlayValues[147] = d147
+						ps471.OverlayValues[148] = d148
+						ps471.OverlayValues[149] = d149
+						ps471.OverlayValues[150] = d150
+						ps471.OverlayValues[152] = d152
+						ps471.OverlayValues[153] = d153
+						ps471.OverlayValues[154] = d154
+						ps471.OverlayValues[155] = d155
+						ps471.OverlayValues[156] = d156
+						ps471.OverlayValues[157] = d157
+						ps471.OverlayValues[158] = d158
+						ps471.OverlayValues[159] = d159
+						ps471.OverlayValues[160] = d160
+						ps471.OverlayValues[163] = d163
+						ps471.OverlayValues[164] = d164
+						ps471.OverlayValues[165] = d165
+						ps471.OverlayValues[166] = d166
+						ps471.OverlayValues[269] = d269
+						ps471.OverlayValues[270] = d270
+						ps471.OverlayValues[271] = d271
+						ps471.OverlayValues[272] = d272
+						ps471.OverlayValues[273] = d273
+						ps471.OverlayValues[274] = d274
+						ps471.OverlayValues[275] = d275
+						ps471.OverlayValues[276] = d276
+						ps471.OverlayValues[277] = d277
+						ps471.OverlayValues[278] = d278
+						ps471.OverlayValues[279] = d279
+						ps471.OverlayValues[280] = d280
+						ps471.OverlayValues[281] = d281
+						ps471.OverlayValues[282] = d282
+						ps471.OverlayValues[283] = d283
+						ps471.OverlayValues[284] = d284
+						ps471.OverlayValues[285] = d285
+						ps471.OverlayValues[286] = d286
+						ps471.OverlayValues[287] = d287
+						ps471.OverlayValues[289] = d289
+						ps471.OverlayValues[290] = d290
+						ps471.OverlayValues[291] = d291
+						ps471.OverlayValues[292] = d292
+						ps471.OverlayValues[293] = d293
+						ps471.OverlayValues[294] = d294
+						ps471.OverlayValues[295] = d295
+						ps471.OverlayValues[296] = d296
+						ps471.OverlayValues[298] = d298
+						ps471.OverlayValues[299] = d299
+						ps471.OverlayValues[300] = d300
+						ps471.OverlayValues[465] = d465
+						ps471.OverlayValues[466] = d466
+						ps471.OverlayValues[467] = d467
+						ps471.OverlayValues[468] = d468
+						ps471.OverlayValues[469] = d469
+						return bbs[12].RenderPS(ps471)
 					}
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d441 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d441)
-							ctx.EmitStoreToStack(d441, int32(bbs[10].PhiBase)+int32(0))
+							d472 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d472)
+							if phiHomeOK6 {
+								ctx.EmitMovToReg(r4, d472)
+							} else {
+								ctx.EmitStoreToStack(d472, int32(bbs[10].PhiBase)+int32(0))
+							}
 						}
 						if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
-							d442 := ps.PhiValues[1]
-							ctx.EnsureDesc(&d442)
-							ctx.EmitStoreToStack(d442, int32(bbs[10].PhiBase)+int32(16))
+							d473 := ps.PhiValues[1]
+							ctx.EnsureDesc(&d473)
+							if phiHomeOK7 {
+								ctx.EmitMovToReg(r5, d473)
+							} else {
+								ctx.EmitStoreToStack(d473, int32(bbs[10].PhiBase)+int32(16))
+							}
 						}
 						ps.General = true
 						return bbs[10].RenderPS(ps)
 					}
-					ctx.EmitJump(d438.Condition, lbl14)
+					ctx.EmitJump(d469.Condition, lbl14)
 					if bbs[12].Rendered {
 						ctx.EmitJmp(lbl13)
 					}
-					ctx.FreeDesc(&d437)
-					snap443 := d1
-					snap444 := d2
-					snap445 := d3
-					snap446 := d4
-					snap447 := d5
-					snap448 := d6
-					snap449 := d7
-					snap450 := d8
-					snap451 := d9
-					snap452 := d10
-					snap453 := d11
-					snap454 := d12
-					snap455 := d13
-					snap456 := d14
-					snap457 := d15
-					snap458 := d18
-					snap459 := d38
-					snap460 := d57
-					snap461 := d58
-					snap462 := d59
-					snap463 := d60
-					snap464 := d61
-					snap465 := d63
-					snap466 := d64
-					snap467 := d65
-					snap468 := d66
-					snap469 := d67
-					snap470 := d68
-					snap471 := d69
-					snap472 := d72
-					snap473 := d138
-					snap474 := d139
-					snap475 := d140
-					snap476 := d141
-					snap477 := d142
-					snap478 := d143
-					snap479 := d145
-					snap480 := d146
-					snap481 := d147
-					snap482 := d148
-					snap483 := d149
-					snap484 := d150
-					snap485 := d151
-					snap486 := d152
-					snap487 := d153
-					snap488 := d156
-					snap489 := d157
-					snap490 := d158
-					snap491 := d159
-					snap492 := d262
-					snap493 := d263
-					snap494 := d264
-					snap495 := d265
-					snap496 := d266
-					snap497 := d267
-					snap498 := d268
-					snap499 := d269
-					snap500 := d270
-					snap501 := d271
-					snap502 := d272
-					snap503 := d273
-					snap504 := d274
-					snap505 := d275
-					snap506 := d276
-					snap507 := d278
-					snap508 := d279
-					snap509 := d280
-					snap510 := d281
-					snap511 := d283
-					snap512 := d284
-					snap513 := d285
-					snap514 := d434
-					snap515 := d435
-					snap516 := d436
-					snap517 := d437
-					snap518 := d438
-					snap519 := d441
-					snap520 := d442
-					alloc521 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc521)
-					d1 = snap443
-					d2 = snap444
-					d3 = snap445
-					d4 = snap446
-					d5 = snap447
-					d6 = snap448
-					d7 = snap449
-					d8 = snap450
-					d9 = snap451
-					d10 = snap452
-					d11 = snap453
-					d12 = snap454
-					d13 = snap455
-					d14 = snap456
-					d15 = snap457
-					d18 = snap458
-					d38 = snap459
-					d57 = snap460
-					d58 = snap461
-					d59 = snap462
-					d60 = snap463
-					d61 = snap464
-					d63 = snap465
-					d64 = snap466
-					d65 = snap467
-					d66 = snap468
-					d67 = snap469
-					d68 = snap470
-					d69 = snap471
-					d72 = snap472
-					d138 = snap473
-					d139 = snap474
-					d140 = snap475
-					d141 = snap476
-					d142 = snap477
-					d143 = snap478
-					d145 = snap479
-					d146 = snap480
-					d147 = snap481
-					d148 = snap482
-					d149 = snap483
-					d150 = snap484
-					d151 = snap485
-					d152 = snap486
-					d153 = snap487
-					d156 = snap488
-					d157 = snap489
-					d158 = snap490
-					d159 = snap491
-					d262 = snap492
-					d263 = snap493
-					d264 = snap494
-					d265 = snap495
-					d266 = snap496
-					d267 = snap497
-					d268 = snap498
-					d269 = snap499
-					d270 = snap500
-					d271 = snap501
-					d272 = snap502
-					d273 = snap503
-					d274 = snap504
-					d275 = snap505
-					d276 = snap506
-					d278 = snap507
-					d279 = snap508
-					d280 = snap509
-					d281 = snap510
-					d283 = snap511
-					d284 = snap512
-					d285 = snap513
-					d434 = snap514
-					d435 = snap515
-					d436 = snap516
-					d437 = snap517
-					d438 = snap518
-					d441 = snap519
-					d442 = snap520
-					ctx.RestoreAllocState(alloc521)
-					d1 = snap443
-					d2 = snap444
-					d3 = snap445
-					d4 = snap446
-					d5 = snap447
-					d6 = snap448
-					d7 = snap449
-					d8 = snap450
-					d9 = snap451
-					d10 = snap452
-					d11 = snap453
-					d12 = snap454
-					d13 = snap455
-					d14 = snap456
-					d15 = snap457
-					d18 = snap458
-					d38 = snap459
-					d57 = snap460
-					d58 = snap461
-					d59 = snap462
-					d60 = snap463
-					d61 = snap464
-					d63 = snap465
-					d64 = snap466
-					d65 = snap467
-					d66 = snap468
-					d67 = snap469
-					d68 = snap470
-					d69 = snap471
-					d72 = snap472
-					d138 = snap473
-					d139 = snap474
-					d140 = snap475
-					d141 = snap476
-					d142 = snap477
-					d143 = snap478
-					d145 = snap479
-					d146 = snap480
-					d147 = snap481
-					d148 = snap482
-					d149 = snap483
-					d150 = snap484
-					d151 = snap485
-					d152 = snap486
-					d153 = snap487
-					d156 = snap488
-					d157 = snap489
-					d158 = snap490
-					d159 = snap491
-					d262 = snap492
-					d263 = snap493
-					d264 = snap494
-					d265 = snap495
-					d266 = snap496
-					d267 = snap497
-					d268 = snap498
-					d269 = snap499
-					d270 = snap500
-					d271 = snap501
-					d272 = snap502
-					d273 = snap503
-					d274 = snap504
-					d275 = snap505
-					d276 = snap506
-					d278 = snap507
-					d279 = snap508
-					d280 = snap509
-					d281 = snap510
-					d283 = snap511
-					d284 = snap512
-					d285 = snap513
-					d434 = snap514
-					d435 = snap515
-					d436 = snap516
-					d437 = snap517
-					d438 = snap518
-					d441 = snap519
-					d442 = snap520
-					ps522 := PhiState{General: true}
-					ps522.OverlayValues = make([]JITValueDesc, 443)
-					ps522.OverlayValues[1] = d1
-					ps522.OverlayValues[2] = d2
-					ps522.OverlayValues[3] = d3
-					ps522.OverlayValues[4] = d4
-					ps522.OverlayValues[5] = d5
-					ps522.OverlayValues[6] = d6
-					ps522.OverlayValues[7] = d7
-					ps522.OverlayValues[8] = d8
-					ps522.OverlayValues[9] = d9
-					ps522.OverlayValues[10] = d10
-					ps522.OverlayValues[11] = d11
-					ps522.OverlayValues[12] = d12
-					ps522.OverlayValues[13] = d13
-					ps522.OverlayValues[14] = d14
-					ps522.OverlayValues[15] = d15
-					ps522.OverlayValues[18] = d18
-					ps522.OverlayValues[38] = d38
-					ps522.OverlayValues[57] = d57
-					ps522.OverlayValues[58] = d58
-					ps522.OverlayValues[59] = d59
-					ps522.OverlayValues[60] = d60
-					ps522.OverlayValues[61] = d61
-					ps522.OverlayValues[63] = d63
-					ps522.OverlayValues[64] = d64
-					ps522.OverlayValues[65] = d65
-					ps522.OverlayValues[66] = d66
-					ps522.OverlayValues[67] = d67
-					ps522.OverlayValues[68] = d68
-					ps522.OverlayValues[69] = d69
-					ps522.OverlayValues[72] = d72
-					ps522.OverlayValues[138] = d138
-					ps522.OverlayValues[139] = d139
-					ps522.OverlayValues[140] = d140
-					ps522.OverlayValues[141] = d141
-					ps522.OverlayValues[142] = d142
-					ps522.OverlayValues[143] = d143
-					ps522.OverlayValues[145] = d145
-					ps522.OverlayValues[146] = d146
-					ps522.OverlayValues[147] = d147
-					ps522.OverlayValues[148] = d148
-					ps522.OverlayValues[149] = d149
-					ps522.OverlayValues[150] = d150
-					ps522.OverlayValues[151] = d151
-					ps522.OverlayValues[152] = d152
-					ps522.OverlayValues[153] = d153
-					ps522.OverlayValues[156] = d156
-					ps522.OverlayValues[157] = d157
-					ps522.OverlayValues[158] = d158
-					ps522.OverlayValues[159] = d159
-					ps522.OverlayValues[262] = d262
-					ps522.OverlayValues[263] = d263
-					ps522.OverlayValues[264] = d264
-					ps522.OverlayValues[265] = d265
-					ps522.OverlayValues[266] = d266
-					ps522.OverlayValues[267] = d267
-					ps522.OverlayValues[268] = d268
-					ps522.OverlayValues[269] = d269
-					ps522.OverlayValues[270] = d270
-					ps522.OverlayValues[271] = d271
-					ps522.OverlayValues[272] = d272
-					ps522.OverlayValues[273] = d273
-					ps522.OverlayValues[274] = d274
-					ps522.OverlayValues[275] = d275
-					ps522.OverlayValues[276] = d276
-					ps522.OverlayValues[278] = d278
-					ps522.OverlayValues[279] = d279
-					ps522.OverlayValues[280] = d280
-					ps522.OverlayValues[281] = d281
-					ps522.OverlayValues[283] = d283
-					ps522.OverlayValues[284] = d284
-					ps522.OverlayValues[285] = d285
-					ps522.OverlayValues[434] = d434
-					ps522.OverlayValues[435] = d435
-					ps522.OverlayValues[436] = d436
-					ps522.OverlayValues[437] = d437
-					ps522.OverlayValues[438] = d438
-					ps522.OverlayValues[441] = d441
-					ps522.OverlayValues[442] = d442
-					ps523 := PhiState{General: true}
-					ps523.OverlayValues = make([]JITValueDesc, 443)
-					ps523.OverlayValues[1] = d1
-					ps523.OverlayValues[2] = d2
-					ps523.OverlayValues[3] = d3
-					ps523.OverlayValues[4] = d4
-					ps523.OverlayValues[5] = d5
-					ps523.OverlayValues[6] = d6
-					ps523.OverlayValues[7] = d7
-					ps523.OverlayValues[8] = d8
-					ps523.OverlayValues[9] = d9
-					ps523.OverlayValues[10] = d10
-					ps523.OverlayValues[11] = d11
-					ps523.OverlayValues[12] = d12
-					ps523.OverlayValues[13] = d13
-					ps523.OverlayValues[14] = d14
-					ps523.OverlayValues[15] = d15
-					ps523.OverlayValues[18] = d18
-					ps523.OverlayValues[38] = d38
-					ps523.OverlayValues[57] = d57
-					ps523.OverlayValues[58] = d58
-					ps523.OverlayValues[59] = d59
-					ps523.OverlayValues[60] = d60
-					ps523.OverlayValues[61] = d61
-					ps523.OverlayValues[63] = d63
-					ps523.OverlayValues[64] = d64
-					ps523.OverlayValues[65] = d65
-					ps523.OverlayValues[66] = d66
-					ps523.OverlayValues[67] = d67
-					ps523.OverlayValues[68] = d68
-					ps523.OverlayValues[69] = d69
-					ps523.OverlayValues[72] = d72
-					ps523.OverlayValues[138] = d138
-					ps523.OverlayValues[139] = d139
-					ps523.OverlayValues[140] = d140
-					ps523.OverlayValues[141] = d141
-					ps523.OverlayValues[142] = d142
-					ps523.OverlayValues[143] = d143
-					ps523.OverlayValues[145] = d145
-					ps523.OverlayValues[146] = d146
-					ps523.OverlayValues[147] = d147
-					ps523.OverlayValues[148] = d148
-					ps523.OverlayValues[149] = d149
-					ps523.OverlayValues[150] = d150
-					ps523.OverlayValues[151] = d151
-					ps523.OverlayValues[152] = d152
-					ps523.OverlayValues[153] = d153
-					ps523.OverlayValues[156] = d156
-					ps523.OverlayValues[157] = d157
-					ps523.OverlayValues[158] = d158
-					ps523.OverlayValues[159] = d159
-					ps523.OverlayValues[262] = d262
-					ps523.OverlayValues[263] = d263
-					ps523.OverlayValues[264] = d264
-					ps523.OverlayValues[265] = d265
-					ps523.OverlayValues[266] = d266
-					ps523.OverlayValues[267] = d267
-					ps523.OverlayValues[268] = d268
-					ps523.OverlayValues[269] = d269
-					ps523.OverlayValues[270] = d270
-					ps523.OverlayValues[271] = d271
-					ps523.OverlayValues[272] = d272
-					ps523.OverlayValues[273] = d273
-					ps523.OverlayValues[274] = d274
-					ps523.OverlayValues[275] = d275
-					ps523.OverlayValues[276] = d276
-					ps523.OverlayValues[278] = d278
-					ps523.OverlayValues[279] = d279
-					ps523.OverlayValues[280] = d280
-					ps523.OverlayValues[281] = d281
-					ps523.OverlayValues[283] = d283
-					ps523.OverlayValues[284] = d284
-					ps523.OverlayValues[285] = d285
-					ps523.OverlayValues[434] = d434
-					ps523.OverlayValues[435] = d435
-					ps523.OverlayValues[436] = d436
-					ps523.OverlayValues[437] = d437
-					ps523.OverlayValues[438] = d438
-					ps523.OverlayValues[441] = d441
-					ps523.OverlayValues[442] = d442
-					snap524 := d1
-					snap525 := d2
-					snap526 := d3
-					snap527 := d4
-					snap528 := d5
-					snap529 := d6
-					snap530 := d7
-					snap531 := d8
-					snap532 := d9
-					snap533 := d10
-					snap534 := d11
-					snap535 := d12
-					snap536 := d13
-					snap537 := d14
-					snap538 := d15
-					snap539 := d18
-					snap540 := d38
-					snap541 := d57
-					snap542 := d58
-					snap543 := d59
-					snap544 := d60
-					snap545 := d61
-					snap546 := d63
-					snap547 := d64
-					snap548 := d65
-					snap549 := d66
-					snap550 := d67
-					snap551 := d68
-					snap552 := d69
-					snap553 := d72
-					snap554 := d138
-					snap555 := d139
-					snap556 := d140
-					snap557 := d141
-					snap558 := d142
-					snap559 := d143
-					snap560 := d145
-					snap561 := d146
-					snap562 := d147
-					snap563 := d148
-					snap564 := d149
-					snap565 := d150
-					snap566 := d151
-					snap567 := d152
-					snap568 := d153
-					snap569 := d156
-					snap570 := d157
-					snap571 := d158
-					snap572 := d159
-					snap573 := d262
-					snap574 := d263
-					snap575 := d264
-					snap576 := d265
-					snap577 := d266
-					snap578 := d267
-					snap579 := d268
-					snap580 := d269
-					snap581 := d270
-					snap582 := d271
-					snap583 := d272
-					snap584 := d273
-					snap585 := d274
-					snap586 := d275
-					snap587 := d276
-					snap588 := d278
-					snap589 := d279
-					snap590 := d280
-					snap591 := d281
-					snap592 := d283
-					snap593 := d284
-					snap594 := d285
-					snap595 := d434
-					snap596 := d435
-					snap597 := d436
-					snap598 := d437
-					snap599 := d438
-					snap600 := d441
-					snap601 := d442
-					alloc602 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d468)
+					snap474 := d8
+					snap475 := d9
+					snap476 := d10
+					snap477 := d11
+					snap478 := d12
+					snap479 := d13
+					snap480 := d14
+					snap481 := d15
+					snap482 := d16
+					snap483 := d17
+					snap484 := d18
+					snap485 := d19
+					snap486 := d20
+					snap487 := d21
+					snap488 := d22
+					snap489 := d25
+					snap490 := d45
+					snap491 := d64
+					snap492 := d65
+					snap493 := d66
+					snap494 := d67
+					snap495 := d68
+					snap496 := d70
+					snap497 := d71
+					snap498 := d72
+					snap499 := d73
+					snap500 := d74
+					snap501 := d75
+					snap502 := d76
+					snap503 := d79
+					snap504 := d145
+					snap505 := d146
+					snap506 := d147
+					snap507 := d148
+					snap508 := d149
+					snap509 := d150
+					snap510 := d152
+					snap511 := d153
+					snap512 := d154
+					snap513 := d155
+					snap514 := d156
+					snap515 := d157
+					snap516 := d158
+					snap517 := d159
+					snap518 := d160
+					snap519 := d163
+					snap520 := d164
+					snap521 := d165
+					snap522 := d166
+					snap523 := d269
+					snap524 := d270
+					snap525 := d271
+					snap526 := d272
+					snap527 := d273
+					snap528 := d274
+					snap529 := d275
+					snap530 := d276
+					snap531 := d277
+					snap532 := d278
+					snap533 := d279
+					snap534 := d280
+					snap535 := d281
+					snap536 := d282
+					snap537 := d283
+					snap538 := d284
+					snap539 := d285
+					snap540 := d286
+					snap541 := d287
+					snap542 := d289
+					snap543 := d290
+					snap544 := d291
+					snap545 := d292
+					snap546 := d293
+					snap547 := d294
+					snap548 := d295
+					snap549 := d296
+					snap550 := d298
+					snap551 := d299
+					snap552 := d300
+					snap553 := d465
+					snap554 := d466
+					snap555 := d467
+					snap556 := d468
+					snap557 := d469
+					snap558 := d472
+					snap559 := d473
+					alloc560 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc560)
+					d8 = snap474
+					d9 = snap475
+					d10 = snap476
+					d11 = snap477
+					d12 = snap478
+					d13 = snap479
+					d14 = snap480
+					d15 = snap481
+					d16 = snap482
+					d17 = snap483
+					d18 = snap484
+					d19 = snap485
+					d20 = snap486
+					d21 = snap487
+					d22 = snap488
+					d25 = snap489
+					d45 = snap490
+					d64 = snap491
+					d65 = snap492
+					d66 = snap493
+					d67 = snap494
+					d68 = snap495
+					d70 = snap496
+					d71 = snap497
+					d72 = snap498
+					d73 = snap499
+					d74 = snap500
+					d75 = snap501
+					d76 = snap502
+					d79 = snap503
+					d145 = snap504
+					d146 = snap505
+					d147 = snap506
+					d148 = snap507
+					d149 = snap508
+					d150 = snap509
+					d152 = snap510
+					d153 = snap511
+					d154 = snap512
+					d155 = snap513
+					d156 = snap514
+					d157 = snap515
+					d158 = snap516
+					d159 = snap517
+					d160 = snap518
+					d163 = snap519
+					d164 = snap520
+					d165 = snap521
+					d166 = snap522
+					d269 = snap523
+					d270 = snap524
+					d271 = snap525
+					d272 = snap526
+					d273 = snap527
+					d274 = snap528
+					d275 = snap529
+					d276 = snap530
+					d277 = snap531
+					d278 = snap532
+					d279 = snap533
+					d280 = snap534
+					d281 = snap535
+					d282 = snap536
+					d283 = snap537
+					d284 = snap538
+					d285 = snap539
+					d286 = snap540
+					d287 = snap541
+					d289 = snap542
+					d290 = snap543
+					d291 = snap544
+					d292 = snap545
+					d293 = snap546
+					d294 = snap547
+					d295 = snap548
+					d296 = snap549
+					d298 = snap550
+					d299 = snap551
+					d300 = snap552
+					d465 = snap553
+					d466 = snap554
+					d467 = snap555
+					d468 = snap556
+					d469 = snap557
+					d472 = snap558
+					d473 = snap559
+					ctx.RestoreAllocState(alloc560)
+					d8 = snap474
+					d9 = snap475
+					d10 = snap476
+					d11 = snap477
+					d12 = snap478
+					d13 = snap479
+					d14 = snap480
+					d15 = snap481
+					d16 = snap482
+					d17 = snap483
+					d18 = snap484
+					d19 = snap485
+					d20 = snap486
+					d21 = snap487
+					d22 = snap488
+					d25 = snap489
+					d45 = snap490
+					d64 = snap491
+					d65 = snap492
+					d66 = snap493
+					d67 = snap494
+					d68 = snap495
+					d70 = snap496
+					d71 = snap497
+					d72 = snap498
+					d73 = snap499
+					d74 = snap500
+					d75 = snap501
+					d76 = snap502
+					d79 = snap503
+					d145 = snap504
+					d146 = snap505
+					d147 = snap506
+					d148 = snap507
+					d149 = snap508
+					d150 = snap509
+					d152 = snap510
+					d153 = snap511
+					d154 = snap512
+					d155 = snap513
+					d156 = snap514
+					d157 = snap515
+					d158 = snap516
+					d159 = snap517
+					d160 = snap518
+					d163 = snap519
+					d164 = snap520
+					d165 = snap521
+					d166 = snap522
+					d269 = snap523
+					d270 = snap524
+					d271 = snap525
+					d272 = snap526
+					d273 = snap527
+					d274 = snap528
+					d275 = snap529
+					d276 = snap530
+					d277 = snap531
+					d278 = snap532
+					d279 = snap533
+					d280 = snap534
+					d281 = snap535
+					d282 = snap536
+					d283 = snap537
+					d284 = snap538
+					d285 = snap539
+					d286 = snap540
+					d287 = snap541
+					d289 = snap542
+					d290 = snap543
+					d291 = snap544
+					d292 = snap545
+					d293 = snap546
+					d294 = snap547
+					d295 = snap548
+					d296 = snap549
+					d298 = snap550
+					d299 = snap551
+					d300 = snap552
+					d465 = snap553
+					d466 = snap554
+					d467 = snap555
+					d468 = snap556
+					d469 = snap557
+					d472 = snap558
+					d473 = snap559
+					ps561 := PhiState{General: true}
+					ps561.OverlayValues = make([]JITValueDesc, 474)
+					ps561.OverlayValues[8] = d8
+					ps561.OverlayValues[9] = d9
+					ps561.OverlayValues[10] = d10
+					ps561.OverlayValues[11] = d11
+					ps561.OverlayValues[12] = d12
+					ps561.OverlayValues[13] = d13
+					ps561.OverlayValues[14] = d14
+					ps561.OverlayValues[15] = d15
+					ps561.OverlayValues[16] = d16
+					ps561.OverlayValues[17] = d17
+					ps561.OverlayValues[18] = d18
+					ps561.OverlayValues[19] = d19
+					ps561.OverlayValues[20] = d20
+					ps561.OverlayValues[21] = d21
+					ps561.OverlayValues[22] = d22
+					ps561.OverlayValues[25] = d25
+					ps561.OverlayValues[45] = d45
+					ps561.OverlayValues[64] = d64
+					ps561.OverlayValues[65] = d65
+					ps561.OverlayValues[66] = d66
+					ps561.OverlayValues[67] = d67
+					ps561.OverlayValues[68] = d68
+					ps561.OverlayValues[70] = d70
+					ps561.OverlayValues[71] = d71
+					ps561.OverlayValues[72] = d72
+					ps561.OverlayValues[73] = d73
+					ps561.OverlayValues[74] = d74
+					ps561.OverlayValues[75] = d75
+					ps561.OverlayValues[76] = d76
+					ps561.OverlayValues[79] = d79
+					ps561.OverlayValues[145] = d145
+					ps561.OverlayValues[146] = d146
+					ps561.OverlayValues[147] = d147
+					ps561.OverlayValues[148] = d148
+					ps561.OverlayValues[149] = d149
+					ps561.OverlayValues[150] = d150
+					ps561.OverlayValues[152] = d152
+					ps561.OverlayValues[153] = d153
+					ps561.OverlayValues[154] = d154
+					ps561.OverlayValues[155] = d155
+					ps561.OverlayValues[156] = d156
+					ps561.OverlayValues[157] = d157
+					ps561.OverlayValues[158] = d158
+					ps561.OverlayValues[159] = d159
+					ps561.OverlayValues[160] = d160
+					ps561.OverlayValues[163] = d163
+					ps561.OverlayValues[164] = d164
+					ps561.OverlayValues[165] = d165
+					ps561.OverlayValues[166] = d166
+					ps561.OverlayValues[269] = d269
+					ps561.OverlayValues[270] = d270
+					ps561.OverlayValues[271] = d271
+					ps561.OverlayValues[272] = d272
+					ps561.OverlayValues[273] = d273
+					ps561.OverlayValues[274] = d274
+					ps561.OverlayValues[275] = d275
+					ps561.OverlayValues[276] = d276
+					ps561.OverlayValues[277] = d277
+					ps561.OverlayValues[278] = d278
+					ps561.OverlayValues[279] = d279
+					ps561.OverlayValues[280] = d280
+					ps561.OverlayValues[281] = d281
+					ps561.OverlayValues[282] = d282
+					ps561.OverlayValues[283] = d283
+					ps561.OverlayValues[284] = d284
+					ps561.OverlayValues[285] = d285
+					ps561.OverlayValues[286] = d286
+					ps561.OverlayValues[287] = d287
+					ps561.OverlayValues[289] = d289
+					ps561.OverlayValues[290] = d290
+					ps561.OverlayValues[291] = d291
+					ps561.OverlayValues[292] = d292
+					ps561.OverlayValues[293] = d293
+					ps561.OverlayValues[294] = d294
+					ps561.OverlayValues[295] = d295
+					ps561.OverlayValues[296] = d296
+					ps561.OverlayValues[298] = d298
+					ps561.OverlayValues[299] = d299
+					ps561.OverlayValues[300] = d300
+					ps561.OverlayValues[465] = d465
+					ps561.OverlayValues[466] = d466
+					ps561.OverlayValues[467] = d467
+					ps561.OverlayValues[468] = d468
+					ps561.OverlayValues[469] = d469
+					ps561.OverlayValues[472] = d472
+					ps561.OverlayValues[473] = d473
+					ps562 := PhiState{General: true}
+					ps562.OverlayValues = make([]JITValueDesc, 474)
+					ps562.OverlayValues[8] = d8
+					ps562.OverlayValues[9] = d9
+					ps562.OverlayValues[10] = d10
+					ps562.OverlayValues[11] = d11
+					ps562.OverlayValues[12] = d12
+					ps562.OverlayValues[13] = d13
+					ps562.OverlayValues[14] = d14
+					ps562.OverlayValues[15] = d15
+					ps562.OverlayValues[16] = d16
+					ps562.OverlayValues[17] = d17
+					ps562.OverlayValues[18] = d18
+					ps562.OverlayValues[19] = d19
+					ps562.OverlayValues[20] = d20
+					ps562.OverlayValues[21] = d21
+					ps562.OverlayValues[22] = d22
+					ps562.OverlayValues[25] = d25
+					ps562.OverlayValues[45] = d45
+					ps562.OverlayValues[64] = d64
+					ps562.OverlayValues[65] = d65
+					ps562.OverlayValues[66] = d66
+					ps562.OverlayValues[67] = d67
+					ps562.OverlayValues[68] = d68
+					ps562.OverlayValues[70] = d70
+					ps562.OverlayValues[71] = d71
+					ps562.OverlayValues[72] = d72
+					ps562.OverlayValues[73] = d73
+					ps562.OverlayValues[74] = d74
+					ps562.OverlayValues[75] = d75
+					ps562.OverlayValues[76] = d76
+					ps562.OverlayValues[79] = d79
+					ps562.OverlayValues[145] = d145
+					ps562.OverlayValues[146] = d146
+					ps562.OverlayValues[147] = d147
+					ps562.OverlayValues[148] = d148
+					ps562.OverlayValues[149] = d149
+					ps562.OverlayValues[150] = d150
+					ps562.OverlayValues[152] = d152
+					ps562.OverlayValues[153] = d153
+					ps562.OverlayValues[154] = d154
+					ps562.OverlayValues[155] = d155
+					ps562.OverlayValues[156] = d156
+					ps562.OverlayValues[157] = d157
+					ps562.OverlayValues[158] = d158
+					ps562.OverlayValues[159] = d159
+					ps562.OverlayValues[160] = d160
+					ps562.OverlayValues[163] = d163
+					ps562.OverlayValues[164] = d164
+					ps562.OverlayValues[165] = d165
+					ps562.OverlayValues[166] = d166
+					ps562.OverlayValues[269] = d269
+					ps562.OverlayValues[270] = d270
+					ps562.OverlayValues[271] = d271
+					ps562.OverlayValues[272] = d272
+					ps562.OverlayValues[273] = d273
+					ps562.OverlayValues[274] = d274
+					ps562.OverlayValues[275] = d275
+					ps562.OverlayValues[276] = d276
+					ps562.OverlayValues[277] = d277
+					ps562.OverlayValues[278] = d278
+					ps562.OverlayValues[279] = d279
+					ps562.OverlayValues[280] = d280
+					ps562.OverlayValues[281] = d281
+					ps562.OverlayValues[282] = d282
+					ps562.OverlayValues[283] = d283
+					ps562.OverlayValues[284] = d284
+					ps562.OverlayValues[285] = d285
+					ps562.OverlayValues[286] = d286
+					ps562.OverlayValues[287] = d287
+					ps562.OverlayValues[289] = d289
+					ps562.OverlayValues[290] = d290
+					ps562.OverlayValues[291] = d291
+					ps562.OverlayValues[292] = d292
+					ps562.OverlayValues[293] = d293
+					ps562.OverlayValues[294] = d294
+					ps562.OverlayValues[295] = d295
+					ps562.OverlayValues[296] = d296
+					ps562.OverlayValues[298] = d298
+					ps562.OverlayValues[299] = d299
+					ps562.OverlayValues[300] = d300
+					ps562.OverlayValues[465] = d465
+					ps562.OverlayValues[466] = d466
+					ps562.OverlayValues[467] = d467
+					ps562.OverlayValues[468] = d468
+					ps562.OverlayValues[469] = d469
+					ps562.OverlayValues[472] = d472
+					ps562.OverlayValues[473] = d473
+					snap563 := d8
+					snap564 := d9
+					snap565 := d10
+					snap566 := d11
+					snap567 := d12
+					snap568 := d13
+					snap569 := d14
+					snap570 := d15
+					snap571 := d16
+					snap572 := d17
+					snap573 := d18
+					snap574 := d19
+					snap575 := d20
+					snap576 := d21
+					snap577 := d22
+					snap578 := d25
+					snap579 := d45
+					snap580 := d64
+					snap581 := d65
+					snap582 := d66
+					snap583 := d67
+					snap584 := d68
+					snap585 := d70
+					snap586 := d71
+					snap587 := d72
+					snap588 := d73
+					snap589 := d74
+					snap590 := d75
+					snap591 := d76
+					snap592 := d79
+					snap593 := d145
+					snap594 := d146
+					snap595 := d147
+					snap596 := d148
+					snap597 := d149
+					snap598 := d150
+					snap599 := d152
+					snap600 := d153
+					snap601 := d154
+					snap602 := d155
+					snap603 := d156
+					snap604 := d157
+					snap605 := d158
+					snap606 := d159
+					snap607 := d160
+					snap608 := d163
+					snap609 := d164
+					snap610 := d165
+					snap611 := d166
+					snap612 := d269
+					snap613 := d270
+					snap614 := d271
+					snap615 := d272
+					snap616 := d273
+					snap617 := d274
+					snap618 := d275
+					snap619 := d276
+					snap620 := d277
+					snap621 := d278
+					snap622 := d279
+					snap623 := d280
+					snap624 := d281
+					snap625 := d282
+					snap626 := d283
+					snap627 := d284
+					snap628 := d285
+					snap629 := d286
+					snap630 := d287
+					snap631 := d289
+					snap632 := d290
+					snap633 := d291
+					snap634 := d292
+					snap635 := d293
+					snap636 := d294
+					snap637 := d295
+					snap638 := d296
+					snap639 := d298
+					snap640 := d299
+					snap641 := d300
+					snap642 := d465
+					snap643 := d466
+					snap644 := d467
+					snap645 := d468
+					snap646 := d469
+					snap647 := d472
+					snap648 := d473
+					alloc649 := ctx.SnapshotAllocState()
 					if !bbs[12].Rendered {
-						bbs[12].RenderPS(ps523)
+						bbs[12].RenderPS(ps562)
 					}
-					ctx.RestoreAllocState(alloc602)
-					d1 = snap524
-					d2 = snap525
-					d3 = snap526
-					d4 = snap527
-					d5 = snap528
-					d6 = snap529
-					d7 = snap530
-					d8 = snap531
-					d9 = snap532
-					d10 = snap533
-					d11 = snap534
-					d12 = snap535
-					d13 = snap536
-					d14 = snap537
-					d15 = snap538
-					d18 = snap539
-					d38 = snap540
-					d57 = snap541
-					d58 = snap542
-					d59 = snap543
-					d60 = snap544
-					d61 = snap545
-					d63 = snap546
-					d64 = snap547
-					d65 = snap548
-					d66 = snap549
-					d67 = snap550
-					d68 = snap551
-					d69 = snap552
-					d72 = snap553
-					d138 = snap554
-					d139 = snap555
-					d140 = snap556
-					d141 = snap557
-					d142 = snap558
-					d143 = snap559
-					d145 = snap560
-					d146 = snap561
-					d147 = snap562
-					d148 = snap563
-					d149 = snap564
-					d150 = snap565
-					d151 = snap566
-					d152 = snap567
-					d153 = snap568
-					d156 = snap569
-					d157 = snap570
-					d158 = snap571
-					d159 = snap572
-					d262 = snap573
-					d263 = snap574
-					d264 = snap575
-					d265 = snap576
-					d266 = snap577
-					d267 = snap578
-					d268 = snap579
-					d269 = snap580
-					d270 = snap581
-					d271 = snap582
-					d272 = snap583
-					d273 = snap584
-					d274 = snap585
-					d275 = snap586
-					d276 = snap587
-					d278 = snap588
-					d279 = snap589
-					d280 = snap590
-					d281 = snap591
-					d283 = snap592
-					d284 = snap593
-					d285 = snap594
-					d434 = snap595
-					d435 = snap596
-					d436 = snap597
-					d437 = snap598
-					d438 = snap599
-					d441 = snap600
-					d442 = snap601
+					ctx.RestoreAllocState(alloc649)
+					d8 = snap563
+					d9 = snap564
+					d10 = snap565
+					d11 = snap566
+					d12 = snap567
+					d13 = snap568
+					d14 = snap569
+					d15 = snap570
+					d16 = snap571
+					d17 = snap572
+					d18 = snap573
+					d19 = snap574
+					d20 = snap575
+					d21 = snap576
+					d22 = snap577
+					d25 = snap578
+					d45 = snap579
+					d64 = snap580
+					d65 = snap581
+					d66 = snap582
+					d67 = snap583
+					d68 = snap584
+					d70 = snap585
+					d71 = snap586
+					d72 = snap587
+					d73 = snap588
+					d74 = snap589
+					d75 = snap590
+					d76 = snap591
+					d79 = snap592
+					d145 = snap593
+					d146 = snap594
+					d147 = snap595
+					d148 = snap596
+					d149 = snap597
+					d150 = snap598
+					d152 = snap599
+					d153 = snap600
+					d154 = snap601
+					d155 = snap602
+					d156 = snap603
+					d157 = snap604
+					d158 = snap605
+					d159 = snap606
+					d160 = snap607
+					d163 = snap608
+					d164 = snap609
+					d165 = snap610
+					d166 = snap611
+					d269 = snap612
+					d270 = snap613
+					d271 = snap614
+					d272 = snap615
+					d273 = snap616
+					d274 = snap617
+					d275 = snap618
+					d276 = snap619
+					d277 = snap620
+					d278 = snap621
+					d279 = snap622
+					d280 = snap623
+					d281 = snap624
+					d282 = snap625
+					d283 = snap626
+					d284 = snap627
+					d285 = snap628
+					d286 = snap629
+					d287 = snap630
+					d289 = snap631
+					d290 = snap632
+					d291 = snap633
+					d292 = snap634
+					d293 = snap635
+					d294 = snap636
+					d295 = snap637
+					d296 = snap638
+					d298 = snap639
+					d299 = snap640
+					d300 = snap641
+					d465 = snap642
+					d466 = snap643
+					d467 = snap644
+					d468 = snap645
+					d469 = snap646
+					d472 = snap647
+					d473 = snap648
 					if !bbs[13].Rendered {
-						return bbs[13].RenderPS(ps522)
+						return bbs[13].RenderPS(ps561)
 					}
 					return result
 					return result
@@ -5554,82 +6084,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl12)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -5646,29 +6182,29 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
 						d145 = ps.OverlayValues[145]
@@ -5688,14 +6224,17 @@ func init_vector() {
 					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
 						d150 = ps.OverlayValues[150]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
-					}
 					if len(ps.OverlayValues) > 152 && ps.OverlayValues[152].Loc != LocNone {
 						d152 = ps.OverlayValues[152]
 					}
 					if len(ps.OverlayValues) > 153 && ps.OverlayValues[153].Loc != LocNone {
 						d153 = ps.OverlayValues[153]
+					}
+					if len(ps.OverlayValues) > 154 && ps.OverlayValues[154].Loc != LocNone {
+						d154 = ps.OverlayValues[154]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
 					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
 						d156 = ps.OverlayValues[156]
@@ -5709,26 +6248,20 @@ func init_vector() {
 					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
 						d159 = ps.OverlayValues[159]
 					}
-					if len(ps.OverlayValues) > 262 && ps.OverlayValues[262].Loc != LocNone {
-						d262 = ps.OverlayValues[262]
+					if len(ps.OverlayValues) > 160 && ps.OverlayValues[160].Loc != LocNone {
+						d160 = ps.OverlayValues[160]
 					}
-					if len(ps.OverlayValues) > 263 && ps.OverlayValues[263].Loc != LocNone {
-						d263 = ps.OverlayValues[263]
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
 					}
-					if len(ps.OverlayValues) > 264 && ps.OverlayValues[264].Loc != LocNone {
-						d264 = ps.OverlayValues[264]
+					if len(ps.OverlayValues) > 164 && ps.OverlayValues[164].Loc != LocNone {
+						d164 = ps.OverlayValues[164]
 					}
-					if len(ps.OverlayValues) > 265 && ps.OverlayValues[265].Loc != LocNone {
-						d265 = ps.OverlayValues[265]
+					if len(ps.OverlayValues) > 165 && ps.OverlayValues[165].Loc != LocNone {
+						d165 = ps.OverlayValues[165]
 					}
-					if len(ps.OverlayValues) > 266 && ps.OverlayValues[266].Loc != LocNone {
-						d266 = ps.OverlayValues[266]
-					}
-					if len(ps.OverlayValues) > 267 && ps.OverlayValues[267].Loc != LocNone {
-						d267 = ps.OverlayValues[267]
-					}
-					if len(ps.OverlayValues) > 268 && ps.OverlayValues[268].Loc != LocNone {
-						d268 = ps.OverlayValues[268]
+					if len(ps.OverlayValues) > 166 && ps.OverlayValues[166].Loc != LocNone {
+						d166 = ps.OverlayValues[166]
 					}
 					if len(ps.OverlayValues) > 269 && ps.OverlayValues[269].Loc != LocNone {
 						d269 = ps.OverlayValues[269]
@@ -5754,6 +6287,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
 						d276 = ps.OverlayValues[276]
 					}
+					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
+						d277 = ps.OverlayValues[277]
+					}
 					if len(ps.OverlayValues) > 278 && ps.OverlayValues[278].Loc != LocNone {
 						d278 = ps.OverlayValues[278]
 					}
@@ -5766,6 +6302,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 281 && ps.OverlayValues[281].Loc != LocNone {
 						d281 = ps.OverlayValues[281]
 					}
+					if len(ps.OverlayValues) > 282 && ps.OverlayValues[282].Loc != LocNone {
+						d282 = ps.OverlayValues[282]
+					}
 					if len(ps.OverlayValues) > 283 && ps.OverlayValues[283].Loc != LocNone {
 						d283 = ps.OverlayValues[283]
 					}
@@ -5775,40 +6314,79 @@ func init_vector() {
 					if len(ps.OverlayValues) > 285 && ps.OverlayValues[285].Loc != LocNone {
 						d285 = ps.OverlayValues[285]
 					}
-					if len(ps.OverlayValues) > 434 && ps.OverlayValues[434].Loc != LocNone {
-						d434 = ps.OverlayValues[434]
+					if len(ps.OverlayValues) > 286 && ps.OverlayValues[286].Loc != LocNone {
+						d286 = ps.OverlayValues[286]
 					}
-					if len(ps.OverlayValues) > 435 && ps.OverlayValues[435].Loc != LocNone {
-						d435 = ps.OverlayValues[435]
+					if len(ps.OverlayValues) > 287 && ps.OverlayValues[287].Loc != LocNone {
+						d287 = ps.OverlayValues[287]
 					}
-					if len(ps.OverlayValues) > 436 && ps.OverlayValues[436].Loc != LocNone {
-						d436 = ps.OverlayValues[436]
+					if len(ps.OverlayValues) > 289 && ps.OverlayValues[289].Loc != LocNone {
+						d289 = ps.OverlayValues[289]
 					}
-					if len(ps.OverlayValues) > 437 && ps.OverlayValues[437].Loc != LocNone {
-						d437 = ps.OverlayValues[437]
+					if len(ps.OverlayValues) > 290 && ps.OverlayValues[290].Loc != LocNone {
+						d290 = ps.OverlayValues[290]
 					}
-					if len(ps.OverlayValues) > 438 && ps.OverlayValues[438].Loc != LocNone {
-						d438 = ps.OverlayValues[438]
+					if len(ps.OverlayValues) > 291 && ps.OverlayValues[291].Loc != LocNone {
+						d291 = ps.OverlayValues[291]
 					}
-					if len(ps.OverlayValues) > 441 && ps.OverlayValues[441].Loc != LocNone {
-						d441 = ps.OverlayValues[441]
+					if len(ps.OverlayValues) > 292 && ps.OverlayValues[292].Loc != LocNone {
+						d292 = ps.OverlayValues[292]
 					}
-					if len(ps.OverlayValues) > 442 && ps.OverlayValues[442].Loc != LocNone {
-						d442 = ps.OverlayValues[442]
+					if len(ps.OverlayValues) > 293 && ps.OverlayValues[293].Loc != LocNone {
+						d293 = ps.OverlayValues[293]
+					}
+					if len(ps.OverlayValues) > 294 && ps.OverlayValues[294].Loc != LocNone {
+						d294 = ps.OverlayValues[294]
+					}
+					if len(ps.OverlayValues) > 295 && ps.OverlayValues[295].Loc != LocNone {
+						d295 = ps.OverlayValues[295]
+					}
+					if len(ps.OverlayValues) > 296 && ps.OverlayValues[296].Loc != LocNone {
+						d296 = ps.OverlayValues[296]
+					}
+					if len(ps.OverlayValues) > 298 && ps.OverlayValues[298].Loc != LocNone {
+						d298 = ps.OverlayValues[298]
+					}
+					if len(ps.OverlayValues) > 299 && ps.OverlayValues[299].Loc != LocNone {
+						d299 = ps.OverlayValues[299]
+					}
+					if len(ps.OverlayValues) > 300 && ps.OverlayValues[300].Loc != LocNone {
+						d300 = ps.OverlayValues[300]
+					}
+					if len(ps.OverlayValues) > 465 && ps.OverlayValues[465].Loc != LocNone {
+						d465 = ps.OverlayValues[465]
+					}
+					if len(ps.OverlayValues) > 466 && ps.OverlayValues[466].Loc != LocNone {
+						d466 = ps.OverlayValues[466]
+					}
+					if len(ps.OverlayValues) > 467 && ps.OverlayValues[467].Loc != LocNone {
+						d467 = ps.OverlayValues[467]
+					}
+					if len(ps.OverlayValues) > 468 && ps.OverlayValues[468].Loc != LocNone {
+						d468 = ps.OverlayValues[468]
+					}
+					if len(ps.OverlayValues) > 469 && ps.OverlayValues[469].Loc != LocNone {
+						d469 = ps.OverlayValues[469]
+					}
+					if len(ps.OverlayValues) > 472 && ps.OverlayValues[472].Loc != LocNone {
+						d472 = ps.OverlayValues[472]
+					}
+					if len(ps.OverlayValues) > 473 && ps.OverlayValues[473].Loc != LocNone {
+						d473 = ps.OverlayValues[473]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d8)
-					d604 = ctx.EmitSliceElementAddress(&d10, &d8, 16)
-					ctx.EnsureDesc(&d604)
-					r19 := ctx.AllocRegExcept(d604.Reg)
-					ctx.EmitMovRegMem(r19, d604.Reg, 8)
-					ctx.EmitMovRegMem(d604.Reg, d604.Reg, 0)
-					d603 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d604.Reg, Reg2: r19}
-					ctx.BindReg(d604.Reg, &d603)
-					ctx.BindReg(r19, &d603)
-					ctx.EnsureDesc(&d603)
-					d605 = d603
-					_ = d605
+					ctx.EnsureDesc(&d15)
+					d651 = ctx.EmitSliceElementAddress(&d17, &d15, 16)
+					ctx.EnsureDesc(&d651)
+					r18 := ctx.AllocRegExcept(d651.Reg)
+					ctx.EmitMovRegMem(r18, d651.Reg, 8)
+					ctx.EmitMovRegMem(d651.Reg, d651.Reg, 0)
+					d650 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d651.Reg, Reg2: r18}
+					ctx.BindReg(d651.Reg, &d650)
+					ctx.BindReg(r18, &d650)
+					ctx.EnsureDesc(&d650)
+					d652 = d650
+					_ = d652
 					bbpos_3_0 := int32(-1)
 					_ = bbpos_3_0
 					lbl19 := ctx.ReserveLabel()
@@ -5818,38 +6396,38 @@ func init_vector() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					var d606 JITValueDesc
-					if d605.Loc == LocImm {
-						d606 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d605.Imm.Float())}
-					} else if d605.Type == tagFloat && d605.Loc == LocReg {
-						d606 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d605.Reg}
-						ctx.BindReg(d605.Reg, &d606)
-						ctx.BindReg(d605.Reg, &d606)
-					} else if d605.Type == tagFloat && d605.Loc == LocRegPair {
-						ctx.FreeReg(d605.Reg)
-						d606 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d605.Reg2}
-						ctx.BindReg(d605.Reg2, &d606)
-						ctx.BindReg(d605.Reg2, &d606)
+					var d653 JITValueDesc
+					if d652.Loc == LocImm {
+						d653 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d652.Imm.Float())}
+					} else if d652.Type == tagFloat && d652.Loc == LocReg {
+						d653 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d652.Reg}
+						ctx.BindReg(d652.Reg, &d653)
+						ctx.BindReg(d652.Reg, &d653)
+					} else if d652.Type == tagFloat && d652.Loc == LocRegPair {
+						ctx.FreeReg(d652.Reg)
+						d653 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d652.Reg2}
+						ctx.BindReg(d652.Reg2, &d653)
+						ctx.BindReg(d652.Reg2, &d653)
 					} else {
-						d606 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d605}, 1)
-						d606.Type = tagFloat
-						ctx.BindReg(d606.Reg, &d606)
+						d653 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d652}, 1)
+						d653.Type = tagFloat
+						ctx.BindReg(d653.Reg, &d653)
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d606)
-					ctx.FreeDesc(&d603)
-					ctx.EnsureDesc(&d8)
-					d608 = ctx.EmitSliceElementAddress(&d12, &d8, 16)
-					ctx.EnsureDesc(&d608)
-					r20 := ctx.AllocRegExcept(d608.Reg)
-					ctx.EmitMovRegMem(r20, d608.Reg, 8)
-					ctx.EmitMovRegMem(d608.Reg, d608.Reg, 0)
-					d607 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d608.Reg, Reg2: r20}
-					ctx.BindReg(d608.Reg, &d607)
-					ctx.BindReg(r20, &d607)
-					ctx.EnsureDesc(&d607)
-					d609 = d607
-					_ = d609
+					ctx.EnsureDesc(&d653)
+					ctx.FreeDesc(&d650)
+					ctx.EnsureDesc(&d15)
+					d655 = ctx.EmitSliceElementAddress(&d19, &d15, 16)
+					ctx.EnsureDesc(&d655)
+					r19 := ctx.AllocRegExcept(d655.Reg)
+					ctx.EmitMovRegMem(r19, d655.Reg, 8)
+					ctx.EmitMovRegMem(d655.Reg, d655.Reg, 0)
+					d654 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d655.Reg, Reg2: r19}
+					ctx.BindReg(d655.Reg, &d654)
+					ctx.BindReg(r19, &d654)
+					ctx.EnsureDesc(&d654)
+					d656 = d654
+					_ = d656
 					bbpos_4_0 := int32(-1)
 					_ = bbpos_4_0
 					lbl20 := ctx.ReserveLabel()
@@ -5859,210 +6437,215 @@ func init_vector() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					var d610 JITValueDesc
-					if d609.Loc == LocImm {
-						d610 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d609.Imm.Float())}
-					} else if d609.Type == tagFloat && d609.Loc == LocReg {
-						d610 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d609.Reg}
-						ctx.BindReg(d609.Reg, &d610)
-						ctx.BindReg(d609.Reg, &d610)
-					} else if d609.Type == tagFloat && d609.Loc == LocRegPair {
-						ctx.FreeReg(d609.Reg)
-						d610 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d609.Reg2}
-						ctx.BindReg(d609.Reg2, &d610)
-						ctx.BindReg(d609.Reg2, &d610)
+					var d657 JITValueDesc
+					if d656.Loc == LocImm {
+						d657 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d656.Imm.Float())}
+					} else if d656.Type == tagFloat && d656.Loc == LocReg {
+						d657 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d656.Reg}
+						ctx.BindReg(d656.Reg, &d657)
+						ctx.BindReg(d656.Reg, &d657)
+					} else if d656.Type == tagFloat && d656.Loc == LocRegPair {
+						ctx.FreeReg(d656.Reg)
+						d657 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d656.Reg2}
+						ctx.BindReg(d656.Reg2, &d657)
+						ctx.BindReg(d656.Reg2, &d657)
 					} else {
-						d610 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d609}, 1)
-						d610.Type = tagFloat
-						ctx.BindReg(d610.Reg, &d610)
+						d657 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d656}, 1)
+						d657.Type = tagFloat
+						ctx.BindReg(d657.Reg, &d657)
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d610)
-					ctx.FreeDesc(&d607)
-					ctx.EnsureDesc(&d606)
-					ctx.EnsureDesc(&d610)
-					ctx.EnsureDescsTogether(&d606, &d610)
-					var d611 JITValueDesc
-					if d606.Loc == LocImm && d610.Loc == LocImm {
-						d611 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d606.Imm.Float() * d610.Imm.Float())}
-					} else if d606.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d610.Reg)
-						_, xBits := d606.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitMulFloat64(scratch, d610.Reg)
-						d611 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d611)
-					} else if d610.Loc == LocImm {
-						_, yBits := d610.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitMulFloat64(d606.Reg, RegR11)
-						d611 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d606.Reg}
-						ctx.BindReg(d606.Reg, &d611)
+					ctx.EnsureDesc(&d657)
+					ctx.FreeDesc(&d654)
+					ctx.EnsureDesc(&d653)
+					ctx.EnsureDesc(&d657)
+					d658 = ctx.EmitFloatBinary(&d653, &d657, JITFloatMul)
+					ctx.FreeDesc(&d653)
+					ctx.FreeDesc(&d657)
+					ctx.EnsureDesc(&d14)
+					ctx.EnsureDesc(&d658)
+					d659 = ctx.EmitFloatBinary(&d14, &d658, JITFloatAdd)
+					ctx.FreeDesc(&d658)
+					ctx.EnsureDesc(&d15)
+					ctx.EnsureDesc(&d15)
+					var d660 JITValueDesc
+					if d15.Loc == LocImm {
+						d660 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d15.Imm.Int() + 1)}
 					} else {
-						ctx.EmitMulFloat64(d606.Reg, d610.Reg)
-						d611 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d606.Reg}
-						ctx.BindReg(d606.Reg, &d611)
-					}
-					if d611.Loc == LocReg && d606.Loc == LocReg && d611.Reg == d606.Reg {
-						ctx.TransferReg(d606.Reg)
-						d606.Loc = LocNone
-					}
-					ctx.FreeDesc(&d606)
-					ctx.FreeDesc(&d610)
-					ctx.EnsureDesc(&d7)
-					ctx.EnsureDesc(&d611)
-					ctx.EnsureDescsTogether(&d7, &d611)
-					var d612 JITValueDesc
-					if d7.Loc == LocImm && d611.Loc == LocImm {
-						d612 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d7.Imm.Float() + d611.Imm.Float())}
-					} else if d7.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d611.Reg)
-						_, xBits := d7.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitAddFloat64(scratch, d611.Reg)
-						d612 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d612)
-					} else if d611.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d7.Reg)
-						ctx.EmitMovRegReg(scratch, d7.Reg)
-						_, yBits := d611.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitAddFloat64(scratch, RegR11)
-						d612 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d612)
-					} else {
-						r21 := ctx.AllocRegExcept(d7.Reg, d611.Reg)
-						ctx.EmitMovRegReg(r21, d7.Reg)
-						ctx.EmitAddFloat64(r21, d611.Reg)
-						d612 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r21}
-						ctx.BindReg(r21, &d612)
-					}
-					if d612.Loc == LocReg && d7.Loc == LocReg && d612.Reg == d7.Reg {
-						ctx.TransferReg(d7.Reg)
-						d7.Loc = LocNone
-					}
-					ctx.EnsureDesc(&d612)
-					ctx.EmitStoreToStack(d612, int32(bbs[10].PhiBase)+int32(0))
-					ctx.StabilizeDescForControlFlow(&d612)
-					ctx.FreeDesc(&d611)
-					ctx.EnsureDesc(&d8)
-					ctx.EnsureDesc(&d8)
-					var d613 JITValueDesc
-					if d8.Loc == LocImm {
-						d613 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d8.Imm.Int() + 1)}
-					} else {
-						scratch := ctx.AllocRegExcept(d8.Reg)
-						ctx.EmitMovRegReg(scratch, d8.Reg)
+						var scratch Reg
+						if phiHomeOK7 {
+							scratch = r5
+						} else {
+							scratch = ctx.AllocRegExcept(d15.Reg)
+						}
+						ctx.EmitMovRegReg(scratch, d15.Reg)
 						ctx.EmitAddRegImm32(scratch, int32(1))
-						d613 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-						ctx.BindReg(scratch, &d613)
+						d660 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d660)
 					}
-					if d613.Loc == LocReg && d8.Loc == LocReg && d613.Reg == d8.Reg {
-						ctx.TransferReg(d8.Reg)
-						d8.Loc = LocNone
+					if d660.Loc == LocReg && d15.Loc == LocReg && d660.Reg == d15.Reg {
+						ctx.TransferReg(d15.Reg)
+						d15.Loc = LocNone
 					}
-					ctx.EnsureDesc(&d613)
-					ctx.EmitStoreToStack(d613, int32(bbs[10].PhiBase)+int32(16))
-					ctx.StabilizeDescForControlFlow(&d613)
 					if ps.General {
+						ctx.SyncDesc(&d659)
+						if d659.Loc == LocReg || d659.Loc == LocFPReg {
+							ctx.ProtectReg(d659.Reg)
+						} else if d659.Loc == LocRegPair {
+							ctx.ProtectReg(d659.Reg)
+							ctx.ProtectReg(d659.Reg2)
+						}
+						ctx.SyncDesc(&d660)
+						if d660.Loc == LocReg || d660.Loc == LocFPReg {
+							ctx.ProtectReg(d660.Reg)
+						} else if d660.Loc == LocRegPair {
+							ctx.ProtectReg(d660.Reg)
+							ctx.ProtectReg(d660.Reg2)
+						}
+						d661 = d659
+						if d661.Loc == LocNone {
+							panic("jit: phi source has no location")
+						}
+						ctx.EnsureDesc(&d661)
+						if phiHomeOK6 {
+							ctx.EmitMovToReg(r4, d661)
+						} else {
+							ctx.EmitStoreToStack(d661, int32(bbs[10].PhiBase)+int32(0))
+						}
+						d662 = d660
+						if d662.Loc == LocNone {
+							panic("jit: phi source has no location")
+						}
+						ctx.EnsureDesc(&d662)
+						if phiHomeOK7 {
+							ctx.EmitMovToReg(r5, d662)
+						} else {
+							ctx.EmitStoreToStack(d662, int32(bbs[10].PhiBase)+int32(16))
+						}
+						if d659.Loc == LocReg || d659.Loc == LocFPReg {
+							ctx.UnprotectReg(d659.Reg)
+						} else if d659.Loc == LocRegPair {
+							ctx.UnprotectReg(d659.Reg)
+							ctx.UnprotectReg(d659.Reg2)
+						}
+						if d660.Loc == LocReg || d660.Loc == LocFPReg {
+							ctx.UnprotectReg(d660.Reg)
+						} else if d660.Loc == LocRegPair {
+							ctx.UnprotectReg(d660.Reg)
+							ctx.UnprotectReg(d660.Reg2)
+						}
 					}
-					ps614 := PhiState{General: ps.General}
-					ps614.OverlayValues = make([]JITValueDesc, 614)
-					ps614.OverlayValues[1] = d1
-					ps614.OverlayValues[2] = d2
-					ps614.OverlayValues[3] = d3
-					ps614.OverlayValues[4] = d4
-					ps614.OverlayValues[5] = d5
-					ps614.OverlayValues[6] = d6
-					ps614.OverlayValues[7] = d7
-					ps614.OverlayValues[8] = d8
-					ps614.OverlayValues[9] = d9
-					ps614.OverlayValues[10] = d10
-					ps614.OverlayValues[11] = d11
-					ps614.OverlayValues[12] = d12
-					ps614.OverlayValues[13] = d13
-					ps614.OverlayValues[14] = d14
-					ps614.OverlayValues[15] = d15
-					ps614.OverlayValues[18] = d18
-					ps614.OverlayValues[38] = d38
-					ps614.OverlayValues[57] = d57
-					ps614.OverlayValues[58] = d58
-					ps614.OverlayValues[59] = d59
-					ps614.OverlayValues[60] = d60
-					ps614.OverlayValues[61] = d61
-					ps614.OverlayValues[63] = d63
-					ps614.OverlayValues[64] = d64
-					ps614.OverlayValues[65] = d65
-					ps614.OverlayValues[66] = d66
-					ps614.OverlayValues[67] = d67
-					ps614.OverlayValues[68] = d68
-					ps614.OverlayValues[69] = d69
-					ps614.OverlayValues[72] = d72
-					ps614.OverlayValues[138] = d138
-					ps614.OverlayValues[139] = d139
-					ps614.OverlayValues[140] = d140
-					ps614.OverlayValues[141] = d141
-					ps614.OverlayValues[142] = d142
-					ps614.OverlayValues[143] = d143
-					ps614.OverlayValues[145] = d145
-					ps614.OverlayValues[146] = d146
-					ps614.OverlayValues[147] = d147
-					ps614.OverlayValues[148] = d148
-					ps614.OverlayValues[149] = d149
-					ps614.OverlayValues[150] = d150
-					ps614.OverlayValues[151] = d151
-					ps614.OverlayValues[152] = d152
-					ps614.OverlayValues[153] = d153
-					ps614.OverlayValues[156] = d156
-					ps614.OverlayValues[157] = d157
-					ps614.OverlayValues[158] = d158
-					ps614.OverlayValues[159] = d159
-					ps614.OverlayValues[262] = d262
-					ps614.OverlayValues[263] = d263
-					ps614.OverlayValues[264] = d264
-					ps614.OverlayValues[265] = d265
-					ps614.OverlayValues[266] = d266
-					ps614.OverlayValues[267] = d267
-					ps614.OverlayValues[268] = d268
-					ps614.OverlayValues[269] = d269
-					ps614.OverlayValues[270] = d270
-					ps614.OverlayValues[271] = d271
-					ps614.OverlayValues[272] = d272
-					ps614.OverlayValues[273] = d273
-					ps614.OverlayValues[274] = d274
-					ps614.OverlayValues[275] = d275
-					ps614.OverlayValues[276] = d276
-					ps614.OverlayValues[278] = d278
-					ps614.OverlayValues[279] = d279
-					ps614.OverlayValues[280] = d280
-					ps614.OverlayValues[281] = d281
-					ps614.OverlayValues[283] = d283
-					ps614.OverlayValues[284] = d284
-					ps614.OverlayValues[285] = d285
-					ps614.OverlayValues[434] = d434
-					ps614.OverlayValues[435] = d435
-					ps614.OverlayValues[436] = d436
-					ps614.OverlayValues[437] = d437
-					ps614.OverlayValues[438] = d438
-					ps614.OverlayValues[441] = d441
-					ps614.OverlayValues[442] = d442
-					ps614.OverlayValues[603] = d603
-					ps614.OverlayValues[604] = d604
-					ps614.OverlayValues[605] = d605
-					ps614.OverlayValues[606] = d606
-					ps614.OverlayValues[607] = d607
-					ps614.OverlayValues[608] = d608
-					ps614.OverlayValues[609] = d609
-					ps614.OverlayValues[610] = d610
-					ps614.OverlayValues[611] = d611
-					ps614.OverlayValues[612] = d612
-					ps614.OverlayValues[613] = d613
-					ps614.PhiValues = make([]JITValueDesc, 2)
-					if ps614.General && bbs[10].Rendered {
+					ps663 := PhiState{General: ps.General}
+					ps663.OverlayValues = make([]JITValueDesc, 663)
+					ps663.OverlayValues[8] = d8
+					ps663.OverlayValues[9] = d9
+					ps663.OverlayValues[10] = d10
+					ps663.OverlayValues[11] = d11
+					ps663.OverlayValues[12] = d12
+					ps663.OverlayValues[13] = d13
+					ps663.OverlayValues[14] = d14
+					ps663.OverlayValues[15] = d15
+					ps663.OverlayValues[16] = d16
+					ps663.OverlayValues[17] = d17
+					ps663.OverlayValues[18] = d18
+					ps663.OverlayValues[19] = d19
+					ps663.OverlayValues[20] = d20
+					ps663.OverlayValues[21] = d21
+					ps663.OverlayValues[22] = d22
+					ps663.OverlayValues[25] = d25
+					ps663.OverlayValues[45] = d45
+					ps663.OverlayValues[64] = d64
+					ps663.OverlayValues[65] = d65
+					ps663.OverlayValues[66] = d66
+					ps663.OverlayValues[67] = d67
+					ps663.OverlayValues[68] = d68
+					ps663.OverlayValues[70] = d70
+					ps663.OverlayValues[71] = d71
+					ps663.OverlayValues[72] = d72
+					ps663.OverlayValues[73] = d73
+					ps663.OverlayValues[74] = d74
+					ps663.OverlayValues[75] = d75
+					ps663.OverlayValues[76] = d76
+					ps663.OverlayValues[79] = d79
+					ps663.OverlayValues[145] = d145
+					ps663.OverlayValues[146] = d146
+					ps663.OverlayValues[147] = d147
+					ps663.OverlayValues[148] = d148
+					ps663.OverlayValues[149] = d149
+					ps663.OverlayValues[150] = d150
+					ps663.OverlayValues[152] = d152
+					ps663.OverlayValues[153] = d153
+					ps663.OverlayValues[154] = d154
+					ps663.OverlayValues[155] = d155
+					ps663.OverlayValues[156] = d156
+					ps663.OverlayValues[157] = d157
+					ps663.OverlayValues[158] = d158
+					ps663.OverlayValues[159] = d159
+					ps663.OverlayValues[160] = d160
+					ps663.OverlayValues[163] = d163
+					ps663.OverlayValues[164] = d164
+					ps663.OverlayValues[165] = d165
+					ps663.OverlayValues[166] = d166
+					ps663.OverlayValues[269] = d269
+					ps663.OverlayValues[270] = d270
+					ps663.OverlayValues[271] = d271
+					ps663.OverlayValues[272] = d272
+					ps663.OverlayValues[273] = d273
+					ps663.OverlayValues[274] = d274
+					ps663.OverlayValues[275] = d275
+					ps663.OverlayValues[276] = d276
+					ps663.OverlayValues[277] = d277
+					ps663.OverlayValues[278] = d278
+					ps663.OverlayValues[279] = d279
+					ps663.OverlayValues[280] = d280
+					ps663.OverlayValues[281] = d281
+					ps663.OverlayValues[282] = d282
+					ps663.OverlayValues[283] = d283
+					ps663.OverlayValues[284] = d284
+					ps663.OverlayValues[285] = d285
+					ps663.OverlayValues[286] = d286
+					ps663.OverlayValues[287] = d287
+					ps663.OverlayValues[289] = d289
+					ps663.OverlayValues[290] = d290
+					ps663.OverlayValues[291] = d291
+					ps663.OverlayValues[292] = d292
+					ps663.OverlayValues[293] = d293
+					ps663.OverlayValues[294] = d294
+					ps663.OverlayValues[295] = d295
+					ps663.OverlayValues[296] = d296
+					ps663.OverlayValues[298] = d298
+					ps663.OverlayValues[299] = d299
+					ps663.OverlayValues[300] = d300
+					ps663.OverlayValues[465] = d465
+					ps663.OverlayValues[466] = d466
+					ps663.OverlayValues[467] = d467
+					ps663.OverlayValues[468] = d468
+					ps663.OverlayValues[469] = d469
+					ps663.OverlayValues[472] = d472
+					ps663.OverlayValues[473] = d473
+					ps663.OverlayValues[650] = d650
+					ps663.OverlayValues[651] = d651
+					ps663.OverlayValues[652] = d652
+					ps663.OverlayValues[653] = d653
+					ps663.OverlayValues[654] = d654
+					ps663.OverlayValues[655] = d655
+					ps663.OverlayValues[656] = d656
+					ps663.OverlayValues[657] = d657
+					ps663.OverlayValues[658] = d658
+					ps663.OverlayValues[659] = d659
+					ps663.OverlayValues[660] = d660
+					ps663.OverlayValues[661] = d661
+					ps663.OverlayValues[662] = d662
+					ps663.PhiValues = make([]JITValueDesc, 2)
+					d664 = d659
+					ps663.PhiValues[0] = d664
+					d665 = d660
+					ps663.PhiValues[1] = d665
+					if ps663.General && bbs[10].Rendered {
 						ctx.EmitJmp(lbl11)
 						return result
 					}
-					return bbs[10].RenderPS(ps614)
+					return bbs[10].RenderPS(ps663)
 					return result
 				}
 				bbs[12].RenderPS = func(ps PhiState) JITValueDesc {
@@ -6084,82 +6667,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl13)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -6176,29 +6765,29 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
 						d145 = ps.OverlayValues[145]
@@ -6218,14 +6807,17 @@ func init_vector() {
 					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
 						d150 = ps.OverlayValues[150]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
-					}
 					if len(ps.OverlayValues) > 152 && ps.OverlayValues[152].Loc != LocNone {
 						d152 = ps.OverlayValues[152]
 					}
 					if len(ps.OverlayValues) > 153 && ps.OverlayValues[153].Loc != LocNone {
 						d153 = ps.OverlayValues[153]
+					}
+					if len(ps.OverlayValues) > 154 && ps.OverlayValues[154].Loc != LocNone {
+						d154 = ps.OverlayValues[154]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
 					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
 						d156 = ps.OverlayValues[156]
@@ -6239,26 +6831,20 @@ func init_vector() {
 					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
 						d159 = ps.OverlayValues[159]
 					}
-					if len(ps.OverlayValues) > 262 && ps.OverlayValues[262].Loc != LocNone {
-						d262 = ps.OverlayValues[262]
+					if len(ps.OverlayValues) > 160 && ps.OverlayValues[160].Loc != LocNone {
+						d160 = ps.OverlayValues[160]
 					}
-					if len(ps.OverlayValues) > 263 && ps.OverlayValues[263].Loc != LocNone {
-						d263 = ps.OverlayValues[263]
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
 					}
-					if len(ps.OverlayValues) > 264 && ps.OverlayValues[264].Loc != LocNone {
-						d264 = ps.OverlayValues[264]
+					if len(ps.OverlayValues) > 164 && ps.OverlayValues[164].Loc != LocNone {
+						d164 = ps.OverlayValues[164]
 					}
-					if len(ps.OverlayValues) > 265 && ps.OverlayValues[265].Loc != LocNone {
-						d265 = ps.OverlayValues[265]
+					if len(ps.OverlayValues) > 165 && ps.OverlayValues[165].Loc != LocNone {
+						d165 = ps.OverlayValues[165]
 					}
-					if len(ps.OverlayValues) > 266 && ps.OverlayValues[266].Loc != LocNone {
-						d266 = ps.OverlayValues[266]
-					}
-					if len(ps.OverlayValues) > 267 && ps.OverlayValues[267].Loc != LocNone {
-						d267 = ps.OverlayValues[267]
-					}
-					if len(ps.OverlayValues) > 268 && ps.OverlayValues[268].Loc != LocNone {
-						d268 = ps.OverlayValues[268]
+					if len(ps.OverlayValues) > 166 && ps.OverlayValues[166].Loc != LocNone {
+						d166 = ps.OverlayValues[166]
 					}
 					if len(ps.OverlayValues) > 269 && ps.OverlayValues[269].Loc != LocNone {
 						d269 = ps.OverlayValues[269]
@@ -6284,6 +6870,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
 						d276 = ps.OverlayValues[276]
 					}
+					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
+						d277 = ps.OverlayValues[277]
+					}
 					if len(ps.OverlayValues) > 278 && ps.OverlayValues[278].Loc != LocNone {
 						d278 = ps.OverlayValues[278]
 					}
@@ -6296,6 +6885,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 281 && ps.OverlayValues[281].Loc != LocNone {
 						d281 = ps.OverlayValues[281]
 					}
+					if len(ps.OverlayValues) > 282 && ps.OverlayValues[282].Loc != LocNone {
+						d282 = ps.OverlayValues[282]
+					}
 					if len(ps.OverlayValues) > 283 && ps.OverlayValues[283].Loc != LocNone {
 						d283 = ps.OverlayValues[283]
 					}
@@ -6305,1048 +6897,1207 @@ func init_vector() {
 					if len(ps.OverlayValues) > 285 && ps.OverlayValues[285].Loc != LocNone {
 						d285 = ps.OverlayValues[285]
 					}
-					if len(ps.OverlayValues) > 434 && ps.OverlayValues[434].Loc != LocNone {
-						d434 = ps.OverlayValues[434]
+					if len(ps.OverlayValues) > 286 && ps.OverlayValues[286].Loc != LocNone {
+						d286 = ps.OverlayValues[286]
 					}
-					if len(ps.OverlayValues) > 435 && ps.OverlayValues[435].Loc != LocNone {
-						d435 = ps.OverlayValues[435]
+					if len(ps.OverlayValues) > 287 && ps.OverlayValues[287].Loc != LocNone {
+						d287 = ps.OverlayValues[287]
 					}
-					if len(ps.OverlayValues) > 436 && ps.OverlayValues[436].Loc != LocNone {
-						d436 = ps.OverlayValues[436]
+					if len(ps.OverlayValues) > 289 && ps.OverlayValues[289].Loc != LocNone {
+						d289 = ps.OverlayValues[289]
 					}
-					if len(ps.OverlayValues) > 437 && ps.OverlayValues[437].Loc != LocNone {
-						d437 = ps.OverlayValues[437]
+					if len(ps.OverlayValues) > 290 && ps.OverlayValues[290].Loc != LocNone {
+						d290 = ps.OverlayValues[290]
 					}
-					if len(ps.OverlayValues) > 438 && ps.OverlayValues[438].Loc != LocNone {
-						d438 = ps.OverlayValues[438]
+					if len(ps.OverlayValues) > 291 && ps.OverlayValues[291].Loc != LocNone {
+						d291 = ps.OverlayValues[291]
 					}
-					if len(ps.OverlayValues) > 441 && ps.OverlayValues[441].Loc != LocNone {
-						d441 = ps.OverlayValues[441]
+					if len(ps.OverlayValues) > 292 && ps.OverlayValues[292].Loc != LocNone {
+						d292 = ps.OverlayValues[292]
 					}
-					if len(ps.OverlayValues) > 442 && ps.OverlayValues[442].Loc != LocNone {
-						d442 = ps.OverlayValues[442]
+					if len(ps.OverlayValues) > 293 && ps.OverlayValues[293].Loc != LocNone {
+						d293 = ps.OverlayValues[293]
 					}
-					if len(ps.OverlayValues) > 603 && ps.OverlayValues[603].Loc != LocNone {
-						d603 = ps.OverlayValues[603]
+					if len(ps.OverlayValues) > 294 && ps.OverlayValues[294].Loc != LocNone {
+						d294 = ps.OverlayValues[294]
 					}
-					if len(ps.OverlayValues) > 604 && ps.OverlayValues[604].Loc != LocNone {
-						d604 = ps.OverlayValues[604]
+					if len(ps.OverlayValues) > 295 && ps.OverlayValues[295].Loc != LocNone {
+						d295 = ps.OverlayValues[295]
 					}
-					if len(ps.OverlayValues) > 605 && ps.OverlayValues[605].Loc != LocNone {
-						d605 = ps.OverlayValues[605]
+					if len(ps.OverlayValues) > 296 && ps.OverlayValues[296].Loc != LocNone {
+						d296 = ps.OverlayValues[296]
 					}
-					if len(ps.OverlayValues) > 606 && ps.OverlayValues[606].Loc != LocNone {
-						d606 = ps.OverlayValues[606]
+					if len(ps.OverlayValues) > 298 && ps.OverlayValues[298].Loc != LocNone {
+						d298 = ps.OverlayValues[298]
 					}
-					if len(ps.OverlayValues) > 607 && ps.OverlayValues[607].Loc != LocNone {
-						d607 = ps.OverlayValues[607]
+					if len(ps.OverlayValues) > 299 && ps.OverlayValues[299].Loc != LocNone {
+						d299 = ps.OverlayValues[299]
 					}
-					if len(ps.OverlayValues) > 608 && ps.OverlayValues[608].Loc != LocNone {
-						d608 = ps.OverlayValues[608]
+					if len(ps.OverlayValues) > 300 && ps.OverlayValues[300].Loc != LocNone {
+						d300 = ps.OverlayValues[300]
 					}
-					if len(ps.OverlayValues) > 609 && ps.OverlayValues[609].Loc != LocNone {
-						d609 = ps.OverlayValues[609]
+					if len(ps.OverlayValues) > 465 && ps.OverlayValues[465].Loc != LocNone {
+						d465 = ps.OverlayValues[465]
 					}
-					if len(ps.OverlayValues) > 610 && ps.OverlayValues[610].Loc != LocNone {
-						d610 = ps.OverlayValues[610]
+					if len(ps.OverlayValues) > 466 && ps.OverlayValues[466].Loc != LocNone {
+						d466 = ps.OverlayValues[466]
 					}
-					if len(ps.OverlayValues) > 611 && ps.OverlayValues[611].Loc != LocNone {
-						d611 = ps.OverlayValues[611]
+					if len(ps.OverlayValues) > 467 && ps.OverlayValues[467].Loc != LocNone {
+						d467 = ps.OverlayValues[467]
 					}
-					if len(ps.OverlayValues) > 612 && ps.OverlayValues[612].Loc != LocNone {
-						d612 = ps.OverlayValues[612]
+					if len(ps.OverlayValues) > 468 && ps.OverlayValues[468].Loc != LocNone {
+						d468 = ps.OverlayValues[468]
 					}
-					if len(ps.OverlayValues) > 613 && ps.OverlayValues[613].Loc != LocNone {
-						d613 = ps.OverlayValues[613]
+					if len(ps.OverlayValues) > 469 && ps.OverlayValues[469].Loc != LocNone {
+						d469 = ps.OverlayValues[469]
+					}
+					if len(ps.OverlayValues) > 472 && ps.OverlayValues[472].Loc != LocNone {
+						d472 = ps.OverlayValues[472]
+					}
+					if len(ps.OverlayValues) > 473 && ps.OverlayValues[473].Loc != LocNone {
+						d473 = ps.OverlayValues[473]
+					}
+					if len(ps.OverlayValues) > 650 && ps.OverlayValues[650].Loc != LocNone {
+						d650 = ps.OverlayValues[650]
+					}
+					if len(ps.OverlayValues) > 651 && ps.OverlayValues[651].Loc != LocNone {
+						d651 = ps.OverlayValues[651]
+					}
+					if len(ps.OverlayValues) > 652 && ps.OverlayValues[652].Loc != LocNone {
+						d652 = ps.OverlayValues[652]
+					}
+					if len(ps.OverlayValues) > 653 && ps.OverlayValues[653].Loc != LocNone {
+						d653 = ps.OverlayValues[653]
+					}
+					if len(ps.OverlayValues) > 654 && ps.OverlayValues[654].Loc != LocNone {
+						d654 = ps.OverlayValues[654]
+					}
+					if len(ps.OverlayValues) > 655 && ps.OverlayValues[655].Loc != LocNone {
+						d655 = ps.OverlayValues[655]
+					}
+					if len(ps.OverlayValues) > 656 && ps.OverlayValues[656].Loc != LocNone {
+						d656 = ps.OverlayValues[656]
+					}
+					if len(ps.OverlayValues) > 657 && ps.OverlayValues[657].Loc != LocNone {
+						d657 = ps.OverlayValues[657]
+					}
+					if len(ps.OverlayValues) > 658 && ps.OverlayValues[658].Loc != LocNone {
+						d658 = ps.OverlayValues[658]
+					}
+					if len(ps.OverlayValues) > 659 && ps.OverlayValues[659].Loc != LocNone {
+						d659 = ps.OverlayValues[659]
+					}
+					if len(ps.OverlayValues) > 660 && ps.OverlayValues[660].Loc != LocNone {
+						d660 = ps.OverlayValues[660]
+					}
+					if len(ps.OverlayValues) > 661 && ps.OverlayValues[661].Loc != LocNone {
+						d661 = ps.OverlayValues[661]
+					}
+					if len(ps.OverlayValues) > 662 && ps.OverlayValues[662].Loc != LocNone {
+						d662 = ps.OverlayValues[662]
+					}
+					if len(ps.OverlayValues) > 664 && ps.OverlayValues[664].Loc != LocNone {
+						d664 = ps.OverlayValues[664]
+					}
+					if len(ps.OverlayValues) > 665 && ps.OverlayValues[665].Loc != LocNone {
+						d665 = ps.OverlayValues[665]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d1)
-					var d615 JITValueDesc
-					if d1.Loc == LocImm {
-						ctx.TrackImm(d1.Imm)
-						ptrWord, _ := d1.Imm.RawWords()
-						d615 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.EmitMovRegImm64(d615.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(d615.Reg2, uint64(len(d1.Imm.String())))
-						ctx.BindReg(d615.Reg, &d615)
-						ctx.BindReg(d615.Reg2, &d615)
+					ctx.EnsureDesc(&d8)
+					var d666 JITValueDesc
+					if d8.Loc == LocImm {
+						ctx.TrackImm(d8.Imm)
+						ptrWord, _ := d8.Imm.RawWords()
+						d666 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.EmitMovRegImm64(d666.Reg, uint64(ptrWord))
+						ctx.EmitMovRegImm64(d666.Reg2, uint64(len(d8.Imm.String())))
+						ctx.BindReg(d666.Reg, &d666)
+						ctx.BindReg(d666.Reg2, &d666)
 					} else {
-						d615 = d1
+						d666 = d8
 					}
-					d616 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("EUCLIDEAN")}
-					var d617 JITValueDesc
-					if d616.Loc == LocImm {
-						ctx.TrackImm(d616.Imm)
-						ptrWord, _ := d616.Imm.RawWords()
-						d617 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.EmitMovRegImm64(d617.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(d617.Reg2, uint64(len(d616.Imm.String())))
-						ctx.BindReg(d617.Reg, &d617)
-						ctx.BindReg(d617.Reg2, &d617)
+					d667 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("EUCLIDEAN")}
+					var d668 JITValueDesc
+					if d667.Loc == LocImm {
+						ctx.TrackImm(d667.Imm)
+						ptrWord, _ := d667.Imm.RawWords()
+						d668 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.EmitMovRegImm64(d668.Reg, uint64(ptrWord))
+						ctx.EmitMovRegImm64(d668.Reg2, uint64(len(d667.Imm.String())))
+						ctx.BindReg(d668.Reg, &d668)
+						ctx.BindReg(d668.Reg2, &d668)
 					} else {
-						d617 = d616
+						d668 = d667
 					}
-					d618 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d615, d617}, 1)
-					ctx.EmitAndRegImm32(d618.Reg, 1)
-					d618.Type = tagBool
-					ctx.BindReg(d618.Reg, &d618)
-					d619 = d618
-					ctx.EnsureDesc(&d619)
-					if d619.Loc != LocImm && d619.Loc != LocReg {
+					d669 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d666, d668}, 1)
+					ctx.EmitAndRegImm32(d669.Reg, 1)
+					d669.Type = tagBool
+					ctx.BindReg(d669.Reg, &d669)
+					d670 = d669
+					ctx.EnsureDesc(&d670)
+					if d670.Loc != LocImm && d670.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d619.Loc == LocImm {
-						if d619.Imm.Bool() {
+					if d670.Loc == LocImm {
+						if d670.Imm.Bool() {
 							if ps.General {
 							}
-							ps620 := PhiState{General: ps.General}
-							ps620.OverlayValues = make([]JITValueDesc, 620)
-							ps620.OverlayValues[1] = d1
-							ps620.OverlayValues[2] = d2
-							ps620.OverlayValues[3] = d3
-							ps620.OverlayValues[4] = d4
-							ps620.OverlayValues[5] = d5
-							ps620.OverlayValues[6] = d6
-							ps620.OverlayValues[7] = d7
-							ps620.OverlayValues[8] = d8
-							ps620.OverlayValues[9] = d9
-							ps620.OverlayValues[10] = d10
-							ps620.OverlayValues[11] = d11
-							ps620.OverlayValues[12] = d12
-							ps620.OverlayValues[13] = d13
-							ps620.OverlayValues[14] = d14
-							ps620.OverlayValues[15] = d15
-							ps620.OverlayValues[18] = d18
-							ps620.OverlayValues[38] = d38
-							ps620.OverlayValues[57] = d57
-							ps620.OverlayValues[58] = d58
-							ps620.OverlayValues[59] = d59
-							ps620.OverlayValues[60] = d60
-							ps620.OverlayValues[61] = d61
-							ps620.OverlayValues[63] = d63
-							ps620.OverlayValues[64] = d64
-							ps620.OverlayValues[65] = d65
-							ps620.OverlayValues[66] = d66
-							ps620.OverlayValues[67] = d67
-							ps620.OverlayValues[68] = d68
-							ps620.OverlayValues[69] = d69
-							ps620.OverlayValues[72] = d72
-							ps620.OverlayValues[138] = d138
-							ps620.OverlayValues[139] = d139
-							ps620.OverlayValues[140] = d140
-							ps620.OverlayValues[141] = d141
-							ps620.OverlayValues[142] = d142
-							ps620.OverlayValues[143] = d143
-							ps620.OverlayValues[145] = d145
-							ps620.OverlayValues[146] = d146
-							ps620.OverlayValues[147] = d147
-							ps620.OverlayValues[148] = d148
-							ps620.OverlayValues[149] = d149
-							ps620.OverlayValues[150] = d150
-							ps620.OverlayValues[151] = d151
-							ps620.OverlayValues[152] = d152
-							ps620.OverlayValues[153] = d153
-							ps620.OverlayValues[156] = d156
-							ps620.OverlayValues[157] = d157
-							ps620.OverlayValues[158] = d158
-							ps620.OverlayValues[159] = d159
-							ps620.OverlayValues[262] = d262
-							ps620.OverlayValues[263] = d263
-							ps620.OverlayValues[264] = d264
-							ps620.OverlayValues[265] = d265
-							ps620.OverlayValues[266] = d266
-							ps620.OverlayValues[267] = d267
-							ps620.OverlayValues[268] = d268
-							ps620.OverlayValues[269] = d269
-							ps620.OverlayValues[270] = d270
-							ps620.OverlayValues[271] = d271
-							ps620.OverlayValues[272] = d272
-							ps620.OverlayValues[273] = d273
-							ps620.OverlayValues[274] = d274
-							ps620.OverlayValues[275] = d275
-							ps620.OverlayValues[276] = d276
-							ps620.OverlayValues[278] = d278
-							ps620.OverlayValues[279] = d279
-							ps620.OverlayValues[280] = d280
-							ps620.OverlayValues[281] = d281
-							ps620.OverlayValues[283] = d283
-							ps620.OverlayValues[284] = d284
-							ps620.OverlayValues[285] = d285
-							ps620.OverlayValues[434] = d434
-							ps620.OverlayValues[435] = d435
-							ps620.OverlayValues[436] = d436
-							ps620.OverlayValues[437] = d437
-							ps620.OverlayValues[438] = d438
-							ps620.OverlayValues[441] = d441
-							ps620.OverlayValues[442] = d442
-							ps620.OverlayValues[603] = d603
-							ps620.OverlayValues[604] = d604
-							ps620.OverlayValues[605] = d605
-							ps620.OverlayValues[606] = d606
-							ps620.OverlayValues[607] = d607
-							ps620.OverlayValues[608] = d608
-							ps620.OverlayValues[609] = d609
-							ps620.OverlayValues[610] = d610
-							ps620.OverlayValues[611] = d611
-							ps620.OverlayValues[612] = d612
-							ps620.OverlayValues[613] = d613
-							ps620.OverlayValues[615] = d615
-							ps620.OverlayValues[616] = d616
-							ps620.OverlayValues[617] = d617
-							ps620.OverlayValues[618] = d618
-							ps620.OverlayValues[619] = d619
-							return bbs[14].RenderPS(ps620)
+							ps671 := PhiState{General: ps.General}
+							ps671.OverlayValues = make([]JITValueDesc, 671)
+							ps671.OverlayValues[8] = d8
+							ps671.OverlayValues[9] = d9
+							ps671.OverlayValues[10] = d10
+							ps671.OverlayValues[11] = d11
+							ps671.OverlayValues[12] = d12
+							ps671.OverlayValues[13] = d13
+							ps671.OverlayValues[14] = d14
+							ps671.OverlayValues[15] = d15
+							ps671.OverlayValues[16] = d16
+							ps671.OverlayValues[17] = d17
+							ps671.OverlayValues[18] = d18
+							ps671.OverlayValues[19] = d19
+							ps671.OverlayValues[20] = d20
+							ps671.OverlayValues[21] = d21
+							ps671.OverlayValues[22] = d22
+							ps671.OverlayValues[25] = d25
+							ps671.OverlayValues[45] = d45
+							ps671.OverlayValues[64] = d64
+							ps671.OverlayValues[65] = d65
+							ps671.OverlayValues[66] = d66
+							ps671.OverlayValues[67] = d67
+							ps671.OverlayValues[68] = d68
+							ps671.OverlayValues[70] = d70
+							ps671.OverlayValues[71] = d71
+							ps671.OverlayValues[72] = d72
+							ps671.OverlayValues[73] = d73
+							ps671.OverlayValues[74] = d74
+							ps671.OverlayValues[75] = d75
+							ps671.OverlayValues[76] = d76
+							ps671.OverlayValues[79] = d79
+							ps671.OverlayValues[145] = d145
+							ps671.OverlayValues[146] = d146
+							ps671.OverlayValues[147] = d147
+							ps671.OverlayValues[148] = d148
+							ps671.OverlayValues[149] = d149
+							ps671.OverlayValues[150] = d150
+							ps671.OverlayValues[152] = d152
+							ps671.OverlayValues[153] = d153
+							ps671.OverlayValues[154] = d154
+							ps671.OverlayValues[155] = d155
+							ps671.OverlayValues[156] = d156
+							ps671.OverlayValues[157] = d157
+							ps671.OverlayValues[158] = d158
+							ps671.OverlayValues[159] = d159
+							ps671.OverlayValues[160] = d160
+							ps671.OverlayValues[163] = d163
+							ps671.OverlayValues[164] = d164
+							ps671.OverlayValues[165] = d165
+							ps671.OverlayValues[166] = d166
+							ps671.OverlayValues[269] = d269
+							ps671.OverlayValues[270] = d270
+							ps671.OverlayValues[271] = d271
+							ps671.OverlayValues[272] = d272
+							ps671.OverlayValues[273] = d273
+							ps671.OverlayValues[274] = d274
+							ps671.OverlayValues[275] = d275
+							ps671.OverlayValues[276] = d276
+							ps671.OverlayValues[277] = d277
+							ps671.OverlayValues[278] = d278
+							ps671.OverlayValues[279] = d279
+							ps671.OverlayValues[280] = d280
+							ps671.OverlayValues[281] = d281
+							ps671.OverlayValues[282] = d282
+							ps671.OverlayValues[283] = d283
+							ps671.OverlayValues[284] = d284
+							ps671.OverlayValues[285] = d285
+							ps671.OverlayValues[286] = d286
+							ps671.OverlayValues[287] = d287
+							ps671.OverlayValues[289] = d289
+							ps671.OverlayValues[290] = d290
+							ps671.OverlayValues[291] = d291
+							ps671.OverlayValues[292] = d292
+							ps671.OverlayValues[293] = d293
+							ps671.OverlayValues[294] = d294
+							ps671.OverlayValues[295] = d295
+							ps671.OverlayValues[296] = d296
+							ps671.OverlayValues[298] = d298
+							ps671.OverlayValues[299] = d299
+							ps671.OverlayValues[300] = d300
+							ps671.OverlayValues[465] = d465
+							ps671.OverlayValues[466] = d466
+							ps671.OverlayValues[467] = d467
+							ps671.OverlayValues[468] = d468
+							ps671.OverlayValues[469] = d469
+							ps671.OverlayValues[472] = d472
+							ps671.OverlayValues[473] = d473
+							ps671.OverlayValues[650] = d650
+							ps671.OverlayValues[651] = d651
+							ps671.OverlayValues[652] = d652
+							ps671.OverlayValues[653] = d653
+							ps671.OverlayValues[654] = d654
+							ps671.OverlayValues[655] = d655
+							ps671.OverlayValues[656] = d656
+							ps671.OverlayValues[657] = d657
+							ps671.OverlayValues[658] = d658
+							ps671.OverlayValues[659] = d659
+							ps671.OverlayValues[660] = d660
+							ps671.OverlayValues[661] = d661
+							ps671.OverlayValues[662] = d662
+							ps671.OverlayValues[664] = d664
+							ps671.OverlayValues[665] = d665
+							ps671.OverlayValues[666] = d666
+							ps671.OverlayValues[667] = d667
+							ps671.OverlayValues[668] = d668
+							ps671.OverlayValues[669] = d669
+							ps671.OverlayValues[670] = d670
+							return bbs[14].RenderPS(ps671)
 						}
 						if ps.General {
-							ctx.SyncDesc(&d7)
-							if d7.Loc == LocReg {
-								ctx.ProtectReg(d7.Reg)
-							} else if d7.Loc == LocRegPair {
-								ctx.ProtectReg(d7.Reg)
-								ctx.ProtectReg(d7.Reg2)
+							ctx.SyncDesc(&d14)
+							if d14.Loc == LocReg || d14.Loc == LocFPReg {
+								ctx.ProtectReg(d14.Reg)
+							} else if d14.Loc == LocRegPair {
+								ctx.ProtectReg(d14.Reg)
+								ctx.ProtectReg(d14.Reg2)
 							}
-							d621 = d7
-							if d621.Loc == LocNone {
+							d672 = d14
+							if d672.Loc == LocNone {
 								panic("jit: phi source has no location")
 							}
-							ctx.EnsureDesc(&d621)
-							ctx.EmitStoreToStack(d621, int32(bbs[4].PhiBase)+int32(0))
-							if d7.Loc == LocReg {
-								ctx.UnprotectReg(d7.Reg)
-							} else if d7.Loc == LocRegPair {
-								ctx.UnprotectReg(d7.Reg)
-								ctx.UnprotectReg(d7.Reg2)
+							ctx.EnsureDesc(&d672)
+							ctx.EmitStoreToStack(d672, int32(bbs[4].PhiBase)+int32(0))
+							if d14.Loc == LocReg || d14.Loc == LocFPReg {
+								ctx.UnprotectReg(d14.Reg)
+							} else if d14.Loc == LocRegPair {
+								ctx.UnprotectReg(d14.Reg)
+								ctx.UnprotectReg(d14.Reg2)
 							}
 						}
-						ps622 := PhiState{General: ps.General}
-						ps622.OverlayValues = make([]JITValueDesc, 622)
-						ps622.OverlayValues[1] = d1
-						ps622.OverlayValues[2] = d2
-						ps622.OverlayValues[3] = d3
-						ps622.OverlayValues[4] = d4
-						ps622.OverlayValues[5] = d5
-						ps622.OverlayValues[6] = d6
-						ps622.OverlayValues[7] = d7
-						ps622.OverlayValues[8] = d8
-						ps622.OverlayValues[9] = d9
-						ps622.OverlayValues[10] = d10
-						ps622.OverlayValues[11] = d11
-						ps622.OverlayValues[12] = d12
-						ps622.OverlayValues[13] = d13
-						ps622.OverlayValues[14] = d14
-						ps622.OverlayValues[15] = d15
-						ps622.OverlayValues[18] = d18
-						ps622.OverlayValues[38] = d38
-						ps622.OverlayValues[57] = d57
-						ps622.OverlayValues[58] = d58
-						ps622.OverlayValues[59] = d59
-						ps622.OverlayValues[60] = d60
-						ps622.OverlayValues[61] = d61
-						ps622.OverlayValues[63] = d63
-						ps622.OverlayValues[64] = d64
-						ps622.OverlayValues[65] = d65
-						ps622.OverlayValues[66] = d66
-						ps622.OverlayValues[67] = d67
-						ps622.OverlayValues[68] = d68
-						ps622.OverlayValues[69] = d69
-						ps622.OverlayValues[72] = d72
-						ps622.OverlayValues[138] = d138
-						ps622.OverlayValues[139] = d139
-						ps622.OverlayValues[140] = d140
-						ps622.OverlayValues[141] = d141
-						ps622.OverlayValues[142] = d142
-						ps622.OverlayValues[143] = d143
-						ps622.OverlayValues[145] = d145
-						ps622.OverlayValues[146] = d146
-						ps622.OverlayValues[147] = d147
-						ps622.OverlayValues[148] = d148
-						ps622.OverlayValues[149] = d149
-						ps622.OverlayValues[150] = d150
-						ps622.OverlayValues[151] = d151
-						ps622.OverlayValues[152] = d152
-						ps622.OverlayValues[153] = d153
-						ps622.OverlayValues[156] = d156
-						ps622.OverlayValues[157] = d157
-						ps622.OverlayValues[158] = d158
-						ps622.OverlayValues[159] = d159
-						ps622.OverlayValues[262] = d262
-						ps622.OverlayValues[263] = d263
-						ps622.OverlayValues[264] = d264
-						ps622.OverlayValues[265] = d265
-						ps622.OverlayValues[266] = d266
-						ps622.OverlayValues[267] = d267
-						ps622.OverlayValues[268] = d268
-						ps622.OverlayValues[269] = d269
-						ps622.OverlayValues[270] = d270
-						ps622.OverlayValues[271] = d271
-						ps622.OverlayValues[272] = d272
-						ps622.OverlayValues[273] = d273
-						ps622.OverlayValues[274] = d274
-						ps622.OverlayValues[275] = d275
-						ps622.OverlayValues[276] = d276
-						ps622.OverlayValues[278] = d278
-						ps622.OverlayValues[279] = d279
-						ps622.OverlayValues[280] = d280
-						ps622.OverlayValues[281] = d281
-						ps622.OverlayValues[283] = d283
-						ps622.OverlayValues[284] = d284
-						ps622.OverlayValues[285] = d285
-						ps622.OverlayValues[434] = d434
-						ps622.OverlayValues[435] = d435
-						ps622.OverlayValues[436] = d436
-						ps622.OverlayValues[437] = d437
-						ps622.OverlayValues[438] = d438
-						ps622.OverlayValues[441] = d441
-						ps622.OverlayValues[442] = d442
-						ps622.OverlayValues[603] = d603
-						ps622.OverlayValues[604] = d604
-						ps622.OverlayValues[605] = d605
-						ps622.OverlayValues[606] = d606
-						ps622.OverlayValues[607] = d607
-						ps622.OverlayValues[608] = d608
-						ps622.OverlayValues[609] = d609
-						ps622.OverlayValues[610] = d610
-						ps622.OverlayValues[611] = d611
-						ps622.OverlayValues[612] = d612
-						ps622.OverlayValues[613] = d613
-						ps622.OverlayValues[615] = d615
-						ps622.OverlayValues[616] = d616
-						ps622.OverlayValues[617] = d617
-						ps622.OverlayValues[618] = d618
-						ps622.OverlayValues[619] = d619
-						ps622.OverlayValues[621] = d621
-						ps622.PhiValues = make([]JITValueDesc, 1)
-						d623 = d7
-						ps622.PhiValues[0] = d623
-						return bbs[4].RenderPS(ps622)
+						ps673 := PhiState{General: ps.General}
+						ps673.OverlayValues = make([]JITValueDesc, 673)
+						ps673.OverlayValues[8] = d8
+						ps673.OverlayValues[9] = d9
+						ps673.OverlayValues[10] = d10
+						ps673.OverlayValues[11] = d11
+						ps673.OverlayValues[12] = d12
+						ps673.OverlayValues[13] = d13
+						ps673.OverlayValues[14] = d14
+						ps673.OverlayValues[15] = d15
+						ps673.OverlayValues[16] = d16
+						ps673.OverlayValues[17] = d17
+						ps673.OverlayValues[18] = d18
+						ps673.OverlayValues[19] = d19
+						ps673.OverlayValues[20] = d20
+						ps673.OverlayValues[21] = d21
+						ps673.OverlayValues[22] = d22
+						ps673.OverlayValues[25] = d25
+						ps673.OverlayValues[45] = d45
+						ps673.OverlayValues[64] = d64
+						ps673.OverlayValues[65] = d65
+						ps673.OverlayValues[66] = d66
+						ps673.OverlayValues[67] = d67
+						ps673.OverlayValues[68] = d68
+						ps673.OverlayValues[70] = d70
+						ps673.OverlayValues[71] = d71
+						ps673.OverlayValues[72] = d72
+						ps673.OverlayValues[73] = d73
+						ps673.OverlayValues[74] = d74
+						ps673.OverlayValues[75] = d75
+						ps673.OverlayValues[76] = d76
+						ps673.OverlayValues[79] = d79
+						ps673.OverlayValues[145] = d145
+						ps673.OverlayValues[146] = d146
+						ps673.OverlayValues[147] = d147
+						ps673.OverlayValues[148] = d148
+						ps673.OverlayValues[149] = d149
+						ps673.OverlayValues[150] = d150
+						ps673.OverlayValues[152] = d152
+						ps673.OverlayValues[153] = d153
+						ps673.OverlayValues[154] = d154
+						ps673.OverlayValues[155] = d155
+						ps673.OverlayValues[156] = d156
+						ps673.OverlayValues[157] = d157
+						ps673.OverlayValues[158] = d158
+						ps673.OverlayValues[159] = d159
+						ps673.OverlayValues[160] = d160
+						ps673.OverlayValues[163] = d163
+						ps673.OverlayValues[164] = d164
+						ps673.OverlayValues[165] = d165
+						ps673.OverlayValues[166] = d166
+						ps673.OverlayValues[269] = d269
+						ps673.OverlayValues[270] = d270
+						ps673.OverlayValues[271] = d271
+						ps673.OverlayValues[272] = d272
+						ps673.OverlayValues[273] = d273
+						ps673.OverlayValues[274] = d274
+						ps673.OverlayValues[275] = d275
+						ps673.OverlayValues[276] = d276
+						ps673.OverlayValues[277] = d277
+						ps673.OverlayValues[278] = d278
+						ps673.OverlayValues[279] = d279
+						ps673.OverlayValues[280] = d280
+						ps673.OverlayValues[281] = d281
+						ps673.OverlayValues[282] = d282
+						ps673.OverlayValues[283] = d283
+						ps673.OverlayValues[284] = d284
+						ps673.OverlayValues[285] = d285
+						ps673.OverlayValues[286] = d286
+						ps673.OverlayValues[287] = d287
+						ps673.OverlayValues[289] = d289
+						ps673.OverlayValues[290] = d290
+						ps673.OverlayValues[291] = d291
+						ps673.OverlayValues[292] = d292
+						ps673.OverlayValues[293] = d293
+						ps673.OverlayValues[294] = d294
+						ps673.OverlayValues[295] = d295
+						ps673.OverlayValues[296] = d296
+						ps673.OverlayValues[298] = d298
+						ps673.OverlayValues[299] = d299
+						ps673.OverlayValues[300] = d300
+						ps673.OverlayValues[465] = d465
+						ps673.OverlayValues[466] = d466
+						ps673.OverlayValues[467] = d467
+						ps673.OverlayValues[468] = d468
+						ps673.OverlayValues[469] = d469
+						ps673.OverlayValues[472] = d472
+						ps673.OverlayValues[473] = d473
+						ps673.OverlayValues[650] = d650
+						ps673.OverlayValues[651] = d651
+						ps673.OverlayValues[652] = d652
+						ps673.OverlayValues[653] = d653
+						ps673.OverlayValues[654] = d654
+						ps673.OverlayValues[655] = d655
+						ps673.OverlayValues[656] = d656
+						ps673.OverlayValues[657] = d657
+						ps673.OverlayValues[658] = d658
+						ps673.OverlayValues[659] = d659
+						ps673.OverlayValues[660] = d660
+						ps673.OverlayValues[661] = d661
+						ps673.OverlayValues[662] = d662
+						ps673.OverlayValues[664] = d664
+						ps673.OverlayValues[665] = d665
+						ps673.OverlayValues[666] = d666
+						ps673.OverlayValues[667] = d667
+						ps673.OverlayValues[668] = d668
+						ps673.OverlayValues[669] = d669
+						ps673.OverlayValues[670] = d670
+						ps673.OverlayValues[672] = d672
+						ps673.PhiValues = make([]JITValueDesc, 1)
+						d674 = d14
+						ps673.PhiValues[0] = d674
+						return bbs[4].RenderPS(ps673)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[12].RenderPS(ps)
 					}
 					lbl21 := ctx.ReserveLabel()
-					ctx.EmitCmpRegImm32(d619.Reg, 0)
+					ctx.EmitCmpRegImm32(d670.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl15)
 					ctx.EmitJmp(lbl21)
-					snap624 := d1
-					snap625 := d2
-					snap626 := d3
-					snap627 := d4
-					snap628 := d5
-					snap629 := d6
-					snap630 := d7
-					snap631 := d8
-					snap632 := d9
-					snap633 := d10
-					snap634 := d11
-					snap635 := d12
-					snap636 := d13
-					snap637 := d14
-					snap638 := d15
-					snap639 := d18
-					snap640 := d38
-					snap641 := d57
-					snap642 := d58
-					snap643 := d59
-					snap644 := d60
-					snap645 := d61
-					snap646 := d63
-					snap647 := d64
-					snap648 := d65
-					snap649 := d66
-					snap650 := d67
-					snap651 := d68
-					snap652 := d69
-					snap653 := d72
-					snap654 := d138
-					snap655 := d139
-					snap656 := d140
-					snap657 := d141
-					snap658 := d142
-					snap659 := d143
-					snap660 := d145
-					snap661 := d146
-					snap662 := d147
-					snap663 := d148
-					snap664 := d149
-					snap665 := d150
-					snap666 := d151
-					snap667 := d152
-					snap668 := d153
-					snap669 := d156
-					snap670 := d157
-					snap671 := d158
-					snap672 := d159
-					snap673 := d262
-					snap674 := d263
-					snap675 := d264
-					snap676 := d265
-					snap677 := d266
-					snap678 := d267
-					snap679 := d268
-					snap680 := d269
-					snap681 := d270
-					snap682 := d271
-					snap683 := d272
-					snap684 := d273
-					snap685 := d274
-					snap686 := d275
-					snap687 := d276
-					snap688 := d278
-					snap689 := d279
-					snap690 := d280
-					snap691 := d281
-					snap692 := d283
-					snap693 := d284
-					snap694 := d285
-					snap695 := d434
-					snap696 := d435
-					snap697 := d436
-					snap698 := d437
-					snap699 := d438
-					snap700 := d441
-					snap701 := d442
-					snap702 := d603
-					snap703 := d604
-					snap704 := d605
-					snap705 := d606
-					snap706 := d607
-					snap707 := d608
-					snap708 := d609
-					snap709 := d610
-					snap710 := d611
-					snap711 := d612
-					snap712 := d613
-					snap713 := d615
-					snap714 := d616
-					snap715 := d617
-					snap716 := d618
-					snap717 := d619
-					snap718 := d621
-					snap719 := d623
-					alloc720 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc720)
-					d1 = snap624
-					d2 = snap625
-					d3 = snap626
-					d4 = snap627
-					d5 = snap628
-					d6 = snap629
-					d7 = snap630
-					d8 = snap631
-					d9 = snap632
-					d10 = snap633
-					d11 = snap634
-					d12 = snap635
-					d13 = snap636
-					d14 = snap637
-					d15 = snap638
-					d18 = snap639
-					d38 = snap640
-					d57 = snap641
-					d58 = snap642
-					d59 = snap643
-					d60 = snap644
-					d61 = snap645
-					d63 = snap646
-					d64 = snap647
-					d65 = snap648
-					d66 = snap649
-					d67 = snap650
-					d68 = snap651
-					d69 = snap652
-					d72 = snap653
-					d138 = snap654
-					d139 = snap655
-					d140 = snap656
-					d141 = snap657
-					d142 = snap658
-					d143 = snap659
-					d145 = snap660
-					d146 = snap661
-					d147 = snap662
-					d148 = snap663
-					d149 = snap664
-					d150 = snap665
-					d151 = snap666
-					d152 = snap667
-					d153 = snap668
-					d156 = snap669
-					d157 = snap670
-					d158 = snap671
-					d159 = snap672
-					d262 = snap673
-					d263 = snap674
-					d264 = snap675
-					d265 = snap676
-					d266 = snap677
-					d267 = snap678
-					d268 = snap679
-					d269 = snap680
-					d270 = snap681
-					d271 = snap682
-					d272 = snap683
-					d273 = snap684
-					d274 = snap685
-					d275 = snap686
-					d276 = snap687
-					d278 = snap688
-					d279 = snap689
-					d280 = snap690
-					d281 = snap691
-					d283 = snap692
-					d284 = snap693
-					d285 = snap694
-					d434 = snap695
-					d435 = snap696
-					d436 = snap697
-					d437 = snap698
-					d438 = snap699
-					d441 = snap700
-					d442 = snap701
-					d603 = snap702
-					d604 = snap703
-					d605 = snap704
-					d606 = snap705
-					d607 = snap706
-					d608 = snap707
-					d609 = snap708
-					d610 = snap709
-					d611 = snap710
-					d612 = snap711
-					d613 = snap712
-					d615 = snap713
-					d616 = snap714
-					d617 = snap715
-					d618 = snap716
-					d619 = snap717
-					d621 = snap718
-					d623 = snap719
+					snap675 := d8
+					snap676 := d9
+					snap677 := d10
+					snap678 := d11
+					snap679 := d12
+					snap680 := d13
+					snap681 := d14
+					snap682 := d15
+					snap683 := d16
+					snap684 := d17
+					snap685 := d18
+					snap686 := d19
+					snap687 := d20
+					snap688 := d21
+					snap689 := d22
+					snap690 := d25
+					snap691 := d45
+					snap692 := d64
+					snap693 := d65
+					snap694 := d66
+					snap695 := d67
+					snap696 := d68
+					snap697 := d70
+					snap698 := d71
+					snap699 := d72
+					snap700 := d73
+					snap701 := d74
+					snap702 := d75
+					snap703 := d76
+					snap704 := d79
+					snap705 := d145
+					snap706 := d146
+					snap707 := d147
+					snap708 := d148
+					snap709 := d149
+					snap710 := d150
+					snap711 := d152
+					snap712 := d153
+					snap713 := d154
+					snap714 := d155
+					snap715 := d156
+					snap716 := d157
+					snap717 := d158
+					snap718 := d159
+					snap719 := d160
+					snap720 := d163
+					snap721 := d164
+					snap722 := d165
+					snap723 := d166
+					snap724 := d269
+					snap725 := d270
+					snap726 := d271
+					snap727 := d272
+					snap728 := d273
+					snap729 := d274
+					snap730 := d275
+					snap731 := d276
+					snap732 := d277
+					snap733 := d278
+					snap734 := d279
+					snap735 := d280
+					snap736 := d281
+					snap737 := d282
+					snap738 := d283
+					snap739 := d284
+					snap740 := d285
+					snap741 := d286
+					snap742 := d287
+					snap743 := d289
+					snap744 := d290
+					snap745 := d291
+					snap746 := d292
+					snap747 := d293
+					snap748 := d294
+					snap749 := d295
+					snap750 := d296
+					snap751 := d298
+					snap752 := d299
+					snap753 := d300
+					snap754 := d465
+					snap755 := d466
+					snap756 := d467
+					snap757 := d468
+					snap758 := d469
+					snap759 := d472
+					snap760 := d473
+					snap761 := d650
+					snap762 := d651
+					snap763 := d652
+					snap764 := d653
+					snap765 := d654
+					snap766 := d655
+					snap767 := d656
+					snap768 := d657
+					snap769 := d658
+					snap770 := d659
+					snap771 := d660
+					snap772 := d661
+					snap773 := d662
+					snap774 := d664
+					snap775 := d665
+					snap776 := d666
+					snap777 := d667
+					snap778 := d668
+					snap779 := d669
+					snap780 := d670
+					snap781 := d672
+					snap782 := d674
+					alloc783 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc783)
+					d8 = snap675
+					d9 = snap676
+					d10 = snap677
+					d11 = snap678
+					d12 = snap679
+					d13 = snap680
+					d14 = snap681
+					d15 = snap682
+					d16 = snap683
+					d17 = snap684
+					d18 = snap685
+					d19 = snap686
+					d20 = snap687
+					d21 = snap688
+					d22 = snap689
+					d25 = snap690
+					d45 = snap691
+					d64 = snap692
+					d65 = snap693
+					d66 = snap694
+					d67 = snap695
+					d68 = snap696
+					d70 = snap697
+					d71 = snap698
+					d72 = snap699
+					d73 = snap700
+					d74 = snap701
+					d75 = snap702
+					d76 = snap703
+					d79 = snap704
+					d145 = snap705
+					d146 = snap706
+					d147 = snap707
+					d148 = snap708
+					d149 = snap709
+					d150 = snap710
+					d152 = snap711
+					d153 = snap712
+					d154 = snap713
+					d155 = snap714
+					d156 = snap715
+					d157 = snap716
+					d158 = snap717
+					d159 = snap718
+					d160 = snap719
+					d163 = snap720
+					d164 = snap721
+					d165 = snap722
+					d166 = snap723
+					d269 = snap724
+					d270 = snap725
+					d271 = snap726
+					d272 = snap727
+					d273 = snap728
+					d274 = snap729
+					d275 = snap730
+					d276 = snap731
+					d277 = snap732
+					d278 = snap733
+					d279 = snap734
+					d280 = snap735
+					d281 = snap736
+					d282 = snap737
+					d283 = snap738
+					d284 = snap739
+					d285 = snap740
+					d286 = snap741
+					d287 = snap742
+					d289 = snap743
+					d290 = snap744
+					d291 = snap745
+					d292 = snap746
+					d293 = snap747
+					d294 = snap748
+					d295 = snap749
+					d296 = snap750
+					d298 = snap751
+					d299 = snap752
+					d300 = snap753
+					d465 = snap754
+					d466 = snap755
+					d467 = snap756
+					d468 = snap757
+					d469 = snap758
+					d472 = snap759
+					d473 = snap760
+					d650 = snap761
+					d651 = snap762
+					d652 = snap763
+					d653 = snap764
+					d654 = snap765
+					d655 = snap766
+					d656 = snap767
+					d657 = snap768
+					d658 = snap769
+					d659 = snap770
+					d660 = snap771
+					d661 = snap772
+					d662 = snap773
+					d664 = snap774
+					d665 = snap775
+					d666 = snap776
+					d667 = snap777
+					d668 = snap778
+					d669 = snap779
+					d670 = snap780
+					d672 = snap781
+					d674 = snap782
 					ctx.MarkLabel(lbl21)
-					ctx.SyncDesc(&d7)
-					if d7.Loc == LocReg {
-						ctx.ProtectReg(d7.Reg)
-					} else if d7.Loc == LocRegPair {
-						ctx.ProtectReg(d7.Reg)
-						ctx.ProtectReg(d7.Reg2)
+					ctx.SyncDesc(&d14)
+					if d14.Loc == LocReg || d14.Loc == LocFPReg {
+						ctx.ProtectReg(d14.Reg)
+					} else if d14.Loc == LocRegPair {
+						ctx.ProtectReg(d14.Reg)
+						ctx.ProtectReg(d14.Reg2)
 					}
-					d721 = d7
-					if d721.Loc == LocNone {
+					d784 = d14
+					if d784.Loc == LocNone {
 						panic("jit: phi source has no location")
 					}
-					ctx.EnsureDesc(&d721)
-					ctx.EmitStoreToStack(d721, int32(bbs[4].PhiBase)+int32(0))
-					if d7.Loc == LocReg {
-						ctx.UnprotectReg(d7.Reg)
-					} else if d7.Loc == LocRegPair {
-						ctx.UnprotectReg(d7.Reg)
-						ctx.UnprotectReg(d7.Reg2)
+					ctx.EnsureDesc(&d784)
+					ctx.EmitStoreToStack(d784, int32(bbs[4].PhiBase)+int32(0))
+					if d14.Loc == LocReg || d14.Loc == LocFPReg {
+						ctx.UnprotectReg(d14.Reg)
+					} else if d14.Loc == LocRegPair {
+						ctx.UnprotectReg(d14.Reg)
+						ctx.UnprotectReg(d14.Reg2)
 					}
 					ctx.EmitJmp(lbl5)
-					ctx.RestoreAllocState(alloc720)
-					d1 = snap624
-					d2 = snap625
-					d3 = snap626
-					d4 = snap627
-					d5 = snap628
-					d6 = snap629
-					d7 = snap630
-					d8 = snap631
-					d9 = snap632
-					d10 = snap633
-					d11 = snap634
-					d12 = snap635
-					d13 = snap636
-					d14 = snap637
-					d15 = snap638
-					d18 = snap639
-					d38 = snap640
-					d57 = snap641
-					d58 = snap642
-					d59 = snap643
-					d60 = snap644
-					d61 = snap645
-					d63 = snap646
-					d64 = snap647
-					d65 = snap648
-					d66 = snap649
-					d67 = snap650
-					d68 = snap651
-					d69 = snap652
-					d72 = snap653
-					d138 = snap654
-					d139 = snap655
-					d140 = snap656
-					d141 = snap657
-					d142 = snap658
-					d143 = snap659
-					d145 = snap660
-					d146 = snap661
-					d147 = snap662
-					d148 = snap663
-					d149 = snap664
-					d150 = snap665
-					d151 = snap666
-					d152 = snap667
-					d153 = snap668
-					d156 = snap669
-					d157 = snap670
-					d158 = snap671
-					d159 = snap672
-					d262 = snap673
-					d263 = snap674
-					d264 = snap675
-					d265 = snap676
-					d266 = snap677
-					d267 = snap678
-					d268 = snap679
-					d269 = snap680
-					d270 = snap681
-					d271 = snap682
-					d272 = snap683
-					d273 = snap684
-					d274 = snap685
-					d275 = snap686
-					d276 = snap687
-					d278 = snap688
-					d279 = snap689
-					d280 = snap690
-					d281 = snap691
-					d283 = snap692
-					d284 = snap693
-					d285 = snap694
-					d434 = snap695
-					d435 = snap696
-					d436 = snap697
-					d437 = snap698
-					d438 = snap699
-					d441 = snap700
-					d442 = snap701
-					d603 = snap702
-					d604 = snap703
-					d605 = snap704
-					d606 = snap705
-					d607 = snap706
-					d608 = snap707
-					d609 = snap708
-					d610 = snap709
-					d611 = snap710
-					d612 = snap711
-					d613 = snap712
-					d615 = snap713
-					d616 = snap714
-					d617 = snap715
-					d618 = snap716
-					d619 = snap717
-					d621 = snap718
-					d623 = snap719
-					ps722 := PhiState{General: true}
-					ps722.OverlayValues = make([]JITValueDesc, 722)
-					ps722.OverlayValues[1] = d1
-					ps722.OverlayValues[2] = d2
-					ps722.OverlayValues[3] = d3
-					ps722.OverlayValues[4] = d4
-					ps722.OverlayValues[5] = d5
-					ps722.OverlayValues[6] = d6
-					ps722.OverlayValues[7] = d7
-					ps722.OverlayValues[8] = d8
-					ps722.OverlayValues[9] = d9
-					ps722.OverlayValues[10] = d10
-					ps722.OverlayValues[11] = d11
-					ps722.OverlayValues[12] = d12
-					ps722.OverlayValues[13] = d13
-					ps722.OverlayValues[14] = d14
-					ps722.OverlayValues[15] = d15
-					ps722.OverlayValues[18] = d18
-					ps722.OverlayValues[38] = d38
-					ps722.OverlayValues[57] = d57
-					ps722.OverlayValues[58] = d58
-					ps722.OverlayValues[59] = d59
-					ps722.OverlayValues[60] = d60
-					ps722.OverlayValues[61] = d61
-					ps722.OverlayValues[63] = d63
-					ps722.OverlayValues[64] = d64
-					ps722.OverlayValues[65] = d65
-					ps722.OverlayValues[66] = d66
-					ps722.OverlayValues[67] = d67
-					ps722.OverlayValues[68] = d68
-					ps722.OverlayValues[69] = d69
-					ps722.OverlayValues[72] = d72
-					ps722.OverlayValues[138] = d138
-					ps722.OverlayValues[139] = d139
-					ps722.OverlayValues[140] = d140
-					ps722.OverlayValues[141] = d141
-					ps722.OverlayValues[142] = d142
-					ps722.OverlayValues[143] = d143
-					ps722.OverlayValues[145] = d145
-					ps722.OverlayValues[146] = d146
-					ps722.OverlayValues[147] = d147
-					ps722.OverlayValues[148] = d148
-					ps722.OverlayValues[149] = d149
-					ps722.OverlayValues[150] = d150
-					ps722.OverlayValues[151] = d151
-					ps722.OverlayValues[152] = d152
-					ps722.OverlayValues[153] = d153
-					ps722.OverlayValues[156] = d156
-					ps722.OverlayValues[157] = d157
-					ps722.OverlayValues[158] = d158
-					ps722.OverlayValues[159] = d159
-					ps722.OverlayValues[262] = d262
-					ps722.OverlayValues[263] = d263
-					ps722.OverlayValues[264] = d264
-					ps722.OverlayValues[265] = d265
-					ps722.OverlayValues[266] = d266
-					ps722.OverlayValues[267] = d267
-					ps722.OverlayValues[268] = d268
-					ps722.OverlayValues[269] = d269
-					ps722.OverlayValues[270] = d270
-					ps722.OverlayValues[271] = d271
-					ps722.OverlayValues[272] = d272
-					ps722.OverlayValues[273] = d273
-					ps722.OverlayValues[274] = d274
-					ps722.OverlayValues[275] = d275
-					ps722.OverlayValues[276] = d276
-					ps722.OverlayValues[278] = d278
-					ps722.OverlayValues[279] = d279
-					ps722.OverlayValues[280] = d280
-					ps722.OverlayValues[281] = d281
-					ps722.OverlayValues[283] = d283
-					ps722.OverlayValues[284] = d284
-					ps722.OverlayValues[285] = d285
-					ps722.OverlayValues[434] = d434
-					ps722.OverlayValues[435] = d435
-					ps722.OverlayValues[436] = d436
-					ps722.OverlayValues[437] = d437
-					ps722.OverlayValues[438] = d438
-					ps722.OverlayValues[441] = d441
-					ps722.OverlayValues[442] = d442
-					ps722.OverlayValues[603] = d603
-					ps722.OverlayValues[604] = d604
-					ps722.OverlayValues[605] = d605
-					ps722.OverlayValues[606] = d606
-					ps722.OverlayValues[607] = d607
-					ps722.OverlayValues[608] = d608
-					ps722.OverlayValues[609] = d609
-					ps722.OverlayValues[610] = d610
-					ps722.OverlayValues[611] = d611
-					ps722.OverlayValues[612] = d612
-					ps722.OverlayValues[613] = d613
-					ps722.OverlayValues[615] = d615
-					ps722.OverlayValues[616] = d616
-					ps722.OverlayValues[617] = d617
-					ps722.OverlayValues[618] = d618
-					ps722.OverlayValues[619] = d619
-					ps722.OverlayValues[621] = d621
-					ps722.OverlayValues[623] = d623
-					ps722.OverlayValues[721] = d721
-					ps723 := PhiState{General: true}
-					ps723.OverlayValues = make([]JITValueDesc, 722)
-					ps723.OverlayValues[1] = d1
-					ps723.OverlayValues[2] = d2
-					ps723.OverlayValues[3] = d3
-					ps723.OverlayValues[4] = d4
-					ps723.OverlayValues[5] = d5
-					ps723.OverlayValues[6] = d6
-					ps723.OverlayValues[7] = d7
-					ps723.OverlayValues[8] = d8
-					ps723.OverlayValues[9] = d9
-					ps723.OverlayValues[10] = d10
-					ps723.OverlayValues[11] = d11
-					ps723.OverlayValues[12] = d12
-					ps723.OverlayValues[13] = d13
-					ps723.OverlayValues[14] = d14
-					ps723.OverlayValues[15] = d15
-					ps723.OverlayValues[18] = d18
-					ps723.OverlayValues[38] = d38
-					ps723.OverlayValues[57] = d57
-					ps723.OverlayValues[58] = d58
-					ps723.OverlayValues[59] = d59
-					ps723.OverlayValues[60] = d60
-					ps723.OverlayValues[61] = d61
-					ps723.OverlayValues[63] = d63
-					ps723.OverlayValues[64] = d64
-					ps723.OverlayValues[65] = d65
-					ps723.OverlayValues[66] = d66
-					ps723.OverlayValues[67] = d67
-					ps723.OverlayValues[68] = d68
-					ps723.OverlayValues[69] = d69
-					ps723.OverlayValues[72] = d72
-					ps723.OverlayValues[138] = d138
-					ps723.OverlayValues[139] = d139
-					ps723.OverlayValues[140] = d140
-					ps723.OverlayValues[141] = d141
-					ps723.OverlayValues[142] = d142
-					ps723.OverlayValues[143] = d143
-					ps723.OverlayValues[145] = d145
-					ps723.OverlayValues[146] = d146
-					ps723.OverlayValues[147] = d147
-					ps723.OverlayValues[148] = d148
-					ps723.OverlayValues[149] = d149
-					ps723.OverlayValues[150] = d150
-					ps723.OverlayValues[151] = d151
-					ps723.OverlayValues[152] = d152
-					ps723.OverlayValues[153] = d153
-					ps723.OverlayValues[156] = d156
-					ps723.OverlayValues[157] = d157
-					ps723.OverlayValues[158] = d158
-					ps723.OverlayValues[159] = d159
-					ps723.OverlayValues[262] = d262
-					ps723.OverlayValues[263] = d263
-					ps723.OverlayValues[264] = d264
-					ps723.OverlayValues[265] = d265
-					ps723.OverlayValues[266] = d266
-					ps723.OverlayValues[267] = d267
-					ps723.OverlayValues[268] = d268
-					ps723.OverlayValues[269] = d269
-					ps723.OverlayValues[270] = d270
-					ps723.OverlayValues[271] = d271
-					ps723.OverlayValues[272] = d272
-					ps723.OverlayValues[273] = d273
-					ps723.OverlayValues[274] = d274
-					ps723.OverlayValues[275] = d275
-					ps723.OverlayValues[276] = d276
-					ps723.OverlayValues[278] = d278
-					ps723.OverlayValues[279] = d279
-					ps723.OverlayValues[280] = d280
-					ps723.OverlayValues[281] = d281
-					ps723.OverlayValues[283] = d283
-					ps723.OverlayValues[284] = d284
-					ps723.OverlayValues[285] = d285
-					ps723.OverlayValues[434] = d434
-					ps723.OverlayValues[435] = d435
-					ps723.OverlayValues[436] = d436
-					ps723.OverlayValues[437] = d437
-					ps723.OverlayValues[438] = d438
-					ps723.OverlayValues[441] = d441
-					ps723.OverlayValues[442] = d442
-					ps723.OverlayValues[603] = d603
-					ps723.OverlayValues[604] = d604
-					ps723.OverlayValues[605] = d605
-					ps723.OverlayValues[606] = d606
-					ps723.OverlayValues[607] = d607
-					ps723.OverlayValues[608] = d608
-					ps723.OverlayValues[609] = d609
-					ps723.OverlayValues[610] = d610
-					ps723.OverlayValues[611] = d611
-					ps723.OverlayValues[612] = d612
-					ps723.OverlayValues[613] = d613
-					ps723.OverlayValues[615] = d615
-					ps723.OverlayValues[616] = d616
-					ps723.OverlayValues[617] = d617
-					ps723.OverlayValues[618] = d618
-					ps723.OverlayValues[619] = d619
-					ps723.OverlayValues[621] = d621
-					ps723.OverlayValues[623] = d623
-					ps723.OverlayValues[721] = d721
-					ps723.PhiValues = make([]JITValueDesc, 1)
-					d724 = d7
-					ps723.PhiValues[0] = d724
-					snap725 := d1
-					snap726 := d2
-					snap727 := d3
-					snap728 := d4
-					snap729 := d5
-					snap730 := d6
-					snap731 := d7
-					snap732 := d8
-					snap733 := d9
-					snap734 := d10
-					snap735 := d11
-					snap736 := d12
-					snap737 := d13
-					snap738 := d14
-					snap739 := d15
-					snap740 := d18
-					snap741 := d38
-					snap742 := d57
-					snap743 := d58
-					snap744 := d59
-					snap745 := d60
-					snap746 := d61
-					snap747 := d63
-					snap748 := d64
-					snap749 := d65
-					snap750 := d66
-					snap751 := d67
-					snap752 := d68
-					snap753 := d69
-					snap754 := d72
-					snap755 := d138
-					snap756 := d139
-					snap757 := d140
-					snap758 := d141
-					snap759 := d142
-					snap760 := d143
-					snap761 := d145
-					snap762 := d146
-					snap763 := d147
-					snap764 := d148
-					snap765 := d149
-					snap766 := d150
-					snap767 := d151
-					snap768 := d152
-					snap769 := d153
-					snap770 := d156
-					snap771 := d157
-					snap772 := d158
-					snap773 := d159
-					snap774 := d262
-					snap775 := d263
-					snap776 := d264
-					snap777 := d265
-					snap778 := d266
-					snap779 := d267
-					snap780 := d268
-					snap781 := d269
-					snap782 := d270
-					snap783 := d271
-					snap784 := d272
-					snap785 := d273
-					snap786 := d274
-					snap787 := d275
-					snap788 := d276
-					snap789 := d278
-					snap790 := d279
-					snap791 := d280
-					snap792 := d281
-					snap793 := d283
-					snap794 := d284
-					snap795 := d285
-					snap796 := d434
-					snap797 := d435
-					snap798 := d436
-					snap799 := d437
-					snap800 := d438
-					snap801 := d441
-					snap802 := d442
-					snap803 := d603
-					snap804 := d604
-					snap805 := d605
-					snap806 := d606
-					snap807 := d607
-					snap808 := d608
-					snap809 := d609
-					snap810 := d610
-					snap811 := d611
-					snap812 := d612
-					snap813 := d613
-					snap814 := d615
-					snap815 := d616
-					snap816 := d617
-					snap817 := d618
-					snap818 := d619
-					snap819 := d621
-					snap820 := d623
-					snap821 := d721
-					snap822 := d724
-					alloc823 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc783)
+					d8 = snap675
+					d9 = snap676
+					d10 = snap677
+					d11 = snap678
+					d12 = snap679
+					d13 = snap680
+					d14 = snap681
+					d15 = snap682
+					d16 = snap683
+					d17 = snap684
+					d18 = snap685
+					d19 = snap686
+					d20 = snap687
+					d21 = snap688
+					d22 = snap689
+					d25 = snap690
+					d45 = snap691
+					d64 = snap692
+					d65 = snap693
+					d66 = snap694
+					d67 = snap695
+					d68 = snap696
+					d70 = snap697
+					d71 = snap698
+					d72 = snap699
+					d73 = snap700
+					d74 = snap701
+					d75 = snap702
+					d76 = snap703
+					d79 = snap704
+					d145 = snap705
+					d146 = snap706
+					d147 = snap707
+					d148 = snap708
+					d149 = snap709
+					d150 = snap710
+					d152 = snap711
+					d153 = snap712
+					d154 = snap713
+					d155 = snap714
+					d156 = snap715
+					d157 = snap716
+					d158 = snap717
+					d159 = snap718
+					d160 = snap719
+					d163 = snap720
+					d164 = snap721
+					d165 = snap722
+					d166 = snap723
+					d269 = snap724
+					d270 = snap725
+					d271 = snap726
+					d272 = snap727
+					d273 = snap728
+					d274 = snap729
+					d275 = snap730
+					d276 = snap731
+					d277 = snap732
+					d278 = snap733
+					d279 = snap734
+					d280 = snap735
+					d281 = snap736
+					d282 = snap737
+					d283 = snap738
+					d284 = snap739
+					d285 = snap740
+					d286 = snap741
+					d287 = snap742
+					d289 = snap743
+					d290 = snap744
+					d291 = snap745
+					d292 = snap746
+					d293 = snap747
+					d294 = snap748
+					d295 = snap749
+					d296 = snap750
+					d298 = snap751
+					d299 = snap752
+					d300 = snap753
+					d465 = snap754
+					d466 = snap755
+					d467 = snap756
+					d468 = snap757
+					d469 = snap758
+					d472 = snap759
+					d473 = snap760
+					d650 = snap761
+					d651 = snap762
+					d652 = snap763
+					d653 = snap764
+					d654 = snap765
+					d655 = snap766
+					d656 = snap767
+					d657 = snap768
+					d658 = snap769
+					d659 = snap770
+					d660 = snap771
+					d661 = snap772
+					d662 = snap773
+					d664 = snap774
+					d665 = snap775
+					d666 = snap776
+					d667 = snap777
+					d668 = snap778
+					d669 = snap779
+					d670 = snap780
+					d672 = snap781
+					d674 = snap782
+					ps785 := PhiState{General: true}
+					ps785.OverlayValues = make([]JITValueDesc, 785)
+					ps785.OverlayValues[8] = d8
+					ps785.OverlayValues[9] = d9
+					ps785.OverlayValues[10] = d10
+					ps785.OverlayValues[11] = d11
+					ps785.OverlayValues[12] = d12
+					ps785.OverlayValues[13] = d13
+					ps785.OverlayValues[14] = d14
+					ps785.OverlayValues[15] = d15
+					ps785.OverlayValues[16] = d16
+					ps785.OverlayValues[17] = d17
+					ps785.OverlayValues[18] = d18
+					ps785.OverlayValues[19] = d19
+					ps785.OverlayValues[20] = d20
+					ps785.OverlayValues[21] = d21
+					ps785.OverlayValues[22] = d22
+					ps785.OverlayValues[25] = d25
+					ps785.OverlayValues[45] = d45
+					ps785.OverlayValues[64] = d64
+					ps785.OverlayValues[65] = d65
+					ps785.OverlayValues[66] = d66
+					ps785.OverlayValues[67] = d67
+					ps785.OverlayValues[68] = d68
+					ps785.OverlayValues[70] = d70
+					ps785.OverlayValues[71] = d71
+					ps785.OverlayValues[72] = d72
+					ps785.OverlayValues[73] = d73
+					ps785.OverlayValues[74] = d74
+					ps785.OverlayValues[75] = d75
+					ps785.OverlayValues[76] = d76
+					ps785.OverlayValues[79] = d79
+					ps785.OverlayValues[145] = d145
+					ps785.OverlayValues[146] = d146
+					ps785.OverlayValues[147] = d147
+					ps785.OverlayValues[148] = d148
+					ps785.OverlayValues[149] = d149
+					ps785.OverlayValues[150] = d150
+					ps785.OverlayValues[152] = d152
+					ps785.OverlayValues[153] = d153
+					ps785.OverlayValues[154] = d154
+					ps785.OverlayValues[155] = d155
+					ps785.OverlayValues[156] = d156
+					ps785.OverlayValues[157] = d157
+					ps785.OverlayValues[158] = d158
+					ps785.OverlayValues[159] = d159
+					ps785.OverlayValues[160] = d160
+					ps785.OverlayValues[163] = d163
+					ps785.OverlayValues[164] = d164
+					ps785.OverlayValues[165] = d165
+					ps785.OverlayValues[166] = d166
+					ps785.OverlayValues[269] = d269
+					ps785.OverlayValues[270] = d270
+					ps785.OverlayValues[271] = d271
+					ps785.OverlayValues[272] = d272
+					ps785.OverlayValues[273] = d273
+					ps785.OverlayValues[274] = d274
+					ps785.OverlayValues[275] = d275
+					ps785.OverlayValues[276] = d276
+					ps785.OverlayValues[277] = d277
+					ps785.OverlayValues[278] = d278
+					ps785.OverlayValues[279] = d279
+					ps785.OverlayValues[280] = d280
+					ps785.OverlayValues[281] = d281
+					ps785.OverlayValues[282] = d282
+					ps785.OverlayValues[283] = d283
+					ps785.OverlayValues[284] = d284
+					ps785.OverlayValues[285] = d285
+					ps785.OverlayValues[286] = d286
+					ps785.OverlayValues[287] = d287
+					ps785.OverlayValues[289] = d289
+					ps785.OverlayValues[290] = d290
+					ps785.OverlayValues[291] = d291
+					ps785.OverlayValues[292] = d292
+					ps785.OverlayValues[293] = d293
+					ps785.OverlayValues[294] = d294
+					ps785.OverlayValues[295] = d295
+					ps785.OverlayValues[296] = d296
+					ps785.OverlayValues[298] = d298
+					ps785.OverlayValues[299] = d299
+					ps785.OverlayValues[300] = d300
+					ps785.OverlayValues[465] = d465
+					ps785.OverlayValues[466] = d466
+					ps785.OverlayValues[467] = d467
+					ps785.OverlayValues[468] = d468
+					ps785.OverlayValues[469] = d469
+					ps785.OverlayValues[472] = d472
+					ps785.OverlayValues[473] = d473
+					ps785.OverlayValues[650] = d650
+					ps785.OverlayValues[651] = d651
+					ps785.OverlayValues[652] = d652
+					ps785.OverlayValues[653] = d653
+					ps785.OverlayValues[654] = d654
+					ps785.OverlayValues[655] = d655
+					ps785.OverlayValues[656] = d656
+					ps785.OverlayValues[657] = d657
+					ps785.OverlayValues[658] = d658
+					ps785.OverlayValues[659] = d659
+					ps785.OverlayValues[660] = d660
+					ps785.OverlayValues[661] = d661
+					ps785.OverlayValues[662] = d662
+					ps785.OverlayValues[664] = d664
+					ps785.OverlayValues[665] = d665
+					ps785.OverlayValues[666] = d666
+					ps785.OverlayValues[667] = d667
+					ps785.OverlayValues[668] = d668
+					ps785.OverlayValues[669] = d669
+					ps785.OverlayValues[670] = d670
+					ps785.OverlayValues[672] = d672
+					ps785.OverlayValues[674] = d674
+					ps785.OverlayValues[784] = d784
+					ps786 := PhiState{General: true}
+					ps786.OverlayValues = make([]JITValueDesc, 785)
+					ps786.OverlayValues[8] = d8
+					ps786.OverlayValues[9] = d9
+					ps786.OverlayValues[10] = d10
+					ps786.OverlayValues[11] = d11
+					ps786.OverlayValues[12] = d12
+					ps786.OverlayValues[13] = d13
+					ps786.OverlayValues[14] = d14
+					ps786.OverlayValues[15] = d15
+					ps786.OverlayValues[16] = d16
+					ps786.OverlayValues[17] = d17
+					ps786.OverlayValues[18] = d18
+					ps786.OverlayValues[19] = d19
+					ps786.OverlayValues[20] = d20
+					ps786.OverlayValues[21] = d21
+					ps786.OverlayValues[22] = d22
+					ps786.OverlayValues[25] = d25
+					ps786.OverlayValues[45] = d45
+					ps786.OverlayValues[64] = d64
+					ps786.OverlayValues[65] = d65
+					ps786.OverlayValues[66] = d66
+					ps786.OverlayValues[67] = d67
+					ps786.OverlayValues[68] = d68
+					ps786.OverlayValues[70] = d70
+					ps786.OverlayValues[71] = d71
+					ps786.OverlayValues[72] = d72
+					ps786.OverlayValues[73] = d73
+					ps786.OverlayValues[74] = d74
+					ps786.OverlayValues[75] = d75
+					ps786.OverlayValues[76] = d76
+					ps786.OverlayValues[79] = d79
+					ps786.OverlayValues[145] = d145
+					ps786.OverlayValues[146] = d146
+					ps786.OverlayValues[147] = d147
+					ps786.OverlayValues[148] = d148
+					ps786.OverlayValues[149] = d149
+					ps786.OverlayValues[150] = d150
+					ps786.OverlayValues[152] = d152
+					ps786.OverlayValues[153] = d153
+					ps786.OverlayValues[154] = d154
+					ps786.OverlayValues[155] = d155
+					ps786.OverlayValues[156] = d156
+					ps786.OverlayValues[157] = d157
+					ps786.OverlayValues[158] = d158
+					ps786.OverlayValues[159] = d159
+					ps786.OverlayValues[160] = d160
+					ps786.OverlayValues[163] = d163
+					ps786.OverlayValues[164] = d164
+					ps786.OverlayValues[165] = d165
+					ps786.OverlayValues[166] = d166
+					ps786.OverlayValues[269] = d269
+					ps786.OverlayValues[270] = d270
+					ps786.OverlayValues[271] = d271
+					ps786.OverlayValues[272] = d272
+					ps786.OverlayValues[273] = d273
+					ps786.OverlayValues[274] = d274
+					ps786.OverlayValues[275] = d275
+					ps786.OverlayValues[276] = d276
+					ps786.OverlayValues[277] = d277
+					ps786.OverlayValues[278] = d278
+					ps786.OverlayValues[279] = d279
+					ps786.OverlayValues[280] = d280
+					ps786.OverlayValues[281] = d281
+					ps786.OverlayValues[282] = d282
+					ps786.OverlayValues[283] = d283
+					ps786.OverlayValues[284] = d284
+					ps786.OverlayValues[285] = d285
+					ps786.OverlayValues[286] = d286
+					ps786.OverlayValues[287] = d287
+					ps786.OverlayValues[289] = d289
+					ps786.OverlayValues[290] = d290
+					ps786.OverlayValues[291] = d291
+					ps786.OverlayValues[292] = d292
+					ps786.OverlayValues[293] = d293
+					ps786.OverlayValues[294] = d294
+					ps786.OverlayValues[295] = d295
+					ps786.OverlayValues[296] = d296
+					ps786.OverlayValues[298] = d298
+					ps786.OverlayValues[299] = d299
+					ps786.OverlayValues[300] = d300
+					ps786.OverlayValues[465] = d465
+					ps786.OverlayValues[466] = d466
+					ps786.OverlayValues[467] = d467
+					ps786.OverlayValues[468] = d468
+					ps786.OverlayValues[469] = d469
+					ps786.OverlayValues[472] = d472
+					ps786.OverlayValues[473] = d473
+					ps786.OverlayValues[650] = d650
+					ps786.OverlayValues[651] = d651
+					ps786.OverlayValues[652] = d652
+					ps786.OverlayValues[653] = d653
+					ps786.OverlayValues[654] = d654
+					ps786.OverlayValues[655] = d655
+					ps786.OverlayValues[656] = d656
+					ps786.OverlayValues[657] = d657
+					ps786.OverlayValues[658] = d658
+					ps786.OverlayValues[659] = d659
+					ps786.OverlayValues[660] = d660
+					ps786.OverlayValues[661] = d661
+					ps786.OverlayValues[662] = d662
+					ps786.OverlayValues[664] = d664
+					ps786.OverlayValues[665] = d665
+					ps786.OverlayValues[666] = d666
+					ps786.OverlayValues[667] = d667
+					ps786.OverlayValues[668] = d668
+					ps786.OverlayValues[669] = d669
+					ps786.OverlayValues[670] = d670
+					ps786.OverlayValues[672] = d672
+					ps786.OverlayValues[674] = d674
+					ps786.OverlayValues[784] = d784
+					ps786.PhiValues = make([]JITValueDesc, 1)
+					d787 = d14
+					ps786.PhiValues[0] = d787
+					snap788 := d8
+					snap789 := d9
+					snap790 := d10
+					snap791 := d11
+					snap792 := d12
+					snap793 := d13
+					snap794 := d14
+					snap795 := d15
+					snap796 := d16
+					snap797 := d17
+					snap798 := d18
+					snap799 := d19
+					snap800 := d20
+					snap801 := d21
+					snap802 := d22
+					snap803 := d25
+					snap804 := d45
+					snap805 := d64
+					snap806 := d65
+					snap807 := d66
+					snap808 := d67
+					snap809 := d68
+					snap810 := d70
+					snap811 := d71
+					snap812 := d72
+					snap813 := d73
+					snap814 := d74
+					snap815 := d75
+					snap816 := d76
+					snap817 := d79
+					snap818 := d145
+					snap819 := d146
+					snap820 := d147
+					snap821 := d148
+					snap822 := d149
+					snap823 := d150
+					snap824 := d152
+					snap825 := d153
+					snap826 := d154
+					snap827 := d155
+					snap828 := d156
+					snap829 := d157
+					snap830 := d158
+					snap831 := d159
+					snap832 := d160
+					snap833 := d163
+					snap834 := d164
+					snap835 := d165
+					snap836 := d166
+					snap837 := d269
+					snap838 := d270
+					snap839 := d271
+					snap840 := d272
+					snap841 := d273
+					snap842 := d274
+					snap843 := d275
+					snap844 := d276
+					snap845 := d277
+					snap846 := d278
+					snap847 := d279
+					snap848 := d280
+					snap849 := d281
+					snap850 := d282
+					snap851 := d283
+					snap852 := d284
+					snap853 := d285
+					snap854 := d286
+					snap855 := d287
+					snap856 := d289
+					snap857 := d290
+					snap858 := d291
+					snap859 := d292
+					snap860 := d293
+					snap861 := d294
+					snap862 := d295
+					snap863 := d296
+					snap864 := d298
+					snap865 := d299
+					snap866 := d300
+					snap867 := d465
+					snap868 := d466
+					snap869 := d467
+					snap870 := d468
+					snap871 := d469
+					snap872 := d472
+					snap873 := d473
+					snap874 := d650
+					snap875 := d651
+					snap876 := d652
+					snap877 := d653
+					snap878 := d654
+					snap879 := d655
+					snap880 := d656
+					snap881 := d657
+					snap882 := d658
+					snap883 := d659
+					snap884 := d660
+					snap885 := d661
+					snap886 := d662
+					snap887 := d664
+					snap888 := d665
+					snap889 := d666
+					snap890 := d667
+					snap891 := d668
+					snap892 := d669
+					snap893 := d670
+					snap894 := d672
+					snap895 := d674
+					snap896 := d784
+					snap897 := d787
+					alloc898 := ctx.SnapshotAllocState()
 					if !bbs[4].Rendered {
-						bbs[4].RenderPS(ps723)
+						bbs[4].RenderPS(ps786)
 					}
-					ctx.RestoreAllocState(alloc823)
-					d1 = snap725
-					d2 = snap726
-					d3 = snap727
-					d4 = snap728
-					d5 = snap729
-					d6 = snap730
-					d7 = snap731
-					d8 = snap732
-					d9 = snap733
-					d10 = snap734
-					d11 = snap735
-					d12 = snap736
-					d13 = snap737
-					d14 = snap738
-					d15 = snap739
-					d18 = snap740
-					d38 = snap741
-					d57 = snap742
-					d58 = snap743
-					d59 = snap744
-					d60 = snap745
-					d61 = snap746
-					d63 = snap747
-					d64 = snap748
-					d65 = snap749
-					d66 = snap750
-					d67 = snap751
-					d68 = snap752
-					d69 = snap753
-					d72 = snap754
-					d138 = snap755
-					d139 = snap756
-					d140 = snap757
-					d141 = snap758
-					d142 = snap759
-					d143 = snap760
-					d145 = snap761
-					d146 = snap762
-					d147 = snap763
-					d148 = snap764
-					d149 = snap765
-					d150 = snap766
-					d151 = snap767
-					d152 = snap768
-					d153 = snap769
-					d156 = snap770
-					d157 = snap771
-					d158 = snap772
-					d159 = snap773
-					d262 = snap774
-					d263 = snap775
-					d264 = snap776
-					d265 = snap777
-					d266 = snap778
-					d267 = snap779
-					d268 = snap780
-					d269 = snap781
-					d270 = snap782
-					d271 = snap783
-					d272 = snap784
-					d273 = snap785
-					d274 = snap786
-					d275 = snap787
-					d276 = snap788
-					d278 = snap789
-					d279 = snap790
-					d280 = snap791
-					d281 = snap792
-					d283 = snap793
-					d284 = snap794
-					d285 = snap795
-					d434 = snap796
-					d435 = snap797
-					d436 = snap798
-					d437 = snap799
-					d438 = snap800
-					d441 = snap801
-					d442 = snap802
-					d603 = snap803
-					d604 = snap804
-					d605 = snap805
-					d606 = snap806
-					d607 = snap807
-					d608 = snap808
-					d609 = snap809
-					d610 = snap810
-					d611 = snap811
-					d612 = snap812
-					d613 = snap813
-					d615 = snap814
-					d616 = snap815
-					d617 = snap816
-					d618 = snap817
-					d619 = snap818
-					d621 = snap819
-					d623 = snap820
-					d721 = snap821
-					d724 = snap822
+					ctx.RestoreAllocState(alloc898)
+					d8 = snap788
+					d9 = snap789
+					d10 = snap790
+					d11 = snap791
+					d12 = snap792
+					d13 = snap793
+					d14 = snap794
+					d15 = snap795
+					d16 = snap796
+					d17 = snap797
+					d18 = snap798
+					d19 = snap799
+					d20 = snap800
+					d21 = snap801
+					d22 = snap802
+					d25 = snap803
+					d45 = snap804
+					d64 = snap805
+					d65 = snap806
+					d66 = snap807
+					d67 = snap808
+					d68 = snap809
+					d70 = snap810
+					d71 = snap811
+					d72 = snap812
+					d73 = snap813
+					d74 = snap814
+					d75 = snap815
+					d76 = snap816
+					d79 = snap817
+					d145 = snap818
+					d146 = snap819
+					d147 = snap820
+					d148 = snap821
+					d149 = snap822
+					d150 = snap823
+					d152 = snap824
+					d153 = snap825
+					d154 = snap826
+					d155 = snap827
+					d156 = snap828
+					d157 = snap829
+					d158 = snap830
+					d159 = snap831
+					d160 = snap832
+					d163 = snap833
+					d164 = snap834
+					d165 = snap835
+					d166 = snap836
+					d269 = snap837
+					d270 = snap838
+					d271 = snap839
+					d272 = snap840
+					d273 = snap841
+					d274 = snap842
+					d275 = snap843
+					d276 = snap844
+					d277 = snap845
+					d278 = snap846
+					d279 = snap847
+					d280 = snap848
+					d281 = snap849
+					d282 = snap850
+					d283 = snap851
+					d284 = snap852
+					d285 = snap853
+					d286 = snap854
+					d287 = snap855
+					d289 = snap856
+					d290 = snap857
+					d291 = snap858
+					d292 = snap859
+					d293 = snap860
+					d294 = snap861
+					d295 = snap862
+					d296 = snap863
+					d298 = snap864
+					d299 = snap865
+					d300 = snap866
+					d465 = snap867
+					d466 = snap868
+					d467 = snap869
+					d468 = snap870
+					d469 = snap871
+					d472 = snap872
+					d473 = snap873
+					d650 = snap874
+					d651 = snap875
+					d652 = snap876
+					d653 = snap877
+					d654 = snap878
+					d655 = snap879
+					d656 = snap880
+					d657 = snap881
+					d658 = snap882
+					d659 = snap883
+					d660 = snap884
+					d661 = snap885
+					d662 = snap886
+					d664 = snap887
+					d665 = snap888
+					d666 = snap889
+					d667 = snap890
+					d668 = snap891
+					d669 = snap892
+					d670 = snap893
+					d672 = snap894
+					d674 = snap895
+					d784 = snap896
+					d787 = snap897
 					if !bbs[14].Rendered {
-						return bbs[14].RenderPS(ps722)
+						return bbs[14].RenderPS(ps785)
 					}
 					return result
-					ctx.FreeDesc(&d618)
+					ctx.FreeDesc(&d669)
 					return result
 				}
 				bbs[13].RenderPS = func(ps PhiState) JITValueDesc {
@@ -7368,82 +8119,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl14)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -7460,29 +8217,29 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
 						d145 = ps.OverlayValues[145]
@@ -7502,14 +8259,17 @@ func init_vector() {
 					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
 						d150 = ps.OverlayValues[150]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
-					}
 					if len(ps.OverlayValues) > 152 && ps.OverlayValues[152].Loc != LocNone {
 						d152 = ps.OverlayValues[152]
 					}
 					if len(ps.OverlayValues) > 153 && ps.OverlayValues[153].Loc != LocNone {
 						d153 = ps.OverlayValues[153]
+					}
+					if len(ps.OverlayValues) > 154 && ps.OverlayValues[154].Loc != LocNone {
+						d154 = ps.OverlayValues[154]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
 					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
 						d156 = ps.OverlayValues[156]
@@ -7523,26 +8283,20 @@ func init_vector() {
 					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
 						d159 = ps.OverlayValues[159]
 					}
-					if len(ps.OverlayValues) > 262 && ps.OverlayValues[262].Loc != LocNone {
-						d262 = ps.OverlayValues[262]
+					if len(ps.OverlayValues) > 160 && ps.OverlayValues[160].Loc != LocNone {
+						d160 = ps.OverlayValues[160]
 					}
-					if len(ps.OverlayValues) > 263 && ps.OverlayValues[263].Loc != LocNone {
-						d263 = ps.OverlayValues[263]
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
 					}
-					if len(ps.OverlayValues) > 264 && ps.OverlayValues[264].Loc != LocNone {
-						d264 = ps.OverlayValues[264]
+					if len(ps.OverlayValues) > 164 && ps.OverlayValues[164].Loc != LocNone {
+						d164 = ps.OverlayValues[164]
 					}
-					if len(ps.OverlayValues) > 265 && ps.OverlayValues[265].Loc != LocNone {
-						d265 = ps.OverlayValues[265]
+					if len(ps.OverlayValues) > 165 && ps.OverlayValues[165].Loc != LocNone {
+						d165 = ps.OverlayValues[165]
 					}
-					if len(ps.OverlayValues) > 266 && ps.OverlayValues[266].Loc != LocNone {
-						d266 = ps.OverlayValues[266]
-					}
-					if len(ps.OverlayValues) > 267 && ps.OverlayValues[267].Loc != LocNone {
-						d267 = ps.OverlayValues[267]
-					}
-					if len(ps.OverlayValues) > 268 && ps.OverlayValues[268].Loc != LocNone {
-						d268 = ps.OverlayValues[268]
+					if len(ps.OverlayValues) > 166 && ps.OverlayValues[166].Loc != LocNone {
+						d166 = ps.OverlayValues[166]
 					}
 					if len(ps.OverlayValues) > 269 && ps.OverlayValues[269].Loc != LocNone {
 						d269 = ps.OverlayValues[269]
@@ -7568,6 +8322,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
 						d276 = ps.OverlayValues[276]
 					}
+					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
+						d277 = ps.OverlayValues[277]
+					}
 					if len(ps.OverlayValues) > 278 && ps.OverlayValues[278].Loc != LocNone {
 						d278 = ps.OverlayValues[278]
 					}
@@ -7580,6 +8337,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 281 && ps.OverlayValues[281].Loc != LocNone {
 						d281 = ps.OverlayValues[281]
 					}
+					if len(ps.OverlayValues) > 282 && ps.OverlayValues[282].Loc != LocNone {
+						d282 = ps.OverlayValues[282]
+					}
 					if len(ps.OverlayValues) > 283 && ps.OverlayValues[283].Loc != LocNone {
 						d283 = ps.OverlayValues[283]
 					}
@@ -7589,1085 +8349,1244 @@ func init_vector() {
 					if len(ps.OverlayValues) > 285 && ps.OverlayValues[285].Loc != LocNone {
 						d285 = ps.OverlayValues[285]
 					}
-					if len(ps.OverlayValues) > 434 && ps.OverlayValues[434].Loc != LocNone {
-						d434 = ps.OverlayValues[434]
+					if len(ps.OverlayValues) > 286 && ps.OverlayValues[286].Loc != LocNone {
+						d286 = ps.OverlayValues[286]
 					}
-					if len(ps.OverlayValues) > 435 && ps.OverlayValues[435].Loc != LocNone {
-						d435 = ps.OverlayValues[435]
+					if len(ps.OverlayValues) > 287 && ps.OverlayValues[287].Loc != LocNone {
+						d287 = ps.OverlayValues[287]
 					}
-					if len(ps.OverlayValues) > 436 && ps.OverlayValues[436].Loc != LocNone {
-						d436 = ps.OverlayValues[436]
+					if len(ps.OverlayValues) > 289 && ps.OverlayValues[289].Loc != LocNone {
+						d289 = ps.OverlayValues[289]
 					}
-					if len(ps.OverlayValues) > 437 && ps.OverlayValues[437].Loc != LocNone {
-						d437 = ps.OverlayValues[437]
+					if len(ps.OverlayValues) > 290 && ps.OverlayValues[290].Loc != LocNone {
+						d290 = ps.OverlayValues[290]
 					}
-					if len(ps.OverlayValues) > 438 && ps.OverlayValues[438].Loc != LocNone {
-						d438 = ps.OverlayValues[438]
+					if len(ps.OverlayValues) > 291 && ps.OverlayValues[291].Loc != LocNone {
+						d291 = ps.OverlayValues[291]
 					}
-					if len(ps.OverlayValues) > 441 && ps.OverlayValues[441].Loc != LocNone {
-						d441 = ps.OverlayValues[441]
+					if len(ps.OverlayValues) > 292 && ps.OverlayValues[292].Loc != LocNone {
+						d292 = ps.OverlayValues[292]
 					}
-					if len(ps.OverlayValues) > 442 && ps.OverlayValues[442].Loc != LocNone {
-						d442 = ps.OverlayValues[442]
+					if len(ps.OverlayValues) > 293 && ps.OverlayValues[293].Loc != LocNone {
+						d293 = ps.OverlayValues[293]
 					}
-					if len(ps.OverlayValues) > 603 && ps.OverlayValues[603].Loc != LocNone {
-						d603 = ps.OverlayValues[603]
+					if len(ps.OverlayValues) > 294 && ps.OverlayValues[294].Loc != LocNone {
+						d294 = ps.OverlayValues[294]
 					}
-					if len(ps.OverlayValues) > 604 && ps.OverlayValues[604].Loc != LocNone {
-						d604 = ps.OverlayValues[604]
+					if len(ps.OverlayValues) > 295 && ps.OverlayValues[295].Loc != LocNone {
+						d295 = ps.OverlayValues[295]
 					}
-					if len(ps.OverlayValues) > 605 && ps.OverlayValues[605].Loc != LocNone {
-						d605 = ps.OverlayValues[605]
+					if len(ps.OverlayValues) > 296 && ps.OverlayValues[296].Loc != LocNone {
+						d296 = ps.OverlayValues[296]
 					}
-					if len(ps.OverlayValues) > 606 && ps.OverlayValues[606].Loc != LocNone {
-						d606 = ps.OverlayValues[606]
+					if len(ps.OverlayValues) > 298 && ps.OverlayValues[298].Loc != LocNone {
+						d298 = ps.OverlayValues[298]
 					}
-					if len(ps.OverlayValues) > 607 && ps.OverlayValues[607].Loc != LocNone {
-						d607 = ps.OverlayValues[607]
+					if len(ps.OverlayValues) > 299 && ps.OverlayValues[299].Loc != LocNone {
+						d299 = ps.OverlayValues[299]
 					}
-					if len(ps.OverlayValues) > 608 && ps.OverlayValues[608].Loc != LocNone {
-						d608 = ps.OverlayValues[608]
+					if len(ps.OverlayValues) > 300 && ps.OverlayValues[300].Loc != LocNone {
+						d300 = ps.OverlayValues[300]
 					}
-					if len(ps.OverlayValues) > 609 && ps.OverlayValues[609].Loc != LocNone {
-						d609 = ps.OverlayValues[609]
+					if len(ps.OverlayValues) > 465 && ps.OverlayValues[465].Loc != LocNone {
+						d465 = ps.OverlayValues[465]
 					}
-					if len(ps.OverlayValues) > 610 && ps.OverlayValues[610].Loc != LocNone {
-						d610 = ps.OverlayValues[610]
+					if len(ps.OverlayValues) > 466 && ps.OverlayValues[466].Loc != LocNone {
+						d466 = ps.OverlayValues[466]
 					}
-					if len(ps.OverlayValues) > 611 && ps.OverlayValues[611].Loc != LocNone {
-						d611 = ps.OverlayValues[611]
+					if len(ps.OverlayValues) > 467 && ps.OverlayValues[467].Loc != LocNone {
+						d467 = ps.OverlayValues[467]
 					}
-					if len(ps.OverlayValues) > 612 && ps.OverlayValues[612].Loc != LocNone {
-						d612 = ps.OverlayValues[612]
+					if len(ps.OverlayValues) > 468 && ps.OverlayValues[468].Loc != LocNone {
+						d468 = ps.OverlayValues[468]
 					}
-					if len(ps.OverlayValues) > 613 && ps.OverlayValues[613].Loc != LocNone {
-						d613 = ps.OverlayValues[613]
+					if len(ps.OverlayValues) > 469 && ps.OverlayValues[469].Loc != LocNone {
+						d469 = ps.OverlayValues[469]
 					}
-					if len(ps.OverlayValues) > 615 && ps.OverlayValues[615].Loc != LocNone {
-						d615 = ps.OverlayValues[615]
+					if len(ps.OverlayValues) > 472 && ps.OverlayValues[472].Loc != LocNone {
+						d472 = ps.OverlayValues[472]
 					}
-					if len(ps.OverlayValues) > 616 && ps.OverlayValues[616].Loc != LocNone {
-						d616 = ps.OverlayValues[616]
+					if len(ps.OverlayValues) > 473 && ps.OverlayValues[473].Loc != LocNone {
+						d473 = ps.OverlayValues[473]
 					}
-					if len(ps.OverlayValues) > 617 && ps.OverlayValues[617].Loc != LocNone {
-						d617 = ps.OverlayValues[617]
+					if len(ps.OverlayValues) > 650 && ps.OverlayValues[650].Loc != LocNone {
+						d650 = ps.OverlayValues[650]
 					}
-					if len(ps.OverlayValues) > 618 && ps.OverlayValues[618].Loc != LocNone {
-						d618 = ps.OverlayValues[618]
+					if len(ps.OverlayValues) > 651 && ps.OverlayValues[651].Loc != LocNone {
+						d651 = ps.OverlayValues[651]
 					}
-					if len(ps.OverlayValues) > 619 && ps.OverlayValues[619].Loc != LocNone {
-						d619 = ps.OverlayValues[619]
+					if len(ps.OverlayValues) > 652 && ps.OverlayValues[652].Loc != LocNone {
+						d652 = ps.OverlayValues[652]
 					}
-					if len(ps.OverlayValues) > 621 && ps.OverlayValues[621].Loc != LocNone {
-						d621 = ps.OverlayValues[621]
+					if len(ps.OverlayValues) > 653 && ps.OverlayValues[653].Loc != LocNone {
+						d653 = ps.OverlayValues[653]
 					}
-					if len(ps.OverlayValues) > 623 && ps.OverlayValues[623].Loc != LocNone {
-						d623 = ps.OverlayValues[623]
+					if len(ps.OverlayValues) > 654 && ps.OverlayValues[654].Loc != LocNone {
+						d654 = ps.OverlayValues[654]
 					}
-					if len(ps.OverlayValues) > 721 && ps.OverlayValues[721].Loc != LocNone {
-						d721 = ps.OverlayValues[721]
+					if len(ps.OverlayValues) > 655 && ps.OverlayValues[655].Loc != LocNone {
+						d655 = ps.OverlayValues[655]
 					}
-					if len(ps.OverlayValues) > 724 && ps.OverlayValues[724].Loc != LocNone {
-						d724 = ps.OverlayValues[724]
+					if len(ps.OverlayValues) > 656 && ps.OverlayValues[656].Loc != LocNone {
+						d656 = ps.OverlayValues[656]
+					}
+					if len(ps.OverlayValues) > 657 && ps.OverlayValues[657].Loc != LocNone {
+						d657 = ps.OverlayValues[657]
+					}
+					if len(ps.OverlayValues) > 658 && ps.OverlayValues[658].Loc != LocNone {
+						d658 = ps.OverlayValues[658]
+					}
+					if len(ps.OverlayValues) > 659 && ps.OverlayValues[659].Loc != LocNone {
+						d659 = ps.OverlayValues[659]
+					}
+					if len(ps.OverlayValues) > 660 && ps.OverlayValues[660].Loc != LocNone {
+						d660 = ps.OverlayValues[660]
+					}
+					if len(ps.OverlayValues) > 661 && ps.OverlayValues[661].Loc != LocNone {
+						d661 = ps.OverlayValues[661]
+					}
+					if len(ps.OverlayValues) > 662 && ps.OverlayValues[662].Loc != LocNone {
+						d662 = ps.OverlayValues[662]
+					}
+					if len(ps.OverlayValues) > 664 && ps.OverlayValues[664].Loc != LocNone {
+						d664 = ps.OverlayValues[664]
+					}
+					if len(ps.OverlayValues) > 665 && ps.OverlayValues[665].Loc != LocNone {
+						d665 = ps.OverlayValues[665]
+					}
+					if len(ps.OverlayValues) > 666 && ps.OverlayValues[666].Loc != LocNone {
+						d666 = ps.OverlayValues[666]
+					}
+					if len(ps.OverlayValues) > 667 && ps.OverlayValues[667].Loc != LocNone {
+						d667 = ps.OverlayValues[667]
+					}
+					if len(ps.OverlayValues) > 668 && ps.OverlayValues[668].Loc != LocNone {
+						d668 = ps.OverlayValues[668]
+					}
+					if len(ps.OverlayValues) > 669 && ps.OverlayValues[669].Loc != LocNone {
+						d669 = ps.OverlayValues[669]
+					}
+					if len(ps.OverlayValues) > 670 && ps.OverlayValues[670].Loc != LocNone {
+						d670 = ps.OverlayValues[670]
+					}
+					if len(ps.OverlayValues) > 672 && ps.OverlayValues[672].Loc != LocNone {
+						d672 = ps.OverlayValues[672]
+					}
+					if len(ps.OverlayValues) > 674 && ps.OverlayValues[674].Loc != LocNone {
+						d674 = ps.OverlayValues[674]
+					}
+					if len(ps.OverlayValues) > 784 && ps.OverlayValues[784].Loc != LocNone {
+						d784 = ps.OverlayValues[784]
+					}
+					if len(ps.OverlayValues) > 787 && ps.OverlayValues[787].Loc != LocNone {
+						d787 = ps.OverlayValues[787]
 					}
 					ctx.ReclaimUntrackedRegs()
-					var d824 JITValueDesc
-					if d12.SliceSizeKnown {
-						d824 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d12.KnownSliceLen))}
-					} else if d12.Loc == LocImm {
-						d824 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d12.StackOff))}
-					} else if d12.Loc == LocStackTriple {
-						d824 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d12.StackOff + 8, NoHeapPointer: true}
+					var d899 JITValueDesc
+					if d19.SliceSizeKnown {
+						d899 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.KnownSliceLen))}
+					} else if d19.Loc == LocImm {
+						d899 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.StackOff))}
+					} else if d19.Loc == LocStackTriple {
+						d899 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d19.StackOff + 8, NoHeapPointer: true}
 					} else {
-						ctx.EnsureDesc(&d12)
-						if d12.Loc == LocRegPair || d12.Loc == LocRegTriple {
-							d824 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d12.Reg2, ID: 0}
-						} else if d12.Loc == LocReg {
-							d824 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d12.Reg, ID: 0}
+						ctx.EnsureDesc(&d19)
+						if d19.Loc == LocRegPair || d19.Loc == LocRegTriple {
+							d899 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg2, ID: 0}
+						} else if d19.Loc == LocReg {
+							d899 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg, ID: 0}
 						} else {
 							panic("len on unsupported descriptor location")
 						}
 					}
-					ctx.EnsureDesc(&d8)
-					ctx.EnsureDesc(&d824)
-					ctx.EnsureDescsTogether(&d8, &d824)
-					var d825 JITValueDesc
-					if d8.Loc == LocImm && d824.Loc == LocImm {
-						d825 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d8.Imm.Int() < d824.Imm.Int())}
-					} else if d824.Loc == LocImm {
-						r22 := ctx.AllocRegExcept(d8.Reg)
-						if d824.Imm.Int() >= -2147483648 && d824.Imm.Int() <= 2147483647 {
-							ctx.EmitCmpRegImm32(d8.Reg, int32(d824.Imm.Int()))
+					ctx.EnsureDesc(&d15)
+					ctx.EnsureDesc(&d899)
+					ctx.EnsureDescsTogether(&d15, &d899)
+					var d900 JITValueDesc
+					if d15.Loc == LocImm && d899.Loc == LocImm {
+						d900 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d15.Imm.Int() < d899.Imm.Int())}
+					} else if d899.Loc == LocImm {
+						r20 := ctx.AllocRegExcept(d15.Reg)
+						if d899.Imm.Int() >= -2147483648 && d899.Imm.Int() <= 2147483647 {
+							ctx.EmitCmpRegImm32(d15.Reg, int32(d899.Imm.Int()))
 						} else {
-							ctx.EmitMovRegImm64(RegR11, uint64(d824.Imm.Int()))
-							ctx.EmitCmpInt64(d8.Reg, RegR11)
+							ctx.EmitMovRegImm64(RegR11, uint64(d899.Imm.Int()))
+							ctx.EmitCmpInt64(d15.Reg, RegR11)
 						}
-						d825 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r22, Condition: CondSignedLess}
-						ctx.BindReg(r22, &d825)
-					} else if d8.Loc == LocImm {
-						r23 := ctx.AllocReg()
-						ctx.EmitMovRegImm64(RegR11, uint64(d8.Imm.Int()))
-						ctx.EmitCmpInt64(RegR11, d824.Reg)
-						d825 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r23, Condition: CondSignedLess}
-						ctx.BindReg(r23, &d825)
+						d900 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r20, Condition: CondSignedLess}
+						ctx.BindReg(r20, &d900)
+					} else if d15.Loc == LocImm {
+						r21 := ctx.AllocReg()
+						ctx.EmitMovRegImm64(RegR11, uint64(d15.Imm.Int()))
+						ctx.EmitCmpInt64(RegR11, d899.Reg)
+						d900 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r21, Condition: CondSignedLess}
+						ctx.BindReg(r21, &d900)
 					} else {
-						r24 := ctx.AllocRegExcept(d8.Reg)
-						ctx.EmitCmpInt64(d8.Reg, d824.Reg)
-						d825 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r24, Condition: CondSignedLess}
-						ctx.BindReg(r24, &d825)
+						r22 := ctx.AllocRegExcept(d15.Reg)
+						ctx.EmitCmpInt64(d15.Reg, d899.Reg)
+						d900 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r22, Condition: CondSignedLess}
+						ctx.BindReg(r22, &d900)
 					}
-					ctx.FreeDesc(&d824)
-					d826 = d825
-					ctx.EnsureDesc(&d826)
-					if d826.Loc != LocImm && d826.Loc != LocFlags {
+					ctx.FreeDesc(&d899)
+					d901 = d900
+					ctx.EnsureDesc(&d901)
+					if d901.Loc != LocImm && d901.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d826.Loc == LocImm {
-						if d826.Imm.Bool() {
+					if d901.Loc == LocImm {
+						if d901.Imm.Bool() {
 							if ps.General {
 							}
-							ps827 := PhiState{General: ps.General}
-							ps827.OverlayValues = make([]JITValueDesc, 827)
-							ps827.OverlayValues[1] = d1
-							ps827.OverlayValues[2] = d2
-							ps827.OverlayValues[3] = d3
-							ps827.OverlayValues[4] = d4
-							ps827.OverlayValues[5] = d5
-							ps827.OverlayValues[6] = d6
-							ps827.OverlayValues[7] = d7
-							ps827.OverlayValues[8] = d8
-							ps827.OverlayValues[9] = d9
-							ps827.OverlayValues[10] = d10
-							ps827.OverlayValues[11] = d11
-							ps827.OverlayValues[12] = d12
-							ps827.OverlayValues[13] = d13
-							ps827.OverlayValues[14] = d14
-							ps827.OverlayValues[15] = d15
-							ps827.OverlayValues[18] = d18
-							ps827.OverlayValues[38] = d38
-							ps827.OverlayValues[57] = d57
-							ps827.OverlayValues[58] = d58
-							ps827.OverlayValues[59] = d59
-							ps827.OverlayValues[60] = d60
-							ps827.OverlayValues[61] = d61
-							ps827.OverlayValues[63] = d63
-							ps827.OverlayValues[64] = d64
-							ps827.OverlayValues[65] = d65
-							ps827.OverlayValues[66] = d66
-							ps827.OverlayValues[67] = d67
-							ps827.OverlayValues[68] = d68
-							ps827.OverlayValues[69] = d69
-							ps827.OverlayValues[72] = d72
-							ps827.OverlayValues[138] = d138
-							ps827.OverlayValues[139] = d139
-							ps827.OverlayValues[140] = d140
-							ps827.OverlayValues[141] = d141
-							ps827.OverlayValues[142] = d142
-							ps827.OverlayValues[143] = d143
-							ps827.OverlayValues[145] = d145
-							ps827.OverlayValues[146] = d146
-							ps827.OverlayValues[147] = d147
-							ps827.OverlayValues[148] = d148
-							ps827.OverlayValues[149] = d149
-							ps827.OverlayValues[150] = d150
-							ps827.OverlayValues[151] = d151
-							ps827.OverlayValues[152] = d152
-							ps827.OverlayValues[153] = d153
-							ps827.OverlayValues[156] = d156
-							ps827.OverlayValues[157] = d157
-							ps827.OverlayValues[158] = d158
-							ps827.OverlayValues[159] = d159
-							ps827.OverlayValues[262] = d262
-							ps827.OverlayValues[263] = d263
-							ps827.OverlayValues[264] = d264
-							ps827.OverlayValues[265] = d265
-							ps827.OverlayValues[266] = d266
-							ps827.OverlayValues[267] = d267
-							ps827.OverlayValues[268] = d268
-							ps827.OverlayValues[269] = d269
-							ps827.OverlayValues[270] = d270
-							ps827.OverlayValues[271] = d271
-							ps827.OverlayValues[272] = d272
-							ps827.OverlayValues[273] = d273
-							ps827.OverlayValues[274] = d274
-							ps827.OverlayValues[275] = d275
-							ps827.OverlayValues[276] = d276
-							ps827.OverlayValues[278] = d278
-							ps827.OverlayValues[279] = d279
-							ps827.OverlayValues[280] = d280
-							ps827.OverlayValues[281] = d281
-							ps827.OverlayValues[283] = d283
-							ps827.OverlayValues[284] = d284
-							ps827.OverlayValues[285] = d285
-							ps827.OverlayValues[434] = d434
-							ps827.OverlayValues[435] = d435
-							ps827.OverlayValues[436] = d436
-							ps827.OverlayValues[437] = d437
-							ps827.OverlayValues[438] = d438
-							ps827.OverlayValues[441] = d441
-							ps827.OverlayValues[442] = d442
-							ps827.OverlayValues[603] = d603
-							ps827.OverlayValues[604] = d604
-							ps827.OverlayValues[605] = d605
-							ps827.OverlayValues[606] = d606
-							ps827.OverlayValues[607] = d607
-							ps827.OverlayValues[608] = d608
-							ps827.OverlayValues[609] = d609
-							ps827.OverlayValues[610] = d610
-							ps827.OverlayValues[611] = d611
-							ps827.OverlayValues[612] = d612
-							ps827.OverlayValues[613] = d613
-							ps827.OverlayValues[615] = d615
-							ps827.OverlayValues[616] = d616
-							ps827.OverlayValues[617] = d617
-							ps827.OverlayValues[618] = d618
-							ps827.OverlayValues[619] = d619
-							ps827.OverlayValues[621] = d621
-							ps827.OverlayValues[623] = d623
-							ps827.OverlayValues[721] = d721
-							ps827.OverlayValues[724] = d724
-							ps827.OverlayValues[824] = d824
-							ps827.OverlayValues[825] = d825
-							ps827.OverlayValues[826] = d826
-							return bbs[11].RenderPS(ps827)
+							ps902 := PhiState{General: ps.General}
+							ps902.OverlayValues = make([]JITValueDesc, 902)
+							ps902.OverlayValues[8] = d8
+							ps902.OverlayValues[9] = d9
+							ps902.OverlayValues[10] = d10
+							ps902.OverlayValues[11] = d11
+							ps902.OverlayValues[12] = d12
+							ps902.OverlayValues[13] = d13
+							ps902.OverlayValues[14] = d14
+							ps902.OverlayValues[15] = d15
+							ps902.OverlayValues[16] = d16
+							ps902.OverlayValues[17] = d17
+							ps902.OverlayValues[18] = d18
+							ps902.OverlayValues[19] = d19
+							ps902.OverlayValues[20] = d20
+							ps902.OverlayValues[21] = d21
+							ps902.OverlayValues[22] = d22
+							ps902.OverlayValues[25] = d25
+							ps902.OverlayValues[45] = d45
+							ps902.OverlayValues[64] = d64
+							ps902.OverlayValues[65] = d65
+							ps902.OverlayValues[66] = d66
+							ps902.OverlayValues[67] = d67
+							ps902.OverlayValues[68] = d68
+							ps902.OverlayValues[70] = d70
+							ps902.OverlayValues[71] = d71
+							ps902.OverlayValues[72] = d72
+							ps902.OverlayValues[73] = d73
+							ps902.OverlayValues[74] = d74
+							ps902.OverlayValues[75] = d75
+							ps902.OverlayValues[76] = d76
+							ps902.OverlayValues[79] = d79
+							ps902.OverlayValues[145] = d145
+							ps902.OverlayValues[146] = d146
+							ps902.OverlayValues[147] = d147
+							ps902.OverlayValues[148] = d148
+							ps902.OverlayValues[149] = d149
+							ps902.OverlayValues[150] = d150
+							ps902.OverlayValues[152] = d152
+							ps902.OverlayValues[153] = d153
+							ps902.OverlayValues[154] = d154
+							ps902.OverlayValues[155] = d155
+							ps902.OverlayValues[156] = d156
+							ps902.OverlayValues[157] = d157
+							ps902.OverlayValues[158] = d158
+							ps902.OverlayValues[159] = d159
+							ps902.OverlayValues[160] = d160
+							ps902.OverlayValues[163] = d163
+							ps902.OverlayValues[164] = d164
+							ps902.OverlayValues[165] = d165
+							ps902.OverlayValues[166] = d166
+							ps902.OverlayValues[269] = d269
+							ps902.OverlayValues[270] = d270
+							ps902.OverlayValues[271] = d271
+							ps902.OverlayValues[272] = d272
+							ps902.OverlayValues[273] = d273
+							ps902.OverlayValues[274] = d274
+							ps902.OverlayValues[275] = d275
+							ps902.OverlayValues[276] = d276
+							ps902.OverlayValues[277] = d277
+							ps902.OverlayValues[278] = d278
+							ps902.OverlayValues[279] = d279
+							ps902.OverlayValues[280] = d280
+							ps902.OverlayValues[281] = d281
+							ps902.OverlayValues[282] = d282
+							ps902.OverlayValues[283] = d283
+							ps902.OverlayValues[284] = d284
+							ps902.OverlayValues[285] = d285
+							ps902.OverlayValues[286] = d286
+							ps902.OverlayValues[287] = d287
+							ps902.OverlayValues[289] = d289
+							ps902.OverlayValues[290] = d290
+							ps902.OverlayValues[291] = d291
+							ps902.OverlayValues[292] = d292
+							ps902.OverlayValues[293] = d293
+							ps902.OverlayValues[294] = d294
+							ps902.OverlayValues[295] = d295
+							ps902.OverlayValues[296] = d296
+							ps902.OverlayValues[298] = d298
+							ps902.OverlayValues[299] = d299
+							ps902.OverlayValues[300] = d300
+							ps902.OverlayValues[465] = d465
+							ps902.OverlayValues[466] = d466
+							ps902.OverlayValues[467] = d467
+							ps902.OverlayValues[468] = d468
+							ps902.OverlayValues[469] = d469
+							ps902.OverlayValues[472] = d472
+							ps902.OverlayValues[473] = d473
+							ps902.OverlayValues[650] = d650
+							ps902.OverlayValues[651] = d651
+							ps902.OverlayValues[652] = d652
+							ps902.OverlayValues[653] = d653
+							ps902.OverlayValues[654] = d654
+							ps902.OverlayValues[655] = d655
+							ps902.OverlayValues[656] = d656
+							ps902.OverlayValues[657] = d657
+							ps902.OverlayValues[658] = d658
+							ps902.OverlayValues[659] = d659
+							ps902.OverlayValues[660] = d660
+							ps902.OverlayValues[661] = d661
+							ps902.OverlayValues[662] = d662
+							ps902.OverlayValues[664] = d664
+							ps902.OverlayValues[665] = d665
+							ps902.OverlayValues[666] = d666
+							ps902.OverlayValues[667] = d667
+							ps902.OverlayValues[668] = d668
+							ps902.OverlayValues[669] = d669
+							ps902.OverlayValues[670] = d670
+							ps902.OverlayValues[672] = d672
+							ps902.OverlayValues[674] = d674
+							ps902.OverlayValues[784] = d784
+							ps902.OverlayValues[787] = d787
+							ps902.OverlayValues[899] = d899
+							ps902.OverlayValues[900] = d900
+							ps902.OverlayValues[901] = d901
+							return bbs[11].RenderPS(ps902)
 						}
 						if ps.General {
 						}
-						ps828 := PhiState{General: ps.General}
-						ps828.OverlayValues = make([]JITValueDesc, 827)
-						ps828.OverlayValues[1] = d1
-						ps828.OverlayValues[2] = d2
-						ps828.OverlayValues[3] = d3
-						ps828.OverlayValues[4] = d4
-						ps828.OverlayValues[5] = d5
-						ps828.OverlayValues[6] = d6
-						ps828.OverlayValues[7] = d7
-						ps828.OverlayValues[8] = d8
-						ps828.OverlayValues[9] = d9
-						ps828.OverlayValues[10] = d10
-						ps828.OverlayValues[11] = d11
-						ps828.OverlayValues[12] = d12
-						ps828.OverlayValues[13] = d13
-						ps828.OverlayValues[14] = d14
-						ps828.OverlayValues[15] = d15
-						ps828.OverlayValues[18] = d18
-						ps828.OverlayValues[38] = d38
-						ps828.OverlayValues[57] = d57
-						ps828.OverlayValues[58] = d58
-						ps828.OverlayValues[59] = d59
-						ps828.OverlayValues[60] = d60
-						ps828.OverlayValues[61] = d61
-						ps828.OverlayValues[63] = d63
-						ps828.OverlayValues[64] = d64
-						ps828.OverlayValues[65] = d65
-						ps828.OverlayValues[66] = d66
-						ps828.OverlayValues[67] = d67
-						ps828.OverlayValues[68] = d68
-						ps828.OverlayValues[69] = d69
-						ps828.OverlayValues[72] = d72
-						ps828.OverlayValues[138] = d138
-						ps828.OverlayValues[139] = d139
-						ps828.OverlayValues[140] = d140
-						ps828.OverlayValues[141] = d141
-						ps828.OverlayValues[142] = d142
-						ps828.OverlayValues[143] = d143
-						ps828.OverlayValues[145] = d145
-						ps828.OverlayValues[146] = d146
-						ps828.OverlayValues[147] = d147
-						ps828.OverlayValues[148] = d148
-						ps828.OverlayValues[149] = d149
-						ps828.OverlayValues[150] = d150
-						ps828.OverlayValues[151] = d151
-						ps828.OverlayValues[152] = d152
-						ps828.OverlayValues[153] = d153
-						ps828.OverlayValues[156] = d156
-						ps828.OverlayValues[157] = d157
-						ps828.OverlayValues[158] = d158
-						ps828.OverlayValues[159] = d159
-						ps828.OverlayValues[262] = d262
-						ps828.OverlayValues[263] = d263
-						ps828.OverlayValues[264] = d264
-						ps828.OverlayValues[265] = d265
-						ps828.OverlayValues[266] = d266
-						ps828.OverlayValues[267] = d267
-						ps828.OverlayValues[268] = d268
-						ps828.OverlayValues[269] = d269
-						ps828.OverlayValues[270] = d270
-						ps828.OverlayValues[271] = d271
-						ps828.OverlayValues[272] = d272
-						ps828.OverlayValues[273] = d273
-						ps828.OverlayValues[274] = d274
-						ps828.OverlayValues[275] = d275
-						ps828.OverlayValues[276] = d276
-						ps828.OverlayValues[278] = d278
-						ps828.OverlayValues[279] = d279
-						ps828.OverlayValues[280] = d280
-						ps828.OverlayValues[281] = d281
-						ps828.OverlayValues[283] = d283
-						ps828.OverlayValues[284] = d284
-						ps828.OverlayValues[285] = d285
-						ps828.OverlayValues[434] = d434
-						ps828.OverlayValues[435] = d435
-						ps828.OverlayValues[436] = d436
-						ps828.OverlayValues[437] = d437
-						ps828.OverlayValues[438] = d438
-						ps828.OverlayValues[441] = d441
-						ps828.OverlayValues[442] = d442
-						ps828.OverlayValues[603] = d603
-						ps828.OverlayValues[604] = d604
-						ps828.OverlayValues[605] = d605
-						ps828.OverlayValues[606] = d606
-						ps828.OverlayValues[607] = d607
-						ps828.OverlayValues[608] = d608
-						ps828.OverlayValues[609] = d609
-						ps828.OverlayValues[610] = d610
-						ps828.OverlayValues[611] = d611
-						ps828.OverlayValues[612] = d612
-						ps828.OverlayValues[613] = d613
-						ps828.OverlayValues[615] = d615
-						ps828.OverlayValues[616] = d616
-						ps828.OverlayValues[617] = d617
-						ps828.OverlayValues[618] = d618
-						ps828.OverlayValues[619] = d619
-						ps828.OverlayValues[621] = d621
-						ps828.OverlayValues[623] = d623
-						ps828.OverlayValues[721] = d721
-						ps828.OverlayValues[724] = d724
-						ps828.OverlayValues[824] = d824
-						ps828.OverlayValues[825] = d825
-						ps828.OverlayValues[826] = d826
-						return bbs[12].RenderPS(ps828)
+						ps903 := PhiState{General: ps.General}
+						ps903.OverlayValues = make([]JITValueDesc, 902)
+						ps903.OverlayValues[8] = d8
+						ps903.OverlayValues[9] = d9
+						ps903.OverlayValues[10] = d10
+						ps903.OverlayValues[11] = d11
+						ps903.OverlayValues[12] = d12
+						ps903.OverlayValues[13] = d13
+						ps903.OverlayValues[14] = d14
+						ps903.OverlayValues[15] = d15
+						ps903.OverlayValues[16] = d16
+						ps903.OverlayValues[17] = d17
+						ps903.OverlayValues[18] = d18
+						ps903.OverlayValues[19] = d19
+						ps903.OverlayValues[20] = d20
+						ps903.OverlayValues[21] = d21
+						ps903.OverlayValues[22] = d22
+						ps903.OverlayValues[25] = d25
+						ps903.OverlayValues[45] = d45
+						ps903.OverlayValues[64] = d64
+						ps903.OverlayValues[65] = d65
+						ps903.OverlayValues[66] = d66
+						ps903.OverlayValues[67] = d67
+						ps903.OverlayValues[68] = d68
+						ps903.OverlayValues[70] = d70
+						ps903.OverlayValues[71] = d71
+						ps903.OverlayValues[72] = d72
+						ps903.OverlayValues[73] = d73
+						ps903.OverlayValues[74] = d74
+						ps903.OverlayValues[75] = d75
+						ps903.OverlayValues[76] = d76
+						ps903.OverlayValues[79] = d79
+						ps903.OverlayValues[145] = d145
+						ps903.OverlayValues[146] = d146
+						ps903.OverlayValues[147] = d147
+						ps903.OverlayValues[148] = d148
+						ps903.OverlayValues[149] = d149
+						ps903.OverlayValues[150] = d150
+						ps903.OverlayValues[152] = d152
+						ps903.OverlayValues[153] = d153
+						ps903.OverlayValues[154] = d154
+						ps903.OverlayValues[155] = d155
+						ps903.OverlayValues[156] = d156
+						ps903.OverlayValues[157] = d157
+						ps903.OverlayValues[158] = d158
+						ps903.OverlayValues[159] = d159
+						ps903.OverlayValues[160] = d160
+						ps903.OverlayValues[163] = d163
+						ps903.OverlayValues[164] = d164
+						ps903.OverlayValues[165] = d165
+						ps903.OverlayValues[166] = d166
+						ps903.OverlayValues[269] = d269
+						ps903.OverlayValues[270] = d270
+						ps903.OverlayValues[271] = d271
+						ps903.OverlayValues[272] = d272
+						ps903.OverlayValues[273] = d273
+						ps903.OverlayValues[274] = d274
+						ps903.OverlayValues[275] = d275
+						ps903.OverlayValues[276] = d276
+						ps903.OverlayValues[277] = d277
+						ps903.OverlayValues[278] = d278
+						ps903.OverlayValues[279] = d279
+						ps903.OverlayValues[280] = d280
+						ps903.OverlayValues[281] = d281
+						ps903.OverlayValues[282] = d282
+						ps903.OverlayValues[283] = d283
+						ps903.OverlayValues[284] = d284
+						ps903.OverlayValues[285] = d285
+						ps903.OverlayValues[286] = d286
+						ps903.OverlayValues[287] = d287
+						ps903.OverlayValues[289] = d289
+						ps903.OverlayValues[290] = d290
+						ps903.OverlayValues[291] = d291
+						ps903.OverlayValues[292] = d292
+						ps903.OverlayValues[293] = d293
+						ps903.OverlayValues[294] = d294
+						ps903.OverlayValues[295] = d295
+						ps903.OverlayValues[296] = d296
+						ps903.OverlayValues[298] = d298
+						ps903.OverlayValues[299] = d299
+						ps903.OverlayValues[300] = d300
+						ps903.OverlayValues[465] = d465
+						ps903.OverlayValues[466] = d466
+						ps903.OverlayValues[467] = d467
+						ps903.OverlayValues[468] = d468
+						ps903.OverlayValues[469] = d469
+						ps903.OverlayValues[472] = d472
+						ps903.OverlayValues[473] = d473
+						ps903.OverlayValues[650] = d650
+						ps903.OverlayValues[651] = d651
+						ps903.OverlayValues[652] = d652
+						ps903.OverlayValues[653] = d653
+						ps903.OverlayValues[654] = d654
+						ps903.OverlayValues[655] = d655
+						ps903.OverlayValues[656] = d656
+						ps903.OverlayValues[657] = d657
+						ps903.OverlayValues[658] = d658
+						ps903.OverlayValues[659] = d659
+						ps903.OverlayValues[660] = d660
+						ps903.OverlayValues[661] = d661
+						ps903.OverlayValues[662] = d662
+						ps903.OverlayValues[664] = d664
+						ps903.OverlayValues[665] = d665
+						ps903.OverlayValues[666] = d666
+						ps903.OverlayValues[667] = d667
+						ps903.OverlayValues[668] = d668
+						ps903.OverlayValues[669] = d669
+						ps903.OverlayValues[670] = d670
+						ps903.OverlayValues[672] = d672
+						ps903.OverlayValues[674] = d674
+						ps903.OverlayValues[784] = d784
+						ps903.OverlayValues[787] = d787
+						ps903.OverlayValues[899] = d899
+						ps903.OverlayValues[900] = d900
+						ps903.OverlayValues[901] = d901
+						return bbs[12].RenderPS(ps903)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[13].RenderPS(ps)
 					}
-					ctx.EmitJump(d826.Condition, lbl12)
+					ctx.EmitJump(d901.Condition, lbl12)
 					if bbs[12].Rendered {
 						ctx.EmitJmp(lbl13)
 					}
-					ctx.FreeDesc(&d825)
-					snap829 := d1
-					snap830 := d2
-					snap831 := d3
-					snap832 := d4
-					snap833 := d5
-					snap834 := d6
-					snap835 := d7
-					snap836 := d8
-					snap837 := d9
-					snap838 := d10
-					snap839 := d11
-					snap840 := d12
-					snap841 := d13
-					snap842 := d14
-					snap843 := d15
-					snap844 := d18
-					snap845 := d38
-					snap846 := d57
-					snap847 := d58
-					snap848 := d59
-					snap849 := d60
-					snap850 := d61
-					snap851 := d63
-					snap852 := d64
-					snap853 := d65
-					snap854 := d66
-					snap855 := d67
-					snap856 := d68
-					snap857 := d69
-					snap858 := d72
-					snap859 := d138
-					snap860 := d139
-					snap861 := d140
-					snap862 := d141
-					snap863 := d142
-					snap864 := d143
-					snap865 := d145
-					snap866 := d146
-					snap867 := d147
-					snap868 := d148
-					snap869 := d149
-					snap870 := d150
-					snap871 := d151
-					snap872 := d152
-					snap873 := d153
-					snap874 := d156
-					snap875 := d157
-					snap876 := d158
-					snap877 := d159
-					snap878 := d262
-					snap879 := d263
-					snap880 := d264
-					snap881 := d265
-					snap882 := d266
-					snap883 := d267
-					snap884 := d268
-					snap885 := d269
-					snap886 := d270
-					snap887 := d271
-					snap888 := d272
-					snap889 := d273
-					snap890 := d274
-					snap891 := d275
-					snap892 := d276
-					snap893 := d278
-					snap894 := d279
-					snap895 := d280
-					snap896 := d281
-					snap897 := d283
-					snap898 := d284
-					snap899 := d285
-					snap900 := d434
-					snap901 := d435
-					snap902 := d436
-					snap903 := d437
-					snap904 := d438
-					snap905 := d441
-					snap906 := d442
-					snap907 := d603
-					snap908 := d604
-					snap909 := d605
-					snap910 := d606
-					snap911 := d607
-					snap912 := d608
-					snap913 := d609
-					snap914 := d610
-					snap915 := d611
-					snap916 := d612
-					snap917 := d613
-					snap918 := d615
-					snap919 := d616
-					snap920 := d617
-					snap921 := d618
-					snap922 := d619
-					snap923 := d621
-					snap924 := d623
-					snap925 := d721
-					snap926 := d724
-					snap927 := d824
-					snap928 := d825
-					snap929 := d826
-					alloc930 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc930)
-					d1 = snap829
-					d2 = snap830
-					d3 = snap831
-					d4 = snap832
-					d5 = snap833
-					d6 = snap834
-					d7 = snap835
-					d8 = snap836
-					d9 = snap837
-					d10 = snap838
-					d11 = snap839
-					d12 = snap840
-					d13 = snap841
-					d14 = snap842
-					d15 = snap843
-					d18 = snap844
-					d38 = snap845
-					d57 = snap846
-					d58 = snap847
-					d59 = snap848
-					d60 = snap849
-					d61 = snap850
-					d63 = snap851
-					d64 = snap852
-					d65 = snap853
-					d66 = snap854
-					d67 = snap855
-					d68 = snap856
-					d69 = snap857
-					d72 = snap858
-					d138 = snap859
-					d139 = snap860
-					d140 = snap861
-					d141 = snap862
-					d142 = snap863
-					d143 = snap864
-					d145 = snap865
-					d146 = snap866
-					d147 = snap867
-					d148 = snap868
-					d149 = snap869
-					d150 = snap870
-					d151 = snap871
-					d152 = snap872
-					d153 = snap873
-					d156 = snap874
-					d157 = snap875
-					d158 = snap876
-					d159 = snap877
-					d262 = snap878
-					d263 = snap879
-					d264 = snap880
-					d265 = snap881
-					d266 = snap882
-					d267 = snap883
-					d268 = snap884
-					d269 = snap885
-					d270 = snap886
-					d271 = snap887
-					d272 = snap888
-					d273 = snap889
-					d274 = snap890
-					d275 = snap891
-					d276 = snap892
-					d278 = snap893
-					d279 = snap894
-					d280 = snap895
-					d281 = snap896
-					d283 = snap897
-					d284 = snap898
-					d285 = snap899
-					d434 = snap900
-					d435 = snap901
-					d436 = snap902
-					d437 = snap903
-					d438 = snap904
-					d441 = snap905
-					d442 = snap906
-					d603 = snap907
-					d604 = snap908
-					d605 = snap909
-					d606 = snap910
-					d607 = snap911
-					d608 = snap912
-					d609 = snap913
-					d610 = snap914
-					d611 = snap915
-					d612 = snap916
-					d613 = snap917
-					d615 = snap918
-					d616 = snap919
-					d617 = snap920
-					d618 = snap921
-					d619 = snap922
-					d621 = snap923
-					d623 = snap924
-					d721 = snap925
-					d724 = snap926
-					d824 = snap927
-					d825 = snap928
-					d826 = snap929
-					ctx.RestoreAllocState(alloc930)
-					d1 = snap829
-					d2 = snap830
-					d3 = snap831
-					d4 = snap832
-					d5 = snap833
-					d6 = snap834
-					d7 = snap835
-					d8 = snap836
-					d9 = snap837
-					d10 = snap838
-					d11 = snap839
-					d12 = snap840
-					d13 = snap841
-					d14 = snap842
-					d15 = snap843
-					d18 = snap844
-					d38 = snap845
-					d57 = snap846
-					d58 = snap847
-					d59 = snap848
-					d60 = snap849
-					d61 = snap850
-					d63 = snap851
-					d64 = snap852
-					d65 = snap853
-					d66 = snap854
-					d67 = snap855
-					d68 = snap856
-					d69 = snap857
-					d72 = snap858
-					d138 = snap859
-					d139 = snap860
-					d140 = snap861
-					d141 = snap862
-					d142 = snap863
-					d143 = snap864
-					d145 = snap865
-					d146 = snap866
-					d147 = snap867
-					d148 = snap868
-					d149 = snap869
-					d150 = snap870
-					d151 = snap871
-					d152 = snap872
-					d153 = snap873
-					d156 = snap874
-					d157 = snap875
-					d158 = snap876
-					d159 = snap877
-					d262 = snap878
-					d263 = snap879
-					d264 = snap880
-					d265 = snap881
-					d266 = snap882
-					d267 = snap883
-					d268 = snap884
-					d269 = snap885
-					d270 = snap886
-					d271 = snap887
-					d272 = snap888
-					d273 = snap889
-					d274 = snap890
-					d275 = snap891
-					d276 = snap892
-					d278 = snap893
-					d279 = snap894
-					d280 = snap895
-					d281 = snap896
-					d283 = snap897
-					d284 = snap898
-					d285 = snap899
-					d434 = snap900
-					d435 = snap901
-					d436 = snap902
-					d437 = snap903
-					d438 = snap904
-					d441 = snap905
-					d442 = snap906
-					d603 = snap907
-					d604 = snap908
-					d605 = snap909
-					d606 = snap910
-					d607 = snap911
-					d608 = snap912
-					d609 = snap913
-					d610 = snap914
-					d611 = snap915
-					d612 = snap916
-					d613 = snap917
-					d615 = snap918
-					d616 = snap919
-					d617 = snap920
-					d618 = snap921
-					d619 = snap922
-					d621 = snap923
-					d623 = snap924
-					d721 = snap925
-					d724 = snap926
-					d824 = snap927
-					d825 = snap928
-					d826 = snap929
-					ps931 := PhiState{General: true}
-					ps931.OverlayValues = make([]JITValueDesc, 827)
-					ps931.OverlayValues[1] = d1
-					ps931.OverlayValues[2] = d2
-					ps931.OverlayValues[3] = d3
-					ps931.OverlayValues[4] = d4
-					ps931.OverlayValues[5] = d5
-					ps931.OverlayValues[6] = d6
-					ps931.OverlayValues[7] = d7
-					ps931.OverlayValues[8] = d8
-					ps931.OverlayValues[9] = d9
-					ps931.OverlayValues[10] = d10
-					ps931.OverlayValues[11] = d11
-					ps931.OverlayValues[12] = d12
-					ps931.OverlayValues[13] = d13
-					ps931.OverlayValues[14] = d14
-					ps931.OverlayValues[15] = d15
-					ps931.OverlayValues[18] = d18
-					ps931.OverlayValues[38] = d38
-					ps931.OverlayValues[57] = d57
-					ps931.OverlayValues[58] = d58
-					ps931.OverlayValues[59] = d59
-					ps931.OverlayValues[60] = d60
-					ps931.OverlayValues[61] = d61
-					ps931.OverlayValues[63] = d63
-					ps931.OverlayValues[64] = d64
-					ps931.OverlayValues[65] = d65
-					ps931.OverlayValues[66] = d66
-					ps931.OverlayValues[67] = d67
-					ps931.OverlayValues[68] = d68
-					ps931.OverlayValues[69] = d69
-					ps931.OverlayValues[72] = d72
-					ps931.OverlayValues[138] = d138
-					ps931.OverlayValues[139] = d139
-					ps931.OverlayValues[140] = d140
-					ps931.OverlayValues[141] = d141
-					ps931.OverlayValues[142] = d142
-					ps931.OverlayValues[143] = d143
-					ps931.OverlayValues[145] = d145
-					ps931.OverlayValues[146] = d146
-					ps931.OverlayValues[147] = d147
-					ps931.OverlayValues[148] = d148
-					ps931.OverlayValues[149] = d149
-					ps931.OverlayValues[150] = d150
-					ps931.OverlayValues[151] = d151
-					ps931.OverlayValues[152] = d152
-					ps931.OverlayValues[153] = d153
-					ps931.OverlayValues[156] = d156
-					ps931.OverlayValues[157] = d157
-					ps931.OverlayValues[158] = d158
-					ps931.OverlayValues[159] = d159
-					ps931.OverlayValues[262] = d262
-					ps931.OverlayValues[263] = d263
-					ps931.OverlayValues[264] = d264
-					ps931.OverlayValues[265] = d265
-					ps931.OverlayValues[266] = d266
-					ps931.OverlayValues[267] = d267
-					ps931.OverlayValues[268] = d268
-					ps931.OverlayValues[269] = d269
-					ps931.OverlayValues[270] = d270
-					ps931.OverlayValues[271] = d271
-					ps931.OverlayValues[272] = d272
-					ps931.OverlayValues[273] = d273
-					ps931.OverlayValues[274] = d274
-					ps931.OverlayValues[275] = d275
-					ps931.OverlayValues[276] = d276
-					ps931.OverlayValues[278] = d278
-					ps931.OverlayValues[279] = d279
-					ps931.OverlayValues[280] = d280
-					ps931.OverlayValues[281] = d281
-					ps931.OverlayValues[283] = d283
-					ps931.OverlayValues[284] = d284
-					ps931.OverlayValues[285] = d285
-					ps931.OverlayValues[434] = d434
-					ps931.OverlayValues[435] = d435
-					ps931.OverlayValues[436] = d436
-					ps931.OverlayValues[437] = d437
-					ps931.OverlayValues[438] = d438
-					ps931.OverlayValues[441] = d441
-					ps931.OverlayValues[442] = d442
-					ps931.OverlayValues[603] = d603
-					ps931.OverlayValues[604] = d604
-					ps931.OverlayValues[605] = d605
-					ps931.OverlayValues[606] = d606
-					ps931.OverlayValues[607] = d607
-					ps931.OverlayValues[608] = d608
-					ps931.OverlayValues[609] = d609
-					ps931.OverlayValues[610] = d610
-					ps931.OverlayValues[611] = d611
-					ps931.OverlayValues[612] = d612
-					ps931.OverlayValues[613] = d613
-					ps931.OverlayValues[615] = d615
-					ps931.OverlayValues[616] = d616
-					ps931.OverlayValues[617] = d617
-					ps931.OverlayValues[618] = d618
-					ps931.OverlayValues[619] = d619
-					ps931.OverlayValues[621] = d621
-					ps931.OverlayValues[623] = d623
-					ps931.OverlayValues[721] = d721
-					ps931.OverlayValues[724] = d724
-					ps931.OverlayValues[824] = d824
-					ps931.OverlayValues[825] = d825
-					ps931.OverlayValues[826] = d826
-					ps932 := PhiState{General: true}
-					ps932.OverlayValues = make([]JITValueDesc, 827)
-					ps932.OverlayValues[1] = d1
-					ps932.OverlayValues[2] = d2
-					ps932.OverlayValues[3] = d3
-					ps932.OverlayValues[4] = d4
-					ps932.OverlayValues[5] = d5
-					ps932.OverlayValues[6] = d6
-					ps932.OverlayValues[7] = d7
-					ps932.OverlayValues[8] = d8
-					ps932.OverlayValues[9] = d9
-					ps932.OverlayValues[10] = d10
-					ps932.OverlayValues[11] = d11
-					ps932.OverlayValues[12] = d12
-					ps932.OverlayValues[13] = d13
-					ps932.OverlayValues[14] = d14
-					ps932.OverlayValues[15] = d15
-					ps932.OverlayValues[18] = d18
-					ps932.OverlayValues[38] = d38
-					ps932.OverlayValues[57] = d57
-					ps932.OverlayValues[58] = d58
-					ps932.OverlayValues[59] = d59
-					ps932.OverlayValues[60] = d60
-					ps932.OverlayValues[61] = d61
-					ps932.OverlayValues[63] = d63
-					ps932.OverlayValues[64] = d64
-					ps932.OverlayValues[65] = d65
-					ps932.OverlayValues[66] = d66
-					ps932.OverlayValues[67] = d67
-					ps932.OverlayValues[68] = d68
-					ps932.OverlayValues[69] = d69
-					ps932.OverlayValues[72] = d72
-					ps932.OverlayValues[138] = d138
-					ps932.OverlayValues[139] = d139
-					ps932.OverlayValues[140] = d140
-					ps932.OverlayValues[141] = d141
-					ps932.OverlayValues[142] = d142
-					ps932.OverlayValues[143] = d143
-					ps932.OverlayValues[145] = d145
-					ps932.OverlayValues[146] = d146
-					ps932.OverlayValues[147] = d147
-					ps932.OverlayValues[148] = d148
-					ps932.OverlayValues[149] = d149
-					ps932.OverlayValues[150] = d150
-					ps932.OverlayValues[151] = d151
-					ps932.OverlayValues[152] = d152
-					ps932.OverlayValues[153] = d153
-					ps932.OverlayValues[156] = d156
-					ps932.OverlayValues[157] = d157
-					ps932.OverlayValues[158] = d158
-					ps932.OverlayValues[159] = d159
-					ps932.OverlayValues[262] = d262
-					ps932.OverlayValues[263] = d263
-					ps932.OverlayValues[264] = d264
-					ps932.OverlayValues[265] = d265
-					ps932.OverlayValues[266] = d266
-					ps932.OverlayValues[267] = d267
-					ps932.OverlayValues[268] = d268
-					ps932.OverlayValues[269] = d269
-					ps932.OverlayValues[270] = d270
-					ps932.OverlayValues[271] = d271
-					ps932.OverlayValues[272] = d272
-					ps932.OverlayValues[273] = d273
-					ps932.OverlayValues[274] = d274
-					ps932.OverlayValues[275] = d275
-					ps932.OverlayValues[276] = d276
-					ps932.OverlayValues[278] = d278
-					ps932.OverlayValues[279] = d279
-					ps932.OverlayValues[280] = d280
-					ps932.OverlayValues[281] = d281
-					ps932.OverlayValues[283] = d283
-					ps932.OverlayValues[284] = d284
-					ps932.OverlayValues[285] = d285
-					ps932.OverlayValues[434] = d434
-					ps932.OverlayValues[435] = d435
-					ps932.OverlayValues[436] = d436
-					ps932.OverlayValues[437] = d437
-					ps932.OverlayValues[438] = d438
-					ps932.OverlayValues[441] = d441
-					ps932.OverlayValues[442] = d442
-					ps932.OverlayValues[603] = d603
-					ps932.OverlayValues[604] = d604
-					ps932.OverlayValues[605] = d605
-					ps932.OverlayValues[606] = d606
-					ps932.OverlayValues[607] = d607
-					ps932.OverlayValues[608] = d608
-					ps932.OverlayValues[609] = d609
-					ps932.OverlayValues[610] = d610
-					ps932.OverlayValues[611] = d611
-					ps932.OverlayValues[612] = d612
-					ps932.OverlayValues[613] = d613
-					ps932.OverlayValues[615] = d615
-					ps932.OverlayValues[616] = d616
-					ps932.OverlayValues[617] = d617
-					ps932.OverlayValues[618] = d618
-					ps932.OverlayValues[619] = d619
-					ps932.OverlayValues[621] = d621
-					ps932.OverlayValues[623] = d623
-					ps932.OverlayValues[721] = d721
-					ps932.OverlayValues[724] = d724
-					ps932.OverlayValues[824] = d824
-					ps932.OverlayValues[825] = d825
-					ps932.OverlayValues[826] = d826
-					snap933 := d1
-					snap934 := d2
-					snap935 := d3
-					snap936 := d4
-					snap937 := d5
-					snap938 := d6
-					snap939 := d7
-					snap940 := d8
-					snap941 := d9
-					snap942 := d10
-					snap943 := d11
-					snap944 := d12
-					snap945 := d13
-					snap946 := d14
-					snap947 := d15
-					snap948 := d18
-					snap949 := d38
-					snap950 := d57
-					snap951 := d58
-					snap952 := d59
-					snap953 := d60
-					snap954 := d61
-					snap955 := d63
-					snap956 := d64
-					snap957 := d65
-					snap958 := d66
-					snap959 := d67
-					snap960 := d68
-					snap961 := d69
-					snap962 := d72
-					snap963 := d138
-					snap964 := d139
-					snap965 := d140
-					snap966 := d141
-					snap967 := d142
-					snap968 := d143
-					snap969 := d145
-					snap970 := d146
-					snap971 := d147
-					snap972 := d148
-					snap973 := d149
-					snap974 := d150
-					snap975 := d151
-					snap976 := d152
-					snap977 := d153
-					snap978 := d156
-					snap979 := d157
-					snap980 := d158
-					snap981 := d159
-					snap982 := d262
-					snap983 := d263
-					snap984 := d264
-					snap985 := d265
-					snap986 := d266
-					snap987 := d267
-					snap988 := d268
-					snap989 := d269
-					snap990 := d270
-					snap991 := d271
-					snap992 := d272
-					snap993 := d273
-					snap994 := d274
-					snap995 := d275
-					snap996 := d276
-					snap997 := d278
-					snap998 := d279
-					snap999 := d280
-					snap1000 := d281
-					snap1001 := d283
-					snap1002 := d284
-					snap1003 := d285
-					snap1004 := d434
-					snap1005 := d435
-					snap1006 := d436
-					snap1007 := d437
-					snap1008 := d438
-					snap1009 := d441
-					snap1010 := d442
-					snap1011 := d603
-					snap1012 := d604
-					snap1013 := d605
-					snap1014 := d606
-					snap1015 := d607
-					snap1016 := d608
-					snap1017 := d609
-					snap1018 := d610
-					snap1019 := d611
-					snap1020 := d612
-					snap1021 := d613
-					snap1022 := d615
-					snap1023 := d616
-					snap1024 := d617
-					snap1025 := d618
-					snap1026 := d619
-					snap1027 := d621
-					snap1028 := d623
-					snap1029 := d721
-					snap1030 := d724
-					snap1031 := d824
-					snap1032 := d825
-					snap1033 := d826
-					alloc1034 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d900)
+					snap904 := d8
+					snap905 := d9
+					snap906 := d10
+					snap907 := d11
+					snap908 := d12
+					snap909 := d13
+					snap910 := d14
+					snap911 := d15
+					snap912 := d16
+					snap913 := d17
+					snap914 := d18
+					snap915 := d19
+					snap916 := d20
+					snap917 := d21
+					snap918 := d22
+					snap919 := d25
+					snap920 := d45
+					snap921 := d64
+					snap922 := d65
+					snap923 := d66
+					snap924 := d67
+					snap925 := d68
+					snap926 := d70
+					snap927 := d71
+					snap928 := d72
+					snap929 := d73
+					snap930 := d74
+					snap931 := d75
+					snap932 := d76
+					snap933 := d79
+					snap934 := d145
+					snap935 := d146
+					snap936 := d147
+					snap937 := d148
+					snap938 := d149
+					snap939 := d150
+					snap940 := d152
+					snap941 := d153
+					snap942 := d154
+					snap943 := d155
+					snap944 := d156
+					snap945 := d157
+					snap946 := d158
+					snap947 := d159
+					snap948 := d160
+					snap949 := d163
+					snap950 := d164
+					snap951 := d165
+					snap952 := d166
+					snap953 := d269
+					snap954 := d270
+					snap955 := d271
+					snap956 := d272
+					snap957 := d273
+					snap958 := d274
+					snap959 := d275
+					snap960 := d276
+					snap961 := d277
+					snap962 := d278
+					snap963 := d279
+					snap964 := d280
+					snap965 := d281
+					snap966 := d282
+					snap967 := d283
+					snap968 := d284
+					snap969 := d285
+					snap970 := d286
+					snap971 := d287
+					snap972 := d289
+					snap973 := d290
+					snap974 := d291
+					snap975 := d292
+					snap976 := d293
+					snap977 := d294
+					snap978 := d295
+					snap979 := d296
+					snap980 := d298
+					snap981 := d299
+					snap982 := d300
+					snap983 := d465
+					snap984 := d466
+					snap985 := d467
+					snap986 := d468
+					snap987 := d469
+					snap988 := d472
+					snap989 := d473
+					snap990 := d650
+					snap991 := d651
+					snap992 := d652
+					snap993 := d653
+					snap994 := d654
+					snap995 := d655
+					snap996 := d656
+					snap997 := d657
+					snap998 := d658
+					snap999 := d659
+					snap1000 := d660
+					snap1001 := d661
+					snap1002 := d662
+					snap1003 := d664
+					snap1004 := d665
+					snap1005 := d666
+					snap1006 := d667
+					snap1007 := d668
+					snap1008 := d669
+					snap1009 := d670
+					snap1010 := d672
+					snap1011 := d674
+					snap1012 := d784
+					snap1013 := d787
+					snap1014 := d899
+					snap1015 := d900
+					snap1016 := d901
+					alloc1017 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc1017)
+					d8 = snap904
+					d9 = snap905
+					d10 = snap906
+					d11 = snap907
+					d12 = snap908
+					d13 = snap909
+					d14 = snap910
+					d15 = snap911
+					d16 = snap912
+					d17 = snap913
+					d18 = snap914
+					d19 = snap915
+					d20 = snap916
+					d21 = snap917
+					d22 = snap918
+					d25 = snap919
+					d45 = snap920
+					d64 = snap921
+					d65 = snap922
+					d66 = snap923
+					d67 = snap924
+					d68 = snap925
+					d70 = snap926
+					d71 = snap927
+					d72 = snap928
+					d73 = snap929
+					d74 = snap930
+					d75 = snap931
+					d76 = snap932
+					d79 = snap933
+					d145 = snap934
+					d146 = snap935
+					d147 = snap936
+					d148 = snap937
+					d149 = snap938
+					d150 = snap939
+					d152 = snap940
+					d153 = snap941
+					d154 = snap942
+					d155 = snap943
+					d156 = snap944
+					d157 = snap945
+					d158 = snap946
+					d159 = snap947
+					d160 = snap948
+					d163 = snap949
+					d164 = snap950
+					d165 = snap951
+					d166 = snap952
+					d269 = snap953
+					d270 = snap954
+					d271 = snap955
+					d272 = snap956
+					d273 = snap957
+					d274 = snap958
+					d275 = snap959
+					d276 = snap960
+					d277 = snap961
+					d278 = snap962
+					d279 = snap963
+					d280 = snap964
+					d281 = snap965
+					d282 = snap966
+					d283 = snap967
+					d284 = snap968
+					d285 = snap969
+					d286 = snap970
+					d287 = snap971
+					d289 = snap972
+					d290 = snap973
+					d291 = snap974
+					d292 = snap975
+					d293 = snap976
+					d294 = snap977
+					d295 = snap978
+					d296 = snap979
+					d298 = snap980
+					d299 = snap981
+					d300 = snap982
+					d465 = snap983
+					d466 = snap984
+					d467 = snap985
+					d468 = snap986
+					d469 = snap987
+					d472 = snap988
+					d473 = snap989
+					d650 = snap990
+					d651 = snap991
+					d652 = snap992
+					d653 = snap993
+					d654 = snap994
+					d655 = snap995
+					d656 = snap996
+					d657 = snap997
+					d658 = snap998
+					d659 = snap999
+					d660 = snap1000
+					d661 = snap1001
+					d662 = snap1002
+					d664 = snap1003
+					d665 = snap1004
+					d666 = snap1005
+					d667 = snap1006
+					d668 = snap1007
+					d669 = snap1008
+					d670 = snap1009
+					d672 = snap1010
+					d674 = snap1011
+					d784 = snap1012
+					d787 = snap1013
+					d899 = snap1014
+					d900 = snap1015
+					d901 = snap1016
+					ctx.RestoreAllocState(alloc1017)
+					d8 = snap904
+					d9 = snap905
+					d10 = snap906
+					d11 = snap907
+					d12 = snap908
+					d13 = snap909
+					d14 = snap910
+					d15 = snap911
+					d16 = snap912
+					d17 = snap913
+					d18 = snap914
+					d19 = snap915
+					d20 = snap916
+					d21 = snap917
+					d22 = snap918
+					d25 = snap919
+					d45 = snap920
+					d64 = snap921
+					d65 = snap922
+					d66 = snap923
+					d67 = snap924
+					d68 = snap925
+					d70 = snap926
+					d71 = snap927
+					d72 = snap928
+					d73 = snap929
+					d74 = snap930
+					d75 = snap931
+					d76 = snap932
+					d79 = snap933
+					d145 = snap934
+					d146 = snap935
+					d147 = snap936
+					d148 = snap937
+					d149 = snap938
+					d150 = snap939
+					d152 = snap940
+					d153 = snap941
+					d154 = snap942
+					d155 = snap943
+					d156 = snap944
+					d157 = snap945
+					d158 = snap946
+					d159 = snap947
+					d160 = snap948
+					d163 = snap949
+					d164 = snap950
+					d165 = snap951
+					d166 = snap952
+					d269 = snap953
+					d270 = snap954
+					d271 = snap955
+					d272 = snap956
+					d273 = snap957
+					d274 = snap958
+					d275 = snap959
+					d276 = snap960
+					d277 = snap961
+					d278 = snap962
+					d279 = snap963
+					d280 = snap964
+					d281 = snap965
+					d282 = snap966
+					d283 = snap967
+					d284 = snap968
+					d285 = snap969
+					d286 = snap970
+					d287 = snap971
+					d289 = snap972
+					d290 = snap973
+					d291 = snap974
+					d292 = snap975
+					d293 = snap976
+					d294 = snap977
+					d295 = snap978
+					d296 = snap979
+					d298 = snap980
+					d299 = snap981
+					d300 = snap982
+					d465 = snap983
+					d466 = snap984
+					d467 = snap985
+					d468 = snap986
+					d469 = snap987
+					d472 = snap988
+					d473 = snap989
+					d650 = snap990
+					d651 = snap991
+					d652 = snap992
+					d653 = snap993
+					d654 = snap994
+					d655 = snap995
+					d656 = snap996
+					d657 = snap997
+					d658 = snap998
+					d659 = snap999
+					d660 = snap1000
+					d661 = snap1001
+					d662 = snap1002
+					d664 = snap1003
+					d665 = snap1004
+					d666 = snap1005
+					d667 = snap1006
+					d668 = snap1007
+					d669 = snap1008
+					d670 = snap1009
+					d672 = snap1010
+					d674 = snap1011
+					d784 = snap1012
+					d787 = snap1013
+					d899 = snap1014
+					d900 = snap1015
+					d901 = snap1016
+					ps1018 := PhiState{General: true}
+					ps1018.OverlayValues = make([]JITValueDesc, 902)
+					ps1018.OverlayValues[8] = d8
+					ps1018.OverlayValues[9] = d9
+					ps1018.OverlayValues[10] = d10
+					ps1018.OverlayValues[11] = d11
+					ps1018.OverlayValues[12] = d12
+					ps1018.OverlayValues[13] = d13
+					ps1018.OverlayValues[14] = d14
+					ps1018.OverlayValues[15] = d15
+					ps1018.OverlayValues[16] = d16
+					ps1018.OverlayValues[17] = d17
+					ps1018.OverlayValues[18] = d18
+					ps1018.OverlayValues[19] = d19
+					ps1018.OverlayValues[20] = d20
+					ps1018.OverlayValues[21] = d21
+					ps1018.OverlayValues[22] = d22
+					ps1018.OverlayValues[25] = d25
+					ps1018.OverlayValues[45] = d45
+					ps1018.OverlayValues[64] = d64
+					ps1018.OverlayValues[65] = d65
+					ps1018.OverlayValues[66] = d66
+					ps1018.OverlayValues[67] = d67
+					ps1018.OverlayValues[68] = d68
+					ps1018.OverlayValues[70] = d70
+					ps1018.OverlayValues[71] = d71
+					ps1018.OverlayValues[72] = d72
+					ps1018.OverlayValues[73] = d73
+					ps1018.OverlayValues[74] = d74
+					ps1018.OverlayValues[75] = d75
+					ps1018.OverlayValues[76] = d76
+					ps1018.OverlayValues[79] = d79
+					ps1018.OverlayValues[145] = d145
+					ps1018.OverlayValues[146] = d146
+					ps1018.OverlayValues[147] = d147
+					ps1018.OverlayValues[148] = d148
+					ps1018.OverlayValues[149] = d149
+					ps1018.OverlayValues[150] = d150
+					ps1018.OverlayValues[152] = d152
+					ps1018.OverlayValues[153] = d153
+					ps1018.OverlayValues[154] = d154
+					ps1018.OverlayValues[155] = d155
+					ps1018.OverlayValues[156] = d156
+					ps1018.OverlayValues[157] = d157
+					ps1018.OverlayValues[158] = d158
+					ps1018.OverlayValues[159] = d159
+					ps1018.OverlayValues[160] = d160
+					ps1018.OverlayValues[163] = d163
+					ps1018.OverlayValues[164] = d164
+					ps1018.OverlayValues[165] = d165
+					ps1018.OverlayValues[166] = d166
+					ps1018.OverlayValues[269] = d269
+					ps1018.OverlayValues[270] = d270
+					ps1018.OverlayValues[271] = d271
+					ps1018.OverlayValues[272] = d272
+					ps1018.OverlayValues[273] = d273
+					ps1018.OverlayValues[274] = d274
+					ps1018.OverlayValues[275] = d275
+					ps1018.OverlayValues[276] = d276
+					ps1018.OverlayValues[277] = d277
+					ps1018.OverlayValues[278] = d278
+					ps1018.OverlayValues[279] = d279
+					ps1018.OverlayValues[280] = d280
+					ps1018.OverlayValues[281] = d281
+					ps1018.OverlayValues[282] = d282
+					ps1018.OverlayValues[283] = d283
+					ps1018.OverlayValues[284] = d284
+					ps1018.OverlayValues[285] = d285
+					ps1018.OverlayValues[286] = d286
+					ps1018.OverlayValues[287] = d287
+					ps1018.OverlayValues[289] = d289
+					ps1018.OverlayValues[290] = d290
+					ps1018.OverlayValues[291] = d291
+					ps1018.OverlayValues[292] = d292
+					ps1018.OverlayValues[293] = d293
+					ps1018.OverlayValues[294] = d294
+					ps1018.OverlayValues[295] = d295
+					ps1018.OverlayValues[296] = d296
+					ps1018.OverlayValues[298] = d298
+					ps1018.OverlayValues[299] = d299
+					ps1018.OverlayValues[300] = d300
+					ps1018.OverlayValues[465] = d465
+					ps1018.OverlayValues[466] = d466
+					ps1018.OverlayValues[467] = d467
+					ps1018.OverlayValues[468] = d468
+					ps1018.OverlayValues[469] = d469
+					ps1018.OverlayValues[472] = d472
+					ps1018.OverlayValues[473] = d473
+					ps1018.OverlayValues[650] = d650
+					ps1018.OverlayValues[651] = d651
+					ps1018.OverlayValues[652] = d652
+					ps1018.OverlayValues[653] = d653
+					ps1018.OverlayValues[654] = d654
+					ps1018.OverlayValues[655] = d655
+					ps1018.OverlayValues[656] = d656
+					ps1018.OverlayValues[657] = d657
+					ps1018.OverlayValues[658] = d658
+					ps1018.OverlayValues[659] = d659
+					ps1018.OverlayValues[660] = d660
+					ps1018.OverlayValues[661] = d661
+					ps1018.OverlayValues[662] = d662
+					ps1018.OverlayValues[664] = d664
+					ps1018.OverlayValues[665] = d665
+					ps1018.OverlayValues[666] = d666
+					ps1018.OverlayValues[667] = d667
+					ps1018.OverlayValues[668] = d668
+					ps1018.OverlayValues[669] = d669
+					ps1018.OverlayValues[670] = d670
+					ps1018.OverlayValues[672] = d672
+					ps1018.OverlayValues[674] = d674
+					ps1018.OverlayValues[784] = d784
+					ps1018.OverlayValues[787] = d787
+					ps1018.OverlayValues[899] = d899
+					ps1018.OverlayValues[900] = d900
+					ps1018.OverlayValues[901] = d901
+					ps1019 := PhiState{General: true}
+					ps1019.OverlayValues = make([]JITValueDesc, 902)
+					ps1019.OverlayValues[8] = d8
+					ps1019.OverlayValues[9] = d9
+					ps1019.OverlayValues[10] = d10
+					ps1019.OverlayValues[11] = d11
+					ps1019.OverlayValues[12] = d12
+					ps1019.OverlayValues[13] = d13
+					ps1019.OverlayValues[14] = d14
+					ps1019.OverlayValues[15] = d15
+					ps1019.OverlayValues[16] = d16
+					ps1019.OverlayValues[17] = d17
+					ps1019.OverlayValues[18] = d18
+					ps1019.OverlayValues[19] = d19
+					ps1019.OverlayValues[20] = d20
+					ps1019.OverlayValues[21] = d21
+					ps1019.OverlayValues[22] = d22
+					ps1019.OverlayValues[25] = d25
+					ps1019.OverlayValues[45] = d45
+					ps1019.OverlayValues[64] = d64
+					ps1019.OverlayValues[65] = d65
+					ps1019.OverlayValues[66] = d66
+					ps1019.OverlayValues[67] = d67
+					ps1019.OverlayValues[68] = d68
+					ps1019.OverlayValues[70] = d70
+					ps1019.OverlayValues[71] = d71
+					ps1019.OverlayValues[72] = d72
+					ps1019.OverlayValues[73] = d73
+					ps1019.OverlayValues[74] = d74
+					ps1019.OverlayValues[75] = d75
+					ps1019.OverlayValues[76] = d76
+					ps1019.OverlayValues[79] = d79
+					ps1019.OverlayValues[145] = d145
+					ps1019.OverlayValues[146] = d146
+					ps1019.OverlayValues[147] = d147
+					ps1019.OverlayValues[148] = d148
+					ps1019.OverlayValues[149] = d149
+					ps1019.OverlayValues[150] = d150
+					ps1019.OverlayValues[152] = d152
+					ps1019.OverlayValues[153] = d153
+					ps1019.OverlayValues[154] = d154
+					ps1019.OverlayValues[155] = d155
+					ps1019.OverlayValues[156] = d156
+					ps1019.OverlayValues[157] = d157
+					ps1019.OverlayValues[158] = d158
+					ps1019.OverlayValues[159] = d159
+					ps1019.OverlayValues[160] = d160
+					ps1019.OverlayValues[163] = d163
+					ps1019.OverlayValues[164] = d164
+					ps1019.OverlayValues[165] = d165
+					ps1019.OverlayValues[166] = d166
+					ps1019.OverlayValues[269] = d269
+					ps1019.OverlayValues[270] = d270
+					ps1019.OverlayValues[271] = d271
+					ps1019.OverlayValues[272] = d272
+					ps1019.OverlayValues[273] = d273
+					ps1019.OverlayValues[274] = d274
+					ps1019.OverlayValues[275] = d275
+					ps1019.OverlayValues[276] = d276
+					ps1019.OverlayValues[277] = d277
+					ps1019.OverlayValues[278] = d278
+					ps1019.OverlayValues[279] = d279
+					ps1019.OverlayValues[280] = d280
+					ps1019.OverlayValues[281] = d281
+					ps1019.OverlayValues[282] = d282
+					ps1019.OverlayValues[283] = d283
+					ps1019.OverlayValues[284] = d284
+					ps1019.OverlayValues[285] = d285
+					ps1019.OverlayValues[286] = d286
+					ps1019.OverlayValues[287] = d287
+					ps1019.OverlayValues[289] = d289
+					ps1019.OverlayValues[290] = d290
+					ps1019.OverlayValues[291] = d291
+					ps1019.OverlayValues[292] = d292
+					ps1019.OverlayValues[293] = d293
+					ps1019.OverlayValues[294] = d294
+					ps1019.OverlayValues[295] = d295
+					ps1019.OverlayValues[296] = d296
+					ps1019.OverlayValues[298] = d298
+					ps1019.OverlayValues[299] = d299
+					ps1019.OverlayValues[300] = d300
+					ps1019.OverlayValues[465] = d465
+					ps1019.OverlayValues[466] = d466
+					ps1019.OverlayValues[467] = d467
+					ps1019.OverlayValues[468] = d468
+					ps1019.OverlayValues[469] = d469
+					ps1019.OverlayValues[472] = d472
+					ps1019.OverlayValues[473] = d473
+					ps1019.OverlayValues[650] = d650
+					ps1019.OverlayValues[651] = d651
+					ps1019.OverlayValues[652] = d652
+					ps1019.OverlayValues[653] = d653
+					ps1019.OverlayValues[654] = d654
+					ps1019.OverlayValues[655] = d655
+					ps1019.OverlayValues[656] = d656
+					ps1019.OverlayValues[657] = d657
+					ps1019.OverlayValues[658] = d658
+					ps1019.OverlayValues[659] = d659
+					ps1019.OverlayValues[660] = d660
+					ps1019.OverlayValues[661] = d661
+					ps1019.OverlayValues[662] = d662
+					ps1019.OverlayValues[664] = d664
+					ps1019.OverlayValues[665] = d665
+					ps1019.OverlayValues[666] = d666
+					ps1019.OverlayValues[667] = d667
+					ps1019.OverlayValues[668] = d668
+					ps1019.OverlayValues[669] = d669
+					ps1019.OverlayValues[670] = d670
+					ps1019.OverlayValues[672] = d672
+					ps1019.OverlayValues[674] = d674
+					ps1019.OverlayValues[784] = d784
+					ps1019.OverlayValues[787] = d787
+					ps1019.OverlayValues[899] = d899
+					ps1019.OverlayValues[900] = d900
+					ps1019.OverlayValues[901] = d901
+					snap1020 := d8
+					snap1021 := d9
+					snap1022 := d10
+					snap1023 := d11
+					snap1024 := d12
+					snap1025 := d13
+					snap1026 := d14
+					snap1027 := d15
+					snap1028 := d16
+					snap1029 := d17
+					snap1030 := d18
+					snap1031 := d19
+					snap1032 := d20
+					snap1033 := d21
+					snap1034 := d22
+					snap1035 := d25
+					snap1036 := d45
+					snap1037 := d64
+					snap1038 := d65
+					snap1039 := d66
+					snap1040 := d67
+					snap1041 := d68
+					snap1042 := d70
+					snap1043 := d71
+					snap1044 := d72
+					snap1045 := d73
+					snap1046 := d74
+					snap1047 := d75
+					snap1048 := d76
+					snap1049 := d79
+					snap1050 := d145
+					snap1051 := d146
+					snap1052 := d147
+					snap1053 := d148
+					snap1054 := d149
+					snap1055 := d150
+					snap1056 := d152
+					snap1057 := d153
+					snap1058 := d154
+					snap1059 := d155
+					snap1060 := d156
+					snap1061 := d157
+					snap1062 := d158
+					snap1063 := d159
+					snap1064 := d160
+					snap1065 := d163
+					snap1066 := d164
+					snap1067 := d165
+					snap1068 := d166
+					snap1069 := d269
+					snap1070 := d270
+					snap1071 := d271
+					snap1072 := d272
+					snap1073 := d273
+					snap1074 := d274
+					snap1075 := d275
+					snap1076 := d276
+					snap1077 := d277
+					snap1078 := d278
+					snap1079 := d279
+					snap1080 := d280
+					snap1081 := d281
+					snap1082 := d282
+					snap1083 := d283
+					snap1084 := d284
+					snap1085 := d285
+					snap1086 := d286
+					snap1087 := d287
+					snap1088 := d289
+					snap1089 := d290
+					snap1090 := d291
+					snap1091 := d292
+					snap1092 := d293
+					snap1093 := d294
+					snap1094 := d295
+					snap1095 := d296
+					snap1096 := d298
+					snap1097 := d299
+					snap1098 := d300
+					snap1099 := d465
+					snap1100 := d466
+					snap1101 := d467
+					snap1102 := d468
+					snap1103 := d469
+					snap1104 := d472
+					snap1105 := d473
+					snap1106 := d650
+					snap1107 := d651
+					snap1108 := d652
+					snap1109 := d653
+					snap1110 := d654
+					snap1111 := d655
+					snap1112 := d656
+					snap1113 := d657
+					snap1114 := d658
+					snap1115 := d659
+					snap1116 := d660
+					snap1117 := d661
+					snap1118 := d662
+					snap1119 := d664
+					snap1120 := d665
+					snap1121 := d666
+					snap1122 := d667
+					snap1123 := d668
+					snap1124 := d669
+					snap1125 := d670
+					snap1126 := d672
+					snap1127 := d674
+					snap1128 := d784
+					snap1129 := d787
+					snap1130 := d899
+					snap1131 := d900
+					snap1132 := d901
+					alloc1133 := ctx.SnapshotAllocState()
 					if !bbs[12].Rendered {
-						bbs[12].RenderPS(ps932)
+						bbs[12].RenderPS(ps1019)
 					}
-					ctx.RestoreAllocState(alloc1034)
-					d1 = snap933
-					d2 = snap934
-					d3 = snap935
-					d4 = snap936
-					d5 = snap937
-					d6 = snap938
-					d7 = snap939
-					d8 = snap940
-					d9 = snap941
-					d10 = snap942
-					d11 = snap943
-					d12 = snap944
-					d13 = snap945
-					d14 = snap946
-					d15 = snap947
-					d18 = snap948
-					d38 = snap949
-					d57 = snap950
-					d58 = snap951
-					d59 = snap952
-					d60 = snap953
-					d61 = snap954
-					d63 = snap955
-					d64 = snap956
-					d65 = snap957
-					d66 = snap958
-					d67 = snap959
-					d68 = snap960
-					d69 = snap961
-					d72 = snap962
-					d138 = snap963
-					d139 = snap964
-					d140 = snap965
-					d141 = snap966
-					d142 = snap967
-					d143 = snap968
-					d145 = snap969
-					d146 = snap970
-					d147 = snap971
-					d148 = snap972
-					d149 = snap973
-					d150 = snap974
-					d151 = snap975
-					d152 = snap976
-					d153 = snap977
-					d156 = snap978
-					d157 = snap979
-					d158 = snap980
-					d159 = snap981
-					d262 = snap982
-					d263 = snap983
-					d264 = snap984
-					d265 = snap985
-					d266 = snap986
-					d267 = snap987
-					d268 = snap988
-					d269 = snap989
-					d270 = snap990
-					d271 = snap991
-					d272 = snap992
-					d273 = snap993
-					d274 = snap994
-					d275 = snap995
-					d276 = snap996
-					d278 = snap997
-					d279 = snap998
-					d280 = snap999
-					d281 = snap1000
-					d283 = snap1001
-					d284 = snap1002
-					d285 = snap1003
-					d434 = snap1004
-					d435 = snap1005
-					d436 = snap1006
-					d437 = snap1007
-					d438 = snap1008
-					d441 = snap1009
-					d442 = snap1010
-					d603 = snap1011
-					d604 = snap1012
-					d605 = snap1013
-					d606 = snap1014
-					d607 = snap1015
-					d608 = snap1016
-					d609 = snap1017
-					d610 = snap1018
-					d611 = snap1019
-					d612 = snap1020
-					d613 = snap1021
-					d615 = snap1022
-					d616 = snap1023
-					d617 = snap1024
-					d618 = snap1025
-					d619 = snap1026
-					d621 = snap1027
-					d623 = snap1028
-					d721 = snap1029
-					d724 = snap1030
-					d824 = snap1031
-					d825 = snap1032
-					d826 = snap1033
+					ctx.RestoreAllocState(alloc1133)
+					d8 = snap1020
+					d9 = snap1021
+					d10 = snap1022
+					d11 = snap1023
+					d12 = snap1024
+					d13 = snap1025
+					d14 = snap1026
+					d15 = snap1027
+					d16 = snap1028
+					d17 = snap1029
+					d18 = snap1030
+					d19 = snap1031
+					d20 = snap1032
+					d21 = snap1033
+					d22 = snap1034
+					d25 = snap1035
+					d45 = snap1036
+					d64 = snap1037
+					d65 = snap1038
+					d66 = snap1039
+					d67 = snap1040
+					d68 = snap1041
+					d70 = snap1042
+					d71 = snap1043
+					d72 = snap1044
+					d73 = snap1045
+					d74 = snap1046
+					d75 = snap1047
+					d76 = snap1048
+					d79 = snap1049
+					d145 = snap1050
+					d146 = snap1051
+					d147 = snap1052
+					d148 = snap1053
+					d149 = snap1054
+					d150 = snap1055
+					d152 = snap1056
+					d153 = snap1057
+					d154 = snap1058
+					d155 = snap1059
+					d156 = snap1060
+					d157 = snap1061
+					d158 = snap1062
+					d159 = snap1063
+					d160 = snap1064
+					d163 = snap1065
+					d164 = snap1066
+					d165 = snap1067
+					d166 = snap1068
+					d269 = snap1069
+					d270 = snap1070
+					d271 = snap1071
+					d272 = snap1072
+					d273 = snap1073
+					d274 = snap1074
+					d275 = snap1075
+					d276 = snap1076
+					d277 = snap1077
+					d278 = snap1078
+					d279 = snap1079
+					d280 = snap1080
+					d281 = snap1081
+					d282 = snap1082
+					d283 = snap1083
+					d284 = snap1084
+					d285 = snap1085
+					d286 = snap1086
+					d287 = snap1087
+					d289 = snap1088
+					d290 = snap1089
+					d291 = snap1090
+					d292 = snap1091
+					d293 = snap1092
+					d294 = snap1093
+					d295 = snap1094
+					d296 = snap1095
+					d298 = snap1096
+					d299 = snap1097
+					d300 = snap1098
+					d465 = snap1099
+					d466 = snap1100
+					d467 = snap1101
+					d468 = snap1102
+					d469 = snap1103
+					d472 = snap1104
+					d473 = snap1105
+					d650 = snap1106
+					d651 = snap1107
+					d652 = snap1108
+					d653 = snap1109
+					d654 = snap1110
+					d655 = snap1111
+					d656 = snap1112
+					d657 = snap1113
+					d658 = snap1114
+					d659 = snap1115
+					d660 = snap1116
+					d661 = snap1117
+					d662 = snap1118
+					d664 = snap1119
+					d665 = snap1120
+					d666 = snap1121
+					d667 = snap1122
+					d668 = snap1123
+					d669 = snap1124
+					d670 = snap1125
+					d672 = snap1126
+					d674 = snap1127
+					d784 = snap1128
+					d787 = snap1129
+					d899 = snap1130
+					d900 = snap1131
+					d901 = snap1132
 					if !bbs[11].Rendered {
-						return bbs[11].RenderPS(ps931)
+						return bbs[11].RenderPS(ps1018)
 					}
 					return result
 					return result
@@ -8691,82 +9610,88 @@ func init_vector() {
 						ctx.MarkLabel(lbl15)
 						ctx.ResolveFixups()
 					}
-					d1 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
-					d2 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
-					d3 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(32)}
-					d4 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(48)}
-					d5 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(64)}
-					d6 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
-					d7 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(96)}
-					d8 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
-					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
-						d1 = ps.OverlayValues[1]
+					d8 = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: int32(phiBase0) + int32(0)}
+					d9 = JITValueDesc{Loc: LocStack, Type: tagFloat, StackOff: int32(phiBase0) + int32(16)}
+					if phiHomeOK2 {
+						d10 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r0, ID: 0}
+					} else {
+						d10 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(32)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
-						d2 = ps.OverlayValues[2]
+					if phiHomeOK3 {
+						d11 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r1, ID: 0}
+					} else {
+						d11 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(48)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
-						d3 = ps.OverlayValues[3]
+					if phiHomeOK4 {
+						d12 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r2, ID: 0}
+					} else {
+						d12 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(64)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
-						d4 = ps.OverlayValues[4]
+					if phiHomeOK5 {
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3, ID: 0}
+					} else {
+						d13 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(80)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
-						d5 = ps.OverlayValues[5]
+					if phiHomeOK6 {
+						d14 = JITValueDesc{Loc: LocFPReg, Type: tagFloat, RegClass: JITRegisterClassFP, Reg: r4, ID: 0}
+					} else {
+						d14 = JITValueDesc{Loc: LocStack, Type: tagFloat, RegClass: JITRegisterClassFP, StackOff: int32(phiBase0) + int32(96)}
 					}
-					if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
-						d6 = ps.OverlayValues[6]
-					}
-					if !ps.General && len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if phiHomeOK7 {
+						d15 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5, ID: 0}
+					} else {
+						d15 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(112)}
 					}
 					if !ps.General && len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
 						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
 						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
 						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
 						d11 = ps.OverlayValues[11]
 					}
-					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
 						d12 = ps.OverlayValues[12]
 					}
-					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
 						d13 = ps.OverlayValues[13]
 					}
-					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
 						d14 = ps.OverlayValues[14]
 					}
-					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+					if !ps.General && len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
 						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 16 && ps.OverlayValues[16].Loc != LocNone {
+						d16 = ps.OverlayValues[16]
+					}
+					if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != LocNone {
+						d17 = ps.OverlayValues[17]
 					}
 					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
 						d18 = ps.OverlayValues[18]
 					}
-					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
-						d38 = ps.OverlayValues[38]
+					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
+						d19 = ps.OverlayValues[19]
 					}
-					if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != LocNone {
-						d57 = ps.OverlayValues[57]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != LocNone {
-						d58 = ps.OverlayValues[58]
+					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
+						d21 = ps.OverlayValues[21]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
-					}
-					if len(ps.OverlayValues) > 63 && ps.OverlayValues[63].Loc != LocNone {
-						d63 = ps.OverlayValues[63]
+					if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != LocNone {
+						d45 = ps.OverlayValues[45]
 					}
 					if len(ps.OverlayValues) > 64 && ps.OverlayValues[64].Loc != LocNone {
 						d64 = ps.OverlayValues[64]
@@ -8783,29 +9708,29 @@ func init_vector() {
 					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
 						d68 = ps.OverlayValues[68]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
 					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
 						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 138 && ps.OverlayValues[138].Loc != LocNone {
-						d138 = ps.OverlayValues[138]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 139 && ps.OverlayValues[139].Loc != LocNone {
-						d139 = ps.OverlayValues[139]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
-					if len(ps.OverlayValues) > 140 && ps.OverlayValues[140].Loc != LocNone {
-						d140 = ps.OverlayValues[140]
+					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
+						d75 = ps.OverlayValues[75]
 					}
-					if len(ps.OverlayValues) > 141 && ps.OverlayValues[141].Loc != LocNone {
-						d141 = ps.OverlayValues[141]
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
 					}
-					if len(ps.OverlayValues) > 142 && ps.OverlayValues[142].Loc != LocNone {
-						d142 = ps.OverlayValues[142]
-					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
 						d145 = ps.OverlayValues[145]
@@ -8825,14 +9750,17 @@ func init_vector() {
 					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
 						d150 = ps.OverlayValues[150]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
-					}
 					if len(ps.OverlayValues) > 152 && ps.OverlayValues[152].Loc != LocNone {
 						d152 = ps.OverlayValues[152]
 					}
 					if len(ps.OverlayValues) > 153 && ps.OverlayValues[153].Loc != LocNone {
 						d153 = ps.OverlayValues[153]
+					}
+					if len(ps.OverlayValues) > 154 && ps.OverlayValues[154].Loc != LocNone {
+						d154 = ps.OverlayValues[154]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
 					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
 						d156 = ps.OverlayValues[156]
@@ -8846,26 +9774,20 @@ func init_vector() {
 					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
 						d159 = ps.OverlayValues[159]
 					}
-					if len(ps.OverlayValues) > 262 && ps.OverlayValues[262].Loc != LocNone {
-						d262 = ps.OverlayValues[262]
+					if len(ps.OverlayValues) > 160 && ps.OverlayValues[160].Loc != LocNone {
+						d160 = ps.OverlayValues[160]
 					}
-					if len(ps.OverlayValues) > 263 && ps.OverlayValues[263].Loc != LocNone {
-						d263 = ps.OverlayValues[263]
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
 					}
-					if len(ps.OverlayValues) > 264 && ps.OverlayValues[264].Loc != LocNone {
-						d264 = ps.OverlayValues[264]
+					if len(ps.OverlayValues) > 164 && ps.OverlayValues[164].Loc != LocNone {
+						d164 = ps.OverlayValues[164]
 					}
-					if len(ps.OverlayValues) > 265 && ps.OverlayValues[265].Loc != LocNone {
-						d265 = ps.OverlayValues[265]
+					if len(ps.OverlayValues) > 165 && ps.OverlayValues[165].Loc != LocNone {
+						d165 = ps.OverlayValues[165]
 					}
-					if len(ps.OverlayValues) > 266 && ps.OverlayValues[266].Loc != LocNone {
-						d266 = ps.OverlayValues[266]
-					}
-					if len(ps.OverlayValues) > 267 && ps.OverlayValues[267].Loc != LocNone {
-						d267 = ps.OverlayValues[267]
-					}
-					if len(ps.OverlayValues) > 268 && ps.OverlayValues[268].Loc != LocNone {
-						d268 = ps.OverlayValues[268]
+					if len(ps.OverlayValues) > 166 && ps.OverlayValues[166].Loc != LocNone {
+						d166 = ps.OverlayValues[166]
 					}
 					if len(ps.OverlayValues) > 269 && ps.OverlayValues[269].Loc != LocNone {
 						d269 = ps.OverlayValues[269]
@@ -8891,6 +9813,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
 						d276 = ps.OverlayValues[276]
 					}
+					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
+						d277 = ps.OverlayValues[277]
+					}
 					if len(ps.OverlayValues) > 278 && ps.OverlayValues[278].Loc != LocNone {
 						d278 = ps.OverlayValues[278]
 					}
@@ -8903,6 +9828,9 @@ func init_vector() {
 					if len(ps.OverlayValues) > 281 && ps.OverlayValues[281].Loc != LocNone {
 						d281 = ps.OverlayValues[281]
 					}
+					if len(ps.OverlayValues) > 282 && ps.OverlayValues[282].Loc != LocNone {
+						d282 = ps.OverlayValues[282]
+					}
 					if len(ps.OverlayValues) > 283 && ps.OverlayValues[283].Loc != LocNone {
 						d283 = ps.OverlayValues[283]
 					}
@@ -8912,258 +9840,321 @@ func init_vector() {
 					if len(ps.OverlayValues) > 285 && ps.OverlayValues[285].Loc != LocNone {
 						d285 = ps.OverlayValues[285]
 					}
-					if len(ps.OverlayValues) > 434 && ps.OverlayValues[434].Loc != LocNone {
-						d434 = ps.OverlayValues[434]
+					if len(ps.OverlayValues) > 286 && ps.OverlayValues[286].Loc != LocNone {
+						d286 = ps.OverlayValues[286]
 					}
-					if len(ps.OverlayValues) > 435 && ps.OverlayValues[435].Loc != LocNone {
-						d435 = ps.OverlayValues[435]
+					if len(ps.OverlayValues) > 287 && ps.OverlayValues[287].Loc != LocNone {
+						d287 = ps.OverlayValues[287]
 					}
-					if len(ps.OverlayValues) > 436 && ps.OverlayValues[436].Loc != LocNone {
-						d436 = ps.OverlayValues[436]
+					if len(ps.OverlayValues) > 289 && ps.OverlayValues[289].Loc != LocNone {
+						d289 = ps.OverlayValues[289]
 					}
-					if len(ps.OverlayValues) > 437 && ps.OverlayValues[437].Loc != LocNone {
-						d437 = ps.OverlayValues[437]
+					if len(ps.OverlayValues) > 290 && ps.OverlayValues[290].Loc != LocNone {
+						d290 = ps.OverlayValues[290]
 					}
-					if len(ps.OverlayValues) > 438 && ps.OverlayValues[438].Loc != LocNone {
-						d438 = ps.OverlayValues[438]
+					if len(ps.OverlayValues) > 291 && ps.OverlayValues[291].Loc != LocNone {
+						d291 = ps.OverlayValues[291]
 					}
-					if len(ps.OverlayValues) > 441 && ps.OverlayValues[441].Loc != LocNone {
-						d441 = ps.OverlayValues[441]
+					if len(ps.OverlayValues) > 292 && ps.OverlayValues[292].Loc != LocNone {
+						d292 = ps.OverlayValues[292]
 					}
-					if len(ps.OverlayValues) > 442 && ps.OverlayValues[442].Loc != LocNone {
-						d442 = ps.OverlayValues[442]
+					if len(ps.OverlayValues) > 293 && ps.OverlayValues[293].Loc != LocNone {
+						d293 = ps.OverlayValues[293]
 					}
-					if len(ps.OverlayValues) > 603 && ps.OverlayValues[603].Loc != LocNone {
-						d603 = ps.OverlayValues[603]
+					if len(ps.OverlayValues) > 294 && ps.OverlayValues[294].Loc != LocNone {
+						d294 = ps.OverlayValues[294]
 					}
-					if len(ps.OverlayValues) > 604 && ps.OverlayValues[604].Loc != LocNone {
-						d604 = ps.OverlayValues[604]
+					if len(ps.OverlayValues) > 295 && ps.OverlayValues[295].Loc != LocNone {
+						d295 = ps.OverlayValues[295]
 					}
-					if len(ps.OverlayValues) > 605 && ps.OverlayValues[605].Loc != LocNone {
-						d605 = ps.OverlayValues[605]
+					if len(ps.OverlayValues) > 296 && ps.OverlayValues[296].Loc != LocNone {
+						d296 = ps.OverlayValues[296]
 					}
-					if len(ps.OverlayValues) > 606 && ps.OverlayValues[606].Loc != LocNone {
-						d606 = ps.OverlayValues[606]
+					if len(ps.OverlayValues) > 298 && ps.OverlayValues[298].Loc != LocNone {
+						d298 = ps.OverlayValues[298]
 					}
-					if len(ps.OverlayValues) > 607 && ps.OverlayValues[607].Loc != LocNone {
-						d607 = ps.OverlayValues[607]
+					if len(ps.OverlayValues) > 299 && ps.OverlayValues[299].Loc != LocNone {
+						d299 = ps.OverlayValues[299]
 					}
-					if len(ps.OverlayValues) > 608 && ps.OverlayValues[608].Loc != LocNone {
-						d608 = ps.OverlayValues[608]
+					if len(ps.OverlayValues) > 300 && ps.OverlayValues[300].Loc != LocNone {
+						d300 = ps.OverlayValues[300]
 					}
-					if len(ps.OverlayValues) > 609 && ps.OverlayValues[609].Loc != LocNone {
-						d609 = ps.OverlayValues[609]
+					if len(ps.OverlayValues) > 465 && ps.OverlayValues[465].Loc != LocNone {
+						d465 = ps.OverlayValues[465]
 					}
-					if len(ps.OverlayValues) > 610 && ps.OverlayValues[610].Loc != LocNone {
-						d610 = ps.OverlayValues[610]
+					if len(ps.OverlayValues) > 466 && ps.OverlayValues[466].Loc != LocNone {
+						d466 = ps.OverlayValues[466]
 					}
-					if len(ps.OverlayValues) > 611 && ps.OverlayValues[611].Loc != LocNone {
-						d611 = ps.OverlayValues[611]
+					if len(ps.OverlayValues) > 467 && ps.OverlayValues[467].Loc != LocNone {
+						d467 = ps.OverlayValues[467]
 					}
-					if len(ps.OverlayValues) > 612 && ps.OverlayValues[612].Loc != LocNone {
-						d612 = ps.OverlayValues[612]
+					if len(ps.OverlayValues) > 468 && ps.OverlayValues[468].Loc != LocNone {
+						d468 = ps.OverlayValues[468]
 					}
-					if len(ps.OverlayValues) > 613 && ps.OverlayValues[613].Loc != LocNone {
-						d613 = ps.OverlayValues[613]
+					if len(ps.OverlayValues) > 469 && ps.OverlayValues[469].Loc != LocNone {
+						d469 = ps.OverlayValues[469]
 					}
-					if len(ps.OverlayValues) > 615 && ps.OverlayValues[615].Loc != LocNone {
-						d615 = ps.OverlayValues[615]
+					if len(ps.OverlayValues) > 472 && ps.OverlayValues[472].Loc != LocNone {
+						d472 = ps.OverlayValues[472]
 					}
-					if len(ps.OverlayValues) > 616 && ps.OverlayValues[616].Loc != LocNone {
-						d616 = ps.OverlayValues[616]
+					if len(ps.OverlayValues) > 473 && ps.OverlayValues[473].Loc != LocNone {
+						d473 = ps.OverlayValues[473]
 					}
-					if len(ps.OverlayValues) > 617 && ps.OverlayValues[617].Loc != LocNone {
-						d617 = ps.OverlayValues[617]
+					if len(ps.OverlayValues) > 650 && ps.OverlayValues[650].Loc != LocNone {
+						d650 = ps.OverlayValues[650]
 					}
-					if len(ps.OverlayValues) > 618 && ps.OverlayValues[618].Loc != LocNone {
-						d618 = ps.OverlayValues[618]
+					if len(ps.OverlayValues) > 651 && ps.OverlayValues[651].Loc != LocNone {
+						d651 = ps.OverlayValues[651]
 					}
-					if len(ps.OverlayValues) > 619 && ps.OverlayValues[619].Loc != LocNone {
-						d619 = ps.OverlayValues[619]
+					if len(ps.OverlayValues) > 652 && ps.OverlayValues[652].Loc != LocNone {
+						d652 = ps.OverlayValues[652]
 					}
-					if len(ps.OverlayValues) > 621 && ps.OverlayValues[621].Loc != LocNone {
-						d621 = ps.OverlayValues[621]
+					if len(ps.OverlayValues) > 653 && ps.OverlayValues[653].Loc != LocNone {
+						d653 = ps.OverlayValues[653]
 					}
-					if len(ps.OverlayValues) > 623 && ps.OverlayValues[623].Loc != LocNone {
-						d623 = ps.OverlayValues[623]
+					if len(ps.OverlayValues) > 654 && ps.OverlayValues[654].Loc != LocNone {
+						d654 = ps.OverlayValues[654]
 					}
-					if len(ps.OverlayValues) > 721 && ps.OverlayValues[721].Loc != LocNone {
-						d721 = ps.OverlayValues[721]
+					if len(ps.OverlayValues) > 655 && ps.OverlayValues[655].Loc != LocNone {
+						d655 = ps.OverlayValues[655]
 					}
-					if len(ps.OverlayValues) > 724 && ps.OverlayValues[724].Loc != LocNone {
-						d724 = ps.OverlayValues[724]
+					if len(ps.OverlayValues) > 656 && ps.OverlayValues[656].Loc != LocNone {
+						d656 = ps.OverlayValues[656]
 					}
-					if len(ps.OverlayValues) > 824 && ps.OverlayValues[824].Loc != LocNone {
-						d824 = ps.OverlayValues[824]
+					if len(ps.OverlayValues) > 657 && ps.OverlayValues[657].Loc != LocNone {
+						d657 = ps.OverlayValues[657]
 					}
-					if len(ps.OverlayValues) > 825 && ps.OverlayValues[825].Loc != LocNone {
-						d825 = ps.OverlayValues[825]
+					if len(ps.OverlayValues) > 658 && ps.OverlayValues[658].Loc != LocNone {
+						d658 = ps.OverlayValues[658]
 					}
-					if len(ps.OverlayValues) > 826 && ps.OverlayValues[826].Loc != LocNone {
-						d826 = ps.OverlayValues[826]
+					if len(ps.OverlayValues) > 659 && ps.OverlayValues[659].Loc != LocNone {
+						d659 = ps.OverlayValues[659]
+					}
+					if len(ps.OverlayValues) > 660 && ps.OverlayValues[660].Loc != LocNone {
+						d660 = ps.OverlayValues[660]
+					}
+					if len(ps.OverlayValues) > 661 && ps.OverlayValues[661].Loc != LocNone {
+						d661 = ps.OverlayValues[661]
+					}
+					if len(ps.OverlayValues) > 662 && ps.OverlayValues[662].Loc != LocNone {
+						d662 = ps.OverlayValues[662]
+					}
+					if len(ps.OverlayValues) > 664 && ps.OverlayValues[664].Loc != LocNone {
+						d664 = ps.OverlayValues[664]
+					}
+					if len(ps.OverlayValues) > 665 && ps.OverlayValues[665].Loc != LocNone {
+						d665 = ps.OverlayValues[665]
+					}
+					if len(ps.OverlayValues) > 666 && ps.OverlayValues[666].Loc != LocNone {
+						d666 = ps.OverlayValues[666]
+					}
+					if len(ps.OverlayValues) > 667 && ps.OverlayValues[667].Loc != LocNone {
+						d667 = ps.OverlayValues[667]
+					}
+					if len(ps.OverlayValues) > 668 && ps.OverlayValues[668].Loc != LocNone {
+						d668 = ps.OverlayValues[668]
+					}
+					if len(ps.OverlayValues) > 669 && ps.OverlayValues[669].Loc != LocNone {
+						d669 = ps.OverlayValues[669]
+					}
+					if len(ps.OverlayValues) > 670 && ps.OverlayValues[670].Loc != LocNone {
+						d670 = ps.OverlayValues[670]
+					}
+					if len(ps.OverlayValues) > 672 && ps.OverlayValues[672].Loc != LocNone {
+						d672 = ps.OverlayValues[672]
+					}
+					if len(ps.OverlayValues) > 674 && ps.OverlayValues[674].Loc != LocNone {
+						d674 = ps.OverlayValues[674]
+					}
+					if len(ps.OverlayValues) > 784 && ps.OverlayValues[784].Loc != LocNone {
+						d784 = ps.OverlayValues[784]
+					}
+					if len(ps.OverlayValues) > 787 && ps.OverlayValues[787].Loc != LocNone {
+						d787 = ps.OverlayValues[787]
+					}
+					if len(ps.OverlayValues) > 899 && ps.OverlayValues[899].Loc != LocNone {
+						d899 = ps.OverlayValues[899]
+					}
+					if len(ps.OverlayValues) > 900 && ps.OverlayValues[900].Loc != LocNone {
+						d900 = ps.OverlayValues[900]
+					}
+					if len(ps.OverlayValues) > 901 && ps.OverlayValues[901].Loc != LocNone {
+						d901 = ps.OverlayValues[901]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d7)
-					var d1035 JITValueDesc
-					if d7.Loc == LocImm {
-						d1035 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(math.Sqrt(d7.Imm.Float()))}
+					ctx.EnsureDesc(&d14)
+					var d1134 JITValueDesc
+					if d14.Loc == LocImm {
+						d1134 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(math.Sqrt(d14.Imm.Float()))}
 					} else {
-						ctx.EnsureDesc(&d7)
-						var d1036 JITValueDesc
-						if d7.Loc == LocRegPair {
-							ctx.FreeReg(d7.Reg)
-							d1036 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d7.Reg2}
-							ctx.BindReg(d7.Reg2, &d1036)
-							ctx.BindReg(d7.Reg2, &d1036)
+						ctx.EnsureDesc(&d14)
+						var d1135 JITValueDesc
+						if d14.Loc == LocRegPair {
+							ctx.FreeReg(d14.Reg)
+							d1135 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d14.Reg2}
+							ctx.BindReg(d14.Reg2, &d1135)
+							ctx.BindReg(d14.Reg2, &d1135)
 						} else {
-							d1036 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d7.Reg}
-							ctx.BindReg(d7.Reg, &d1036)
-							ctx.BindReg(d7.Reg, &d1036)
+							d1135 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d14.Reg}
+							ctx.BindReg(d14.Reg, &d1135)
+							ctx.BindReg(d14.Reg, &d1135)
 						}
-						d1035 = ctx.EmitGoCallScalar(GoFuncAddr(JITSqrtBits), []JITValueDesc{d1036}, 1)
-						d1035.Type = tagFloat
-						ctx.BindReg(d1035.Reg, &d1035)
+						d1134 = ctx.EmitGoCallScalar(GoFuncAddr(JITSqrtBits), []JITValueDesc{d1135}, 1)
+						d1134.Type = tagFloat
+						ctx.BindReg(d1134.Reg, &d1134)
 					}
-					ctx.StabilizeDescForControlFlow(&d1035)
+					ctx.StabilizeDescForControlFlow(&d1134)
 					if ps.General {
-						ctx.SyncDesc(&d1035)
-						if d1035.Loc == LocReg {
-							ctx.ProtectReg(d1035.Reg)
-						} else if d1035.Loc == LocRegPair {
-							ctx.ProtectReg(d1035.Reg)
-							ctx.ProtectReg(d1035.Reg2)
+						ctx.SyncDesc(&d1134)
+						if d1134.Loc == LocReg || d1134.Loc == LocFPReg {
+							ctx.ProtectReg(d1134.Reg)
+						} else if d1134.Loc == LocRegPair {
+							ctx.ProtectReg(d1134.Reg)
+							ctx.ProtectReg(d1134.Reg2)
 						}
-						d1037 = d1035
-						if d1037.Loc == LocNone {
+						d1136 = d1134
+						if d1136.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.EnsureDesc(&d1037)
-						ctx.EmitStoreToStack(d1037, int32(bbs[4].PhiBase)+int32(0))
-						if d1035.Loc == LocReg {
-							ctx.UnprotectReg(d1035.Reg)
-						} else if d1035.Loc == LocRegPair {
-							ctx.UnprotectReg(d1035.Reg)
-							ctx.UnprotectReg(d1035.Reg2)
+						ctx.EnsureDesc(&d1136)
+						ctx.EmitStoreToStack(d1136, int32(bbs[4].PhiBase)+int32(0))
+						if d1134.Loc == LocReg || d1134.Loc == LocFPReg {
+							ctx.UnprotectReg(d1134.Reg)
+						} else if d1134.Loc == LocRegPair {
+							ctx.UnprotectReg(d1134.Reg)
+							ctx.UnprotectReg(d1134.Reg2)
 						}
 					}
-					ps1038 := PhiState{General: ps.General}
-					ps1038.OverlayValues = make([]JITValueDesc, 1038)
-					ps1038.OverlayValues[1] = d1
-					ps1038.OverlayValues[2] = d2
-					ps1038.OverlayValues[3] = d3
-					ps1038.OverlayValues[4] = d4
-					ps1038.OverlayValues[5] = d5
-					ps1038.OverlayValues[6] = d6
-					ps1038.OverlayValues[7] = d7
-					ps1038.OverlayValues[8] = d8
-					ps1038.OverlayValues[9] = d9
-					ps1038.OverlayValues[10] = d10
-					ps1038.OverlayValues[11] = d11
-					ps1038.OverlayValues[12] = d12
-					ps1038.OverlayValues[13] = d13
-					ps1038.OverlayValues[14] = d14
-					ps1038.OverlayValues[15] = d15
-					ps1038.OverlayValues[18] = d18
-					ps1038.OverlayValues[38] = d38
-					ps1038.OverlayValues[57] = d57
-					ps1038.OverlayValues[58] = d58
-					ps1038.OverlayValues[59] = d59
-					ps1038.OverlayValues[60] = d60
-					ps1038.OverlayValues[61] = d61
-					ps1038.OverlayValues[63] = d63
-					ps1038.OverlayValues[64] = d64
-					ps1038.OverlayValues[65] = d65
-					ps1038.OverlayValues[66] = d66
-					ps1038.OverlayValues[67] = d67
-					ps1038.OverlayValues[68] = d68
-					ps1038.OverlayValues[69] = d69
-					ps1038.OverlayValues[72] = d72
-					ps1038.OverlayValues[138] = d138
-					ps1038.OverlayValues[139] = d139
-					ps1038.OverlayValues[140] = d140
-					ps1038.OverlayValues[141] = d141
-					ps1038.OverlayValues[142] = d142
-					ps1038.OverlayValues[143] = d143
-					ps1038.OverlayValues[145] = d145
-					ps1038.OverlayValues[146] = d146
-					ps1038.OverlayValues[147] = d147
-					ps1038.OverlayValues[148] = d148
-					ps1038.OverlayValues[149] = d149
-					ps1038.OverlayValues[150] = d150
-					ps1038.OverlayValues[151] = d151
-					ps1038.OverlayValues[152] = d152
-					ps1038.OverlayValues[153] = d153
-					ps1038.OverlayValues[156] = d156
-					ps1038.OverlayValues[157] = d157
-					ps1038.OverlayValues[158] = d158
-					ps1038.OverlayValues[159] = d159
-					ps1038.OverlayValues[262] = d262
-					ps1038.OverlayValues[263] = d263
-					ps1038.OverlayValues[264] = d264
-					ps1038.OverlayValues[265] = d265
-					ps1038.OverlayValues[266] = d266
-					ps1038.OverlayValues[267] = d267
-					ps1038.OverlayValues[268] = d268
-					ps1038.OverlayValues[269] = d269
-					ps1038.OverlayValues[270] = d270
-					ps1038.OverlayValues[271] = d271
-					ps1038.OverlayValues[272] = d272
-					ps1038.OverlayValues[273] = d273
-					ps1038.OverlayValues[274] = d274
-					ps1038.OverlayValues[275] = d275
-					ps1038.OverlayValues[276] = d276
-					ps1038.OverlayValues[278] = d278
-					ps1038.OverlayValues[279] = d279
-					ps1038.OverlayValues[280] = d280
-					ps1038.OverlayValues[281] = d281
-					ps1038.OverlayValues[283] = d283
-					ps1038.OverlayValues[284] = d284
-					ps1038.OverlayValues[285] = d285
-					ps1038.OverlayValues[434] = d434
-					ps1038.OverlayValues[435] = d435
-					ps1038.OverlayValues[436] = d436
-					ps1038.OverlayValues[437] = d437
-					ps1038.OverlayValues[438] = d438
-					ps1038.OverlayValues[441] = d441
-					ps1038.OverlayValues[442] = d442
-					ps1038.OverlayValues[603] = d603
-					ps1038.OverlayValues[604] = d604
-					ps1038.OverlayValues[605] = d605
-					ps1038.OverlayValues[606] = d606
-					ps1038.OverlayValues[607] = d607
-					ps1038.OverlayValues[608] = d608
-					ps1038.OverlayValues[609] = d609
-					ps1038.OverlayValues[610] = d610
-					ps1038.OverlayValues[611] = d611
-					ps1038.OverlayValues[612] = d612
-					ps1038.OverlayValues[613] = d613
-					ps1038.OverlayValues[615] = d615
-					ps1038.OverlayValues[616] = d616
-					ps1038.OverlayValues[617] = d617
-					ps1038.OverlayValues[618] = d618
-					ps1038.OverlayValues[619] = d619
-					ps1038.OverlayValues[621] = d621
-					ps1038.OverlayValues[623] = d623
-					ps1038.OverlayValues[721] = d721
-					ps1038.OverlayValues[724] = d724
-					ps1038.OverlayValues[824] = d824
-					ps1038.OverlayValues[825] = d825
-					ps1038.OverlayValues[826] = d826
-					ps1038.OverlayValues[1035] = d1035
-					ps1038.OverlayValues[1036] = d1036
-					ps1038.OverlayValues[1037] = d1037
-					ps1038.PhiValues = make([]JITValueDesc, 1)
-					d1039 = d1035
-					ps1038.PhiValues[0] = d1039
-					if ps1038.General && bbs[4].Rendered {
+					ps1137 := PhiState{General: ps.General}
+					ps1137.OverlayValues = make([]JITValueDesc, 1137)
+					ps1137.OverlayValues[8] = d8
+					ps1137.OverlayValues[9] = d9
+					ps1137.OverlayValues[10] = d10
+					ps1137.OverlayValues[11] = d11
+					ps1137.OverlayValues[12] = d12
+					ps1137.OverlayValues[13] = d13
+					ps1137.OverlayValues[14] = d14
+					ps1137.OverlayValues[15] = d15
+					ps1137.OverlayValues[16] = d16
+					ps1137.OverlayValues[17] = d17
+					ps1137.OverlayValues[18] = d18
+					ps1137.OverlayValues[19] = d19
+					ps1137.OverlayValues[20] = d20
+					ps1137.OverlayValues[21] = d21
+					ps1137.OverlayValues[22] = d22
+					ps1137.OverlayValues[25] = d25
+					ps1137.OverlayValues[45] = d45
+					ps1137.OverlayValues[64] = d64
+					ps1137.OverlayValues[65] = d65
+					ps1137.OverlayValues[66] = d66
+					ps1137.OverlayValues[67] = d67
+					ps1137.OverlayValues[68] = d68
+					ps1137.OverlayValues[70] = d70
+					ps1137.OverlayValues[71] = d71
+					ps1137.OverlayValues[72] = d72
+					ps1137.OverlayValues[73] = d73
+					ps1137.OverlayValues[74] = d74
+					ps1137.OverlayValues[75] = d75
+					ps1137.OverlayValues[76] = d76
+					ps1137.OverlayValues[79] = d79
+					ps1137.OverlayValues[145] = d145
+					ps1137.OverlayValues[146] = d146
+					ps1137.OverlayValues[147] = d147
+					ps1137.OverlayValues[148] = d148
+					ps1137.OverlayValues[149] = d149
+					ps1137.OverlayValues[150] = d150
+					ps1137.OverlayValues[152] = d152
+					ps1137.OverlayValues[153] = d153
+					ps1137.OverlayValues[154] = d154
+					ps1137.OverlayValues[155] = d155
+					ps1137.OverlayValues[156] = d156
+					ps1137.OverlayValues[157] = d157
+					ps1137.OverlayValues[158] = d158
+					ps1137.OverlayValues[159] = d159
+					ps1137.OverlayValues[160] = d160
+					ps1137.OverlayValues[163] = d163
+					ps1137.OverlayValues[164] = d164
+					ps1137.OverlayValues[165] = d165
+					ps1137.OverlayValues[166] = d166
+					ps1137.OverlayValues[269] = d269
+					ps1137.OverlayValues[270] = d270
+					ps1137.OverlayValues[271] = d271
+					ps1137.OverlayValues[272] = d272
+					ps1137.OverlayValues[273] = d273
+					ps1137.OverlayValues[274] = d274
+					ps1137.OverlayValues[275] = d275
+					ps1137.OverlayValues[276] = d276
+					ps1137.OverlayValues[277] = d277
+					ps1137.OverlayValues[278] = d278
+					ps1137.OverlayValues[279] = d279
+					ps1137.OverlayValues[280] = d280
+					ps1137.OverlayValues[281] = d281
+					ps1137.OverlayValues[282] = d282
+					ps1137.OverlayValues[283] = d283
+					ps1137.OverlayValues[284] = d284
+					ps1137.OverlayValues[285] = d285
+					ps1137.OverlayValues[286] = d286
+					ps1137.OverlayValues[287] = d287
+					ps1137.OverlayValues[289] = d289
+					ps1137.OverlayValues[290] = d290
+					ps1137.OverlayValues[291] = d291
+					ps1137.OverlayValues[292] = d292
+					ps1137.OverlayValues[293] = d293
+					ps1137.OverlayValues[294] = d294
+					ps1137.OverlayValues[295] = d295
+					ps1137.OverlayValues[296] = d296
+					ps1137.OverlayValues[298] = d298
+					ps1137.OverlayValues[299] = d299
+					ps1137.OverlayValues[300] = d300
+					ps1137.OverlayValues[465] = d465
+					ps1137.OverlayValues[466] = d466
+					ps1137.OverlayValues[467] = d467
+					ps1137.OverlayValues[468] = d468
+					ps1137.OverlayValues[469] = d469
+					ps1137.OverlayValues[472] = d472
+					ps1137.OverlayValues[473] = d473
+					ps1137.OverlayValues[650] = d650
+					ps1137.OverlayValues[651] = d651
+					ps1137.OverlayValues[652] = d652
+					ps1137.OverlayValues[653] = d653
+					ps1137.OverlayValues[654] = d654
+					ps1137.OverlayValues[655] = d655
+					ps1137.OverlayValues[656] = d656
+					ps1137.OverlayValues[657] = d657
+					ps1137.OverlayValues[658] = d658
+					ps1137.OverlayValues[659] = d659
+					ps1137.OverlayValues[660] = d660
+					ps1137.OverlayValues[661] = d661
+					ps1137.OverlayValues[662] = d662
+					ps1137.OverlayValues[664] = d664
+					ps1137.OverlayValues[665] = d665
+					ps1137.OverlayValues[666] = d666
+					ps1137.OverlayValues[667] = d667
+					ps1137.OverlayValues[668] = d668
+					ps1137.OverlayValues[669] = d669
+					ps1137.OverlayValues[670] = d670
+					ps1137.OverlayValues[672] = d672
+					ps1137.OverlayValues[674] = d674
+					ps1137.OverlayValues[784] = d784
+					ps1137.OverlayValues[787] = d787
+					ps1137.OverlayValues[899] = d899
+					ps1137.OverlayValues[900] = d900
+					ps1137.OverlayValues[901] = d901
+					ps1137.OverlayValues[1134] = d1134
+					ps1137.OverlayValues[1135] = d1135
+					ps1137.OverlayValues[1136] = d1136
+					ps1137.PhiValues = make([]JITValueDesc, 1)
+					d1138 = d1134
+					ps1137.PhiValues[0] = d1138
+					if ps1137.General && bbs[4].Rendered {
 						ctx.EmitJmp(lbl5)
 						return result
 					}
-					return bbs[4].RenderPS(ps1038)
+					return bbs[4].RenderPS(ps1137)
 					return result
 				}
-				ps1040 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps1040)
+				ps1139 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps1139)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {


### PR DESCRIPTION
## Summary

- keep `dot`/cosine loop accumulators in the native FP register class until the final Scheme-value boundary
- use otherwise-free FP/SIMD registers as overflow homes for proven pointer-free scalar payloads before spilling GPR values to memory
- reconstruct integer/float sentinels and boolean encodings only at Scmer return, slice-store, and Go ABI boundaries
- preserve the original register class across an FP-bank spill, so opaque integer/boolean payloads return to GPRs while native floats return to FP registers
- explicitly exclude unknown values, Scmer pairs, address-bearing scalar shapes, and `RelocatablePointer` values from the SIMD overflow path

This extends the typed scalar representation introduced by #802 rather than adding operator-specific spill behavior. Inside generated code, a proven scalar is payload-only. Full two-word Scmer representation is restored only where the ABI or storage layout requires it. Pointer-bearing values retain the existing stack-map path.

`scm/vector.go` contains the mechanically regenerated `dot` emitter after enabling its existing `JITNativeFP` policy; the large generated diff is confined to that generated section.

## Manual A/B: isolated operator

Same host, same 4096-float input vectors, same compiled lambda, warm benchmark, `GOEXPERIMENT=jit`, `-benchtime=2s -count=5`, median of five samples:

| case | master / #802 | this PR | change |
|---|---:|---:|---:|
| DOT | 14,727 ns/op | 13,989 ns/op | **-5.0%** |
| COSINE | 15,513 ns/op | 14,910 ns/op | **-3.9%** |
| allocations | 0 B / 0 allocs | 0 B / 0 allocs | unchanged |

## Manual A/B: HTTP end to end

Two separately built JIT-enabled servers were run from `master` and this branch. Each authenticated `/scm` request parses/evaluates the source, builds a 4096-float vector with `produceN`, compiles the lambda, executes DOT repeatedly, and serializes the response. After three warmups, 15 alternating samples were taken for the short case and 11 for the amortized case.

| request workload | master median | this PR median | change |
|---|---:|---:|---:|
| 200 DOT calls | 3.283 ms | 3.481 ms | **+6.0%** |
| 2,000 DOT calls | 28.700 ms | 28.901 ms | **+0.7%** |

Thus the isolated FP loop is measurably faster, but the complete request currently shows **no end-to-end improvement**. In the short case, regenerating/compiling the larger native-FP emitter appears to cost more than execution saves; with 10x more execution work, the result is within run-to-run jitter. This PR should not claim an application-level speedup on the present evidence. The generic overflow-home work is pressure-dependent and is covered structurally, but it also has no measured end-to-end win yet.

The focused allocator test verifies that numeric register pressure emits no stack spill/root when an FP overflow home is free. Its paired pointer test verifies that an address-bearing scalar still spills into a GC-visible stack slot.

## Validation

- `GOEXPERIMENT=jit /home/carli/projekte/go-jit/goroot/bin/go test ./scm -run 'TestJIT|Test.*JIT' -count=1`
- `go test ./scm ./tools/jitgen`
- JIT build plus `lib/main.scm` startup: **1276/1276 Scheme unit tests passed**
- focused DOT/COSINE correctness covers native return/sentinel reconstruction
- full SQL and performance A/B suites are left to CI
