### PR TITLE
Migrate legacy RDF type predicates

### DIFF
--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -1101,6 +1101,33 @@ consumer stage. */
 	deterministic even when the table-function source is lowered directly. */
 	(sort (seen) (lambda (left right) (< left right)))
 )))
+(define rdf_table_migrations (coalesce rdf_table_migrations (newsession)))
+(define rdf_migrate_legacy_type_predicates (lambda (rdf_table) (begin
+	(define replacements (newsession))
+	(define replacement_count (newsession))
+	(replacement_count "value" 0)
+	(scan nil rdf_table '() '() '() (lambda () true) '("s" "p" "o")
+		(lambda (acc s p o) (begin
+			(if (equal? p "a")
+				(begin
+					(replacements (replacement_count "value")
+						(list s "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" o))
+					(replacement_count "value" (+ (replacement_count "value") 1))) nil)
+			acc)))
+	(if (> (replacement_count "value") 0)
+		(begin
+			/* Insert first so an interruption can never discard the only form of a
+			legacy type statement. The triple key makes this idempotent when both
+			spellings already exist. */
+			(insert rdf_table '("s" "p" "o")
+				(map (produceN (replacement_count "value")) (lambda (idx) (replacements idx)))
+				'() (lambda () true))
+			(scan nil rdf_table '() '() '() (lambda () true) '("p" "$update")
+				(lambda (acc p $update) (begin
+					(if (equal? p "a") ($update) nil)
+					acc)))) nil)
+	true)
+)))
 (define rdf_ensure_table (lambda (schema)
 	(begin
 		/* Avoid replaying idempotent DDL on every RDF read. Besides being wasted
@@ -1127,6 +1154,11 @@ consumer stage. */
 						(if (seen identity) ($update) (seen identity true))
 						acc)))
 				(createkey (table schema "rdf") "rdf_spo" true '("s" "p" "o"))))
+		(define rdf_table (table schema "rdf"))
+		/* Key the one-time migration by the table handle rather than the schema
+		name, so DROP/CREATE receives a fresh migration pass in the same process. */
+		(rdf_table_migrations "get_or_compute_scoped" rdf_table "legacy-type-predicate"
+			(lambda () (rdf_migrate_legacy_type_predicates rdf_table)))
 		true)
 ))
 (define rdf_ensure_named_table (lambda (schema)

--- a/tests/rdf/rdf-storage-migration.yaml
+++ b/tests/rdf/rdf-storage-migration.yaml
@@ -10,7 +10,13 @@ metadata:
 setup:
   - sql: "DROP TABLE IF EXISTS rdf"
   - sql: "CREATE TABLE rdf (s TEXT, p TEXT, o TEXT)"
-  - sql: "INSERT INTO rdf VALUES ('subject', 'predicate', 'object'), ('subject', 'predicate', 'object')"
+  - sql: >-
+      INSERT INTO rdf VALUES
+      ('subject', 'predicate', 'object'),
+      ('subject', 'predicate', 'object'),
+      ('legacy-subject', 'a', 'legacy-class'),
+      ('mixed-subject', 'a', 'mixed-class'),
+      ('mixed-subject', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'mixed-class')
 
 test_cases:
   - name: "rdf_ensure_table deduplicates and installs the triple key"
@@ -26,7 +32,29 @@ test_cases:
     expect:
       rows: 1
       data:
-        - cnt: 1
+        - cnt: 3
+
+  - name: "Legacy Turtle a predicates were removed"
+    sql: "SELECT COUNT(*) AS cnt FROM rdf WHERE p = 'a'"
+    expect:
+      rows: 1
+      data:
+        - cnt: 0
+
+  - name: "Legacy Turtle a predicates became standard rdf type triples"
+    sparql: |
+      SELECT ?subject ?class WHERE {
+        ?subject a ?class .
+        FILTER(?subject = <legacy-subject> || ?subject = <mixed-subject>)
+      }
+      ORDER BY ?subject
+    expect:
+      rows: 2
+      data:
+        - "?subject": "legacy-subject"
+          "?class": "legacy-class"
+        - "?subject": "mixed-subject"
+          "?class": "mixed-class"
 
   - name: "Migrated table enforces triple uniqueness"
     sql: "INSERT INTO rdf VALUES ('subject', 'predicate', 'object')"


### PR DESCRIPTION
## Summary
- migrate legacy Turtle `a` predicates to the standard `rdf:type` IRI when an existing RDF table is first ensured
- insert the canonical triple before deleting the legacy row so interrupted migration cannot lose the assertion
- key the migration by the table handle so recreated RDF tables are handled in the same process
- cover legacy-only and mixed legacy/canonical storage without duplicates

## Verification
- `python3 run_sql_tests.py tests/rdf/rdf-storage-migration.yaml` (5/5)
- Full suite intentionally delegated to CI as requested.