### PR TITLE
build: add reproducible make jit target

### DIFF
--- a/.github/workflows/jit-performance.yml
+++ b/.github/workflows/jit-performance.yml
@@ -42,14 +42,14 @@ jobs:
         with:
           repository: launix-de/go
           ref: ${{ env.JIT_GO_REF }}
-          path: go-jit
+          path: candidate/.third_party/go-jit
 
       - name: Read patched Go version
         id: jit-go-version
         shell: bash
         run: |
           set -euo pipefail
-          version=$(sed -n 's/^go\([0-9].*\)$/\1/p' go-jit/VERSION | head -n 1)
+          version=$(sed -n 's/^go\([0-9].*\)$/\1/p' candidate/.third_party/go-jit/VERSION | head -n 1)
           test -n "$version"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
@@ -59,26 +59,22 @@ jobs:
           go-version: ${{ steps.jit-go-version.outputs.version }}
           cache: false
 
-      - name: Build patched Go compiler
-        shell: bash
-        run: |
-          set -euo pipefail
-          bootstrap_goroot=$(go env GOROOT)
-          (cd go-jit/src && GOROOT_BOOTSTRAP="$bootstrap_goroot" ./make.bash)
+      - name: Build JIT candidate and patched Go compiler
+        run: make -C candidate jit
 
       - name: Select patched Go compiler
         shell: bash
         run: |
-          printf '%s\n' "$GITHUB_WORKSPACE/go-jit/bin" >> "$GITHUB_PATH"
-          printf 'GOROOT=%s\n' "$GITHUB_WORKSPACE/go-jit" >> "$GITHUB_ENV"
+          printf '%s\n' "$GITHUB_WORKSPACE/candidate/.third_party/go-jit/bin" >> "$GITHUB_PATH"
+          printf 'GOROOT=%s\n' "$GITHUB_WORKSPACE/candidate/.third_party/go-jit" >> "$GITHUB_ENV"
           printf 'GOEXPERIMENT=jit\n' >> "$GITHUB_ENV"
 
       - name: Verify compiler identity
         shell: bash
         run: |
           set -euo pipefail
-          test "$(go env GOROOT)" = "$GITHUB_WORKSPACE/go-jit"
-          jit_go_revision=$(git -C "$GITHUB_WORKSPACE/go-jit" rev-parse HEAD)
+          test "$(go env GOROOT)" = "$GITHUB_WORKSPACE/candidate/.third_party/go-jit"
+          jit_go_revision=$(git -C "$GITHUB_WORKSPACE/candidate/.third_party/go-jit" rev-parse HEAD)
           printf 'Patched Go revision: `%s`\n' "$jit_go_revision" >> "$GITHUB_STEP_SUMMARY"
           go version
           go env GOEXPERIMENT
@@ -86,11 +82,8 @@ jobs:
       - name: Install test dependencies
         run: pip install requests PyYAML
 
-      - name: Build JIT base and candidate
-        shell: bash
-        run: |
-          (cd base && go build -o memcp)
-          (cd candidate && go build -o memcp)
+      - name: Build JIT base with the same compiler
+        run: make -C base jit JIT_GOROOT="$GITHUB_WORKSPACE/candidate/.third_party/go-jit"
 
       - name: Measure JIT base and candidate with the SQL test runner
         shell: bash

--- a/.github/workflows/jit-test.yml
+++ b/.github/workflows/jit-test.yml
@@ -46,14 +46,14 @@ jobs:
         with:
           repository: launix-de/go
           ref: ${{ env.JIT_GO_REF }}
-          path: go-jit
+          path: .third_party/go-jit
 
       - name: Read patched Go version
         id: jit-go-version
         shell: bash
         run: |
           set -euo pipefail
-          version=$(sed -n 's/^go\([0-9].*\)$/\1/p' go-jit/VERSION | head -n 1)
+          version=$(sed -n 's/^go\([0-9].*\)$/\1/p' .third_party/go-jit/VERSION | head -n 1)
           test -n "$version"
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
@@ -63,26 +63,22 @@ jobs:
           go-version: ${{ steps.jit-go-version.outputs.version }}
           cache: false
 
-      - name: Build patched Go compiler
-        shell: bash
-        run: |
-          set -euo pipefail
-          bootstrap_goroot=$(go env GOROOT)
-          (cd go-jit/src && GOROOT_BOOTSTRAP="$bootstrap_goroot" ./make.bash)
+      - name: Build MemCP with patched Go compiler
+        run: make jit
 
       - name: Select patched Go compiler
         shell: bash
         run: |
-          printf '%s\n' "$GITHUB_WORKSPACE/go-jit/bin" >> "$GITHUB_PATH"
-          printf 'GOROOT=%s\n' "$GITHUB_WORKSPACE/go-jit" >> "$GITHUB_ENV"
+          printf '%s\n' "$GITHUB_WORKSPACE/.third_party/go-jit/bin" >> "$GITHUB_PATH"
+          printf 'GOROOT=%s\n' "$GITHUB_WORKSPACE/.third_party/go-jit" >> "$GITHUB_ENV"
           printf 'GOEXPERIMENT=jit\n' >> "$GITHUB_ENV"
 
       - name: Verify compiler identity
         shell: bash
         run: |
           set -euo pipefail
-          test "$(go env GOROOT)" = "$GITHUB_WORKSPACE/go-jit"
-          jit_go_revision=$(git -C "$GITHUB_WORKSPACE/go-jit" rev-parse HEAD)
+          test "$(go env GOROOT)" = "$GITHUB_WORKSPACE/.third_party/go-jit"
+          jit_go_revision=$(git -C "$GITHUB_WORKSPACE/.third_party/go-jit" rev-parse HEAD)
           printf 'Patched Go revision: `%s`\n' "$jit_go_revision" >> "$GITHUB_STEP_SUMMARY"
           go version
           go env GOEXPERIMENT

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ todos/
 .perf_runner_gate.lock
 .gocache/
 .gomodcache/
+.third_party/
 __pycache__/
 .build/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,21 @@ export SOURCE_DATE_EPOCH
 all:
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o memcp .
 
-# Keep the experimental compiler outside the tracked source tree. Existing
-# checkouts are left untouched so local compiler patches are never discarded;
-# remove the disposable checkout explicitly to recreate it at JIT_GO_REF.
+# Keep the experimental compiler outside the tracked source tree. Clean
+# checkouts fast-forward on every invocation, while a checkout with local
+# tracked changes is left untouched so compiler work is never discarded.
 jit-toolchain:
 	@set -eu; \
 	if [ ! -e "$(JIT_GOROOT)" ]; then \
 		mkdir -p "$(dir $(JIT_GOROOT))"; \
 		git clone --depth 1 --branch "$(JIT_GO_REF)" "$(JIT_GO_REPOSITORY)" "$(JIT_GOROOT)"; \
+	else \
+		test -d "$(JIT_GOROOT)/.git" || { echo "$(JIT_GOROOT) is not a Go git checkout" >&2; exit 1; }; \
+		if git -C "$(JIT_GOROOT)" diff --quiet && git -C "$(JIT_GOROOT)" diff --cached --quiet; then \
+			git -C "$(JIT_GOROOT)" pull --ff-only origin "$(JIT_GO_REF)"; \
+		else \
+			echo "warning: $(JIT_GOROOT) has local changes; skipping compiler update" >&2; \
+		fi; \
 	fi; \
 	test -d "$(JIT_GOROOT)/.git" || { echo "$(JIT_GOROOT) is not a Go git checkout" >&2; exit 1; }; \
 	revision=$$(git -C "$(JIT_GOROOT)" rev-parse HEAD); \

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,38 @@ PACKAGE_LDFLAGS ?= -s -w
 DIST_DIR     ?= dist
 PACKAGE_DIR  ?= .build/packages
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --format=%ct)
+JIT_GOROOT   ?= $(CURDIR)/.third_party/go-jit
+JIT_GO_REPOSITORY ?= https://github.com/launix-de/go.git
+JIT_GO_REF   ?= jit-foreign-frames-go1.27.0
 export SOURCE_DATE_EPOCH
 
 all:
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o memcp .
+
+# Keep the experimental compiler outside the tracked source tree. Existing
+# checkouts are left untouched so local compiler patches are never discarded;
+# remove the disposable checkout explicitly to recreate it at JIT_GO_REF.
+jit-toolchain:
+	@set -eu; \
+	if [ ! -e "$(JIT_GOROOT)" ]; then \
+		mkdir -p "$(dir $(JIT_GOROOT))"; \
+		git clone --depth 1 --branch "$(JIT_GO_REF)" "$(JIT_GO_REPOSITORY)" "$(JIT_GOROOT)"; \
+	fi; \
+	test -d "$(JIT_GOROOT)/.git" || { echo "$(JIT_GOROOT) is not a Go git checkout" >&2; exit 1; }; \
+	revision=$$(git -C "$(JIT_GOROOT)" rev-parse HEAD); \
+	built_revision=$$(cat "$(JIT_GOROOT)/.memcp-built-revision" 2>/dev/null || true); \
+	if [ ! -x "$(JIT_GOROOT)/bin/go" ] || [ "$$built_revision" != "$$revision" ]; then \
+		version=$$(sed -n 's/^go\([0-9].*\)$$/\1/p' "$(JIT_GOROOT)/VERSION" | head -n 1); \
+		test -n "$$version"; \
+		bootstrap_goroot=$$(GOTOOLCHAIN="go$$version" go env GOROOT); \
+		(cd "$(JIT_GOROOT)/src" && GOROOT_BOOTSTRAP="$$bootstrap_goroot" ./make.bash); \
+		printf '%s\n' "$$revision" > "$(JIT_GOROOT)/.memcp-built-revision"; \
+	fi
+
+jit: jit-toolchain
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
+		GOROOT="$(JIT_GOROOT)" GOEXPERIMENT=jit "$(JIT_GOROOT)/bin/go" \
+		build $(BUILD_FLAGS) -ldflags="$(LDFLAGS)" -o memcp .
 
 jitgen:
 	@set -eu; \
@@ -175,5 +203,5 @@ docker-release:
 		--provenance=mode=max --sbom=true --push \
 		-t carli2/memcp:$(VERSION) -t carli2/memcp:latest .
 
-.PHONY: all install install-files memcp.sif memcp.deb memcp.rpm package-check \
-	version artifact-names docs docker-release jitgen costgen
+.PHONY: all jit jit-toolchain install install-files memcp.sif memcp.deb memcp.rpm \
+	package-check version artifact-names docs docker-release jitgen costgen


### PR DESCRIPTION
## Summary

- add `make jit` to build `./memcp` with the patched Go JIT toolchain
- keep the compiler checkout untracked under `.third_party/go-jit`
- clone the configured compiler ref only when the checkout is missing
- fast-forward an existing clean checkout on every invocation, so newly published compiler patches are picked up automatically
- preserve an existing checkout with tracked local changes and emit a warning instead of overwriting compiler work
- bootstrap the matching official Go version automatically and rebuild the patched toolchain only when its revision changes
- route JIT correctness and JIT performance CI builds through the same Makefile target

`JIT_GOROOT`, `JIT_GO_REPOSITORY`, and `JIT_GO_REF` remain configurable. Updates use `git pull --ff-only`, so the build never resets or force-overwrites an existing compiler checkout.

## Validation

- fresh `make jit`: cloned and built `launix-de/go@jit-foreign-frames-go1.27.0`, then produced `./memcp`
- repeated `make jit`: fast-forward checked the existing compiler checkout (`Already up to date`) and reused the built compiler
- binary reports `go1.27.0-X:jit`
- JIT binary startup: 1276/1276 Scheme unit tests passed
- authenticated SQL smoke query returned the expected result
- workflow YAML parsed successfully
- standard `go test ./tools/jitgen` passed

The complete test matrix is delegated to CI.
