### PR TITLE
JIT: propagate finalized main-storage value types

### DIFF
--- a/storage/shard_jit.go
+++ b/storage/shard_jit.go
@@ -225,7 +225,7 @@ func emitFusedLoop(ctx *scm.JITContext, mainCols []ColumnStorage, mapProc, reduc
 		idxCopy := ctx.AllocReg()
 		ctx.EmitMovRegReg(idxCopy, recidReg)
 		idxDesc := scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: idxCopy}
-		colDescs[i] = col.JITEmit(ctx, idxDesc, scm.JITValueDesc{Loc: scm.LocAny})
+		colDescs[i] = emitMainStorageValue(ctx, col, idxDesc, scm.JITValueDesc{Loc: scm.LocAny})
 	}
 	ctx.UnprotectReg(recidReg)
 	ctx.FreeReg(recidReg)
@@ -274,6 +274,18 @@ func emitFusedLoop(ctx *scm.JITContext, mainCols []ColumnStorage, mapProc, reduc
 	ctx.PatchInt32(spFixup, stackSize)
 	ctx.EmitAddRSP32(stackSize)
 	ctx.EmitByte(0xC3) // RET
+}
+
+// emitMainStorageValue is the only point where a finished storage's physical
+// type proof enters an inlined query callback. The caller is intentionally the
+// main-only loop above. Delta rows live outside ColumnStorage and must continue
+// through getDelta plus the ordinary dynamically typed lambda call.
+func emitMainStorageValue(ctx *scm.JITContext, col ColumnStorage, idx, result scm.JITValueDesc) scm.JITValueDesc {
+	value := col.JITEmit(ctx, idx, result)
+	if valueType := col.JITValueType(); valueType != scm.JITTypeUnknown {
+		value.Type = valueType
+	}
+	return value
 }
 
 // emitProcInlineWithStackArgs materializes proc arguments as a contiguous

--- a/storage/storage-float.go
+++ b/storage/storage-float.go
@@ -27,6 +27,10 @@ import "github.com/launix-de/memcp/scm"
 type StorageFloat struct {
 	storageJITFunctions
 	values []float64 `jit:"immutable-after-finish"`
+	// hasNull is collected while the storage is built (or reconstructed while
+	// it is loaded) and is immutable after finish. Keeping the proof beside the
+	// payload lets query code specialize the main column in O(1).
+	hasNull bool
 }
 
 func (s *StorageFloat) ComputeSize() uint {
@@ -408,6 +412,13 @@ func (s *StorageFloat) deserializeFloatV0(f io.Reader) uint {
 	rawdata := make([]byte, 8*l)
 	f.Read(rawdata)
 	s.values = unsafe.Slice((*float64)(unsafe.Pointer(&rawdata[0])), l)
+	s.hasNull = false
+	for _, value := range s.values {
+		if math.IsNaN(value) {
+			s.hasNull = true
+			break
+		}
+	}
 	return uint(l)
 }
 
@@ -457,8 +468,12 @@ func (s *StorageFloat) GetValueMulti(recids []uint32, target []scm.Scmer, stride
 }
 
 func (s *StorageFloat) scan(i uint32, value scm.Scmer) {
+	if value.IsNil() {
+		s.hasNull = true
+	}
 }
 func (s *StorageFloat) prepare() {
+	s.hasNull = false
 }
 func (s *StorageFloat) init(i uint32) {
 	// allocate
@@ -467,6 +482,7 @@ func (s *StorageFloat) init(i uint32) {
 func (s *StorageFloat) build(i uint32, value scm.Scmer) {
 	// store
 	if value.IsNil() {
+		s.hasNull = true
 		s.values[i] = math.NaN()
 	} else {
 		s.values[i] = value.Float()

--- a/storage/storage-int_jit_bench_test.go
+++ b/storage/storage-int_jit_bench_test.go
@@ -427,6 +427,66 @@ func BenchmarkStorageIntFinishedReaders(b *testing.B) {
 	})
 }
 
+// BenchmarkStorageIntTypedConsumer isolates the benefit of transporting the
+// finished main storage's exact tag into an immediately inlined Scheme
+// consumer. Both variants emit the same GetValue body and call ABI; only the
+// descriptor presented to the arithmetic emitter differs.
+func BenchmarkStorageIntTypedConsumer(b *testing.B) {
+	if !scm.JITEnabled() {
+		b.Skip("requires the JIT experiment")
+	}
+	s := buildBenchStorageInt(benchN)
+	Init(scm.Globalenv)
+	less := scm.Globalenv.Vars[scm.Symbol("<")]
+	if less.IsNil() {
+		b.Fatal("< builtin is not registered")
+	}
+	consumer := &scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("value")}),
+		Body: scm.NewSlice([]scm.Scmer{
+			less,
+			scm.NewSymbol("value"),
+			scm.NewInt(511),
+		}),
+		En: &scm.Globalenv,
+	}
+
+	build := func(typed bool) scm.JITStorageGetValueFunc {
+		return scm.CompileJITStorageGetValue(func(ctx *scm.JITContext, idx, result scm.JITValueDesc) scm.JITValueDesc {
+			var value scm.JITValueDesc
+			if typed {
+				value = emitMainStorageValue(ctx, s, idx, scm.JITValueDesc{Loc: scm.LocAny})
+			} else {
+				value = s.JITEmit(ctx, idx, scm.JITValueDesc{Loc: scm.LocAny})
+				value.Type = scm.JITTypeUnknown
+			}
+			return scm.JITEmitProcInline(ctx, consumer, []scm.JITValueDesc{value}, scm.RegR12, result)
+		})
+	}
+
+	unknown := build(false)
+	typed := build(true)
+	if unknown == nil || typed == nil {
+		b.Fatal("failed to compile typed-consumer benchmark")
+	}
+
+	run := func(b *testing.B, fn scm.JITStorageGetValueFunc) {
+		var sum int64
+		b.ReportAllocs()
+		b.ResetTimer()
+		for sample := 0; sample < b.N; sample++ {
+			for i := uint32(0); i < benchN; i++ {
+				if fn(i).Bool() {
+					sum++
+				}
+			}
+		}
+		runtime.KeepAlive(sum)
+	}
+	b.Run("Unknown", func(b *testing.B) { run(b, unknown) })
+	b.Run("Typed", func(b *testing.B) { run(b, typed) })
+}
+
 // BenchmarkStorageIntCachedReader measures the same indirection shape used by
 // scans after resolving a ColumnReader from the query plan. The direct typed
 // function benchmarks below isolate generated code quality; this benchmark

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -237,6 +237,12 @@ type ColumnStorage interface {
 	DistinctCount() uint // estimated number of distinct values in this shard column
 
 	// JIT compilation
+	// JITValueType describes the exact physical Scmer tag returned for every
+	// valid row of this finalized main storage. It must return JITTypeUnknown
+	// when NULLs or representation variants make the tag non-uniform. This is
+	// deliberately a property of the immutable main storage, not of the logical
+	// column: delta rows always retain their runtime tags.
+	JITValueType() uint8
 	JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result scm.JITValueDesc) scm.JITValueDesc
 	JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, stride, result scm.JITValueDesc) scm.JITValueDesc
 	JITEmitGetValueRange(ctx *scm.JITContext, recid, count, target, stride, result scm.JITValueDesc) scm.JITValueDesc

--- a/storage/storage_jit_type.go
+++ b/storage/storage_jit_type.go
@@ -1,0 +1,148 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "github.com/launix-de/memcp/scm"
+
+// JITValueType reports an exact physical Scmer tag only when every valid main
+// row has that representation. In particular, a nullable storage is not given
+// the type of its non-NULL values: an inlined consumer is then still required
+// to inspect the runtime tag. Delta rows are not represented by ColumnStorage
+// and must never use these answers.
+
+func (s *StorageInt) JITValueType() uint8 {
+	if s.hasNull {
+		return scm.JITTypeUnknown
+	}
+	return scm.TagInt
+}
+
+func (s *StorageFloat) JITValueType() uint8 {
+	if s.hasNull {
+		return scm.JITTypeUnknown
+	}
+	return scm.TagFloat
+}
+
+func (s *StorageDecimal) JITValueType() uint8 {
+	if s.inner.hasNull {
+		return scm.JITTypeUnknown
+	}
+	if s.scaleExp > 0 {
+		return scm.TagInt
+	}
+	return scm.TagFloat
+}
+
+func (s *StorageConst) JITValueType() uint8 {
+	return s.value.GetTag()
+}
+
+func (s *StorageSCMER) JITValueType() uint8 {
+	// StorageSCMER is also the mutable backing store used by compute proxies.
+	// Its analysis-time enum sample would become stale after SetValue, so it
+	// cannot provide a durable finished-main-column type guarantee.
+	return scm.JITTypeUnknown
+}
+
+func (s *StorageSeq) JITValueType() uint8 {
+	if s.start.hasNull {
+		return scm.JITTypeUnknown
+	}
+	return scm.TagFloat
+}
+
+func (s *StorageEnum) JITValueType() uint8 {
+	if s.k == 0 {
+		return scm.JITTypeUnknown
+	}
+	tag := s.values[0].GetTag()
+	for i := uint8(1); i < s.k; i++ {
+		if s.values[i].GetTag() != tag {
+			return scm.JITTypeUnknown
+		}
+	}
+	return tag
+}
+
+func (s *StorageString) JITValueType() uint8 {
+	if s.stringHasNull() {
+		return scm.JITTypeUnknown
+	}
+	switch s.format {
+	case FormatRaw:
+		return scm.TagString
+	case FormatUUIDLower, FormatUUIDUpper:
+		return scm.TagCString
+	case FormatHexLower, FormatHexUpper,
+		FormatPhone, FormatPhoneDTMF, FormatDecimal, FormatDateTime:
+		// decodeAt represents an empty value as TagString because no payload
+		// pointer exists. A positive minimum length proves uniform CString.
+		if s.lens.offset > 0 {
+			return scm.TagCString
+		}
+	case FormatBase64Upper, FormatBase64Lower:
+		if s.lens.offset > 0 {
+			return scm.TagBString
+		}
+	}
+	return scm.JITTypeUnknown
+}
+
+func (s *StorageString) stringHasNull() bool {
+	if s.nodict {
+		return s.starts.hasNull
+	}
+	return s.values.hasNull
+}
+
+func (s *StoragePrefix) JITValueType() uint8 {
+	if s.values.stringHasNull() {
+		return scm.JITTypeUnknown
+	}
+	// Prefix concatenation always materializes a plain Go string, regardless
+	// of the suffix storage's physical string representation.
+	return scm.TagString
+}
+
+func (s *StorageSparse) JITValueType() uint8 {
+	if s.count > 0 && s.i == 0 {
+		return scm.TagNil
+	}
+	return scm.JITTypeUnknown
+}
+
+func (s *StorageComputeProxy) JITValueType() uint8 {
+	// A proxy may repair an invalid main entry by evaluating its computor. Its
+	// backing storage therefore cannot prove the tag returned by the proxy.
+	return scm.JITTypeUnknown
+}
+
+func (s *OverlayBlob) JITValueType() uint8 {
+	if s.Base == nil {
+		return scm.JITTypeUnknown
+	}
+	tag := s.Base.JITValueType()
+	switch tag {
+	case scm.TagCString, scm.TagBString:
+		// Resolving a blob marker materializes TagString, whereas an ordinary
+		// compressed value passes through unchanged.
+		return scm.JITTypeUnknown
+	default:
+		return tag
+	}
+}

--- a/storage/storage_jit_type_test.go
+++ b/storage/storage_jit_type_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func TestFinishedMainStorageJITValueTypes(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []scm.Scmer
+		want   uint8
+	}{
+		{"int", []scm.Scmer{scm.NewInt(1), scm.NewInt(7)}, scm.TagInt},
+		{"nullable-int", []scm.Scmer{scm.NewInt(1), scm.NewNil()}, scm.JITTypeUnknown},
+		{"float", []scm.Scmer{scm.NewFloat(1.5), scm.NewFloat(7.25)}, scm.TagFloat},
+		{"nullable-float", []scm.Scmer{scm.NewFloat(1.5), scm.NewNil()}, scm.JITTypeUnknown},
+		{"string", []scm.Scmer{scm.NewString("alpha/path"), scm.NewString("beta path")}, scm.TagString},
+		{"nullable-string", []scm.Scmer{scm.NewString("alpha/path"), scm.NewNil()}, scm.JITTypeUnknown},
+		{"constant", []scm.Scmer{scm.NewBool(true), scm.NewBool(true)}, scm.TagBool},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			storage := buildViaCompression(len(test.values), func(i int) scm.Scmer { return test.values[i] })
+			got := storage.JITValueType()
+			if got != test.want {
+				t.Fatalf("%T.JITValueType() = %d, want %d", storage, got, test.want)
+			}
+			if got != scm.JITTypeUnknown {
+				for i := range test.values {
+					if valueTag := storage.GetValue(uint32(i)).GetTag(); valueTag != got {
+						t.Fatalf("%T promised tag %d but row %d returned %d", storage, got, i, valueTag)
+					}
+				}
+			}
+		})
+	}
+
+	homogeneousEnum := buildEnum(3, func(i int) scm.Scmer {
+		return []scm.Scmer{scm.NewString("a"), scm.NewString("b"), scm.NewString("a")}[i]
+	})
+	if got := homogeneousEnum.JITValueType(); got != scm.TagString {
+		t.Fatalf("homogeneous enum type = %d, want string", got)
+	}
+	mixedEnum := buildEnum(3, func(i int) scm.Scmer {
+		return []scm.Scmer{scm.NewInt(1), scm.NewString("one"), scm.NewInt(1)}[i]
+	})
+	if got := mixedEnum.JITValueType(); got != scm.JITTypeUnknown {
+		t.Fatalf("mixed enum type = %d, want unknown", got)
+	}
+
+	mutable := &StorageSCMER{}
+	mutable.prepare()
+	mutable.scan(0, scm.NewInt(1))
+	mutable.init(1)
+	mutable.build(0, scm.NewInt(1))
+	mutable.finish()
+	if got := mutable.JITValueType(); got != scm.JITTypeUnknown {
+		t.Fatalf("mutable SCMER storage type = %d, want unknown", got)
+	}
+}
+
+func TestDirectReadDeltaKeepsRuntimeScmerType(t *testing.T) {
+	main := buildStorageInt([]scm.Scmer{scm.NewInt(7)})
+	shard := &storageShard{
+		main_count:   1,
+		columns:      map[string]ColumnStorage{"value": main},
+		deltaColumns: map[string]int{"value": 0},
+		inserts:      [][]scm.Scmer{{scm.NewString("delta")}},
+	}
+	mr := ShardMapReducer{
+		shard:       shard,
+		mainCount:   1,
+		mainCols:    []ColumnStorage{main},
+		colNames:    []string{"value"},
+		args:        make([]scm.Scmer, 2),
+		directRead:  true,
+		mainGetters: nil,
+	}
+
+	mr.loadDirectReadArgs(1, 0, false)
+	if got := mr.args[1]; got.GetTag() != scm.TagString || got.String() != "delta" {
+		t.Fatalf("delta value was specialized as main storage: got %v (tag %d)", got, got.GetTag())
+	}
+}

--- a/storage/storage_jit_type_test.go
+++ b/storage/storage_jit_type_test.go
@@ -17,6 +17,7 @@ Copyright (C) 2026  Carl-Philip Hänsch
 package storage
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/launix-de/memcp/scm"
@@ -74,6 +75,40 @@ func TestFinishedMainStorageJITValueTypes(t *testing.T) {
 	mutable.finish()
 	if got := mutable.JITValueType(); got != scm.JITTypeUnknown {
 		t.Fatalf("mutable SCMER storage type = %d, want unknown", got)
+	}
+}
+
+func TestStorageFloatJITValueTypeSurvivesSerialization(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		values []scm.Scmer
+		want   uint8
+	}{
+		{"not-null", []scm.Scmer{scm.NewFloat(1.25), scm.NewFloat(2.5)}, scm.TagFloat},
+		{"nullable", []scm.Scmer{scm.NewFloat(1.25), scm.NewNil()}, scm.JITTypeUnknown},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := &StorageFloat{}
+			source.prepare()
+			source.init(uint32(len(test.values)))
+			for i, value := range test.values {
+				source.scan(uint32(i), value)
+				source.build(uint32(i), value)
+			}
+
+			var encoded bytes.Buffer
+			source.Serialize(&encoded)
+			if magic, err := encoded.ReadByte(); err != nil || magic != 12 {
+				t.Fatalf("float magic = %d, %v; want 12", magic, err)
+			}
+			loaded := &StorageFloat{}
+			if count := loaded.Deserialize(&encoded); count != uint(len(test.values)) {
+				t.Fatalf("deserialized count = %d, want %d", count, len(test.values))
+			}
+			if got := loaded.JITValueType(); got != test.want {
+				t.Fatalf("deserialized type = %d, want %d", got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

A storage-specialized JIT reader currently returns a dynamically typed `JITValueDesc` even when the finalized main storage proves that every row has one physical `Scmer` tag. The immediately composed filter/map/reduce emitter therefore retains generic tag dispatch and, for some declarations, a generic argument-slice call boundary.

This information is valid for immutable main storage only. Delta rows can have a different runtime tag and must remain dynamically typed.

## Solution

- add `ColumnStorage.JITValueType()` as a conservative exact-tag contract for finalized main storage
- implement the contract for all storage implementations, returning `JITTypeUnknown` for nullable or mutable/variant representations
- retain the float NULL proof during build and reconstruct it during deserialization, so querying the type remains O(1)
- feed the proven type into the main-only fused storage consumer
- leave delta lookup and callback dispatch unchanged
- add storage-shape and delta-regression tests

`StorageSCMER` and compute proxies deliberately stay unknown because their values can be repaired or replaced after the analysis pass. String compression reports its actual physical `String`, `CString`, or `BString` tag only when empty/NULL representation cannot vary it.

## Manual A/B measurement

Same checkout, same generated storage reader, fixed CPU 2, `GOMAXPROCS=1`, patched Go with `GOEXPERIMENT=jit`, 60,000 integer values followed immediately by the Scheme predicate `(< value 511)`, 500 ms samples, 10 repetitions. The only A/B variable is the descriptor that the consumer receives: the previous unknown tag versus the finalized storage's exact tag.

| Variant | Median | Allocations | Change |
|---|---:|---:|---:|
| unknown type (baseline) | 737,247 ns / 60k rows | 0 | baseline |
| finalized main type | 605,174 ns / 60k rows | 0 | **17.9% faster** |

Command:

```sh
GOMAXPROCS=1 taskset -c 2 env GOROOT=../go-jit/goroot GOEXPERIMENT=jit ../go-jit/goroot/bin/go test ./storage -run '^$' -bench '^BenchmarkStorageIntTypedConsumer$' -benchtime=500ms -count=10
```

## Disassembly

For the same composed reader/predicate:

- unknown type: 399 bytes, `0x50` local frame, generic two-`Scmer` declaration boundary
- exact main type: 372 bytes, `0x20` local frame, direct typed declaration path

This is **27 bytes / 6.8% smaller** and removes the generic argument materialization boundary. The storage bit-unpacking body is otherwise identical, so the measurement isolates type propagation rather than a different reader.

## Validation

- `go test ./...`
- `GOROOT=../go-jit/goroot GOEXPERIMENT=jit go test ./scm ./storage ./tools/jitgen`
- post-rebase `go test ./storage` with both stock Go and patched JIT Go
- JIT SQL needle: `tests/sql/expressions/basic-sql.yaml`, 33/33 passed

## Follow-up

Use this contract while emitting the query-specific main-storage scan pipeline so known filter/map/reduce bodies can fold type branches together with the storage constants. Delta processing remains a separate dynamically typed tail of the scan.
