### PR TITLE
Add streaming HTTP response proxy

### DIFF
--- a/scm/network.go
+++ b/scm/network.go
@@ -211,6 +211,35 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			res_lock.Unlock()
 			return NewString("ok")
 		}),
+		NewString("proxy"), NewFunc(func(a ...Scmer) Scmer {
+			if len(a) != 1 {
+				panic("response proxy expects exactly one target URL")
+			}
+			upstreamReq, err := http.NewRequestWithContext(req.Context(), req.Method, a[0].String(), req.Body)
+			if err != nil {
+				panic(err)
+			}
+			upstreamReq.Header = req.Header.Clone()
+			upstreamResp, err := http.DefaultClient.Do(upstreamReq)
+			if err != nil {
+				panic(err)
+			}
+			defer upstreamResp.Body.Close()
+
+			res_lock.Lock()
+			defer res_lock.Unlock()
+			for key, values := range upstreamResp.Header {
+				res.Header().Del(key)
+				for _, value := range values {
+					res.Header().Add(key, value)
+				}
+			}
+			res.WriteHeader(upstreamResp.StatusCode)
+			if _, err := io.Copy(res, upstreamResp.Body); err != nil {
+				panic(err)
+			}
+			return NewString("ok")
+		}),
 		NewString("jsonl"), NewFunc(func(a ...Scmer) Scmer {
 			// print json line (only assoc)
 			res_lock.Lock()

--- a/scm/network_test.go
+++ b/scm/network_test.go
@@ -18,10 +18,51 @@ Copyright (C) 2026  Carl-Philip Hänsch
 package scm
 
 import (
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func TestHTTPResponseProxyForwardsStreamingRequestAndResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r.Method != http.MethodPost || string(body) != `{"question":"test"}` {
+			t.Fatalf("unexpected proxied request: %s %q", r.Method, body)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("expected content type to be forwarded, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, "{\"answer\":\"ok\"}\n")
+	}))
+	defer upstream.Close()
+
+	server := &HttpServer{callback: NewFunc(func(a ...Scmer) Scmer {
+		proxy := Apply(a[1], NewString("proxy"))
+		return Apply(proxy, NewString(upstream.URL+"/api/chat"))
+	})}
+	req := httptest.NewRequest(http.MethodPost, "/ollama-chat", strings.NewReader(`{"question":"test"}`))
+	req.Header.Set("Content-Type", "application/json")
+	res := httptest.NewRecorder()
+
+	server.ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("expected upstream status %d, got %d", http.StatusCreated, res.Code)
+	}
+	if got := res.Header().Get("Content-Type"); got != "application/x-ndjson" {
+		t.Fatalf("expected upstream content type, got %q", got)
+	}
+	if got := res.Body.String(); got != "{\"answer\":\"ok\"}\n" {
+		t.Fatalf("unexpected upstream body %q", got)
+	}
+}
 
 func TestHTTPSQLBodyUpdatesProcesslistInfo(t *testing.T) {
 	const query = "SELECT SLEEP(1)"


### PR DESCRIPTION
Adds a response-local `proxy` primitive for trusted Scheme HTTP handlers. It forwards the inbound method, body, and headers to a target URL and streams the upstream status, headers, and body back to the client. This lets server-rendered applications keep loopback-only services such as Ollama behind their same-origin endpoint.\n\nIncludes an httptest regression covering JSON request forwarding and NDJSON response/status/header propagation.\n\nTargeted test: `go test ./scm -run TestHTTP`.