### PR TITLE
Add server-controlled HTTP client primitive

### DIFF
--- a/main.go
+++ b/main.go
@@ -832,6 +832,19 @@ func setupIO(wd string) {
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
+		Name: "http_request",
+		Fn:   scm.HTTPRequest,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Performs an outbound HTTP request assembled by trusted Scheme code", HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", Label: "method"},
+				{Kind: "string", Label: "url"},
+				{Kind: "list", Label: "headers"},
+				{Kind: "string", Label: "body"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "list", Label: "response"},
+		},
+	})
+	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "serveStatic",
 
 		Fn: (func(...scm.Scmer) scm.Scmer)(scm.HTTPStaticGetter(wd)),

--- a/scm/network.go
+++ b/scm/network.go
@@ -35,6 +35,46 @@ import "github.com/gorilla/websocket"
 var httpServersMu sync.Mutex
 var httpServers []*http.Server
 
+// HTTPRequest performs an outbound request assembled by trusted Scheme code.
+// Browser-controlled requests are deliberately not forwarded implicitly.
+func HTTPRequest(a ...Scmer) Scmer {
+	if len(a) != 4 {
+		panic("http_request expects method, URL, headers, and body")
+	}
+	req, err := http.NewRequest(a[0].String(), a[1].String(), strings.NewReader(a[3].String()))
+	if err != nil {
+		panic(err)
+	}
+	headers := mustSliceNet("http_request headers", a[2])
+	if len(headers)%2 != 0 {
+		panic("http_request headers must contain key/value pairs")
+	}
+	for i := 0; i < len(headers); i += 2 {
+		req.Header.Add(headers[i].String(), headers[i+1].String())
+	}
+	client := &http.Client{Timeout: 300 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	responseHeaders := make([]Scmer, 0, len(resp.Header)*2)
+	for key, values := range resp.Header {
+		for _, value := range values {
+			responseHeaders = append(responseHeaders, NewString(key), NewString(value))
+		}
+	}
+	return NewSlice([]Scmer{
+		NewString("status"), NewInt(int64(resp.StatusCode)),
+		NewString("headers"), NewSlice(responseHeaders),
+		NewString("body"), NewString(string(body)),
+	})
+}
+
 // build this function into your SCM environment to offer http server capabilities
 func HTTPServe(a ...Scmer) Scmer {
 	// HTTP endpoint; params: (port, handler)

--- a/scm/network_test.go
+++ b/scm/network_test.go
@@ -18,10 +18,44 @@ Copyright (C) 2026  Carl-Philip Hänsch
 package scm
 
 import (
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func TestHTTPRequestUsesOnlyExplicitServerBuiltPayload(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r.Method != http.MethodPost || string(body) != `{"model":"server-choice","input":"checked"}` {
+			t.Fatalf("unexpected request: %s %q", r.Method, body)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("unexpected content type %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"output":"filtered"}`)
+	}))
+	defer upstream.Close()
+
+	result := HTTPRequest(
+		NewString(http.MethodPost),
+		NewString(upstream.URL+"/model"),
+		NewSlice([]Scmer{NewString("Content-Type"), NewString("application/json")}),
+		NewString(`{"model":"server-choice","input":"checked"}`),
+	)
+	if got := Apply(result, NewString("status")).Int(); got != http.StatusCreated {
+		t.Fatalf("unexpected status %d", got)
+	}
+	if got := Apply(result, NewString("body")).String(); got != `{"output":"filtered"}` {
+		t.Fatalf("unexpected body %q", got)
+	}
+}
 
 func TestHTTPSQLBodyUpdatesProcesslistInfo(t *testing.T) {
 	const query = "SELECT SLEEP(1)"


### PR DESCRIPTION
Provides `http_request` to trusted Scheme server code. Unlike the closed proxy proposal, it never forwards an inbound browser request: method, target URL, headers, and body must all be explicitly constructed by server code. The buffered response can be inspected and filtered before anything is returned to a client.\n\nThe regression test verifies an explicitly server-selected model payload and response inspection.\n\nTargeted test: `go test ./scm -run TestHTTP`.