### PR TITLE
Fix schema snapshot races during rebuild

### DIFF
--- a/scm/coverage.go
+++ b/scm/coverage.go
@@ -16,9 +16,28 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
-import "strings"
+import (
+	"strings"
+	"sync"
+)
 
-var sourceCoverageInfos []*SourceInfo
+var (
+	sourceCoverageMu    sync.RWMutex
+	sourceCoverageInfos []*SourceInfo
+)
+
+func registerSourceCoverageInfo(info *SourceInfo) {
+	sourceCoverageMu.Lock()
+	sourceCoverageInfos = append(sourceCoverageInfos, info)
+	sourceCoverageMu.Unlock()
+}
+
+func sourceCoverageSnapshot() []*SourceInfo {
+	sourceCoverageMu.RLock()
+	infos := append([]*SourceInfo(nil), sourceCoverageInfos...)
+	sourceCoverageMu.RUnlock()
+	return infos
+}
 
 func sourceCoverageMatchesPrefix(source string, prefix string) bool {
 	if prefix == "" || strings.HasPrefix(source, prefix) {
@@ -50,7 +69,7 @@ func sourceCoverageReport(a ...Scmer) Scmer {
 	}
 
 	points := map[sourceCoveragePoint]bool{}
-	for _, si := range sourceCoverageInfos {
+	for _, si := range sourceCoverageSnapshot() {
 		if si == nil || si.source == "" || !sourceCoverageMatchesPrefix(si.source, prefix) {
 			continue
 		}

--- a/scm/coverage_test.go
+++ b/scm/coverage_test.go
@@ -16,7 +16,10 @@ Copyright (C) 2026  Carl-Philip Haensch
 */
 package scm
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func sourceCoverageCounts(source string) (covered, total int) {
 	type point struct {
@@ -24,7 +27,7 @@ func sourceCoverageCounts(source string) (covered, total int) {
 		col  int
 	}
 	points := make(map[point]bool)
-	for _, info := range sourceCoverageInfos {
+	for _, info := range sourceCoverageSnapshot() {
 		if info != nil && info.source == source {
 			key := point{line: info.line, col: info.col}
 			points[key] = points[key] || info.wasInterpreted()
@@ -37,6 +40,33 @@ func sourceCoverageCounts(source string) (covered, total int) {
 		}
 	}
 	return covered, total
+}
+
+func TestSourceCoverageRegistrySupportsConcurrentCompilation(t *testing.T) {
+	const source = "coverage-concurrent-registration.scm"
+	const workers = 8
+	const registrations = 100
+	var done sync.WaitGroup
+	done.Add(workers)
+	for range workers {
+		go func() {
+			defer done.Done()
+			for index := range registrations {
+				NewSourceInfo(SourceInfo{source: source, line: index + 1, col: 1, value: NewNil()})
+				_ = sourceCoverageSnapshot()
+			}
+		}()
+	}
+	done.Wait()
+	count := 0
+	for _, info := range sourceCoverageSnapshot() {
+		if info != nil && info.source == source {
+			count++
+		}
+	}
+	if count != workers*registrations {
+		t.Fatalf("registered coverage points = %d, want %d", count, workers*registrations)
+	}
 }
 
 func TestSourceCoverageTracksInterpreterExecutionOnly(t *testing.T) {

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -394,7 +394,7 @@ func NewNthLocalVar(idx NthLocalVar) Scmer {
 func NewSourceInfo(si SourceInfo) Scmer {
 	ptr := new(SourceInfo)
 	*ptr = si
-	sourceCoverageInfos = append(sourceCoverageInfos, ptr)
+	registerSourceCoverageInfo(ptr)
 	return Scmer{(*byte)(unsafe.Pointer(ptr)), makeAux(tagSourceInfo, 0)}
 }
 

--- a/storage/database.go
+++ b/storage/database.go
@@ -994,6 +994,7 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 			} else {
 				t.Shards = newShardList
 			}
+			previousSchemaTopology := t.publishSchemaTopology(origTopology.mode, newShardList, origTopology.dimensions)
 			t.mu.Unlock()
 			tableLocked = false
 
@@ -1011,6 +1012,7 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 				} else {
 					t.Shards = origShardList
 				}
+				t.schemaTopology.Store(previousSchemaTopology)
 				t.maintenanceKind = 0
 				t.mu.Unlock()
 				if durablePublication {
@@ -1392,11 +1394,12 @@ func CreateDatabaseFrom(schema string, ignoreexists bool, sourceDB string) bool 
 }
 
 type storageMoveGeneration struct {
-	table       *table
-	oldTopology *tableShardTopology
-	oldShards   []*storageShard
-	newShards   []*storageShard
-	partitioned bool
+	table             *table
+	oldTopology       *tableShardTopology
+	oldSchemaTopology *tableSchemaTopology
+	oldShards         []*storageShard
+	newShards         []*storageShard
+	partitioned       bool
 }
 
 func prepareStorageMoveGeneration(t *table) (generation storageMoveGeneration) {
@@ -1414,11 +1417,12 @@ func prepareStorageMoveGeneration(t *table) (generation storageMoveGeneration) {
 	t.mu.Unlock()
 
 	generation = storageMoveGeneration{
-		table:       t,
-		oldTopology: topology,
-		oldShards:   oldShards,
-		newShards:   make([]*storageShard, len(oldShards)),
-		partitioned: partitioned,
+		table:             t,
+		oldTopology:       topology,
+		oldSchemaTopology: t.schemaTopology.Load(),
+		oldShards:         oldShards,
+		newShards:         make([]*storageShard, len(oldShards)),
+		partitioned:       partitioned,
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
@@ -1445,6 +1449,7 @@ func abortStorageMoveGenerations(generations []storageMoveGeneration) {
 			discardUnpublishedShard(generation.newShards[index])
 		}
 		generation.table.mu.Lock()
+		generation.table.schemaTopology.Store(generation.oldSchemaTopology)
 		if generation.partitioned {
 			generation.table.PShards = generation.oldShards
 		} else {
@@ -1515,6 +1520,11 @@ func publishStorageMoveGenerations(db *database, dst PersistenceEngine, generati
 		} else {
 			generation.table.Shards = generation.newShards
 		}
+		generation.table.publishSchemaTopology(
+			generation.oldTopology.mode,
+			generation.newShards,
+			generation.oldTopology.dimensions,
+		)
 		generation.table.mu.Unlock()
 	}
 
@@ -1522,6 +1532,7 @@ func publishStorageMoveGenerations(db *database, dst PersistenceEngine, generati
 	for index := len(generations) - 1; index >= 0; index-- {
 		generation := generations[index]
 		generation.table.mu.Lock()
+		generation.table.schemaTopology.Store(generation.oldSchemaTopology)
 		if generation.partitioned {
 			generation.table.PShards = generation.oldShards
 		} else {

--- a/storage/index.go
+++ b/storage/index.go
@@ -18,6 +18,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 package storage
 
 import "fmt"
+import "math"
 import "math/bits"
 import "sort"
 import "sync"
@@ -113,8 +114,8 @@ type StorageIndex struct {
 	ColOrder []func(scm.Scmer, scm.Scmer) bool
 	// ColOrderMeta identifies the source relation for equality and reuse checks.
 	ColOrderMeta []string
-	Savings      float64 // store the amount of time savings here -> add selectivity (outputted / size) on each
-	Native       bool    // true when data is physically sorted by this index (zero-cost)
+	savings      atomic.Uint64 // float64 bits; accumulated lock-free by concurrent scans
+	Native       bool          // true when data is physically sorted by this index (zero-cost)
 	t            *storageShard
 	lastHit      atomic.Uint32 // last search position for sorted access pattern optimization
 	mu           sync.Mutex
@@ -387,10 +388,24 @@ func (idx *StorageIndex) columnIsSorted(i int) bool {
 }
 
 func (idx *StorageIndex) addSavings(state *storageIndexState, usageWeight float64) float64 {
-	if usageWeight > 0 {
-		idx.Savings += usageWeight
+	if usageWeight <= 0 {
+		return idx.loadSavings()
 	}
-	return idx.Savings
+	for {
+		oldBits := idx.savings.Load()
+		next := math.Float64frombits(oldBits) + usageWeight
+		if idx.savings.CompareAndSwap(oldBits, math.Float64bits(next)) {
+			return next
+		}
+	}
+}
+
+func (idx *StorageIndex) loadSavings() float64 {
+	return math.Float64frombits(idx.savings.Load())
+}
+
+func (idx *StorageIndex) storeSavings(value float64) {
+	idx.savings.Store(math.Float64bits(value))
 }
 
 func (idx *StorageIndex) ComputeSize() uint {
@@ -811,7 +826,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertI
 				index.ColMatchers[i] = cols.boundaryAnalyzer(i)
 			}
 		}
-		index.Savings = 0.0            // count how many cost we wasted so we decide when to build the index
+		index.storeSavings(0.0)        // count how many cost we wasted so we decide when to build the index
 		index.baseState.active = false // tell the engine that index has to be built first
 		index.t = t
 		index.Native = true
@@ -899,7 +914,7 @@ func snapshotIndexesForRebuild(indexes []*StorageIndex) []*StorageIndex {
 		}
 		clone.ColOrder = append([]func(scm.Scmer, scm.Scmer) bool(nil), idx.ColOrder...)
 		clone.ColOrderMeta = append([]string(nil), idx.ColOrderMeta...)
-		clone.Savings = idx.Savings * 0.9
+		clone.storeSavings(idx.loadSavings() * 0.9)
 		clone.baseState.active = false
 		candidates = append(candidates, clone)
 	}
@@ -957,7 +972,7 @@ func rebuildIndexes(candidates []*StorageIndex, t2 *storageShard) {
 				}
 			}
 			if isPrefix {
-				longer.Savings += shorter.Savings
+				longer.addSavings(nil, shorter.loadSavings())
 				removed[j] = true
 			}
 		}
@@ -976,8 +991,8 @@ func rebuildIndexes(candidates []*StorageIndex, t2 *storageShard) {
 	bestSavings := 4.0 // minimum threshold for physical sort
 	bestIdx := -1
 	for i, idx := range result {
-		if idx.Savings > bestSavings && !indexHasComputedCol(t2, idx) {
-			bestSavings = idx.Savings
+		if savings := idx.loadSavings(); savings > bestSavings && !indexHasComputedCol(t2, idx) {
+			bestSavings = savings
 			bestIdx = i
 		}
 	}
@@ -2057,5 +2072,5 @@ func indexLastUsed(ptr any) time.Time {
 }
 
 func indexGetScore(ptr any) float64 {
-	return ptr.(*StorageIndex).Savings
+	return ptr.(*StorageIndex).loadSavings()
 }

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -16,10 +16,31 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package storage
 
+import "sync"
 import "testing"
 
 import "github.com/google/btree"
 import "github.com/launix-de/memcp/scm"
+
+func TestStorageIndexSavingsAccumulateConcurrently(t *testing.T) {
+	idx := new(StorageIndex)
+	const workers = 8
+	const additions = 1000
+	var done sync.WaitGroup
+	done.Add(workers)
+	for range workers {
+		go func() {
+			defer done.Done()
+			for range additions {
+				idx.addSavings(nil, 1)
+			}
+		}()
+	}
+	done.Wait()
+	if got, want := idx.loadSavings(), float64(workers*additions); got != want {
+		t.Fatalf("concurrent savings = %v, want %v", got, want)
+	}
+}
 
 func TestPlannerIndexProbeDoesNotIncreaseIndexSavings(t *testing.T) {
 	Init(scm.Globalenv)
@@ -46,8 +67,8 @@ func TestPlannerIndexProbeDoesNotIncreaseIndexSavings(t *testing.T) {
 	if len(shard.Indexes) != 1 {
 		t.Fatalf("metadata indexes = %d, want 1", len(shard.Indexes))
 	}
-	if shard.Indexes[0].Savings != 0 {
-		t.Fatalf("estimate must not count as index usage, savings = %v", shard.Indexes[0].Savings)
+	if savings := shard.Indexes[0].loadSavings(); savings != 0 {
+		t.Fatalf("estimate must not count as index usage, savings = %v", savings)
 	}
 	if len(shard.Indexes[0].ColMatchers) != 0 {
 		t.Fatalf("sorted index persisted redundant matcher metadata: %#v", shard.Indexes[0].ColMatchers)

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -665,6 +665,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 	oldFreeShards := append([]*storageShard(nil), t.Shards...)
 	oldPartitionShards := append([]*storageShard(nil), t.PShards...)
 	oldPartitionDimensions := append([]shardDimension(nil), t.PDimensions...)
+	oldSchemaTopology := t.schemaTopology.Load()
 	t.mu.Unlock()
 
 	// Eagerly load all shard data before taking any locks for partitioning.
@@ -705,6 +706,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 		t.Shards = oldFreeShards
 		t.PShards = oldPartitionShards
 		t.PDimensions = oldPartitionDimensions
+		t.schemaTopology.Store(oldSchemaTopology)
 		t.maintenanceKind = 0
 		t.repartitionDualWriteActive.Store(false)
 		t.repartitionSources.Store(nil)
@@ -1173,6 +1175,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 	t.PDimensions = shardCandidates
 	t.ShardMode = ShardModePartition
 	t.Shards = nil
+	t.publishSchemaTopology(ShardModePartition, newshards, shardCandidates)
 	t.mu.Unlock()
 	var savePanic any
 	func() {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -3635,7 +3635,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 		// Eagerly rebuild indexes with sufficient Savings so the first
 		// query after rebuild does not pay a cold-start full-scan penalty.
 		for _, idx := range result.Indexes {
-			if idx.Savings >= 2.0 && !idx.baseState.active {
+			if idx.loadSavings() >= 2.0 && !idx.baseState.active {
 				// Verify all required columns exist before building the index.
 				// A column may be absent from this shard if it was added after
 				// the shard was created (e.g. ALTER TABLE ADD COLUMN).

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -49,6 +49,41 @@ type failSchemaWritePersistence struct {
 	failAt int32
 }
 
+func TestTableSchemaMarshalUsesPublishedTopologyGeneration(t *testing.T) {
+	tbl := &table{Name: "items", PersistencyMode: Memory, ShardMode: ShardModeFree}
+	oldShard := NewShard(tbl)
+	newShard := NewShard(tbl)
+	tbl.Shards = []*storageShard{oldShard}
+	tbl.publishTopologyLocked()
+
+	// Rebuild prepares compatibility fields before the durable schema commit,
+	// while live readers remain pinned to the preceding topology generation.
+	tbl.Shards = []*storageShard{newShard}
+	assertSchemaShard := func(want *storageShard) {
+		t.Helper()
+		data, err := json.Marshal(tbl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var persisted struct {
+			Shards []string
+		}
+		if err := json.Unmarshal(data, &persisted); err != nil {
+			t.Fatal(err)
+		}
+		if len(persisted.Shards) != 1 || persisted.Shards[0] != want.uuid.String() {
+			t.Fatalf("persisted shards = %v, want [%s]", persisted.Shards, want.uuid.String())
+		}
+	}
+
+	assertSchemaShard(oldShard)
+	tbl.publishSchemaTopology(ShardModeFree, []*storageShard{newShard}, nil)
+	assertSchemaShard(newShard)
+	if active := tbl.activeTopology(); len(active.shards) != 1 || active.shards[0] != oldShard {
+		t.Fatal("schema publication changed the live topology before durable commit")
+	}
+}
+
 func (p *failSchemaWritePersistence) WriteSchema(schema []byte) {
 	if p.calls.Add(1) == p.failAt {
 		panic("injected schema publication failure")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3832,7 +3832,7 @@ func Init(en scm.Env) {
 								scm.NewString("orders"), scm.NewSlice(orders),
 								scm.NewString("active"), scm.NewBool(ix.baseState.active),
 								scm.NewString("native"), scm.NewBool(ix.Native),
-								scm.NewString("savings"), scm.NewFloat(ix.Savings),
+								scm.NewString("savings"), scm.NewFloat(ix.loadSavings()),
 								scm.NewString("size_bytes"), scm.NewInt(int64(ix.ComputeSize())),
 							}))
 						}

--- a/storage/table.go
+++ b/storage/table.go
@@ -275,6 +275,16 @@ type tableShardTopology struct {
 	drainOnce          sync.Once
 }
 
+// tableSchemaTopology is the immutable storage generation written to
+// schema.json. It is separate from tableShardTopology because a durable
+// rebuild must publish the successor UUIDs to disk before making that
+// generation authoritative for live readers and writers.
+type tableSchemaTopology struct {
+	mode       ShardMode
+	shards     []*storageShard
+	dimensions []shardDimension
+}
+
 func (topology *tableShardTopology) acquireOperation() bool {
 	topology.operations.Add(1)
 	if topology.retired.Load() {
@@ -567,6 +577,10 @@ type table struct {
 	PShards     []*storageShard // partitioned shards according to PDimensions (used when ShardMode == ShardModePartition)
 	PDimensions []shardDimension
 	topology    atomic.Pointer[tableShardTopology]
+	// schemaTopology is the sole topology source for JSON persistence. Writers
+	// replace the complete immutable value; schema serialization never reads the
+	// mutable compatibility fields above.
+	schemaTopology atomic.Pointer[tableSchemaTopology]
 
 	// maintenanceMu prevents concurrent rebuild and repartition on this table.
 	// Holders: db.rebuild() claims it for rebuild (maintenanceKind=1) and may
@@ -723,11 +737,81 @@ func (t *table) publishTopologyLocked() *tableShardTopology {
 			shard.generation.Store(topology)
 		}
 	}
+	t.publishSchemaTopology(topology.mode, topology.shards, topology.dimensions)
 	previous := t.topology.Swap(topology)
 	if previous != nil {
 		previous.retire()
 	}
 	return topology
+}
+
+func (t *table) publishSchemaTopology(mode ShardMode, shards []*storageShard, dimensions []shardDimension) *tableSchemaTopology {
+	next := &tableSchemaTopology{
+		mode:       mode,
+		shards:     append([]*storageShard(nil), shards...),
+		dimensions: append([]shardDimension(nil), dimensions...),
+	}
+	return t.schemaTopology.Swap(next)
+}
+
+// MarshalJSON reads topology only from an immutable, atomically published
+// generation. Database schema locking keeps the remaining DDL fields stable.
+func (t *table) MarshalJSON() ([]byte, error) {
+	topology := t.schemaTopology.Load()
+	if topology == nil {
+		active := t.activeTopology()
+		topology = t.schemaTopology.Load()
+		if topology == nil {
+			topology = &tableSchemaTopology{
+				mode:       active.mode,
+				shards:     active.shards,
+				dimensions: active.dimensions,
+			}
+		}
+	}
+	var shards []*storageShard
+	var partitionedShards []*storageShard
+	if topology.mode == ShardModePartition {
+		partitionedShards = topology.shards
+	} else {
+		shards = topology.shards
+	}
+	type persistedTable struct {
+		Name               string
+		Columns            []*column
+		Unique             []uniqueKey
+		Foreign            []foreignKey
+		Triggers           []TriggerDescription
+		PersistencyMode    PersistencyMode
+		OnInit             *scm.Scmer `json:"oninit,omitempty"`
+		AutoIncrement      uint64     `json:"Auto_increment"`
+		Collation          string
+		Charset            string
+		Comment            string
+		PlannerRowEstimate uint64 `json:"planner_row_estimate"`
+		ShardMode          ShardMode
+		Shards             []*storageShard
+		PShards            []*storageShard
+		PDimensions        []shardDimension
+	}
+	return json.Marshal(&persistedTable{
+		Name:               t.Name,
+		Columns:            t.Columns,
+		Unique:             t.Unique,
+		Foreign:            t.Foreign,
+		Triggers:           t.Triggers,
+		PersistencyMode:    t.PersistencyMode,
+		OnInit:             t.OnInit,
+		AutoIncrement:      t.Auto_increment,
+		Collation:          t.Collation,
+		Charset:            t.Charset,
+		Comment:            t.Comment,
+		PlannerRowEstimate: t.PlannerRowEstimate.value.Load(),
+		ShardMode:          topology.mode,
+		Shards:             shards,
+		PShards:            partitionedShards,
+		PDimensions:        topology.dimensions,
+	})
 }
 
 func (t *table) pinActiveTopology() *tableShardTopology {
@@ -2216,6 +2300,7 @@ func (t *table) appendFreeShardDurably(topology *tableShardTopology, source *sto
 	newShard := NewShard(t)
 	t.maintenanceKind = 1
 	t.Shards = append(t.Shards, newShard)
+	previousSchemaTopology := t.publishSchemaTopology(ShardModeFree, t.Shards, t.PDimensions)
 	newIndex := len(t.Shards) - 1
 	sourceIndex := newIndex - 1
 	t.mu.Unlock()
@@ -2230,6 +2315,7 @@ func (t *table) appendFreeShardDurably(topology *tableShardTopology, source *sto
 		if newIndex < len(t.Shards) && t.Shards[newIndex] == newShard {
 			t.Shards = t.Shards[:newIndex]
 		}
+		t.schemaTopology.Store(previousSchemaTopology)
 		t.maintenanceKind = 0
 		t.mu.Unlock()
 		t.maintenanceMu.Unlock()
@@ -2275,6 +2361,7 @@ func (t *table) finishOverflowRebuild(index int, source *storageShard) {
 		return
 	}
 	t.Shards[index] = rebuilt
+	previousSchemaTopology := t.publishSchemaTopology(ShardModeFree, t.Shards, t.PDimensions)
 	t.mu.Unlock()
 
 	var savePanic any
@@ -2287,6 +2374,7 @@ func (t *table) finishOverflowRebuild(index int, source *storageShard) {
 		if index < len(t.Shards) && t.Shards[index] == rebuilt {
 			t.Shards[index] = source
 		}
+		t.schemaTopology.Store(previousSchemaTopology)
 		t.mu.Unlock()
 		source.mu.Unlock()
 		panic(savePanic)

--- a/tools/reliability-drill.md
+++ b/tools/reliability-drill.md
@@ -27,6 +27,21 @@ transactions fail, retry the writes, and crash-recover the exact result:
 python3 tools/reliability_drill.py --mode io-failures
 ```
 
+To race rebuild topology publication against complete `schema.json`
+serialization, build with Go's race detector and run the dedicated mode:
+
+```sh
+go build -race -o /tmp/memcp-race .
+python3 tools/reliability_drill.py --mode schema-race --binary /tmp/memcp-race
+```
+
+This mode repeatedly rebuilds a wide multi-shard SAFE table while another
+worker creates and drops persistent tables, forcing concurrent schema
+snapshots. A third worker verifies that reads remain available. The runner sets
+up the fixture first, restarts it under `GORACE=halt_on_error=1`, retains the
+detector log, and crash-recovers the expected row signature after a successful
+run. Increase `--schema-race-rows` or `--schema-race-rounds` for longer runs.
+
 To run the same transaction/crash oracle against a remote backend, pass the
 options accepted by `CREATE DATABASE ... SET` as JSON. For example, against a
 local MinIO instance:
@@ -87,6 +102,8 @@ The current drill covers:
 - statement rollback when a trigger fails partway through a multi-row insert;
 - a hard kill racing a rebuild and publication of its replacement shards;
 - concurrent disjoint writers and rebuilds followed by another hard kill;
+- rebuild publication raced against full schema serialization under Go's race
+  detector, with concurrent reads and crash-recovery validation;
 - deterministic partial-write failures in autocommit and explicit transactions,
   aborted-transaction enforcement, sync failures, successful retries, and exact
   crash recovery;

--- a/tools/reliability_drill.py
+++ b/tools/reliability_drill.py
@@ -309,6 +309,108 @@ def initialize_atomicity(client: HttpClient, rows: int,
 	)
 
 
+def schema_race_signature(client: HttpClient) -> dict[str, int]:
+	return {
+		"row_count": scalar(client, "SELECT COUNT(*) AS value FROM drill_schema_race"),
+		"id_sum": scalar(client, "SELECT COALESCE(SUM(id), 0) AS value FROM drill_schema_race"),
+	}
+
+
+def initialize_schema_race(client: HttpClient, rows: int,
+		backend_config: dict[str, object] | None = None) -> dict[str, int]:
+	create_database(client, backend_config)
+	# Build the fixture in one shard so asynchronous overflow publication cannot
+	# consume the detector failure before the deliberate race phase starts.
+	client.scm(f'(settings "ShardSize" {max(1000, rows * 2)})')
+	extra_columns = ",".join(f"schema_probe_{index:02d} BIGINT" for index in range(32))
+	client.sql(
+		"CREATE TABLE drill_schema_race (id INT PRIMARY KEY, payload BIGINT," +
+		extra_columns + ") ENGINE=safe"
+	)
+	client.scm(
+		f'(insert (table "{DATABASE}" "drill_schema_race") \'("id" "payload") '
+		f'(map (produceN {rows}) (lambda (i) (list (+ i 1) (+ i 1)))))',
+		timeout=300,
+	)
+	client.scm('(settings "ShardSize" 100)')
+	client.scm(f'(rebuild (table "{DATABASE}" "drill_schema_race") true true)', timeout=300)
+	wanted = {"row_count": rows, "id_sum": rows * (rows + 1) // 2}
+	expect(schema_race_signature(client), wanted, "schema-race fixture")
+	return wanted
+
+
+def race_detector_environment() -> dict[str, str]:
+	return {"GORACE": "halt_on_error=1 exitcode=66"}
+
+
+def run_schema_race(server: OwnedServer, rounds: int, wanted: dict[str, int],
+		journal: list[dict]) -> None:
+	client = server.client
+	assert client is not None
+	start = threading.Barrier(4)
+	stop = threading.Event()
+	failures: list[str] = []
+
+	def rebuilder() -> None:
+		try:
+			start.wait()
+			for _ in range(rounds):
+				client.scm(
+					f'(rebuild (table "{DATABASE}" "drill_schema_race") true false)',
+					timeout=300,
+				)
+		except Exception as error:
+			failures.append(f"rebuilder: {error}")
+		finally:
+			stop.set()
+
+	def schema_publisher() -> None:
+		iteration = 0
+		try:
+			start.wait()
+			while not stop.is_set():
+				name = f"drill_schema_publish_{iteration % 4}"
+				client.sql(
+					f"CREATE TABLE {name} (id INT PRIMARY KEY, value BIGINT) ENGINE=safe",
+					timeout=300,
+				)
+				client.sql(f"DROP TABLE {name}", timeout=300)
+				iteration += 1
+		except Exception as error:
+			failures.append(f"schema publisher: {error}")
+			stop.set()
+
+	def reader() -> None:
+		try:
+			start.wait()
+			while not stop.is_set():
+				expect(schema_race_signature(client), wanted, "read during schema race")
+		except Exception as error:
+			failures.append(f"reader: {error}")
+			stop.set()
+
+	threads = [
+		threading.Thread(target=rebuilder, name="schema-race-rebuilder", daemon=True),
+		threading.Thread(target=schema_publisher, name="schema-race-publisher", daemon=True),
+		threading.Thread(target=reader, name="schema-race-reader", daemon=True),
+	]
+	for thread in threads:
+		thread.start()
+	start.wait()
+	for thread in threads:
+		thread.join(timeout=max(300, rounds * 30))
+	stop.set()
+	if any(thread.is_alive() for thread in threads):
+		raise DrillFailure("schema-race worker did not terminate")
+	if failures:
+		raise DrillFailure("; ".join(failures))
+	expect(schema_race_signature(client), wanted, "schema race result")
+	journal.append({"scenario": "schema-race", "rounds": rounds, "expected": wanted})
+	server.kill()
+	client = server.start(race_detector_environment())
+	expect(schema_race_signature(client), wanted, "schema race crash recovery")
+
+
 def run_commit_crash(server: OwnedServer, rows: int, rounds: int,
 		rng: random.Random, journal: list[dict]) -> None:
 	committed_x = 0
@@ -625,7 +727,7 @@ def parse_args() -> argparse.Namespace:
 	parser.add_argument("--app", type=Path, default=ROOT / "lib/main.scm")
 	parser.add_argument("--artifacts", type=Path, help="new directory for data, logs, journal, and restore snapshot")
 	parser.add_argument("--seed", type=int, default=random.SystemRandom().randrange(2**63))
-	parser.add_argument("--mode", choices=("atomicity", "io-failures", "crash", "soak", "restore", "all"), default="all")
+	parser.add_argument("--mode", choices=("atomicity", "io-failures", "schema-race", "crash", "soak", "restore", "all"), default="all")
 	parser.add_argument("--workers", type=int, default=4)
 	parser.add_argument("--operations", type=int, default=25, help="rows written by each soak worker")
 	parser.add_argument("--rebuild-crashes", type=int, default=5,
@@ -638,6 +740,10 @@ def parse_args() -> argparse.Namespace:
 		help="rows updated across ShardSize=100 shards in I/O failure mode")
 	parser.add_argument("--rebuild-rows", type=int, default=100000,
 		help="rows used to keep rebuild publication active during crash tests")
+	parser.add_argument("--schema-race-rows", type=int, default=20000,
+		help="rows in the sharded table used by schema-race mode")
+	parser.add_argument("--schema-race-rounds", type=int, default=20,
+		help="rebuild rounds raced against schema publication")
 	parser.add_argument("--database-config-json",
 		help="JSON object passed as CREATE DATABASE SET backend options")
 	parser.add_argument("--timeout", type=float, default=30)
@@ -648,7 +754,8 @@ def main() -> int:
 	args = parse_args()
 	if (args.workers < 1 or args.operations < 1 or args.rebuild_crashes < 1 or
 			args.commit_crashes < 1 or args.atomicity_rows < 1 or
-			args.io_failure_rows < 1 or args.rebuild_rows < 1 or args.timeout <= 0):
+			args.io_failure_rows < 1 or args.rebuild_rows < 1 or
+			args.schema_race_rows < 1 or args.schema_race_rounds < 1 or args.timeout <= 0):
 		raise DrillFailure("workers, operations, crash rounds, row counts, and timeout must be positive")
 	backend_config = None
 	if args.database_config_json:
@@ -685,6 +792,14 @@ def main() -> int:
 		if args.mode == "io-failures":
 			initialize_atomicity(client, args.io_failure_rows, backend_config)
 			run_io_failures(server, args.io_failure_rows, args.seed, journal)
+			write_manifest(manifest, args.seed, "passed", journal)
+			print(f"PASS: {len(journal)} reliability scenarios; manifest: {manifest}")
+			return 0
+		if args.mode == "schema-race":
+			wanted_schema = initialize_schema_race(client, args.schema_race_rows, backend_config)
+			server.stop()
+			client = server.start(race_detector_environment())
+			run_schema_race(server, args.schema_race_rounds, wanted_schema, journal)
 			write_manifest(manifest, args.seed, "passed", journal)
 			print(f"PASS: {len(journal)} reliability scenarios; manifest: {manifest}")
 			return 0

--- a/tools/test_reliability_drill.py
+++ b/tools/test_reliability_drill.py
@@ -14,6 +14,7 @@ import importlib.util
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 
 MODULE_PATH = Path(__file__).with_name("reliability_drill.py")
@@ -80,6 +81,17 @@ class ReliabilityDrillTests(unittest.TestCase):
 			drill.classify_atomic_signature({
 				"row_count": 73, "min_x": 5, "max_x": 5, "x_sum": 365,
 			}, 100, 4)
+
+	def test_schema_race_mode_enables_fail_fast_race_reporting(self) -> None:
+		self.assertEqual(
+			drill.race_detector_environment(),
+			{"GORACE": "halt_on_error=1 exitcode=66"},
+		)
+		with mock.patch("sys.argv", ["reliability_drill.py", "--mode", "schema-race"]):
+			args = drill.parse_args()
+		self.assertEqual(args.mode, "schema-race")
+		self.assertGreater(args.schema_race_rows, 0)
+		self.assertGreater(args.schema_race_rounds, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a targeted reliability-drill mode that races multi-shard rebuilds with schema publication and concurrent reads under Go's race detector
- serialize table topology from an immutable atomically published schema generation instead of mutable Shards/PShards fields
- preserve build -> durable schema commit -> live topology publication ordering, including rollback for rebuild, repartition, overflow, and storage migration
- make source coverage registration and adaptive index savings safe during concurrent compilation and scans

## Test-first reproduction
An unfixed race build failed in about 6 seconds with 5,000 rows and 10 rebuild rounds. The detector reported encoding/json reading table.Shards from database.MarshalJSON while rebuildWithLifecycle wrote the same slice at storage/database.go:995.

The new mode also exposed two preceding real races, which are fixed here: concurrent sourceCoverageInfos append/read and concurrent StorageIndex savings updates.

## Validation
- python3 -m unittest tools/test_reliability_drill.py
- python3 -m py_compile tools/reliability_drill.py
- go test ./storage ./scm
- go test -race ./scm ./storage -run 'TestSourceCoverageRegistrySupportsConcurrentCompilation|TestStorageIndexSavingsAccumulateConcurrently|TestTableSchemaMarshalUsesPublishedTopologyGeneration|TestOverflowRebuildSchemaFailureKeepsWritesRecoverable' -count=1
- schema-race drill, 5,000 rows / 10 rounds: PASS
- schema-race drill, default 20,000 rows / 20 rounds: PASS, including hard-kill recovery

## Manual hot-path A/B
Same host, warm setup, 8 samples per benchmark:
- ScanUniquePointCompiledAccessWithTx median: 2,960 ns/op on master -> 2,941 ns/op on this branch (-0.6%); 330 B/op and 8 allocs/op unchanged
- CompiledScanLookupWithTx median: 1,690 ns/op on master -> 1,708 ns/op on this branch (+1.1%); 224 B/op and 3 allocs/op unchanged

The small latency movements are within run-to-run noise; no allocation regression was observed.

## Data-safety review
- no cleanup or persistence-deletion call sites were added
- no storage serialization format or magic byte changed
- failed durable schema publication restores the previous schema topology generation
- readers and writers remain on the old live topology until the successor schema generation is durable