### PR TITLE
Inline reusable comparison emitters in JITGen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ jitgen:
 	jitgen_bin=$$(mktemp /tmp/memcp-jitgen.XXXXXX); \
 	trap 'rm -f "$$jitgen_bin"' EXIT; \
 	go build -o "$$jitgen_bin" ./tools/jitgen/; \
-	"$$jitgen_bin" -patch scm/alu.go scm/list.go scm/strings.go scm/scm.go scm/date.go scm/streams.go scm/sync.go scm/metrics.go scm/scheduler.go scm/window.go scm/vector.go scm/packrat.go scm/jit.go scm/timezone.go scm/processlist.go scm/list_assoc_extra.go scm/sql_literals.go scm/json_functions.go; \
+	"$$jitgen_bin" -patch scm/alu.go scm/compare.go scm/list.go scm/strings.go scm/scm.go scm/date.go scm/streams.go scm/sync.go scm/metrics.go scm/scheduler.go scm/window.go scm/vector.go scm/packrat.go scm/jit.go scm/timezone.go scm/processlist.go scm/list_assoc_extra.go scm/sql_literals.go scm/json_functions.go; \
 	"$$jitgen_bin" -patch storage/storage-int.go storage/storage-float.go storage/storage-decimal.go storage/storage-string.go storage/storage-prefix.go storage/storage-enum.go storage/storage-scmer.go storage/storage-sparse.go storage/storage-seq.go storage/storage-const.go storage/overlay-blob.go storage/compute_proxy.go storage/jit_getters.go; \
 	gofmt -w scm storage
 
@@ -70,7 +70,7 @@ jitgen-policy:
 	jitgen_bin=$$(mktemp /tmp/memcp-jitgen.XXXXXX); \
 	trap 'rm -f "$$jitgen_bin"' EXIT; \
 	go build -o "$$jitgen_bin" ./tools/jitgen/; \
-	"$$jitgen_bin" -patch -policy-only scm/alu.go scm/list.go scm/strings.go scm/scm.go scm/date.go scm/streams.go scm/sync.go scm/metrics.go scm/scheduler.go scm/window.go scm/vector.go scm/packrat.go scm/jit.go scm/timezone.go scm/processlist.go scm/list_assoc_extra.go scm/sql_literals.go scm/json_functions.go; \
+	"$$jitgen_bin" -patch -policy-only scm/alu.go scm/compare.go scm/list.go scm/strings.go scm/scm.go scm/date.go scm/streams.go scm/sync.go scm/metrics.go scm/scheduler.go scm/window.go scm/vector.go scm/packrat.go scm/jit.go scm/timezone.go scm/processlist.go scm/list_assoc_extra.go scm/sql_literals.go scm/json_functions.go; \
 	gofmt -w scm
 
 costgen:

--- a/scm/alu.go
+++ b/scm/alu.go
@@ -100,31 +100,43 @@ func init_alu() {
 				}
 				d0 := args[0]
 				d0.ID = 0
-				d1 := ctx.EmitGetTagDesc(&d0, JITValueDesc{Loc: LocAny})
+				d1 := d0
+				d1.ID = 0
+				d2 := ctx.EmitGetTagDesc(&d1, JITValueDesc{Loc: LocAny})
 				ctx.FreeDesc(&d0)
-				ctx.EnsureDesc(&d1)
-				var d2 JITValueDesc
-				if d1.Loc == LocImm {
-					d2 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d1.Imm.Int()) == uint64(0x4))}
-				} else {
-					ctx.EmitCmpRegImm32(d1.Reg, 4)
-					r0 := ctx.AllocReg()
-					ctx.EmitSetcc(r0, CondEqual)
-					d2 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}
-					ctx.BindReg(r0, &d2)
-				}
-				ctx.FreeDesc(&d1)
 				ctx.EnsureDesc(&d2)
+				resultTarget3 := false
+				_ = resultTarget3
+				var d4 JITValueDesc
+				if d2.Loc == LocImm {
+					d4 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d2.Imm.Int()) == uint64(0x4))}
+				} else {
+					ctx.EmitCmpRegImm32(d2.Reg, 4)
+					var r0 Reg
+					if result.Loc == LocRegPair && result.Reg2 != d2.Reg {
+						r0 = result.Reg2
+						resultTarget3 = true
+					} else {
+						r0 = ctx.AllocRegExcept(d2.Reg)
+					}
+					ctx.EmitSetcc(r0, CondEqual)
+					d4 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}
+					ctx.BindReg(r0, &d4)
+				}
+				ctx.FreeDesc(&d2)
+				ctx.EnsureDesc(&d4)
 				if result.Loc == LocAny {
 					result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
 					ctx.BindReg(result.Reg, &result)
 					ctx.BindReg(result.Reg2, &result)
 				}
-				if d2.Loc == LocImm {
-					ctx.EmitMakeBool(result, d2)
+				if d4.Loc == LocImm {
+					ctx.EmitMakeBool(result, d4)
 				} else {
-					ctx.EmitMakeBool(result, d2)
-					ctx.FreeReg(d2.Reg)
+					ctx.EmitMakeBool(result, d4)
+					if !resultTarget3 {
+						ctx.FreeReg(d4.Reg)
+					}
 				}
 				result.Type = tagBool
 				return result
@@ -161,24 +173,26 @@ func init_alu() {
 				_ = d4
 				var d5 JITValueDesc
 				_ = d5
-				var d7 JITValueDesc
-				_ = d7
-				var d18 JITValueDesc
-				_ = d18
-				var d27 JITValueDesc
-				_ = d27
-				var d29 JITValueDesc
-				_ = d29
+				var d6 JITValueDesc
+				_ = d6
+				var d8 JITValueDesc
+				_ = d8
+				var d20 JITValueDesc
+				_ = d20
 				var d30 JITValueDesc
 				_ = d30
-				var d31 JITValueDesc
-				_ = d31
 				var d32 JITValueDesc
 				_ = d32
+				var d33 JITValueDesc
+				_ = d33
 				var d34 JITValueDesc
 				_ = d34
-				var d52 JITValueDesc
-				_ = d52
+				var d35 JITValueDesc
+				_ = d35
+				var d37 JITValueDesc
+				_ = d37
+				var d56 JITValueDesc
+				_ = d56
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				phiBase0 := ctx.AllocStack(int32(16))
 				var bbs [4]BBDescriptor
@@ -242,126 +256,137 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d2 = args[0]
 					d2.ID = 0
-					d3 = ctx.EmitGetTagDesc(&d2, JITValueDesc{Loc: LocAny})
-					ctx.StabilizeDescForControlFlow(&d3)
+					d3 = d2
+					d3.ID = 0
+					d4 = ctx.EmitGetTagDesc(&d3, JITValueDesc{Loc: LocAny})
+					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d2)
-					ctx.EnsureDesc(&d3)
-					var d4 JITValueDesc
-					if d3.Loc == LocImm {
-						d4 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d3.Imm.Int()) == uint64(0x3))}
+					ctx.EnsureDesc(&d4)
+					var d5 JITValueDesc
+					if d4.Loc == LocImm {
+						d5 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d4.Imm.Int()) == uint64(0x3))}
 					} else {
-						r0 := ctx.AllocRegExcept(d3.Reg)
-						ctx.EmitCmpRegImm32(d3.Reg, 3)
-						d4 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
-						ctx.BindReg(r0, &d4)
+						r0 := ctx.AllocRegExcept(d4.Reg)
+						ctx.EmitCmpRegImm32(d4.Reg, 3)
+						d5 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
+						ctx.BindReg(r0, &d5)
 					}
-					d5 = d4
-					ctx.EnsureDesc(&d5)
-					if d5.Loc != LocImm && d5.Loc != LocFlags {
+					d6 = d5
+					ctx.EnsureDesc(&d6)
+					if d6.Loc != LocImm && d6.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d5.Loc == LocImm {
-						if d5.Imm.Bool() {
+					if d6.Loc == LocImm {
+						if d6.Imm.Bool() {
 							if ps.General {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 							}
-							ps6 := PhiState{General: ps.General}
-							ps6.OverlayValues = make([]JITValueDesc, 6)
-							ps6.OverlayValues[1] = d1
-							ps6.OverlayValues[2] = d2
-							ps6.OverlayValues[3] = d3
-							ps6.OverlayValues[4] = d4
-							ps6.OverlayValues[5] = d5
-							ps6.PhiValues = make([]JITValueDesc, 1)
-							d7 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
-							ps6.PhiValues[0] = d7
-							return bbs[2].RenderPS(ps6)
+							ps7 := PhiState{General: ps.General}
+							ps7.OverlayValues = make([]JITValueDesc, 7)
+							ps7.OverlayValues[1] = d1
+							ps7.OverlayValues[2] = d2
+							ps7.OverlayValues[3] = d3
+							ps7.OverlayValues[4] = d4
+							ps7.OverlayValues[5] = d5
+							ps7.OverlayValues[6] = d6
+							ps7.PhiValues = make([]JITValueDesc, 1)
+							d8 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
+							ps7.PhiValues[0] = d8
+							return bbs[2].RenderPS(ps7)
 						}
 						if ps.General {
 						}
-						ps8 := PhiState{General: ps.General}
-						ps8.OverlayValues = make([]JITValueDesc, 8)
-						ps8.OverlayValues[1] = d1
-						ps8.OverlayValues[2] = d2
-						ps8.OverlayValues[3] = d3
-						ps8.OverlayValues[4] = d4
-						ps8.OverlayValues[5] = d5
-						ps8.OverlayValues[7] = d7
-						return bbs[3].RenderPS(ps8)
+						ps9 := PhiState{General: ps.General}
+						ps9.OverlayValues = make([]JITValueDesc, 9)
+						ps9.OverlayValues[1] = d1
+						ps9.OverlayValues[2] = d2
+						ps9.OverlayValues[3] = d3
+						ps9.OverlayValues[4] = d4
+						ps9.OverlayValues[5] = d5
+						ps9.OverlayValues[6] = d6
+						ps9.OverlayValues[8] = d8
+						return bbs[3].RenderPS(ps9)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[0].RenderPS(ps)
 					}
 					lbl5 := ctx.ReserveLabel()
-					ctx.EmitJump(d5.Condition, lbl5)
+					ctx.EmitJump(d6.Condition, lbl5)
 					ctx.EmitJmp(lbl4)
-					ctx.FreeDesc(&d4)
-					snap9 := d1
-					snap10 := d2
-					snap11 := d3
-					snap12 := d4
-					snap13 := d5
-					snap14 := d7
-					alloc15 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d5)
+					snap10 := d1
+					snap11 := d2
+					snap12 := d3
+					snap13 := d4
+					snap14 := d5
+					snap15 := d6
+					snap16 := d8
+					alloc17 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl5)
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 					ctx.EmitJmp(lbl3)
-					ctx.RestoreAllocState(alloc15)
-					d1 = snap9
-					d2 = snap10
-					d3 = snap11
-					d4 = snap12
-					d5 = snap13
-					d7 = snap14
-					ctx.RestoreAllocState(alloc15)
-					d1 = snap9
-					d2 = snap10
-					d3 = snap11
-					d4 = snap12
-					d5 = snap13
-					d7 = snap14
-					ps16 := PhiState{General: true}
-					ps16.OverlayValues = make([]JITValueDesc, 8)
-					ps16.OverlayValues[1] = d1
-					ps16.OverlayValues[2] = d2
-					ps16.OverlayValues[3] = d3
-					ps16.OverlayValues[4] = d4
-					ps16.OverlayValues[5] = d5
-					ps16.OverlayValues[7] = d7
-					ps16.PhiValues = make([]JITValueDesc, 1)
-					d18 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
-					ps16.PhiValues[0] = d18
-					ps17 := PhiState{General: true}
-					ps17.OverlayValues = make([]JITValueDesc, 19)
-					ps17.OverlayValues[1] = d1
-					ps17.OverlayValues[2] = d2
-					ps17.OverlayValues[3] = d3
-					ps17.OverlayValues[4] = d4
-					ps17.OverlayValues[5] = d5
-					ps17.OverlayValues[7] = d7
-					ps17.OverlayValues[18] = d18
-					snap19 := d1
-					snap20 := d2
-					snap21 := d3
-					snap22 := d4
-					snap23 := d5
-					snap24 := d7
-					snap25 := d18
-					alloc26 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc17)
+					d1 = snap10
+					d2 = snap11
+					d3 = snap12
+					d4 = snap13
+					d5 = snap14
+					d6 = snap15
+					d8 = snap16
+					ctx.RestoreAllocState(alloc17)
+					d1 = snap10
+					d2 = snap11
+					d3 = snap12
+					d4 = snap13
+					d5 = snap14
+					d6 = snap15
+					d8 = snap16
+					ps18 := PhiState{General: true}
+					ps18.OverlayValues = make([]JITValueDesc, 9)
+					ps18.OverlayValues[1] = d1
+					ps18.OverlayValues[2] = d2
+					ps18.OverlayValues[3] = d3
+					ps18.OverlayValues[4] = d4
+					ps18.OverlayValues[5] = d5
+					ps18.OverlayValues[6] = d6
+					ps18.OverlayValues[8] = d8
+					ps18.PhiValues = make([]JITValueDesc, 1)
+					d20 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
+					ps18.PhiValues[0] = d20
+					ps19 := PhiState{General: true}
+					ps19.OverlayValues = make([]JITValueDesc, 21)
+					ps19.OverlayValues[1] = d1
+					ps19.OverlayValues[2] = d2
+					ps19.OverlayValues[3] = d3
+					ps19.OverlayValues[4] = d4
+					ps19.OverlayValues[5] = d5
+					ps19.OverlayValues[6] = d6
+					ps19.OverlayValues[8] = d8
+					ps19.OverlayValues[20] = d20
+					snap21 := d1
+					snap22 := d2
+					snap23 := d3
+					snap24 := d4
+					snap25 := d5
+					snap26 := d6
+					snap27 := d8
+					snap28 := d20
+					alloc29 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps16)
+						bbs[2].RenderPS(ps18)
 					}
-					ctx.RestoreAllocState(alloc26)
-					d1 = snap19
-					d2 = snap20
-					d3 = snap21
-					d4 = snap22
-					d5 = snap23
-					d7 = snap24
-					d18 = snap25
+					ctx.RestoreAllocState(alloc29)
+					d1 = snap21
+					d2 = snap22
+					d3 = snap23
+					d4 = snap24
+					d5 = snap25
+					d6 = snap26
+					d8 = snap27
+					d20 = snap28
 					if !bbs[3].Rendered {
-						return bbs[3].RenderPS(ps17)
+						return bbs[3].RenderPS(ps19)
 					}
 					return result
 					return result
@@ -401,53 +426,57 @@ func init_alu() {
 					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
 						d5 = ps.OverlayValues[5]
 					}
-					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
 					}
-					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
-						d18 = ps.OverlayValues[18]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d3)
-					var d27 JITValueDesc
-					if d3.Loc == LocImm {
-						d27 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d3.Imm.Int()) == uint64(0x10))}
+					ctx.EnsureDesc(&d4)
+					var d30 JITValueDesc
+					if d4.Loc == LocImm {
+						d30 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d4.Imm.Int()) == uint64(0x10))}
 					} else {
-						ctx.EmitCmpRegImm32(d3.Reg, 16)
-						r1 := ctx.AllocRegExcept(d3.Reg)
+						ctx.EmitCmpRegImm32(d4.Reg, 16)
+						r1 := ctx.AllocRegExcept(d4.Reg)
 						ctx.EmitSetcc(r1, CondEqual)
-						d27 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
-						ctx.BindReg(r1, &d27)
+						d30 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
+						ctx.BindReg(r1, &d30)
 					}
-					ctx.EnsureDesc(&d27)
-					ctx.EmitStoreToStack(d27, int32(bbs[2].PhiBase)+int32(0))
-					ctx.StabilizeDescForControlFlow(&d27)
+					ctx.EnsureDesc(&d30)
+					ctx.EmitStoreToStack(d30, int32(bbs[2].PhiBase)+int32(0))
+					ctx.StabilizeDescForControlFlow(&d30)
 					if ps.General {
 					}
-					ps28 := PhiState{General: ps.General}
-					ps28.OverlayValues = make([]JITValueDesc, 28)
-					ps28.OverlayValues[1] = d1
-					ps28.OverlayValues[2] = d2
-					ps28.OverlayValues[3] = d3
-					ps28.OverlayValues[4] = d4
-					ps28.OverlayValues[5] = d5
-					ps28.OverlayValues[7] = d7
-					ps28.OverlayValues[18] = d18
-					ps28.OverlayValues[27] = d27
-					ps28.PhiValues = make([]JITValueDesc, 1)
-					if ps28.General && bbs[2].Rendered {
+					ps31 := PhiState{General: ps.General}
+					ps31.OverlayValues = make([]JITValueDesc, 31)
+					ps31.OverlayValues[1] = d1
+					ps31.OverlayValues[2] = d2
+					ps31.OverlayValues[3] = d3
+					ps31.OverlayValues[4] = d4
+					ps31.OverlayValues[5] = d5
+					ps31.OverlayValues[6] = d6
+					ps31.OverlayValues[8] = d8
+					ps31.OverlayValues[20] = d20
+					ps31.OverlayValues[30] = d30
+					ps31.PhiValues = make([]JITValueDesc, 1)
+					if ps31.General && bbs[2].Rendered {
 						ctx.EmitJmp(lbl3)
 						return result
 					}
-					return bbs[2].RenderPS(ps28)
+					return bbs[2].RenderPS(ps31)
 					return result
 				}
 				bbs[2].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d29 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d29)
-							ctx.EmitStoreToStack(d29, int32(bbs[2].PhiBase)+int32(0))
+							d32 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d32)
+							ctx.EmitStoreToStack(d32, int32(bbs[2].PhiBase)+int32(0))
 						}
 						if bbs[2].VisitCount >= 0 {
 							ps.General = true
@@ -482,17 +511,20 @@ func init_alu() {
 					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
 						d5 = ps.OverlayValues[5]
 					}
-					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
 					}
-					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
-						d18 = ps.OverlayValues[18]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
-						d27 = ps.OverlayValues[27]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
-					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
-						d29 = ps.OverlayValues[29]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
+					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
+						d32 = ps.OverlayValues[32]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
 						d1 = ps.PhiValues[0]
@@ -503,8 +535,8 @@ func init_alu() {
 						ctx.EmitMakeBool(result, d1)
 					} else {
 						ctx.EmitMovToReg(result.Reg2, d1)
-						d30 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeBool(result, d30)
+						d33 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeBool(result, d33)
 						if d1.Loc == LocReg && d1.Reg != result.Reg2 {
 							ctx.FreeReg(d1.Reg)
 						}
@@ -548,208 +580,220 @@ func init_alu() {
 					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
 						d5 = ps.OverlayValues[5]
 					}
-					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
-						d7 = ps.OverlayValues[7]
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
 					}
-					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
-						d18 = ps.OverlayValues[18]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
-						d27 = ps.OverlayValues[27]
-					}
-					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
-						d29 = ps.OverlayValues[29]
+					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
+						d20 = ps.OverlayValues[20]
 					}
 					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
 						d30 = ps.OverlayValues[30]
 					}
-					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d3)
-					var d31 JITValueDesc
-					if d3.Loc == LocImm {
-						d31 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d3.Imm.Int()) == uint64(0x4))}
-					} else {
-						r2 := ctx.AllocRegExcept(d3.Reg)
-						ctx.EmitCmpRegImm32(d3.Reg, 4)
-						d31 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondEqual}
-						ctx.BindReg(r2, &d31)
+					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
+						d32 = ps.OverlayValues[32]
 					}
-					d32 = d31
-					ctx.EnsureDesc(&d32)
-					if d32.Loc != LocImm && d32.Loc != LocFlags {
+					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
+						d33 = ps.OverlayValues[33]
+					}
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d4)
+					var d34 JITValueDesc
+					if d4.Loc == LocImm {
+						d34 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d4.Imm.Int()) == uint64(0x4))}
+					} else {
+						r2 := ctx.AllocRegExcept(d4.Reg)
+						ctx.EmitCmpRegImm32(d4.Reg, 4)
+						d34 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondEqual}
+						ctx.BindReg(r2, &d34)
+					}
+					d35 = d34
+					ctx.EnsureDesc(&d35)
+					if d35.Loc != LocImm && d35.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d32.Loc == LocImm {
-						if d32.Imm.Bool() {
+					if d35.Loc == LocImm {
+						if d35.Imm.Bool() {
 							if ps.General {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 							}
-							ps33 := PhiState{General: ps.General}
-							ps33.OverlayValues = make([]JITValueDesc, 33)
-							ps33.OverlayValues[1] = d1
-							ps33.OverlayValues[2] = d2
-							ps33.OverlayValues[3] = d3
-							ps33.OverlayValues[4] = d4
-							ps33.OverlayValues[5] = d5
-							ps33.OverlayValues[7] = d7
-							ps33.OverlayValues[18] = d18
-							ps33.OverlayValues[27] = d27
-							ps33.OverlayValues[29] = d29
-							ps33.OverlayValues[30] = d30
-							ps33.OverlayValues[31] = d31
-							ps33.OverlayValues[32] = d32
-							ps33.PhiValues = make([]JITValueDesc, 1)
-							d34 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
-							ps33.PhiValues[0] = d34
-							return bbs[2].RenderPS(ps33)
+							ps36 := PhiState{General: ps.General}
+							ps36.OverlayValues = make([]JITValueDesc, 36)
+							ps36.OverlayValues[1] = d1
+							ps36.OverlayValues[2] = d2
+							ps36.OverlayValues[3] = d3
+							ps36.OverlayValues[4] = d4
+							ps36.OverlayValues[5] = d5
+							ps36.OverlayValues[6] = d6
+							ps36.OverlayValues[8] = d8
+							ps36.OverlayValues[20] = d20
+							ps36.OverlayValues[30] = d30
+							ps36.OverlayValues[32] = d32
+							ps36.OverlayValues[33] = d33
+							ps36.OverlayValues[34] = d34
+							ps36.OverlayValues[35] = d35
+							ps36.PhiValues = make([]JITValueDesc, 1)
+							d37 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
+							ps36.PhiValues[0] = d37
+							return bbs[2].RenderPS(ps36)
 						}
 						if ps.General {
 						}
-						ps35 := PhiState{General: ps.General}
-						ps35.OverlayValues = make([]JITValueDesc, 35)
-						ps35.OverlayValues[1] = d1
-						ps35.OverlayValues[2] = d2
-						ps35.OverlayValues[3] = d3
-						ps35.OverlayValues[4] = d4
-						ps35.OverlayValues[5] = d5
-						ps35.OverlayValues[7] = d7
-						ps35.OverlayValues[18] = d18
-						ps35.OverlayValues[27] = d27
-						ps35.OverlayValues[29] = d29
-						ps35.OverlayValues[30] = d30
-						ps35.OverlayValues[31] = d31
-						ps35.OverlayValues[32] = d32
-						ps35.OverlayValues[34] = d34
-						return bbs[1].RenderPS(ps35)
+						ps38 := PhiState{General: ps.General}
+						ps38.OverlayValues = make([]JITValueDesc, 38)
+						ps38.OverlayValues[1] = d1
+						ps38.OverlayValues[2] = d2
+						ps38.OverlayValues[3] = d3
+						ps38.OverlayValues[4] = d4
+						ps38.OverlayValues[5] = d5
+						ps38.OverlayValues[6] = d6
+						ps38.OverlayValues[8] = d8
+						ps38.OverlayValues[20] = d20
+						ps38.OverlayValues[30] = d30
+						ps38.OverlayValues[32] = d32
+						ps38.OverlayValues[33] = d33
+						ps38.OverlayValues[34] = d34
+						ps38.OverlayValues[35] = d35
+						ps38.OverlayValues[37] = d37
+						return bbs[1].RenderPS(ps38)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[3].RenderPS(ps)
 					}
 					lbl6 := ctx.ReserveLabel()
-					ctx.EmitJump(d32.Condition, lbl6)
+					ctx.EmitJump(d35.Condition, lbl6)
 					ctx.EmitJmp(lbl2)
-					ctx.FreeDesc(&d31)
-					snap36 := d1
-					snap37 := d2
-					snap38 := d3
-					snap39 := d4
-					snap40 := d5
-					snap41 := d7
-					snap42 := d18
-					snap43 := d27
-					snap44 := d29
-					snap45 := d30
-					snap46 := d31
-					snap47 := d32
-					snap48 := d34
-					alloc49 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d34)
+					snap39 := d1
+					snap40 := d2
+					snap41 := d3
+					snap42 := d4
+					snap43 := d5
+					snap44 := d6
+					snap45 := d8
+					snap46 := d20
+					snap47 := d30
+					snap48 := d32
+					snap49 := d33
+					snap50 := d34
+					snap51 := d35
+					snap52 := d37
+					alloc53 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl6)
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 					ctx.EmitJmp(lbl3)
-					ctx.RestoreAllocState(alloc49)
-					d1 = snap36
-					d2 = snap37
-					d3 = snap38
-					d4 = snap39
-					d5 = snap40
-					d7 = snap41
-					d18 = snap42
-					d27 = snap43
-					d29 = snap44
-					d30 = snap45
-					d31 = snap46
-					d32 = snap47
-					d34 = snap48
-					ctx.RestoreAllocState(alloc49)
-					d1 = snap36
-					d2 = snap37
-					d3 = snap38
-					d4 = snap39
-					d5 = snap40
-					d7 = snap41
-					d18 = snap42
-					d27 = snap43
-					d29 = snap44
-					d30 = snap45
-					d31 = snap46
-					d32 = snap47
-					d34 = snap48
-					ps50 := PhiState{General: true}
-					ps50.OverlayValues = make([]JITValueDesc, 35)
-					ps50.OverlayValues[1] = d1
-					ps50.OverlayValues[2] = d2
-					ps50.OverlayValues[3] = d3
-					ps50.OverlayValues[4] = d4
-					ps50.OverlayValues[5] = d5
-					ps50.OverlayValues[7] = d7
-					ps50.OverlayValues[18] = d18
-					ps50.OverlayValues[27] = d27
-					ps50.OverlayValues[29] = d29
-					ps50.OverlayValues[30] = d30
-					ps50.OverlayValues[31] = d31
-					ps50.OverlayValues[32] = d32
-					ps50.OverlayValues[34] = d34
-					ps50.PhiValues = make([]JITValueDesc, 1)
-					d52 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
-					ps50.PhiValues[0] = d52
-					ps51 := PhiState{General: true}
-					ps51.OverlayValues = make([]JITValueDesc, 53)
-					ps51.OverlayValues[1] = d1
-					ps51.OverlayValues[2] = d2
-					ps51.OverlayValues[3] = d3
-					ps51.OverlayValues[4] = d4
-					ps51.OverlayValues[5] = d5
-					ps51.OverlayValues[7] = d7
-					ps51.OverlayValues[18] = d18
-					ps51.OverlayValues[27] = d27
-					ps51.OverlayValues[29] = d29
-					ps51.OverlayValues[30] = d30
-					ps51.OverlayValues[31] = d31
-					ps51.OverlayValues[32] = d32
-					ps51.OverlayValues[34] = d34
-					ps51.OverlayValues[52] = d52
-					snap53 := d1
-					snap54 := d2
-					snap55 := d3
-					snap56 := d4
-					snap57 := d5
-					snap58 := d7
-					snap59 := d18
-					snap60 := d27
-					snap61 := d29
-					snap62 := d30
-					snap63 := d31
-					snap64 := d32
-					snap65 := d34
-					snap66 := d52
-					alloc67 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc53)
+					d1 = snap39
+					d2 = snap40
+					d3 = snap41
+					d4 = snap42
+					d5 = snap43
+					d6 = snap44
+					d8 = snap45
+					d20 = snap46
+					d30 = snap47
+					d32 = snap48
+					d33 = snap49
+					d34 = snap50
+					d35 = snap51
+					d37 = snap52
+					ctx.RestoreAllocState(alloc53)
+					d1 = snap39
+					d2 = snap40
+					d3 = snap41
+					d4 = snap42
+					d5 = snap43
+					d6 = snap44
+					d8 = snap45
+					d20 = snap46
+					d30 = snap47
+					d32 = snap48
+					d33 = snap49
+					d34 = snap50
+					d35 = snap51
+					d37 = snap52
+					ps54 := PhiState{General: true}
+					ps54.OverlayValues = make([]JITValueDesc, 38)
+					ps54.OverlayValues[1] = d1
+					ps54.OverlayValues[2] = d2
+					ps54.OverlayValues[3] = d3
+					ps54.OverlayValues[4] = d4
+					ps54.OverlayValues[5] = d5
+					ps54.OverlayValues[6] = d6
+					ps54.OverlayValues[8] = d8
+					ps54.OverlayValues[20] = d20
+					ps54.OverlayValues[30] = d30
+					ps54.OverlayValues[32] = d32
+					ps54.OverlayValues[33] = d33
+					ps54.OverlayValues[34] = d34
+					ps54.OverlayValues[35] = d35
+					ps54.OverlayValues[37] = d37
+					ps54.PhiValues = make([]JITValueDesc, 1)
+					d56 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
+					ps54.PhiValues[0] = d56
+					ps55 := PhiState{General: true}
+					ps55.OverlayValues = make([]JITValueDesc, 57)
+					ps55.OverlayValues[1] = d1
+					ps55.OverlayValues[2] = d2
+					ps55.OverlayValues[3] = d3
+					ps55.OverlayValues[4] = d4
+					ps55.OverlayValues[5] = d5
+					ps55.OverlayValues[6] = d6
+					ps55.OverlayValues[8] = d8
+					ps55.OverlayValues[20] = d20
+					ps55.OverlayValues[30] = d30
+					ps55.OverlayValues[32] = d32
+					ps55.OverlayValues[33] = d33
+					ps55.OverlayValues[34] = d34
+					ps55.OverlayValues[35] = d35
+					ps55.OverlayValues[37] = d37
+					ps55.OverlayValues[56] = d56
+					snap57 := d1
+					snap58 := d2
+					snap59 := d3
+					snap60 := d4
+					snap61 := d5
+					snap62 := d6
+					snap63 := d8
+					snap64 := d20
+					snap65 := d30
+					snap66 := d32
+					snap67 := d33
+					snap68 := d34
+					snap69 := d35
+					snap70 := d37
+					snap71 := d56
+					alloc72 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps50)
+						bbs[2].RenderPS(ps54)
 					}
-					ctx.RestoreAllocState(alloc67)
-					d1 = snap53
-					d2 = snap54
-					d3 = snap55
-					d4 = snap56
-					d5 = snap57
-					d7 = snap58
-					d18 = snap59
-					d27 = snap60
-					d29 = snap61
-					d30 = snap62
-					d31 = snap63
-					d32 = snap64
-					d34 = snap65
-					d52 = snap66
+					ctx.RestoreAllocState(alloc72)
+					d1 = snap57
+					d2 = snap58
+					d3 = snap59
+					d4 = snap60
+					d5 = snap61
+					d6 = snap62
+					d8 = snap63
+					d20 = snap64
+					d30 = snap65
+					d32 = snap66
+					d33 = snap67
+					d34 = snap68
+					d35 = snap69
+					d37 = snap70
+					d56 = snap71
 					if !bbs[1].Rendered {
-						return bbs[1].RenderPS(ps51)
+						return bbs[1].RenderPS(ps55)
 					}
 					return result
 					return result
 				}
-				ps68 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps68)
+				ps73 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps73)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -786,31 +830,43 @@ func init_alu() {
 				}
 				d0 := args[0]
 				d0.ID = 0
-				d1 := ctx.EmitGetTagDesc(&d0, JITValueDesc{Loc: LocAny})
+				d1 := d0
+				d1.ID = 0
+				d2 := ctx.EmitGetTagDesc(&d1, JITValueDesc{Loc: LocAny})
 				ctx.FreeDesc(&d0)
-				ctx.EnsureDesc(&d1)
-				var d2 JITValueDesc
-				if d1.Loc == LocImm {
-					d2 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d1.Imm.Int()) == uint64(0x2))}
-				} else {
-					ctx.EmitCmpRegImm32(d1.Reg, 2)
-					r0 := ctx.AllocReg()
-					ctx.EmitSetcc(r0, CondEqual)
-					d2 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}
-					ctx.BindReg(r0, &d2)
-				}
-				ctx.FreeDesc(&d1)
 				ctx.EnsureDesc(&d2)
+				resultTarget3 := false
+				_ = resultTarget3
+				var d4 JITValueDesc
+				if d2.Loc == LocImm {
+					d4 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d2.Imm.Int()) == uint64(0x2))}
+				} else {
+					ctx.EmitCmpRegImm32(d2.Reg, 2)
+					var r0 Reg
+					if result.Loc == LocRegPair && result.Reg2 != d2.Reg {
+						r0 = result.Reg2
+						resultTarget3 = true
+					} else {
+						r0 = ctx.AllocRegExcept(d2.Reg)
+					}
+					ctx.EmitSetcc(r0, CondEqual)
+					d4 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}
+					ctx.BindReg(r0, &d4)
+				}
+				ctx.FreeDesc(&d2)
+				ctx.EnsureDesc(&d4)
 				if result.Loc == LocAny {
 					result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
 					ctx.BindReg(result.Reg, &result)
 					ctx.BindReg(result.Reg2, &result)
 				}
-				if d2.Loc == LocImm {
-					ctx.EmitMakeBool(result, d2)
+				if d4.Loc == LocImm {
+					ctx.EmitMakeBool(result, d4)
 				} else {
-					ctx.EmitMakeBool(result, d2)
-					ctx.FreeReg(d2.Reg)
+					ctx.EmitMakeBool(result, d4)
+					if !resultTarget3 {
+						ctx.FreeReg(d4.Reg)
+					}
 				}
 				result.Type = tagBool
 				return result
@@ -2311,7 +2367,8 @@ func init_alu() {
 					if d1.Loc == LocImm {
 						d133 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d1.Imm.Int()))}
 					} else {
-						r8 := ctx.AllocRegExcept(d1.Reg)
+						var r8 Reg
+						r8 = ctx.AllocRegExcept(d1.Reg)
 						ctx.EmitMovRegReg(r8, d1.Reg)
 						ctx.EmitCvtInt64ToFloat64(RegX0, r8)
 						d133 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r8}
@@ -2320,14 +2377,14 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d133)
 					if ps.General {
 						ctx.SyncDesc(&d2)
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.ProtectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.ProtectReg(d2.Reg)
 							ctx.ProtectReg(d2.Reg2)
 						}
 						ctx.SyncDesc(&d133)
-						if d133.Loc == LocReg {
+						if d133.Loc == LocReg || d133.Loc == LocFPReg {
 							ctx.ProtectReg(d133.Reg)
 						} else if d133.Loc == LocRegPair {
 							ctx.ProtectReg(d133.Reg)
@@ -2345,13 +2402,13 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d135)
 						ctx.EmitStoreToStack(d135, int32(bbs[9].PhiBase)+int32(16))
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.UnprotectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.UnprotectReg(d2.Reg)
 							ctx.UnprotectReg(d2.Reg2)
 						}
-						if d133.Loc == LocReg {
+						if d133.Loc == LocReg || d133.Loc == LocFPReg {
 							ctx.UnprotectReg(d133.Reg)
 						} else if d133.Loc == LocRegPair {
 							ctx.UnprotectReg(d133.Reg)
@@ -4167,8 +4224,6 @@ func init_alu() {
 				_ = d88
 				var d89 JITValueDesc
 				_ = d89
-				var d90 JITValueDesc
-				_ = d90
 				var d91 JITValueDesc
 				_ = d91
 				var d92 JITValueDesc
@@ -4181,8 +4236,6 @@ func init_alu() {
 				_ = d95
 				var d96 JITValueDesc
 				_ = d96
-				var d97 JITValueDesc
-				_ = d97
 				var d98 JITValueDesc
 				_ = d98
 				var d99 JITValueDesc
@@ -4191,6 +4244,10 @@ func init_alu() {
 				_ = d100
 				var d101 JITValueDesc
 				_ = d101
+				var d102 JITValueDesc
+				_ = d102
+				var d103 JITValueDesc
+				_ = d103
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				var bbs [8]BBDescriptor
 				for i := range args {
@@ -4984,27 +5041,47 @@ func init_alu() {
 					}
 					ctx.FreeDesc(&d88)
 					ctx.EnsureDesc(&d87)
+					resultTarget90 := false
+					_ = resultTarget90
 					ctx.EnsureDesc(&d89)
 					ctx.EnsureDescsTogether(&d87, &d89)
-					var d90 JITValueDesc
+					var d91 JITValueDesc
 					if d87.Loc == LocImm && d89.Loc == LocImm {
-						d90 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d87.Imm.Int() + d89.Imm.Int())}
+						d91 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d87.Imm.Int() + d89.Imm.Int())}
 					} else if d89.Loc == LocImm && d89.Imm.Int() == 0 {
-						r0 := ctx.AllocRegExcept(d87.Reg)
+						var r0 Reg
+						if result.Loc == LocRegPair && result.Reg2 != d87.Reg {
+							r0 = result.Reg2
+							resultTarget90 = true
+						} else {
+							r0 = ctx.AllocRegExcept(d87.Reg)
+						}
 						ctx.EmitMovRegReg(r0, d87.Reg)
-						d90 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r0}
-						ctx.BindReg(r0, &d90)
+						d91 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r0}
+						ctx.BindReg(r0, &d91)
 					} else if d87.Loc == LocImm && d87.Imm.Int() == 0 {
-						d90 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d89.Reg}
-						ctx.BindReg(d89.Reg, &d90)
+						d91 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d89.Reg}
+						ctx.BindReg(d89.Reg, &d91)
 					} else if d87.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d89.Reg)
+						var scratch Reg
+						if result.Loc == LocRegPair && result.Reg2 != d89.Reg {
+							scratch = result.Reg2
+							resultTarget90 = true
+						} else {
+							scratch = ctx.AllocRegExcept(d89.Reg)
+						}
 						ctx.EmitMovRegImm64(scratch, uint64(d87.Imm.Int()))
 						ctx.EmitAddInt64(scratch, d89.Reg)
-						d90 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-						ctx.BindReg(scratch, &d90)
+						d91 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d91)
 					} else if d89.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d87.Reg)
+						var scratch Reg
+						if result.Loc == LocRegPair && result.Reg2 != d87.Reg {
+							scratch = result.Reg2
+							resultTarget90 = true
+						} else {
+							scratch = ctx.AllocRegExcept(d87.Reg)
+						}
 						ctx.EmitMovRegReg(scratch, d87.Reg)
 						if d89.Imm.Int() >= -2147483648 && d89.Imm.Int() <= 2147483647 {
 							ctx.EmitAddRegImm32(scratch, int32(d89.Imm.Int()))
@@ -5012,30 +5089,39 @@ func init_alu() {
 							ctx.EmitMovRegImm64(RegR11, uint64(d89.Imm.Int()))
 							ctx.EmitAddInt64(scratch, RegR11)
 						}
-						d90 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-						ctx.BindReg(scratch, &d90)
+						d91 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d91)
 					} else {
-						r1 := ctx.AllocRegExcept(d87.Reg, d89.Reg)
+						var r1 Reg
+						if result.Loc == LocRegPair && result.Reg2 != d87.Reg && result.Reg2 != d89.Reg {
+							r1 = result.Reg2
+							resultTarget90 = true
+						} else {
+							r1 = ctx.AllocRegExcept(d87.Reg, d89.Reg)
+						}
 						ctx.EmitMovRegReg(r1, d87.Reg)
 						ctx.EmitAddInt64(r1, d89.Reg)
-						d90 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r1}
-						ctx.BindReg(r1, &d90)
+						d91 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r1}
+						ctx.BindReg(r1, &d91)
 					}
-					if d90.Loc == LocReg && d87.Loc == LocReg && d90.Reg == d87.Reg {
+					if d91.Loc == LocReg && d87.Loc == LocReg && d91.Reg == d87.Reg {
 						ctx.TransferReg(d87.Reg)
 						d87.Loc = LocNone
 					}
+					if resultTarget90 && d91.Loc == LocReg {
+						ctx.BindReg(result.Reg2, &result)
+					}
 					ctx.FreeDesc(&d87)
 					ctx.FreeDesc(&d89)
-					ctx.EnsureDesc(&d90)
-					if d90.Loc == LocImm {
-						ctx.EmitMakeInt(result, d90)
-					} else {
-						ctx.EmitMovToReg(result.Reg2, d90)
-						d91 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+					ctx.EnsureDesc(&d91)
+					if d91.Loc == LocImm {
 						ctx.EmitMakeInt(result, d91)
-						if d90.Loc == LocReg && d90.Reg != result.Reg2 {
-							ctx.FreeReg(d90.Reg)
+					} else {
+						ctx.EmitMovToReg(result.Reg2, d91)
+						d92 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d92)
+						if d91.Loc == LocReg && d91.Reg != result.Reg2 {
+							ctx.FreeReg(d91.Reg)
 						}
 					}
 					result.Type = tagInt
@@ -5115,96 +5201,119 @@ func init_alu() {
 					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
 						d89 = ps.OverlayValues[89]
 					}
-					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
-						d90 = ps.OverlayValues[90]
-					}
 					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
 						d91 = ps.OverlayValues[91]
 					}
+					if len(ps.OverlayValues) > 92 && ps.OverlayValues[92].Loc != LocNone {
+						d92 = ps.OverlayValues[92]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d92 = args[0]
-					d92.ID = 0
-					var d93 JITValueDesc
-					if d92.Loc == LocImm {
-						d93 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d92.Imm.Float())}
-					} else if d92.Type == tagFloat && d92.Loc == LocReg {
-						d93 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d92.Reg}
-						ctx.BindReg(d92.Reg, &d93)
-						ctx.BindReg(d92.Reg, &d93)
-					} else if d92.Type == tagFloat && d92.Loc == LocRegPair {
-						ctx.FreeReg(d92.Reg)
-						d93 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d92.Reg2}
-						ctx.BindReg(d92.Reg2, &d93)
-						ctx.BindReg(d92.Reg2, &d93)
+					d93 = args[0]
+					d93.ID = 0
+					var d94 JITValueDesc
+					if d93.Loc == LocImm {
+						d94 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d93.Imm.Float())}
+					} else if d93.Type == tagFloat && d93.Loc == LocReg {
+						d94 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d93.Reg}
+						ctx.BindReg(d93.Reg, &d94)
+						ctx.BindReg(d93.Reg, &d94)
+					} else if d93.Type == tagFloat && d93.Loc == LocRegPair {
+						ctx.FreeReg(d93.Reg)
+						d94 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d93.Reg2}
+						ctx.BindReg(d93.Reg2, &d94)
+						ctx.BindReg(d93.Reg2, &d94)
 					} else {
-						d93 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d92}, 1)
-						d93.Type = tagFloat
-						ctx.BindReg(d93.Reg, &d93)
-					}
-					ctx.FreeDesc(&d92)
-					d94 = args[1]
-					d94.ID = 0
-					var d95 JITValueDesc
-					if d94.Loc == LocImm {
-						d95 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d94.Imm.Float())}
-					} else if d94.Type == tagFloat && d94.Loc == LocReg {
-						d95 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d94.Reg}
-						ctx.BindReg(d94.Reg, &d95)
-						ctx.BindReg(d94.Reg, &d95)
-					} else if d94.Type == tagFloat && d94.Loc == LocRegPair {
-						ctx.FreeReg(d94.Reg)
-						d95 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d94.Reg2}
-						ctx.BindReg(d94.Reg2, &d95)
-						ctx.BindReg(d94.Reg2, &d95)
-					} else {
-						d95 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d94}, 1)
-						d95.Type = tagFloat
-						ctx.BindReg(d95.Reg, &d95)
-					}
-					ctx.FreeDesc(&d94)
-					ctx.EnsureDesc(&d93)
-					ctx.EnsureDesc(&d95)
-					ctx.EnsureDescsTogether(&d93, &d95)
-					var d96 JITValueDesc
-					if d93.Loc == LocImm && d95.Loc == LocImm {
-						d96 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d93.Imm.Float() + d95.Imm.Float())}
-					} else if d93.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d95.Reg)
-						_, xBits := d93.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitAddFloat64(scratch, d95.Reg)
-						d96 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d96)
-					} else if d95.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d93.Reg)
-						ctx.EmitMovRegReg(scratch, d93.Reg)
-						_, yBits := d95.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitAddFloat64(scratch, RegR11)
-						d96 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d96)
-					} else {
-						r2 := ctx.AllocRegExcept(d93.Reg, d95.Reg)
-						ctx.EmitMovRegReg(r2, d93.Reg)
-						ctx.EmitAddFloat64(r2, d95.Reg)
-						d96 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r2}
-						ctx.BindReg(r2, &d96)
-					}
-					if d96.Loc == LocReg && d93.Loc == LocReg && d96.Reg == d93.Reg {
-						ctx.TransferReg(d93.Reg)
-						d93.Loc = LocNone
+						d94 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d93}, 1)
+						d94.Type = tagFloat
+						ctx.BindReg(d94.Reg, &d94)
 					}
 					ctx.FreeDesc(&d93)
-					ctx.FreeDesc(&d95)
-					ctx.EnsureDesc(&d96)
-					if d96.Loc == LocImm {
-						ctx.EmitMakeFloat(result, d96)
+					d95 = args[1]
+					d95.ID = 0
+					var d96 JITValueDesc
+					if d95.Loc == LocImm {
+						d96 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d95.Imm.Float())}
+					} else if d95.Type == tagFloat && d95.Loc == LocReg {
+						d96 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d95.Reg}
+						ctx.BindReg(d95.Reg, &d96)
+						ctx.BindReg(d95.Reg, &d96)
+					} else if d95.Type == tagFloat && d95.Loc == LocRegPair {
+						ctx.FreeReg(d95.Reg)
+						d96 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d95.Reg2}
+						ctx.BindReg(d95.Reg2, &d96)
+						ctx.BindReg(d95.Reg2, &d96)
 					} else {
-						ctx.EmitMovToReg(result.Reg2, d96)
-						d97 := JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeFloat(result, d97)
-						if d96.Loc == LocReg && d96.Reg != result.Reg2 {
-							ctx.FreeReg(d96.Reg)
+						d96 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d95}, 1)
+						d96.Type = tagFloat
+						ctx.BindReg(d96.Reg, &d96)
+					}
+					ctx.FreeDesc(&d95)
+					ctx.EnsureDesc(&d94)
+					resultTarget97 := false
+					_ = resultTarget97
+					ctx.EnsureDesc(&d96)
+					ctx.EnsureDescsTogether(&d94, &d96)
+					var d98 JITValueDesc
+					if d94.Loc == LocImm && d96.Loc == LocImm {
+						d98 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d94.Imm.Float() + d96.Imm.Float())}
+					} else if d94.Loc == LocImm {
+						var scratch Reg
+						if result.Loc == LocRegPair && result.Reg2 != d96.Reg {
+							scratch = result.Reg2
+							resultTarget97 = true
+						} else {
+							scratch = ctx.AllocRegExcept(d96.Reg)
+						}
+						_, xBits := d94.Imm.RawWords()
+						ctx.EmitMovRegImm64(scratch, xBits)
+						ctx.EmitAddFloat64(scratch, d96.Reg)
+						d98 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
+						ctx.BindReg(scratch, &d98)
+					} else if d96.Loc == LocImm {
+						var scratch Reg
+						if result.Loc == LocRegPair && result.Reg2 != d94.Reg {
+							scratch = result.Reg2
+							resultTarget97 = true
+						} else {
+							scratch = ctx.AllocRegExcept(d94.Reg)
+						}
+						ctx.EmitMovRegReg(scratch, d94.Reg)
+						_, yBits := d96.Imm.RawWords()
+						ctx.EmitMovRegImm64(RegR11, yBits)
+						ctx.EmitAddFloat64(scratch, RegR11)
+						d98 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
+						ctx.BindReg(scratch, &d98)
+					} else {
+						var r2 Reg
+						if result.Loc == LocRegPair && result.Reg2 != d94.Reg && result.Reg2 != d96.Reg {
+							r2 = result.Reg2
+							resultTarget97 = true
+						} else {
+							r2 = ctx.AllocRegExcept(d94.Reg, d96.Reg)
+						}
+						ctx.EmitMovRegReg(r2, d94.Reg)
+						ctx.EmitAddFloat64(r2, d96.Reg)
+						d98 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r2}
+						ctx.BindReg(r2, &d98)
+					}
+					if d98.Loc == LocReg && d94.Loc == LocReg && d98.Reg == d94.Reg {
+						ctx.TransferReg(d94.Reg)
+						d94.Loc = LocNone
+					}
+					if resultTarget97 && d98.Loc == LocReg {
+						ctx.BindReg(result.Reg2, &result)
+					}
+					ctx.FreeDesc(&d94)
+					ctx.FreeDesc(&d96)
+					ctx.EnsureDesc(&d98)
+					if d98.Loc == LocImm {
+						ctx.EmitMakeFloat(result, d98)
+					} else {
+						ctx.EmitMovToReg(result.Reg2, d98)
+						d99 := JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeFloat(result, d99)
+						if d98.Loc == LocReg && d98.Reg != result.Reg2 {
+							ctx.FreeReg(d98.Reg)
 						}
 					}
 					result.Type = tagFloat
@@ -5284,9 +5393,6 @@ func init_alu() {
 					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
 						d89 = ps.OverlayValues[89]
 					}
-					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
-						d90 = ps.OverlayValues[90]
-					}
 					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
 						d91 = ps.OverlayValues[91]
 					}
@@ -5305,335 +5411,338 @@ func init_alu() {
 					if len(ps.OverlayValues) > 96 && ps.OverlayValues[96].Loc != LocNone {
 						d96 = ps.OverlayValues[96]
 					}
-					if len(ps.OverlayValues) > 97 && ps.OverlayValues[97].Loc != LocNone {
-						d97 = ps.OverlayValues[97]
+					if len(ps.OverlayValues) > 98 && ps.OverlayValues[98].Loc != LocNone {
+						d98 = ps.OverlayValues[98]
+					}
+					if len(ps.OverlayValues) > 99 && ps.OverlayValues[99].Loc != LocNone {
+						d99 = ps.OverlayValues[99]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d98 = args[1]
-					d98.ID = 0
-					d100 = d98
+					d100 = args[1]
 					d100.ID = 0
-					d99 = ctx.EmitTagEqualsBorrowed(&d100, tagInt, JITValueDesc{Loc: LocAny})
-					ctx.FreeDesc(&d98)
-					d101 = d99
-					ctx.EnsureDesc(&d101)
-					if d101.Loc != LocImm && d101.Loc != LocReg {
+					d102 = d100
+					d102.ID = 0
+					d101 = ctx.EmitTagEqualsBorrowed(&d102, tagInt, JITValueDesc{Loc: LocAny})
+					ctx.FreeDesc(&d100)
+					d103 = d101
+					ctx.EnsureDesc(&d103)
+					if d103.Loc != LocImm && d103.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d101.Loc == LocImm {
-						if d101.Imm.Bool() {
+					if d103.Loc == LocImm {
+						if d103.Imm.Bool() {
 							if ps.General {
 							}
-							ps102 := PhiState{General: ps.General}
-							ps102.OverlayValues = make([]JITValueDesc, 102)
-							ps102.OverlayValues[0] = d0
-							ps102.OverlayValues[1] = d1
-							ps102.OverlayValues[2] = d2
-							ps102.OverlayValues[3] = d3
-							ps102.OverlayValues[18] = d18
-							ps102.OverlayValues[19] = d19
-							ps102.OverlayValues[20] = d20
-							ps102.OverlayValues[21] = d21
-							ps102.OverlayValues[22] = d22
-							ps102.OverlayValues[47] = d47
-							ps102.OverlayValues[48] = d48
-							ps102.OverlayValues[49] = d49
-							ps102.OverlayValues[50] = d50
-							ps102.OverlayValues[51] = d51
-							ps102.OverlayValues[86] = d86
-							ps102.OverlayValues[87] = d87
-							ps102.OverlayValues[88] = d88
-							ps102.OverlayValues[89] = d89
-							ps102.OverlayValues[90] = d90
-							ps102.OverlayValues[91] = d91
-							ps102.OverlayValues[92] = d92
-							ps102.OverlayValues[93] = d93
-							ps102.OverlayValues[94] = d94
-							ps102.OverlayValues[95] = d95
-							ps102.OverlayValues[96] = d96
-							ps102.OverlayValues[97] = d97
-							ps102.OverlayValues[98] = d98
-							ps102.OverlayValues[99] = d99
-							ps102.OverlayValues[100] = d100
-							ps102.OverlayValues[101] = d101
-							return bbs[5].RenderPS(ps102)
+							ps104 := PhiState{General: ps.General}
+							ps104.OverlayValues = make([]JITValueDesc, 104)
+							ps104.OverlayValues[0] = d0
+							ps104.OverlayValues[1] = d1
+							ps104.OverlayValues[2] = d2
+							ps104.OverlayValues[3] = d3
+							ps104.OverlayValues[18] = d18
+							ps104.OverlayValues[19] = d19
+							ps104.OverlayValues[20] = d20
+							ps104.OverlayValues[21] = d21
+							ps104.OverlayValues[22] = d22
+							ps104.OverlayValues[47] = d47
+							ps104.OverlayValues[48] = d48
+							ps104.OverlayValues[49] = d49
+							ps104.OverlayValues[50] = d50
+							ps104.OverlayValues[51] = d51
+							ps104.OverlayValues[86] = d86
+							ps104.OverlayValues[87] = d87
+							ps104.OverlayValues[88] = d88
+							ps104.OverlayValues[89] = d89
+							ps104.OverlayValues[91] = d91
+							ps104.OverlayValues[92] = d92
+							ps104.OverlayValues[93] = d93
+							ps104.OverlayValues[94] = d94
+							ps104.OverlayValues[95] = d95
+							ps104.OverlayValues[96] = d96
+							ps104.OverlayValues[98] = d98
+							ps104.OverlayValues[99] = d99
+							ps104.OverlayValues[100] = d100
+							ps104.OverlayValues[101] = d101
+							ps104.OverlayValues[102] = d102
+							ps104.OverlayValues[103] = d103
+							return bbs[5].RenderPS(ps104)
 						}
 						if ps.General {
 						}
-						ps103 := PhiState{General: ps.General}
-						ps103.OverlayValues = make([]JITValueDesc, 102)
-						ps103.OverlayValues[0] = d0
-						ps103.OverlayValues[1] = d1
-						ps103.OverlayValues[2] = d2
-						ps103.OverlayValues[3] = d3
-						ps103.OverlayValues[18] = d18
-						ps103.OverlayValues[19] = d19
-						ps103.OverlayValues[20] = d20
-						ps103.OverlayValues[21] = d21
-						ps103.OverlayValues[22] = d22
-						ps103.OverlayValues[47] = d47
-						ps103.OverlayValues[48] = d48
-						ps103.OverlayValues[49] = d49
-						ps103.OverlayValues[50] = d50
-						ps103.OverlayValues[51] = d51
-						ps103.OverlayValues[86] = d86
-						ps103.OverlayValues[87] = d87
-						ps103.OverlayValues[88] = d88
-						ps103.OverlayValues[89] = d89
-						ps103.OverlayValues[90] = d90
-						ps103.OverlayValues[91] = d91
-						ps103.OverlayValues[92] = d92
-						ps103.OverlayValues[93] = d93
-						ps103.OverlayValues[94] = d94
-						ps103.OverlayValues[95] = d95
-						ps103.OverlayValues[96] = d96
-						ps103.OverlayValues[97] = d97
-						ps103.OverlayValues[98] = d98
-						ps103.OverlayValues[99] = d99
-						ps103.OverlayValues[100] = d100
-						ps103.OverlayValues[101] = d101
-						return bbs[6].RenderPS(ps103)
+						ps105 := PhiState{General: ps.General}
+						ps105.OverlayValues = make([]JITValueDesc, 104)
+						ps105.OverlayValues[0] = d0
+						ps105.OverlayValues[1] = d1
+						ps105.OverlayValues[2] = d2
+						ps105.OverlayValues[3] = d3
+						ps105.OverlayValues[18] = d18
+						ps105.OverlayValues[19] = d19
+						ps105.OverlayValues[20] = d20
+						ps105.OverlayValues[21] = d21
+						ps105.OverlayValues[22] = d22
+						ps105.OverlayValues[47] = d47
+						ps105.OverlayValues[48] = d48
+						ps105.OverlayValues[49] = d49
+						ps105.OverlayValues[50] = d50
+						ps105.OverlayValues[51] = d51
+						ps105.OverlayValues[86] = d86
+						ps105.OverlayValues[87] = d87
+						ps105.OverlayValues[88] = d88
+						ps105.OverlayValues[89] = d89
+						ps105.OverlayValues[91] = d91
+						ps105.OverlayValues[92] = d92
+						ps105.OverlayValues[93] = d93
+						ps105.OverlayValues[94] = d94
+						ps105.OverlayValues[95] = d95
+						ps105.OverlayValues[96] = d96
+						ps105.OverlayValues[98] = d98
+						ps105.OverlayValues[99] = d99
+						ps105.OverlayValues[100] = d100
+						ps105.OverlayValues[101] = d101
+						ps105.OverlayValues[102] = d102
+						ps105.OverlayValues[103] = d103
+						return bbs[6].RenderPS(ps105)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[7].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d101.Reg, 0)
+					ctx.EmitCmpRegImm32(d103.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl6)
 					if bbs[6].Rendered {
 						ctx.EmitJmp(lbl7)
 					}
-					snap104 := d0
-					snap105 := d1
-					snap106 := d2
-					snap107 := d3
-					snap108 := d18
-					snap109 := d19
-					snap110 := d20
-					snap111 := d21
-					snap112 := d22
-					snap113 := d47
-					snap114 := d48
-					snap115 := d49
-					snap116 := d50
-					snap117 := d51
-					snap118 := d86
-					snap119 := d87
-					snap120 := d88
-					snap121 := d89
-					snap122 := d90
-					snap123 := d91
-					snap124 := d92
-					snap125 := d93
-					snap126 := d94
-					snap127 := d95
-					snap128 := d96
-					snap129 := d97
+					snap106 := d0
+					snap107 := d1
+					snap108 := d2
+					snap109 := d3
+					snap110 := d18
+					snap111 := d19
+					snap112 := d20
+					snap113 := d21
+					snap114 := d22
+					snap115 := d47
+					snap116 := d48
+					snap117 := d49
+					snap118 := d50
+					snap119 := d51
+					snap120 := d86
+					snap121 := d87
+					snap122 := d88
+					snap123 := d89
+					snap124 := d91
+					snap125 := d92
+					snap126 := d93
+					snap127 := d94
+					snap128 := d95
+					snap129 := d96
 					snap130 := d98
 					snap131 := d99
 					snap132 := d100
 					snap133 := d101
-					alloc134 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc134)
-					d0 = snap104
-					d1 = snap105
-					d2 = snap106
-					d3 = snap107
-					d18 = snap108
-					d19 = snap109
-					d20 = snap110
-					d21 = snap111
-					d22 = snap112
-					d47 = snap113
-					d48 = snap114
-					d49 = snap115
-					d50 = snap116
-					d51 = snap117
-					d86 = snap118
-					d87 = snap119
-					d88 = snap120
-					d89 = snap121
-					d90 = snap122
-					d91 = snap123
-					d92 = snap124
-					d93 = snap125
-					d94 = snap126
-					d95 = snap127
-					d96 = snap128
-					d97 = snap129
+					snap134 := d102
+					snap135 := d103
+					alloc136 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc136)
+					d0 = snap106
+					d1 = snap107
+					d2 = snap108
+					d3 = snap109
+					d18 = snap110
+					d19 = snap111
+					d20 = snap112
+					d21 = snap113
+					d22 = snap114
+					d47 = snap115
+					d48 = snap116
+					d49 = snap117
+					d50 = snap118
+					d51 = snap119
+					d86 = snap120
+					d87 = snap121
+					d88 = snap122
+					d89 = snap123
+					d91 = snap124
+					d92 = snap125
+					d93 = snap126
+					d94 = snap127
+					d95 = snap128
+					d96 = snap129
 					d98 = snap130
 					d99 = snap131
 					d100 = snap132
 					d101 = snap133
-					ctx.RestoreAllocState(alloc134)
-					d0 = snap104
-					d1 = snap105
-					d2 = snap106
-					d3 = snap107
-					d18 = snap108
-					d19 = snap109
-					d20 = snap110
-					d21 = snap111
-					d22 = snap112
-					d47 = snap113
-					d48 = snap114
-					d49 = snap115
-					d50 = snap116
-					d51 = snap117
-					d86 = snap118
-					d87 = snap119
-					d88 = snap120
-					d89 = snap121
-					d90 = snap122
-					d91 = snap123
-					d92 = snap124
-					d93 = snap125
-					d94 = snap126
-					d95 = snap127
-					d96 = snap128
-					d97 = snap129
+					d102 = snap134
+					d103 = snap135
+					ctx.RestoreAllocState(alloc136)
+					d0 = snap106
+					d1 = snap107
+					d2 = snap108
+					d3 = snap109
+					d18 = snap110
+					d19 = snap111
+					d20 = snap112
+					d21 = snap113
+					d22 = snap114
+					d47 = snap115
+					d48 = snap116
+					d49 = snap117
+					d50 = snap118
+					d51 = snap119
+					d86 = snap120
+					d87 = snap121
+					d88 = snap122
+					d89 = snap123
+					d91 = snap124
+					d92 = snap125
+					d93 = snap126
+					d94 = snap127
+					d95 = snap128
+					d96 = snap129
 					d98 = snap130
 					d99 = snap131
 					d100 = snap132
 					d101 = snap133
-					ps135 := PhiState{General: true}
-					ps135.OverlayValues = make([]JITValueDesc, 102)
-					ps135.OverlayValues[0] = d0
-					ps135.OverlayValues[1] = d1
-					ps135.OverlayValues[2] = d2
-					ps135.OverlayValues[3] = d3
-					ps135.OverlayValues[18] = d18
-					ps135.OverlayValues[19] = d19
-					ps135.OverlayValues[20] = d20
-					ps135.OverlayValues[21] = d21
-					ps135.OverlayValues[22] = d22
-					ps135.OverlayValues[47] = d47
-					ps135.OverlayValues[48] = d48
-					ps135.OverlayValues[49] = d49
-					ps135.OverlayValues[50] = d50
-					ps135.OverlayValues[51] = d51
-					ps135.OverlayValues[86] = d86
-					ps135.OverlayValues[87] = d87
-					ps135.OverlayValues[88] = d88
-					ps135.OverlayValues[89] = d89
-					ps135.OverlayValues[90] = d90
-					ps135.OverlayValues[91] = d91
-					ps135.OverlayValues[92] = d92
-					ps135.OverlayValues[93] = d93
-					ps135.OverlayValues[94] = d94
-					ps135.OverlayValues[95] = d95
-					ps135.OverlayValues[96] = d96
-					ps135.OverlayValues[97] = d97
-					ps135.OverlayValues[98] = d98
-					ps135.OverlayValues[99] = d99
-					ps135.OverlayValues[100] = d100
-					ps135.OverlayValues[101] = d101
-					ps136 := PhiState{General: true}
-					ps136.OverlayValues = make([]JITValueDesc, 102)
-					ps136.OverlayValues[0] = d0
-					ps136.OverlayValues[1] = d1
-					ps136.OverlayValues[2] = d2
-					ps136.OverlayValues[3] = d3
-					ps136.OverlayValues[18] = d18
-					ps136.OverlayValues[19] = d19
-					ps136.OverlayValues[20] = d20
-					ps136.OverlayValues[21] = d21
-					ps136.OverlayValues[22] = d22
-					ps136.OverlayValues[47] = d47
-					ps136.OverlayValues[48] = d48
-					ps136.OverlayValues[49] = d49
-					ps136.OverlayValues[50] = d50
-					ps136.OverlayValues[51] = d51
-					ps136.OverlayValues[86] = d86
-					ps136.OverlayValues[87] = d87
-					ps136.OverlayValues[88] = d88
-					ps136.OverlayValues[89] = d89
-					ps136.OverlayValues[90] = d90
-					ps136.OverlayValues[91] = d91
-					ps136.OverlayValues[92] = d92
-					ps136.OverlayValues[93] = d93
-					ps136.OverlayValues[94] = d94
-					ps136.OverlayValues[95] = d95
-					ps136.OverlayValues[96] = d96
-					ps136.OverlayValues[97] = d97
-					ps136.OverlayValues[98] = d98
-					ps136.OverlayValues[99] = d99
-					ps136.OverlayValues[100] = d100
-					ps136.OverlayValues[101] = d101
-					snap137 := d0
-					snap138 := d1
-					snap139 := d2
-					snap140 := d3
-					snap141 := d18
-					snap142 := d19
-					snap143 := d20
-					snap144 := d21
-					snap145 := d22
-					snap146 := d47
-					snap147 := d48
-					snap148 := d49
-					snap149 := d50
-					snap150 := d51
-					snap151 := d86
-					snap152 := d87
-					snap153 := d88
-					snap154 := d89
-					snap155 := d90
-					snap156 := d91
-					snap157 := d92
-					snap158 := d93
-					snap159 := d94
-					snap160 := d95
-					snap161 := d96
-					snap162 := d97
+					d102 = snap134
+					d103 = snap135
+					ps137 := PhiState{General: true}
+					ps137.OverlayValues = make([]JITValueDesc, 104)
+					ps137.OverlayValues[0] = d0
+					ps137.OverlayValues[1] = d1
+					ps137.OverlayValues[2] = d2
+					ps137.OverlayValues[3] = d3
+					ps137.OverlayValues[18] = d18
+					ps137.OverlayValues[19] = d19
+					ps137.OverlayValues[20] = d20
+					ps137.OverlayValues[21] = d21
+					ps137.OverlayValues[22] = d22
+					ps137.OverlayValues[47] = d47
+					ps137.OverlayValues[48] = d48
+					ps137.OverlayValues[49] = d49
+					ps137.OverlayValues[50] = d50
+					ps137.OverlayValues[51] = d51
+					ps137.OverlayValues[86] = d86
+					ps137.OverlayValues[87] = d87
+					ps137.OverlayValues[88] = d88
+					ps137.OverlayValues[89] = d89
+					ps137.OverlayValues[91] = d91
+					ps137.OverlayValues[92] = d92
+					ps137.OverlayValues[93] = d93
+					ps137.OverlayValues[94] = d94
+					ps137.OverlayValues[95] = d95
+					ps137.OverlayValues[96] = d96
+					ps137.OverlayValues[98] = d98
+					ps137.OverlayValues[99] = d99
+					ps137.OverlayValues[100] = d100
+					ps137.OverlayValues[101] = d101
+					ps137.OverlayValues[102] = d102
+					ps137.OverlayValues[103] = d103
+					ps138 := PhiState{General: true}
+					ps138.OverlayValues = make([]JITValueDesc, 104)
+					ps138.OverlayValues[0] = d0
+					ps138.OverlayValues[1] = d1
+					ps138.OverlayValues[2] = d2
+					ps138.OverlayValues[3] = d3
+					ps138.OverlayValues[18] = d18
+					ps138.OverlayValues[19] = d19
+					ps138.OverlayValues[20] = d20
+					ps138.OverlayValues[21] = d21
+					ps138.OverlayValues[22] = d22
+					ps138.OverlayValues[47] = d47
+					ps138.OverlayValues[48] = d48
+					ps138.OverlayValues[49] = d49
+					ps138.OverlayValues[50] = d50
+					ps138.OverlayValues[51] = d51
+					ps138.OverlayValues[86] = d86
+					ps138.OverlayValues[87] = d87
+					ps138.OverlayValues[88] = d88
+					ps138.OverlayValues[89] = d89
+					ps138.OverlayValues[91] = d91
+					ps138.OverlayValues[92] = d92
+					ps138.OverlayValues[93] = d93
+					ps138.OverlayValues[94] = d94
+					ps138.OverlayValues[95] = d95
+					ps138.OverlayValues[96] = d96
+					ps138.OverlayValues[98] = d98
+					ps138.OverlayValues[99] = d99
+					ps138.OverlayValues[100] = d100
+					ps138.OverlayValues[101] = d101
+					ps138.OverlayValues[102] = d102
+					ps138.OverlayValues[103] = d103
+					snap139 := d0
+					snap140 := d1
+					snap141 := d2
+					snap142 := d3
+					snap143 := d18
+					snap144 := d19
+					snap145 := d20
+					snap146 := d21
+					snap147 := d22
+					snap148 := d47
+					snap149 := d48
+					snap150 := d49
+					snap151 := d50
+					snap152 := d51
+					snap153 := d86
+					snap154 := d87
+					snap155 := d88
+					snap156 := d89
+					snap157 := d91
+					snap158 := d92
+					snap159 := d93
+					snap160 := d94
+					snap161 := d95
+					snap162 := d96
 					snap163 := d98
 					snap164 := d99
 					snap165 := d100
 					snap166 := d101
-					alloc167 := ctx.SnapshotAllocState()
+					snap167 := d102
+					snap168 := d103
+					alloc169 := ctx.SnapshotAllocState()
 					if !bbs[6].Rendered {
-						bbs[6].RenderPS(ps136)
+						bbs[6].RenderPS(ps138)
 					}
-					ctx.RestoreAllocState(alloc167)
-					d0 = snap137
-					d1 = snap138
-					d2 = snap139
-					d3 = snap140
-					d18 = snap141
-					d19 = snap142
-					d20 = snap143
-					d21 = snap144
-					d22 = snap145
-					d47 = snap146
-					d48 = snap147
-					d49 = snap148
-					d50 = snap149
-					d51 = snap150
-					d86 = snap151
-					d87 = snap152
-					d88 = snap153
-					d89 = snap154
-					d90 = snap155
-					d91 = snap156
-					d92 = snap157
-					d93 = snap158
-					d94 = snap159
-					d95 = snap160
-					d96 = snap161
-					d97 = snap162
+					ctx.RestoreAllocState(alloc169)
+					d0 = snap139
+					d1 = snap140
+					d2 = snap141
+					d3 = snap142
+					d18 = snap143
+					d19 = snap144
+					d20 = snap145
+					d21 = snap146
+					d22 = snap147
+					d47 = snap148
+					d48 = snap149
+					d49 = snap150
+					d50 = snap151
+					d51 = snap152
+					d86 = snap153
+					d87 = snap154
+					d88 = snap155
+					d89 = snap156
+					d91 = snap157
+					d92 = snap158
+					d93 = snap159
+					d94 = snap160
+					d95 = snap161
+					d96 = snap162
 					d98 = snap163
 					d99 = snap164
 					d100 = snap165
 					d101 = snap166
+					d102 = snap167
+					d103 = snap168
 					if !bbs[5].Rendered {
-						return bbs[5].RenderPS(ps135)
+						return bbs[5].RenderPS(ps137)
 					}
 					return result
-					ctx.FreeDesc(&d99)
+					ctx.FreeDesc(&d101)
 					return result
 				}
-				ps168 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps168)
+				ps170 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps170)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -6465,7 +6574,7 @@ func init_alu() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d12)
-							if d12.Loc == LocReg {
+							if d12.Loc == LocReg || d12.Loc == LocFPReg {
 								ctx.ProtectReg(d12.Reg)
 							} else if d12.Loc == LocRegPair {
 								ctx.ProtectReg(d12.Reg)
@@ -6477,7 +6586,7 @@ func init_alu() {
 							}
 							ctx.EnsureDesc(&d56)
 							ctx.EmitStoreToStack(d56, int32(bbs[1].PhiBase)+int32(0))
-							if d12.Loc == LocReg {
+							if d12.Loc == LocReg || d12.Loc == LocFPReg {
 								ctx.UnprotectReg(d12.Reg)
 							} else if d12.Loc == LocRegPair {
 								ctx.UnprotectReg(d12.Reg)
@@ -6562,7 +6671,7 @@ func init_alu() {
 					d58 = snap78
 					ctx.MarkLabel(lbl22)
 					ctx.SyncDesc(&d12)
-					if d12.Loc == LocReg {
+					if d12.Loc == LocReg || d12.Loc == LocFPReg {
 						ctx.ProtectReg(d12.Reg)
 					} else if d12.Loc == LocRegPair {
 						ctx.ProtectReg(d12.Reg)
@@ -6574,7 +6683,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d80)
 					ctx.EmitStoreToStack(d80, int32(bbs[1].PhiBase)+int32(0))
-					if d12.Loc == LocReg {
+					if d12.Loc == LocReg || d12.Loc == LocFPReg {
 						ctx.UnprotectReg(d12.Reg)
 					} else if d12.Loc == LocRegPair {
 						ctx.UnprotectReg(d12.Reg)
@@ -7350,7 +7459,7 @@ func init_alu() {
 					ctx.FreeDesc(&d170)
 					if ps.General {
 						ctx.SyncDesc(&d171)
-						if d171.Loc == LocReg {
+						if d171.Loc == LocReg || d171.Loc == LocFPReg {
 							ctx.ProtectReg(d171.Reg)
 						} else if d171.Loc == LocRegPair {
 							ctx.ProtectReg(d171.Reg)
@@ -7363,7 +7472,7 @@ func init_alu() {
 						ctx.EnsureDesc(&d172)
 						ctx.EmitStoreToStack(d172, int32(bbs[9].PhiBase)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(1)}, int32(bbs[9].PhiBase)+int32(16))
-						if d171.Loc == LocReg {
+						if d171.Loc == LocReg || d171.Loc == LocFPReg {
 							ctx.UnprotectReg(d171.Reg)
 						} else if d171.Loc == LocRegPair {
 							ctx.UnprotectReg(d171.Reg)
@@ -7560,7 +7669,7 @@ func init_alu() {
 					ctx.FreeDesc(&d176)
 					if ps.General {
 						ctx.SyncDesc(&d177)
-						if d177.Loc == LocReg {
+						if d177.Loc == LocReg || d177.Loc == LocFPReg {
 							ctx.ProtectReg(d177.Reg)
 						} else if d177.Loc == LocRegPair {
 							ctx.ProtectReg(d177.Reg)
@@ -7573,7 +7682,7 @@ func init_alu() {
 						ctx.EnsureDesc(&d178)
 						ctx.EmitStoreToStack(d178, int32(bbs[16].PhiBase)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(1)}, int32(bbs[16].PhiBase)+int32(16))
-						if d177.Loc == LocReg {
+						if d177.Loc == LocReg || d177.Loc == LocFPReg {
 							ctx.UnprotectReg(d177.Reg)
 						} else if d177.Loc == LocRegPair {
 							ctx.UnprotectReg(d177.Reg)
@@ -10444,7 +10553,8 @@ func init_alu() {
 					if d2.Loc == LocImm {
 						d522 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d2.Imm.Int()))}
 					} else {
-						r11 := ctx.AllocRegExcept(d2.Reg)
+						var r11 Reg
+						r11 = ctx.AllocRegExcept(d2.Reg)
 						ctx.EmitMovRegReg(r11, d2.Reg)
 						ctx.EmitCvtInt64ToFloat64(RegX0, r11)
 						d522 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r11}
@@ -10453,14 +10563,14 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d522)
 					if ps.General {
 						ctx.SyncDesc(&d3)
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.ProtectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.ProtectReg(d3.Reg)
 							ctx.ProtectReg(d3.Reg2)
 						}
 						ctx.SyncDesc(&d522)
-						if d522.Loc == LocReg {
+						if d522.Loc == LocReg || d522.Loc == LocFPReg {
 							ctx.ProtectReg(d522.Reg)
 						} else if d522.Loc == LocRegPair {
 							ctx.ProtectReg(d522.Reg)
@@ -10478,13 +10588,13 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d524)
 						ctx.EmitStoreToStack(d524, int32(bbs[15].PhiBase)+int32(16))
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.UnprotectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.UnprotectReg(d3.Reg)
 							ctx.UnprotectReg(d3.Reg2)
 						}
-						if d522.Loc == LocReg {
+						if d522.Loc == LocReg || d522.Loc == LocFPReg {
 							ctx.UnprotectReg(d522.Reg)
 						} else if d522.Loc == LocRegPair {
 							ctx.UnprotectReg(d522.Reg)
@@ -14960,7 +15070,7 @@ func init_alu() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d11)
-							if d11.Loc == LocReg {
+							if d11.Loc == LocReg || d11.Loc == LocFPReg {
 								ctx.ProtectReg(d11.Reg)
 							} else if d11.Loc == LocRegPair {
 								ctx.ProtectReg(d11.Reg)
@@ -14972,7 +15082,7 @@ func init_alu() {
 							}
 							ctx.EnsureDesc(&d53)
 							ctx.EmitStoreToStack(d53, int32(bbs[1].PhiBase)+int32(0))
-							if d11.Loc == LocReg {
+							if d11.Loc == LocReg || d11.Loc == LocFPReg {
 								ctx.UnprotectReg(d11.Reg)
 							} else if d11.Loc == LocRegPair {
 								ctx.UnprotectReg(d11.Reg)
@@ -15054,7 +15164,7 @@ func init_alu() {
 					d55 = snap74
 					ctx.MarkLabel(lbl21)
 					ctx.SyncDesc(&d11)
-					if d11.Loc == LocReg {
+					if d11.Loc == LocReg || d11.Loc == LocFPReg {
 						ctx.ProtectReg(d11.Reg)
 					} else if d11.Loc == LocRegPair {
 						ctx.ProtectReg(d11.Reg)
@@ -15066,7 +15176,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d76)
 					ctx.EmitStoreToStack(d76, int32(bbs[1].PhiBase)+int32(0))
-					if d11.Loc == LocReg {
+					if d11.Loc == LocReg || d11.Loc == LocFPReg {
 						ctx.UnprotectReg(d11.Reg)
 					} else if d11.Loc == LocRegPair {
 						ctx.UnprotectReg(d11.Reg)
@@ -17087,7 +17197,7 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d335)
 					if ps.General {
 						ctx.SyncDesc(&d4)
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.ProtectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.ProtectReg(d4.Reg)
@@ -17099,7 +17209,7 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d336)
 						ctx.EmitStoreToStack(d336, int32(bbs[7].PhiBase)+int32(0))
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.UnprotectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.UnprotectReg(d4.Reg)
@@ -19481,7 +19591,8 @@ func init_alu() {
 					if d2.Loc == LocImm {
 						d561 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d2.Imm.Int()))}
 					} else {
-						r15 := ctx.AllocRegExcept(d2.Reg)
+						var r15 Reg
+						r15 = ctx.AllocRegExcept(d2.Reg)
 						ctx.EmitMovRegReg(r15, d2.Reg)
 						ctx.EmitCvtInt64ToFloat64(RegX0, r15)
 						d561 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r15}
@@ -19490,14 +19601,14 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d561)
 					if ps.General {
 						ctx.SyncDesc(&d3)
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.ProtectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.ProtectReg(d3.Reg)
 							ctx.ProtectReg(d3.Reg2)
 						}
 						ctx.SyncDesc(&d561)
-						if d561.Loc == LocReg {
+						if d561.Loc == LocReg || d561.Loc == LocFPReg {
 							ctx.ProtectReg(d561.Reg)
 						} else if d561.Loc == LocRegPair {
 							ctx.ProtectReg(d561.Reg)
@@ -19515,13 +19626,13 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d563)
 						ctx.EmitStoreToStack(d563, int32(bbs[17].PhiBase)+int32(16))
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.UnprotectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.UnprotectReg(d3.Reg)
 							ctx.UnprotectReg(d3.Reg2)
 						}
-						if d561.Loc == LocReg {
+						if d561.Loc == LocReg || d561.Loc == LocFPReg {
 							ctx.UnprotectReg(d561.Reg)
 						} else if d561.Loc == LocRegPair {
 							ctx.UnprotectReg(d561.Reg)
@@ -21754,7 +21865,7 @@ func init_alu() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d8)
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.ProtectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.ProtectReg(d8.Reg)
@@ -21766,7 +21877,7 @@ func init_alu() {
 							}
 							ctx.EnsureDesc(&d44)
 							ctx.EmitStoreToStack(d44, int32(bbs[1].PhiBase)+int32(0))
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.UnprotectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.UnprotectReg(d8.Reg)
@@ -21839,7 +21950,7 @@ func init_alu() {
 					d46 = snap62
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d8)
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.ProtectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.ProtectReg(d8.Reg)
@@ -21851,7 +21962,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d64)
 					ctx.EmitStoreToStack(d64, int32(bbs[1].PhiBase)+int32(0))
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.UnprotectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.UnprotectReg(d8.Reg)
@@ -22066,7 +22177,7 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d89)
 					if ps.General {
 						ctx.SyncDesc(&d88)
-						if d88.Loc == LocReg {
+						if d88.Loc == LocReg || d88.Loc == LocFPReg {
 							ctx.ProtectReg(d88.Reg)
 						} else if d88.Loc == LocRegPair {
 							ctx.ProtectReg(d88.Reg)
@@ -22079,7 +22190,7 @@ func init_alu() {
 						ctx.EnsureDesc(&d90)
 						ctx.EmitStoreToStack(d90, int32(bbs[5].PhiBase)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[5].PhiBase)+int32(16))
-						if d88.Loc == LocReg {
+						if d88.Loc == LocReg || d88.Loc == LocFPReg {
 							ctx.UnprotectReg(d88.Reg)
 						} else if d88.Loc == LocRegPair {
 							ctx.UnprotectReg(d88.Reg)
@@ -22958,7 +23069,7 @@ func init_alu() {
 					ctx.FreeDesc(&d174)
 					if ps.General {
 						ctx.SyncDesc(&d97)
-						if d97.Loc == LocReg {
+						if d97.Loc == LocReg || d97.Loc == LocFPReg {
 							ctx.ProtectReg(d97.Reg)
 						} else if d97.Loc == LocRegPair {
 							ctx.ProtectReg(d97.Reg)
@@ -22970,7 +23081,7 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d176)
 						ctx.EmitStoreToStack(d176, int32(bbs[5].PhiBase)+int32(16))
-						if d97.Loc == LocReg {
+						if d97.Loc == LocReg || d97.Loc == LocFPReg {
 							ctx.UnprotectReg(d97.Reg)
 						} else if d97.Loc == LocRegPair {
 							ctx.UnprotectReg(d97.Reg)
@@ -23281,8 +23392,6 @@ func init_alu() {
 				_ = d240
 				var d241 JITValueDesc
 				_ = d241
-				var d242 JITValueDesc
-				_ = d242
 				var d243 JITValueDesc
 				_ = d243
 				var d244 JITValueDesc
@@ -23293,12 +23402,12 @@ func init_alu() {
 				_ = d246
 				var d247 JITValueDesc
 				_ = d247
-				var d322 JITValueDesc
-				_ = d322
+				var d248 JITValueDesc
+				_ = d248
 				var d323 JITValueDesc
 				_ = d323
-				var d402 JITValueDesc
-				_ = d402
+				var d324 JITValueDesc
+				_ = d324
 				var d403 JITValueDesc
 				_ = d403
 				var d404 JITValueDesc
@@ -23309,10 +23418,10 @@ func init_alu() {
 				_ = d406
 				var d407 JITValueDesc
 				_ = d407
-				var d409 JITValueDesc
-				_ = d409
-				var d502 JITValueDesc
-				_ = d502
+				var d408 JITValueDesc
+				_ = d408
+				var d410 JITValueDesc
+				_ = d410
 				var d503 JITValueDesc
 				_ = d503
 				var d504 JITValueDesc
@@ -23321,10 +23430,12 @@ func init_alu() {
 				_ = d505
 				var d506 JITValueDesc
 				_ = d506
-				var d609 JITValueDesc
-				_ = d609
+				var d507 JITValueDesc
+				_ = d507
 				var d610 JITValueDesc
 				_ = d610
+				var d611 JITValueDesc
+				_ = d611
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				var bbs [17]BBDescriptor
 				for i := range args {
@@ -25193,28 +25304,30 @@ func init_alu() {
 					}
 					ctx.FreeDesc(&d240)
 					ctx.EnsureDesc(&d241)
+					resultTarget242 := false
+					_ = resultTarget242
 					ctx.EnsureDesc(&d84)
 					ctx.EnsureDescsTogether(&d241, &d84)
-					var d242 JITValueDesc
+					var d243 JITValueDesc
 					if d241.Loc == LocImm && d84.Loc == LocImm {
-						d242 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d241.Imm.Int() / d84.Imm.Int())}
+						d243 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d241.Imm.Int() / d84.Imm.Int())}
 					} else {
-						d242 = ctx.EmitGoCallScalar(GoFuncAddr(JITIntDiv), []JITValueDesc{d241, d84}, 1)
+						d243 = ctx.EmitGoCallScalar(GoFuncAddr(JITIntDiv), []JITValueDesc{d241, d84}, 1)
 					}
-					if d242.Loc == LocReg && d241.Loc == LocReg && d242.Reg == d241.Reg {
+					if d243.Loc == LocReg && d241.Loc == LocReg && d243.Reg == d241.Reg {
 						ctx.TransferReg(d241.Reg)
 						d241.Loc = LocNone
 					}
 					ctx.FreeDesc(&d241)
-					ctx.EnsureDesc(&d242)
-					if d242.Loc == LocImm {
-						ctx.EmitMakeInt(result, d242)
-					} else {
-						ctx.EmitMovToReg(result.Reg2, d242)
-						d243 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+					ctx.EnsureDesc(&d243)
+					if d243.Loc == LocImm {
 						ctx.EmitMakeInt(result, d243)
-						if d242.Loc == LocReg && d242.Reg != result.Reg2 {
-							ctx.FreeReg(d242.Reg)
+					} else {
+						ctx.EmitMovToReg(result.Reg2, d243)
+						d244 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d244)
+						if d243.Loc == LocReg && d243.Reg != result.Reg2 {
+							ctx.FreeReg(d243.Reg)
 						}
 					}
 					result.Type = tagInt
@@ -25324,284 +25437,248 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
-					ctx.ReclaimUntrackedRegs()
-					d244 = args[0]
-					d244.ID = 0
-					var d245 JITValueDesc
-					if d244.Loc == LocImm {
-						d245 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d244.Imm.Int())}
-					} else if d244.Type == tagInt && d244.Loc == LocRegPair {
-						ctx.FreeReg(d244.Reg)
-						d245 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d244.Reg2}
-						ctx.BindReg(d244.Reg2, &d245)
-						ctx.BindReg(d244.Reg2, &d245)
-					} else if d244.Type == tagInt && d244.Loc == LocReg {
-						d245 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d244.Reg}
-						ctx.BindReg(d244.Reg, &d245)
-						ctx.BindReg(d244.Reg, &d245)
-					} else {
-						d245 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{d244}, 1)
-						d245.Type = tagInt
-						ctx.BindReg(d245.Reg, &d245)
+					if len(ps.OverlayValues) > 244 && ps.OverlayValues[244].Loc != LocNone {
+						d244 = ps.OverlayValues[244]
 					}
-					ctx.FreeDesc(&d244)
-					ctx.EnsureDesc(&d245)
+					ctx.ReclaimUntrackedRegs()
+					d245 = args[0]
+					d245.ID = 0
 					var d246 JITValueDesc
 					if d245.Loc == LocImm {
-						d246 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d245.Imm.Int() == -9223372036854775808)}
+						d246 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d245.Imm.Int())}
+					} else if d245.Type == tagInt && d245.Loc == LocRegPair {
+						ctx.FreeReg(d245.Reg)
+						d246 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d245.Reg2}
+						ctx.BindReg(d245.Reg2, &d246)
+						ctx.BindReg(d245.Reg2, &d246)
+					} else if d245.Type == tagInt && d245.Loc == LocReg {
+						d246 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d245.Reg}
+						ctx.BindReg(d245.Reg, &d246)
+						ctx.BindReg(d245.Reg, &d246)
+					} else {
+						d246 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{d245}, 1)
+						d246.Type = tagInt
+						ctx.BindReg(d246.Reg, &d246)
+					}
+					ctx.FreeDesc(&d245)
+					ctx.EnsureDesc(&d246)
+					var d247 JITValueDesc
+					if d246.Loc == LocImm {
+						d247 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d246.Imm.Int() == -9223372036854775808)}
 					} else {
 						r2 := ctx.AllocReg()
 						ctx.EmitMovRegImm64(RegR11, 0x8000000000000000)
-						ctx.EmitCmpInt64(d245.Reg, RegR11)
-						d246 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondEqual}
-						ctx.BindReg(r2, &d246)
+						ctx.EmitCmpInt64(d246.Reg, RegR11)
+						d247 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondEqual}
+						ctx.BindReg(r2, &d247)
 					}
-					ctx.FreeDesc(&d245)
-					d247 = d246
-					ctx.EnsureDesc(&d247)
-					if d247.Loc != LocImm && d247.Loc != LocFlags {
+					ctx.FreeDesc(&d246)
+					d248 = d247
+					ctx.EnsureDesc(&d248)
+					if d248.Loc != LocImm && d248.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d247.Loc == LocImm {
-						if d247.Imm.Bool() {
+					if d248.Loc == LocImm {
+						if d248.Imm.Bool() {
 							if ps.General {
 							}
-							ps248 := PhiState{General: ps.General}
-							ps248.OverlayValues = make([]JITValueDesc, 248)
-							ps248.OverlayValues[0] = d0
-							ps248.OverlayValues[1] = d1
-							ps248.OverlayValues[2] = d2
-							ps248.OverlayValues[3] = d3
-							ps248.OverlayValues[18] = d18
-							ps248.OverlayValues[19] = d19
-							ps248.OverlayValues[20] = d20
-							ps248.OverlayValues[21] = d21
-							ps248.OverlayValues[22] = d22
-							ps248.OverlayValues[47] = d47
-							ps248.OverlayValues[48] = d48
-							ps248.OverlayValues[49] = d49
-							ps248.OverlayValues[50] = d50
-							ps248.OverlayValues[83] = d83
-							ps248.OverlayValues[84] = d84
-							ps248.OverlayValues[85] = d85
-							ps248.OverlayValues[86] = d86
-							ps248.OverlayValues[127] = d127
-							ps248.OverlayValues[128] = d128
-							ps248.OverlayValues[129] = d129
-							ps248.OverlayValues[130] = d130
-							ps248.OverlayValues[179] = d179
-							ps248.OverlayValues[180] = d180
-							ps248.OverlayValues[181] = d181
-							ps248.OverlayValues[182] = d182
-							ps248.OverlayValues[239] = d239
-							ps248.OverlayValues[240] = d240
-							ps248.OverlayValues[241] = d241
-							ps248.OverlayValues[242] = d242
-							ps248.OverlayValues[243] = d243
-							ps248.OverlayValues[244] = d244
-							ps248.OverlayValues[245] = d245
-							ps248.OverlayValues[246] = d246
-							ps248.OverlayValues[247] = d247
-							return bbs[10].RenderPS(ps248)
+							ps249 := PhiState{General: ps.General}
+							ps249.OverlayValues = make([]JITValueDesc, 249)
+							ps249.OverlayValues[0] = d0
+							ps249.OverlayValues[1] = d1
+							ps249.OverlayValues[2] = d2
+							ps249.OverlayValues[3] = d3
+							ps249.OverlayValues[18] = d18
+							ps249.OverlayValues[19] = d19
+							ps249.OverlayValues[20] = d20
+							ps249.OverlayValues[21] = d21
+							ps249.OverlayValues[22] = d22
+							ps249.OverlayValues[47] = d47
+							ps249.OverlayValues[48] = d48
+							ps249.OverlayValues[49] = d49
+							ps249.OverlayValues[50] = d50
+							ps249.OverlayValues[83] = d83
+							ps249.OverlayValues[84] = d84
+							ps249.OverlayValues[85] = d85
+							ps249.OverlayValues[86] = d86
+							ps249.OverlayValues[127] = d127
+							ps249.OverlayValues[128] = d128
+							ps249.OverlayValues[129] = d129
+							ps249.OverlayValues[130] = d130
+							ps249.OverlayValues[179] = d179
+							ps249.OverlayValues[180] = d180
+							ps249.OverlayValues[181] = d181
+							ps249.OverlayValues[182] = d182
+							ps249.OverlayValues[239] = d239
+							ps249.OverlayValues[240] = d240
+							ps249.OverlayValues[241] = d241
+							ps249.OverlayValues[243] = d243
+							ps249.OverlayValues[244] = d244
+							ps249.OverlayValues[245] = d245
+							ps249.OverlayValues[246] = d246
+							ps249.OverlayValues[247] = d247
+							ps249.OverlayValues[248] = d248
+							return bbs[10].RenderPS(ps249)
 						}
 						if ps.General {
 						}
-						ps249 := PhiState{General: ps.General}
-						ps249.OverlayValues = make([]JITValueDesc, 248)
-						ps249.OverlayValues[0] = d0
-						ps249.OverlayValues[1] = d1
-						ps249.OverlayValues[2] = d2
-						ps249.OverlayValues[3] = d3
-						ps249.OverlayValues[18] = d18
-						ps249.OverlayValues[19] = d19
-						ps249.OverlayValues[20] = d20
-						ps249.OverlayValues[21] = d21
-						ps249.OverlayValues[22] = d22
-						ps249.OverlayValues[47] = d47
-						ps249.OverlayValues[48] = d48
-						ps249.OverlayValues[49] = d49
-						ps249.OverlayValues[50] = d50
-						ps249.OverlayValues[83] = d83
-						ps249.OverlayValues[84] = d84
-						ps249.OverlayValues[85] = d85
-						ps249.OverlayValues[86] = d86
-						ps249.OverlayValues[127] = d127
-						ps249.OverlayValues[128] = d128
-						ps249.OverlayValues[129] = d129
-						ps249.OverlayValues[130] = d130
-						ps249.OverlayValues[179] = d179
-						ps249.OverlayValues[180] = d180
-						ps249.OverlayValues[181] = d181
-						ps249.OverlayValues[182] = d182
-						ps249.OverlayValues[239] = d239
-						ps249.OverlayValues[240] = d240
-						ps249.OverlayValues[241] = d241
-						ps249.OverlayValues[242] = d242
-						ps249.OverlayValues[243] = d243
-						ps249.OverlayValues[244] = d244
-						ps249.OverlayValues[245] = d245
-						ps249.OverlayValues[246] = d246
-						ps249.OverlayValues[247] = d247
-						return bbs[8].RenderPS(ps249)
+						ps250 := PhiState{General: ps.General}
+						ps250.OverlayValues = make([]JITValueDesc, 249)
+						ps250.OverlayValues[0] = d0
+						ps250.OverlayValues[1] = d1
+						ps250.OverlayValues[2] = d2
+						ps250.OverlayValues[3] = d3
+						ps250.OverlayValues[18] = d18
+						ps250.OverlayValues[19] = d19
+						ps250.OverlayValues[20] = d20
+						ps250.OverlayValues[21] = d21
+						ps250.OverlayValues[22] = d22
+						ps250.OverlayValues[47] = d47
+						ps250.OverlayValues[48] = d48
+						ps250.OverlayValues[49] = d49
+						ps250.OverlayValues[50] = d50
+						ps250.OverlayValues[83] = d83
+						ps250.OverlayValues[84] = d84
+						ps250.OverlayValues[85] = d85
+						ps250.OverlayValues[86] = d86
+						ps250.OverlayValues[127] = d127
+						ps250.OverlayValues[128] = d128
+						ps250.OverlayValues[129] = d129
+						ps250.OverlayValues[130] = d130
+						ps250.OverlayValues[179] = d179
+						ps250.OverlayValues[180] = d180
+						ps250.OverlayValues[181] = d181
+						ps250.OverlayValues[182] = d182
+						ps250.OverlayValues[239] = d239
+						ps250.OverlayValues[240] = d240
+						ps250.OverlayValues[241] = d241
+						ps250.OverlayValues[243] = d243
+						ps250.OverlayValues[244] = d244
+						ps250.OverlayValues[245] = d245
+						ps250.OverlayValues[246] = d246
+						ps250.OverlayValues[247] = d247
+						ps250.OverlayValues[248] = d248
+						return bbs[8].RenderPS(ps250)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[9].RenderPS(ps)
 					}
-					ctx.EmitJump(d247.Condition, lbl11)
+					ctx.EmitJump(d248.Condition, lbl11)
 					if bbs[8].Rendered {
 						ctx.EmitJmp(lbl9)
 					}
-					ctx.FreeDesc(&d246)
-					snap250 := d0
-					snap251 := d1
-					snap252 := d2
-					snap253 := d3
-					snap254 := d18
-					snap255 := d19
-					snap256 := d20
-					snap257 := d21
-					snap258 := d22
-					snap259 := d47
-					snap260 := d48
-					snap261 := d49
-					snap262 := d50
-					snap263 := d83
-					snap264 := d84
-					snap265 := d85
-					snap266 := d86
-					snap267 := d127
-					snap268 := d128
-					snap269 := d129
-					snap270 := d130
-					snap271 := d179
-					snap272 := d180
-					snap273 := d181
-					snap274 := d182
-					snap275 := d239
-					snap276 := d240
-					snap277 := d241
-					snap278 := d242
+					ctx.FreeDesc(&d247)
+					snap251 := d0
+					snap252 := d1
+					snap253 := d2
+					snap254 := d3
+					snap255 := d18
+					snap256 := d19
+					snap257 := d20
+					snap258 := d21
+					snap259 := d22
+					snap260 := d47
+					snap261 := d48
+					snap262 := d49
+					snap263 := d50
+					snap264 := d83
+					snap265 := d84
+					snap266 := d85
+					snap267 := d86
+					snap268 := d127
+					snap269 := d128
+					snap270 := d129
+					snap271 := d130
+					snap272 := d179
+					snap273 := d180
+					snap274 := d181
+					snap275 := d182
+					snap276 := d239
+					snap277 := d240
+					snap278 := d241
 					snap279 := d243
 					snap280 := d244
 					snap281 := d245
 					snap282 := d246
 					snap283 := d247
-					alloc284 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc284)
-					d0 = snap250
-					d1 = snap251
-					d2 = snap252
-					d3 = snap253
-					d18 = snap254
-					d19 = snap255
-					d20 = snap256
-					d21 = snap257
-					d22 = snap258
-					d47 = snap259
-					d48 = snap260
-					d49 = snap261
-					d50 = snap262
-					d83 = snap263
-					d84 = snap264
-					d85 = snap265
-					d86 = snap266
-					d127 = snap267
-					d128 = snap268
-					d129 = snap269
-					d130 = snap270
-					d179 = snap271
-					d180 = snap272
-					d181 = snap273
-					d182 = snap274
-					d239 = snap275
-					d240 = snap276
-					d241 = snap277
-					d242 = snap278
+					snap284 := d248
+					alloc285 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc285)
+					d0 = snap251
+					d1 = snap252
+					d2 = snap253
+					d3 = snap254
+					d18 = snap255
+					d19 = snap256
+					d20 = snap257
+					d21 = snap258
+					d22 = snap259
+					d47 = snap260
+					d48 = snap261
+					d49 = snap262
+					d50 = snap263
+					d83 = snap264
+					d84 = snap265
+					d85 = snap266
+					d86 = snap267
+					d127 = snap268
+					d128 = snap269
+					d129 = snap270
+					d130 = snap271
+					d179 = snap272
+					d180 = snap273
+					d181 = snap274
+					d182 = snap275
+					d239 = snap276
+					d240 = snap277
+					d241 = snap278
 					d243 = snap279
 					d244 = snap280
 					d245 = snap281
 					d246 = snap282
 					d247 = snap283
-					ctx.RestoreAllocState(alloc284)
-					d0 = snap250
-					d1 = snap251
-					d2 = snap252
-					d3 = snap253
-					d18 = snap254
-					d19 = snap255
-					d20 = snap256
-					d21 = snap257
-					d22 = snap258
-					d47 = snap259
-					d48 = snap260
-					d49 = snap261
-					d50 = snap262
-					d83 = snap263
-					d84 = snap264
-					d85 = snap265
-					d86 = snap266
-					d127 = snap267
-					d128 = snap268
-					d129 = snap269
-					d130 = snap270
-					d179 = snap271
-					d180 = snap272
-					d181 = snap273
-					d182 = snap274
-					d239 = snap275
-					d240 = snap276
-					d241 = snap277
-					d242 = snap278
+					d248 = snap284
+					ctx.RestoreAllocState(alloc285)
+					d0 = snap251
+					d1 = snap252
+					d2 = snap253
+					d3 = snap254
+					d18 = snap255
+					d19 = snap256
+					d20 = snap257
+					d21 = snap258
+					d22 = snap259
+					d47 = snap260
+					d48 = snap261
+					d49 = snap262
+					d50 = snap263
+					d83 = snap264
+					d84 = snap265
+					d85 = snap266
+					d86 = snap267
+					d127 = snap268
+					d128 = snap269
+					d129 = snap270
+					d130 = snap271
+					d179 = snap272
+					d180 = snap273
+					d181 = snap274
+					d182 = snap275
+					d239 = snap276
+					d240 = snap277
+					d241 = snap278
 					d243 = snap279
 					d244 = snap280
 					d245 = snap281
 					d246 = snap282
 					d247 = snap283
-					ps285 := PhiState{General: true}
-					ps285.OverlayValues = make([]JITValueDesc, 248)
-					ps285.OverlayValues[0] = d0
-					ps285.OverlayValues[1] = d1
-					ps285.OverlayValues[2] = d2
-					ps285.OverlayValues[3] = d3
-					ps285.OverlayValues[18] = d18
-					ps285.OverlayValues[19] = d19
-					ps285.OverlayValues[20] = d20
-					ps285.OverlayValues[21] = d21
-					ps285.OverlayValues[22] = d22
-					ps285.OverlayValues[47] = d47
-					ps285.OverlayValues[48] = d48
-					ps285.OverlayValues[49] = d49
-					ps285.OverlayValues[50] = d50
-					ps285.OverlayValues[83] = d83
-					ps285.OverlayValues[84] = d84
-					ps285.OverlayValues[85] = d85
-					ps285.OverlayValues[86] = d86
-					ps285.OverlayValues[127] = d127
-					ps285.OverlayValues[128] = d128
-					ps285.OverlayValues[129] = d129
-					ps285.OverlayValues[130] = d130
-					ps285.OverlayValues[179] = d179
-					ps285.OverlayValues[180] = d180
-					ps285.OverlayValues[181] = d181
-					ps285.OverlayValues[182] = d182
-					ps285.OverlayValues[239] = d239
-					ps285.OverlayValues[240] = d240
-					ps285.OverlayValues[241] = d241
-					ps285.OverlayValues[242] = d242
-					ps285.OverlayValues[243] = d243
-					ps285.OverlayValues[244] = d244
-					ps285.OverlayValues[245] = d245
-					ps285.OverlayValues[246] = d246
-					ps285.OverlayValues[247] = d247
+					d248 = snap284
 					ps286 := PhiState{General: true}
-					ps286.OverlayValues = make([]JITValueDesc, 248)
+					ps286.OverlayValues = make([]JITValueDesc, 249)
 					ps286.OverlayValues[0] = d0
 					ps286.OverlayValues[1] = d1
 					ps286.OverlayValues[2] = d2
@@ -25630,87 +25707,123 @@ func init_alu() {
 					ps286.OverlayValues[239] = d239
 					ps286.OverlayValues[240] = d240
 					ps286.OverlayValues[241] = d241
-					ps286.OverlayValues[242] = d242
 					ps286.OverlayValues[243] = d243
 					ps286.OverlayValues[244] = d244
 					ps286.OverlayValues[245] = d245
 					ps286.OverlayValues[246] = d246
 					ps286.OverlayValues[247] = d247
-					snap287 := d0
-					snap288 := d1
-					snap289 := d2
-					snap290 := d3
-					snap291 := d18
-					snap292 := d19
-					snap293 := d20
-					snap294 := d21
-					snap295 := d22
-					snap296 := d47
-					snap297 := d48
-					snap298 := d49
-					snap299 := d50
-					snap300 := d83
-					snap301 := d84
-					snap302 := d85
-					snap303 := d86
-					snap304 := d127
-					snap305 := d128
-					snap306 := d129
-					snap307 := d130
-					snap308 := d179
-					snap309 := d180
-					snap310 := d181
-					snap311 := d182
-					snap312 := d239
-					snap313 := d240
-					snap314 := d241
-					snap315 := d242
+					ps286.OverlayValues[248] = d248
+					ps287 := PhiState{General: true}
+					ps287.OverlayValues = make([]JITValueDesc, 249)
+					ps287.OverlayValues[0] = d0
+					ps287.OverlayValues[1] = d1
+					ps287.OverlayValues[2] = d2
+					ps287.OverlayValues[3] = d3
+					ps287.OverlayValues[18] = d18
+					ps287.OverlayValues[19] = d19
+					ps287.OverlayValues[20] = d20
+					ps287.OverlayValues[21] = d21
+					ps287.OverlayValues[22] = d22
+					ps287.OverlayValues[47] = d47
+					ps287.OverlayValues[48] = d48
+					ps287.OverlayValues[49] = d49
+					ps287.OverlayValues[50] = d50
+					ps287.OverlayValues[83] = d83
+					ps287.OverlayValues[84] = d84
+					ps287.OverlayValues[85] = d85
+					ps287.OverlayValues[86] = d86
+					ps287.OverlayValues[127] = d127
+					ps287.OverlayValues[128] = d128
+					ps287.OverlayValues[129] = d129
+					ps287.OverlayValues[130] = d130
+					ps287.OverlayValues[179] = d179
+					ps287.OverlayValues[180] = d180
+					ps287.OverlayValues[181] = d181
+					ps287.OverlayValues[182] = d182
+					ps287.OverlayValues[239] = d239
+					ps287.OverlayValues[240] = d240
+					ps287.OverlayValues[241] = d241
+					ps287.OverlayValues[243] = d243
+					ps287.OverlayValues[244] = d244
+					ps287.OverlayValues[245] = d245
+					ps287.OverlayValues[246] = d246
+					ps287.OverlayValues[247] = d247
+					ps287.OverlayValues[248] = d248
+					snap288 := d0
+					snap289 := d1
+					snap290 := d2
+					snap291 := d3
+					snap292 := d18
+					snap293 := d19
+					snap294 := d20
+					snap295 := d21
+					snap296 := d22
+					snap297 := d47
+					snap298 := d48
+					snap299 := d49
+					snap300 := d50
+					snap301 := d83
+					snap302 := d84
+					snap303 := d85
+					snap304 := d86
+					snap305 := d127
+					snap306 := d128
+					snap307 := d129
+					snap308 := d130
+					snap309 := d179
+					snap310 := d180
+					snap311 := d181
+					snap312 := d182
+					snap313 := d239
+					snap314 := d240
+					snap315 := d241
 					snap316 := d243
 					snap317 := d244
 					snap318 := d245
 					snap319 := d246
 					snap320 := d247
-					alloc321 := ctx.SnapshotAllocState()
+					snap321 := d248
+					alloc322 := ctx.SnapshotAllocState()
 					if !bbs[8].Rendered {
-						bbs[8].RenderPS(ps286)
+						bbs[8].RenderPS(ps287)
 					}
-					ctx.RestoreAllocState(alloc321)
-					d0 = snap287
-					d1 = snap288
-					d2 = snap289
-					d3 = snap290
-					d18 = snap291
-					d19 = snap292
-					d20 = snap293
-					d21 = snap294
-					d22 = snap295
-					d47 = snap296
-					d48 = snap297
-					d49 = snap298
-					d50 = snap299
-					d83 = snap300
-					d84 = snap301
-					d85 = snap302
-					d86 = snap303
-					d127 = snap304
-					d128 = snap305
-					d129 = snap306
-					d130 = snap307
-					d179 = snap308
-					d180 = snap309
-					d181 = snap310
-					d182 = snap311
-					d239 = snap312
-					d240 = snap313
-					d241 = snap314
-					d242 = snap315
+					ctx.RestoreAllocState(alloc322)
+					d0 = snap288
+					d1 = snap289
+					d2 = snap290
+					d3 = snap291
+					d18 = snap292
+					d19 = snap293
+					d20 = snap294
+					d21 = snap295
+					d22 = snap296
+					d47 = snap297
+					d48 = snap298
+					d49 = snap299
+					d50 = snap300
+					d83 = snap301
+					d84 = snap302
+					d85 = snap303
+					d86 = snap304
+					d127 = snap305
+					d128 = snap306
+					d129 = snap307
+					d130 = snap308
+					d179 = snap309
+					d180 = snap310
+					d181 = snap311
+					d182 = snap312
+					d239 = snap313
+					d240 = snap314
+					d241 = snap315
 					d243 = snap316
 					d244 = snap317
 					d245 = snap318
 					d246 = snap319
 					d247 = snap320
+					d248 = snap321
 					if !bbs[10].Rendered {
-						return bbs[10].RenderPS(ps285)
+						return bbs[10].RenderPS(ps286)
 					}
 					return result
 					return result
@@ -25818,9 +25931,6 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
@@ -25836,268 +25946,233 @@ func init_alu() {
 					if len(ps.OverlayValues) > 247 && ps.OverlayValues[247].Loc != LocNone {
 						d247 = ps.OverlayValues[247]
 					}
+					if len(ps.OverlayValues) > 248 && ps.OverlayValues[248].Loc != LocNone {
+						d248 = ps.OverlayValues[248]
+					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d84)
-					var d322 JITValueDesc
+					var d323 JITValueDesc
 					if d84.Loc == LocImm {
-						d322 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d84.Imm.Int() == -1)}
+						d323 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d84.Imm.Int() == -1)}
 					} else {
 						r3 := ctx.AllocRegExcept(d84.Reg)
 						ctx.EmitCmpRegImm32(d84.Reg, -1)
-						d322 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r3, Condition: CondEqual}
-						ctx.BindReg(r3, &d322)
+						d323 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r3, Condition: CondEqual}
+						ctx.BindReg(r3, &d323)
 					}
-					d323 = d322
-					ctx.EnsureDesc(&d323)
-					if d323.Loc != LocImm && d323.Loc != LocFlags {
+					d324 = d323
+					ctx.EnsureDesc(&d324)
+					if d324.Loc != LocImm && d324.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d323.Loc == LocImm {
-						if d323.Imm.Bool() {
+					if d324.Loc == LocImm {
+						if d324.Imm.Bool() {
 							if ps.General {
 							}
-							ps324 := PhiState{General: ps.General}
-							ps324.OverlayValues = make([]JITValueDesc, 324)
-							ps324.OverlayValues[0] = d0
-							ps324.OverlayValues[1] = d1
-							ps324.OverlayValues[2] = d2
-							ps324.OverlayValues[3] = d3
-							ps324.OverlayValues[18] = d18
-							ps324.OverlayValues[19] = d19
-							ps324.OverlayValues[20] = d20
-							ps324.OverlayValues[21] = d21
-							ps324.OverlayValues[22] = d22
-							ps324.OverlayValues[47] = d47
-							ps324.OverlayValues[48] = d48
-							ps324.OverlayValues[49] = d49
-							ps324.OverlayValues[50] = d50
-							ps324.OverlayValues[83] = d83
-							ps324.OverlayValues[84] = d84
-							ps324.OverlayValues[85] = d85
-							ps324.OverlayValues[86] = d86
-							ps324.OverlayValues[127] = d127
-							ps324.OverlayValues[128] = d128
-							ps324.OverlayValues[129] = d129
-							ps324.OverlayValues[130] = d130
-							ps324.OverlayValues[179] = d179
-							ps324.OverlayValues[180] = d180
-							ps324.OverlayValues[181] = d181
-							ps324.OverlayValues[182] = d182
-							ps324.OverlayValues[239] = d239
-							ps324.OverlayValues[240] = d240
-							ps324.OverlayValues[241] = d241
-							ps324.OverlayValues[242] = d242
-							ps324.OverlayValues[243] = d243
-							ps324.OverlayValues[244] = d244
-							ps324.OverlayValues[245] = d245
-							ps324.OverlayValues[246] = d246
-							ps324.OverlayValues[247] = d247
-							ps324.OverlayValues[322] = d322
-							ps324.OverlayValues[323] = d323
-							return bbs[7].RenderPS(ps324)
+							ps325 := PhiState{General: ps.General}
+							ps325.OverlayValues = make([]JITValueDesc, 325)
+							ps325.OverlayValues[0] = d0
+							ps325.OverlayValues[1] = d1
+							ps325.OverlayValues[2] = d2
+							ps325.OverlayValues[3] = d3
+							ps325.OverlayValues[18] = d18
+							ps325.OverlayValues[19] = d19
+							ps325.OverlayValues[20] = d20
+							ps325.OverlayValues[21] = d21
+							ps325.OverlayValues[22] = d22
+							ps325.OverlayValues[47] = d47
+							ps325.OverlayValues[48] = d48
+							ps325.OverlayValues[49] = d49
+							ps325.OverlayValues[50] = d50
+							ps325.OverlayValues[83] = d83
+							ps325.OverlayValues[84] = d84
+							ps325.OverlayValues[85] = d85
+							ps325.OverlayValues[86] = d86
+							ps325.OverlayValues[127] = d127
+							ps325.OverlayValues[128] = d128
+							ps325.OverlayValues[129] = d129
+							ps325.OverlayValues[130] = d130
+							ps325.OverlayValues[179] = d179
+							ps325.OverlayValues[180] = d180
+							ps325.OverlayValues[181] = d181
+							ps325.OverlayValues[182] = d182
+							ps325.OverlayValues[239] = d239
+							ps325.OverlayValues[240] = d240
+							ps325.OverlayValues[241] = d241
+							ps325.OverlayValues[243] = d243
+							ps325.OverlayValues[244] = d244
+							ps325.OverlayValues[245] = d245
+							ps325.OverlayValues[246] = d246
+							ps325.OverlayValues[247] = d247
+							ps325.OverlayValues[248] = d248
+							ps325.OverlayValues[323] = d323
+							ps325.OverlayValues[324] = d324
+							return bbs[7].RenderPS(ps325)
 						}
 						if ps.General {
 						}
-						ps325 := PhiState{General: ps.General}
-						ps325.OverlayValues = make([]JITValueDesc, 324)
-						ps325.OverlayValues[0] = d0
-						ps325.OverlayValues[1] = d1
-						ps325.OverlayValues[2] = d2
-						ps325.OverlayValues[3] = d3
-						ps325.OverlayValues[18] = d18
-						ps325.OverlayValues[19] = d19
-						ps325.OverlayValues[20] = d20
-						ps325.OverlayValues[21] = d21
-						ps325.OverlayValues[22] = d22
-						ps325.OverlayValues[47] = d47
-						ps325.OverlayValues[48] = d48
-						ps325.OverlayValues[49] = d49
-						ps325.OverlayValues[50] = d50
-						ps325.OverlayValues[83] = d83
-						ps325.OverlayValues[84] = d84
-						ps325.OverlayValues[85] = d85
-						ps325.OverlayValues[86] = d86
-						ps325.OverlayValues[127] = d127
-						ps325.OverlayValues[128] = d128
-						ps325.OverlayValues[129] = d129
-						ps325.OverlayValues[130] = d130
-						ps325.OverlayValues[179] = d179
-						ps325.OverlayValues[180] = d180
-						ps325.OverlayValues[181] = d181
-						ps325.OverlayValues[182] = d182
-						ps325.OverlayValues[239] = d239
-						ps325.OverlayValues[240] = d240
-						ps325.OverlayValues[241] = d241
-						ps325.OverlayValues[242] = d242
-						ps325.OverlayValues[243] = d243
-						ps325.OverlayValues[244] = d244
-						ps325.OverlayValues[245] = d245
-						ps325.OverlayValues[246] = d246
-						ps325.OverlayValues[247] = d247
-						ps325.OverlayValues[322] = d322
-						ps325.OverlayValues[323] = d323
-						return bbs[8].RenderPS(ps325)
+						ps326 := PhiState{General: ps.General}
+						ps326.OverlayValues = make([]JITValueDesc, 325)
+						ps326.OverlayValues[0] = d0
+						ps326.OverlayValues[1] = d1
+						ps326.OverlayValues[2] = d2
+						ps326.OverlayValues[3] = d3
+						ps326.OverlayValues[18] = d18
+						ps326.OverlayValues[19] = d19
+						ps326.OverlayValues[20] = d20
+						ps326.OverlayValues[21] = d21
+						ps326.OverlayValues[22] = d22
+						ps326.OverlayValues[47] = d47
+						ps326.OverlayValues[48] = d48
+						ps326.OverlayValues[49] = d49
+						ps326.OverlayValues[50] = d50
+						ps326.OverlayValues[83] = d83
+						ps326.OverlayValues[84] = d84
+						ps326.OverlayValues[85] = d85
+						ps326.OverlayValues[86] = d86
+						ps326.OverlayValues[127] = d127
+						ps326.OverlayValues[128] = d128
+						ps326.OverlayValues[129] = d129
+						ps326.OverlayValues[130] = d130
+						ps326.OverlayValues[179] = d179
+						ps326.OverlayValues[180] = d180
+						ps326.OverlayValues[181] = d181
+						ps326.OverlayValues[182] = d182
+						ps326.OverlayValues[239] = d239
+						ps326.OverlayValues[240] = d240
+						ps326.OverlayValues[241] = d241
+						ps326.OverlayValues[243] = d243
+						ps326.OverlayValues[244] = d244
+						ps326.OverlayValues[245] = d245
+						ps326.OverlayValues[246] = d246
+						ps326.OverlayValues[247] = d247
+						ps326.OverlayValues[248] = d248
+						ps326.OverlayValues[323] = d323
+						ps326.OverlayValues[324] = d324
+						return bbs[8].RenderPS(ps326)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[10].RenderPS(ps)
 					}
-					ctx.EmitJump(d323.Condition, lbl8)
+					ctx.EmitJump(d324.Condition, lbl8)
 					if bbs[8].Rendered {
 						ctx.EmitJmp(lbl9)
 					}
-					ctx.FreeDesc(&d322)
-					snap326 := d0
-					snap327 := d1
-					snap328 := d2
-					snap329 := d3
-					snap330 := d18
-					snap331 := d19
-					snap332 := d20
-					snap333 := d21
-					snap334 := d22
-					snap335 := d47
-					snap336 := d48
-					snap337 := d49
-					snap338 := d50
-					snap339 := d83
-					snap340 := d84
-					snap341 := d85
-					snap342 := d86
-					snap343 := d127
-					snap344 := d128
-					snap345 := d129
-					snap346 := d130
-					snap347 := d179
-					snap348 := d180
-					snap349 := d181
-					snap350 := d182
-					snap351 := d239
-					snap352 := d240
-					snap353 := d241
-					snap354 := d242
+					ctx.FreeDesc(&d323)
+					snap327 := d0
+					snap328 := d1
+					snap329 := d2
+					snap330 := d3
+					snap331 := d18
+					snap332 := d19
+					snap333 := d20
+					snap334 := d21
+					snap335 := d22
+					snap336 := d47
+					snap337 := d48
+					snap338 := d49
+					snap339 := d50
+					snap340 := d83
+					snap341 := d84
+					snap342 := d85
+					snap343 := d86
+					snap344 := d127
+					snap345 := d128
+					snap346 := d129
+					snap347 := d130
+					snap348 := d179
+					snap349 := d180
+					snap350 := d181
+					snap351 := d182
+					snap352 := d239
+					snap353 := d240
+					snap354 := d241
 					snap355 := d243
 					snap356 := d244
 					snap357 := d245
 					snap358 := d246
 					snap359 := d247
-					snap360 := d322
+					snap360 := d248
 					snap361 := d323
-					alloc362 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc362)
-					d0 = snap326
-					d1 = snap327
-					d2 = snap328
-					d3 = snap329
-					d18 = snap330
-					d19 = snap331
-					d20 = snap332
-					d21 = snap333
-					d22 = snap334
-					d47 = snap335
-					d48 = snap336
-					d49 = snap337
-					d50 = snap338
-					d83 = snap339
-					d84 = snap340
-					d85 = snap341
-					d86 = snap342
-					d127 = snap343
-					d128 = snap344
-					d129 = snap345
-					d130 = snap346
-					d179 = snap347
-					d180 = snap348
-					d181 = snap349
-					d182 = snap350
-					d239 = snap351
-					d240 = snap352
-					d241 = snap353
-					d242 = snap354
+					snap362 := d324
+					alloc363 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc363)
+					d0 = snap327
+					d1 = snap328
+					d2 = snap329
+					d3 = snap330
+					d18 = snap331
+					d19 = snap332
+					d20 = snap333
+					d21 = snap334
+					d22 = snap335
+					d47 = snap336
+					d48 = snap337
+					d49 = snap338
+					d50 = snap339
+					d83 = snap340
+					d84 = snap341
+					d85 = snap342
+					d86 = snap343
+					d127 = snap344
+					d128 = snap345
+					d129 = snap346
+					d130 = snap347
+					d179 = snap348
+					d180 = snap349
+					d181 = snap350
+					d182 = snap351
+					d239 = snap352
+					d240 = snap353
+					d241 = snap354
 					d243 = snap355
 					d244 = snap356
 					d245 = snap357
 					d246 = snap358
 					d247 = snap359
-					d322 = snap360
+					d248 = snap360
 					d323 = snap361
-					ctx.RestoreAllocState(alloc362)
-					d0 = snap326
-					d1 = snap327
-					d2 = snap328
-					d3 = snap329
-					d18 = snap330
-					d19 = snap331
-					d20 = snap332
-					d21 = snap333
-					d22 = snap334
-					d47 = snap335
-					d48 = snap336
-					d49 = snap337
-					d50 = snap338
-					d83 = snap339
-					d84 = snap340
-					d85 = snap341
-					d86 = snap342
-					d127 = snap343
-					d128 = snap344
-					d129 = snap345
-					d130 = snap346
-					d179 = snap347
-					d180 = snap348
-					d181 = snap349
-					d182 = snap350
-					d239 = snap351
-					d240 = snap352
-					d241 = snap353
-					d242 = snap354
+					d324 = snap362
+					ctx.RestoreAllocState(alloc363)
+					d0 = snap327
+					d1 = snap328
+					d2 = snap329
+					d3 = snap330
+					d18 = snap331
+					d19 = snap332
+					d20 = snap333
+					d21 = snap334
+					d22 = snap335
+					d47 = snap336
+					d48 = snap337
+					d49 = snap338
+					d50 = snap339
+					d83 = snap340
+					d84 = snap341
+					d85 = snap342
+					d86 = snap343
+					d127 = snap344
+					d128 = snap345
+					d129 = snap346
+					d130 = snap347
+					d179 = snap348
+					d180 = snap349
+					d181 = snap350
+					d182 = snap351
+					d239 = snap352
+					d240 = snap353
+					d241 = snap354
 					d243 = snap355
 					d244 = snap356
 					d245 = snap357
 					d246 = snap358
 					d247 = snap359
-					d322 = snap360
+					d248 = snap360
 					d323 = snap361
-					ps363 := PhiState{General: true}
-					ps363.OverlayValues = make([]JITValueDesc, 324)
-					ps363.OverlayValues[0] = d0
-					ps363.OverlayValues[1] = d1
-					ps363.OverlayValues[2] = d2
-					ps363.OverlayValues[3] = d3
-					ps363.OverlayValues[18] = d18
-					ps363.OverlayValues[19] = d19
-					ps363.OverlayValues[20] = d20
-					ps363.OverlayValues[21] = d21
-					ps363.OverlayValues[22] = d22
-					ps363.OverlayValues[47] = d47
-					ps363.OverlayValues[48] = d48
-					ps363.OverlayValues[49] = d49
-					ps363.OverlayValues[50] = d50
-					ps363.OverlayValues[83] = d83
-					ps363.OverlayValues[84] = d84
-					ps363.OverlayValues[85] = d85
-					ps363.OverlayValues[86] = d86
-					ps363.OverlayValues[127] = d127
-					ps363.OverlayValues[128] = d128
-					ps363.OverlayValues[129] = d129
-					ps363.OverlayValues[130] = d130
-					ps363.OverlayValues[179] = d179
-					ps363.OverlayValues[180] = d180
-					ps363.OverlayValues[181] = d181
-					ps363.OverlayValues[182] = d182
-					ps363.OverlayValues[239] = d239
-					ps363.OverlayValues[240] = d240
-					ps363.OverlayValues[241] = d241
-					ps363.OverlayValues[242] = d242
-					ps363.OverlayValues[243] = d243
-					ps363.OverlayValues[244] = d244
-					ps363.OverlayValues[245] = d245
-					ps363.OverlayValues[246] = d246
-					ps363.OverlayValues[247] = d247
-					ps363.OverlayValues[322] = d322
-					ps363.OverlayValues[323] = d323
+					d324 = snap362
 					ps364 := PhiState{General: true}
-					ps364.OverlayValues = make([]JITValueDesc, 324)
+					ps364.OverlayValues = make([]JITValueDesc, 325)
 					ps364.OverlayValues[0] = d0
 					ps364.OverlayValues[1] = d1
 					ps364.OverlayValues[2] = d2
@@ -26126,93 +26201,131 @@ func init_alu() {
 					ps364.OverlayValues[239] = d239
 					ps364.OverlayValues[240] = d240
 					ps364.OverlayValues[241] = d241
-					ps364.OverlayValues[242] = d242
 					ps364.OverlayValues[243] = d243
 					ps364.OverlayValues[244] = d244
 					ps364.OverlayValues[245] = d245
 					ps364.OverlayValues[246] = d246
 					ps364.OverlayValues[247] = d247
-					ps364.OverlayValues[322] = d322
+					ps364.OverlayValues[248] = d248
 					ps364.OverlayValues[323] = d323
-					snap365 := d0
-					snap366 := d1
-					snap367 := d2
-					snap368 := d3
-					snap369 := d18
-					snap370 := d19
-					snap371 := d20
-					snap372 := d21
-					snap373 := d22
-					snap374 := d47
-					snap375 := d48
-					snap376 := d49
-					snap377 := d50
-					snap378 := d83
-					snap379 := d84
-					snap380 := d85
-					snap381 := d86
-					snap382 := d127
-					snap383 := d128
-					snap384 := d129
-					snap385 := d130
-					snap386 := d179
-					snap387 := d180
-					snap388 := d181
-					snap389 := d182
-					snap390 := d239
-					snap391 := d240
-					snap392 := d241
-					snap393 := d242
+					ps364.OverlayValues[324] = d324
+					ps365 := PhiState{General: true}
+					ps365.OverlayValues = make([]JITValueDesc, 325)
+					ps365.OverlayValues[0] = d0
+					ps365.OverlayValues[1] = d1
+					ps365.OverlayValues[2] = d2
+					ps365.OverlayValues[3] = d3
+					ps365.OverlayValues[18] = d18
+					ps365.OverlayValues[19] = d19
+					ps365.OverlayValues[20] = d20
+					ps365.OverlayValues[21] = d21
+					ps365.OverlayValues[22] = d22
+					ps365.OverlayValues[47] = d47
+					ps365.OverlayValues[48] = d48
+					ps365.OverlayValues[49] = d49
+					ps365.OverlayValues[50] = d50
+					ps365.OverlayValues[83] = d83
+					ps365.OverlayValues[84] = d84
+					ps365.OverlayValues[85] = d85
+					ps365.OverlayValues[86] = d86
+					ps365.OverlayValues[127] = d127
+					ps365.OverlayValues[128] = d128
+					ps365.OverlayValues[129] = d129
+					ps365.OverlayValues[130] = d130
+					ps365.OverlayValues[179] = d179
+					ps365.OverlayValues[180] = d180
+					ps365.OverlayValues[181] = d181
+					ps365.OverlayValues[182] = d182
+					ps365.OverlayValues[239] = d239
+					ps365.OverlayValues[240] = d240
+					ps365.OverlayValues[241] = d241
+					ps365.OverlayValues[243] = d243
+					ps365.OverlayValues[244] = d244
+					ps365.OverlayValues[245] = d245
+					ps365.OverlayValues[246] = d246
+					ps365.OverlayValues[247] = d247
+					ps365.OverlayValues[248] = d248
+					ps365.OverlayValues[323] = d323
+					ps365.OverlayValues[324] = d324
+					snap366 := d0
+					snap367 := d1
+					snap368 := d2
+					snap369 := d3
+					snap370 := d18
+					snap371 := d19
+					snap372 := d20
+					snap373 := d21
+					snap374 := d22
+					snap375 := d47
+					snap376 := d48
+					snap377 := d49
+					snap378 := d50
+					snap379 := d83
+					snap380 := d84
+					snap381 := d85
+					snap382 := d86
+					snap383 := d127
+					snap384 := d128
+					snap385 := d129
+					snap386 := d130
+					snap387 := d179
+					snap388 := d180
+					snap389 := d181
+					snap390 := d182
+					snap391 := d239
+					snap392 := d240
+					snap393 := d241
 					snap394 := d243
 					snap395 := d244
 					snap396 := d245
 					snap397 := d246
 					snap398 := d247
-					snap399 := d322
+					snap399 := d248
 					snap400 := d323
-					alloc401 := ctx.SnapshotAllocState()
+					snap401 := d324
+					alloc402 := ctx.SnapshotAllocState()
 					if !bbs[8].Rendered {
-						bbs[8].RenderPS(ps364)
+						bbs[8].RenderPS(ps365)
 					}
-					ctx.RestoreAllocState(alloc401)
-					d0 = snap365
-					d1 = snap366
-					d2 = snap367
-					d3 = snap368
-					d18 = snap369
-					d19 = snap370
-					d20 = snap371
-					d21 = snap372
-					d22 = snap373
-					d47 = snap374
-					d48 = snap375
-					d49 = snap376
-					d50 = snap377
-					d83 = snap378
-					d84 = snap379
-					d85 = snap380
-					d86 = snap381
-					d127 = snap382
-					d128 = snap383
-					d129 = snap384
-					d130 = snap385
-					d179 = snap386
-					d180 = snap387
-					d181 = snap388
-					d182 = snap389
-					d239 = snap390
-					d240 = snap391
-					d241 = snap392
-					d242 = snap393
+					ctx.RestoreAllocState(alloc402)
+					d0 = snap366
+					d1 = snap367
+					d2 = snap368
+					d3 = snap369
+					d18 = snap370
+					d19 = snap371
+					d20 = snap372
+					d21 = snap373
+					d22 = snap374
+					d47 = snap375
+					d48 = snap376
+					d49 = snap377
+					d50 = snap378
+					d83 = snap379
+					d84 = snap380
+					d85 = snap381
+					d86 = snap382
+					d127 = snap383
+					d128 = snap384
+					d129 = snap385
+					d130 = snap386
+					d179 = snap387
+					d180 = snap388
+					d181 = snap389
+					d182 = snap390
+					d239 = snap391
+					d240 = snap392
+					d241 = snap393
 					d243 = snap394
 					d244 = snap395
 					d245 = snap396
 					d246 = snap397
 					d247 = snap398
-					d322 = snap399
+					d248 = snap399
 					d323 = snap400
+					d324 = snap401
 					if !bbs[7].Rendered {
-						return bbs[7].RenderPS(ps363)
+						return bbs[7].RenderPS(ps364)
 					}
 					return result
 					return result
@@ -26320,9 +26433,6 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
@@ -26338,35 +26448,38 @@ func init_alu() {
 					if len(ps.OverlayValues) > 247 && ps.OverlayValues[247].Loc != LocNone {
 						d247 = ps.OverlayValues[247]
 					}
-					if len(ps.OverlayValues) > 322 && ps.OverlayValues[322].Loc != LocNone {
-						d322 = ps.OverlayValues[322]
+					if len(ps.OverlayValues) > 248 && ps.OverlayValues[248].Loc != LocNone {
+						d248 = ps.OverlayValues[248]
 					}
 					if len(ps.OverlayValues) > 323 && ps.OverlayValues[323].Loc != LocNone {
 						d323 = ps.OverlayValues[323]
 					}
+					if len(ps.OverlayValues) > 324 && ps.OverlayValues[324].Loc != LocNone {
+						d324 = ps.OverlayValues[324]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d402 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
-					ctx.SyncDesc(&d402)
-					if d402.Loc == LocRegPair || d402.Loc == LocStackPair || d402.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d402, &result)
-						result.Type = d402.Type
+					d403 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+					ctx.SyncDesc(&d403)
+					if d403.Loc == LocRegPair || d403.Loc == LocStackPair || d403.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d403, &result)
+						result.Type = d403.Type
 					} else {
-						switch d402.Type {
+						switch d403.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d402)
+							ctx.EmitMakeBool(result, d403)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d402)
+							ctx.EmitMakeInt(result, d403)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d402)
+							ctx.EmitMakeFloat(result, d403)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d402, &result)
-							result.Type = d402.Type
+							ctx.EmitMovPairToResult(&d403, &result)
+							result.Type = d403.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -26475,9 +26588,6 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
@@ -26493,395 +26603,353 @@ func init_alu() {
 					if len(ps.OverlayValues) > 247 && ps.OverlayValues[247].Loc != LocNone {
 						d247 = ps.OverlayValues[247]
 					}
-					if len(ps.OverlayValues) > 322 && ps.OverlayValues[322].Loc != LocNone {
-						d322 = ps.OverlayValues[322]
+					if len(ps.OverlayValues) > 248 && ps.OverlayValues[248].Loc != LocNone {
+						d248 = ps.OverlayValues[248]
 					}
 					if len(ps.OverlayValues) > 323 && ps.OverlayValues[323].Loc != LocNone {
 						d323 = ps.OverlayValues[323]
 					}
-					if len(ps.OverlayValues) > 402 && ps.OverlayValues[402].Loc != LocNone {
-						d402 = ps.OverlayValues[402]
+					if len(ps.OverlayValues) > 324 && ps.OverlayValues[324].Loc != LocNone {
+						d324 = ps.OverlayValues[324]
+					}
+					if len(ps.OverlayValues) > 403 && ps.OverlayValues[403].Loc != LocNone {
+						d403 = ps.OverlayValues[403]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d403 = args[0]
-					d403.ID = 0
-					var d404 JITValueDesc
-					if d403.Loc == LocImm {
-						d404 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d403.Imm.Float())}
-					} else if d403.Type == tagFloat && d403.Loc == LocReg {
-						d404 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d403.Reg}
-						ctx.BindReg(d403.Reg, &d404)
-						ctx.BindReg(d403.Reg, &d404)
-					} else if d403.Type == tagFloat && d403.Loc == LocRegPair {
-						ctx.FreeReg(d403.Reg)
-						d404 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d403.Reg2}
-						ctx.BindReg(d403.Reg2, &d404)
-						ctx.BindReg(d403.Reg2, &d404)
-					} else {
-						d404 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d403}, 1)
-						d404.Type = tagFloat
-						ctx.BindReg(d404.Reg, &d404)
-					}
-					ctx.FreeDesc(&d403)
-					ctx.EnsureDesc(&d404)
-					ctx.EnsureDesc(&d128)
-					ctx.EnsureDescsTogether(&d404, &d128)
+					d404 = args[0]
+					d404.ID = 0
 					var d405 JITValueDesc
-					if d404.Loc == LocImm && d128.Loc == LocImm {
-						d405 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d404.Imm.Float() / d128.Imm.Float())}
-					} else if d404.Loc == LocImm {
-						scratch := ctx.AllocRegExcept(d128.Reg)
-						_, xBits := d404.Imm.RawWords()
-						ctx.EmitMovRegImm64(scratch, xBits)
-						ctx.EmitDivFloat64(scratch, d128.Reg)
-						d405 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
-						ctx.BindReg(scratch, &d405)
-					} else if d128.Loc == LocImm {
-						_, yBits := d128.Imm.RawWords()
-						ctx.EmitMovRegImm64(RegR11, yBits)
-						ctx.EmitDivFloat64(d404.Reg, RegR11)
+					if d404.Loc == LocImm {
+						d405 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d404.Imm.Float())}
+					} else if d404.Type == tagFloat && d404.Loc == LocReg {
 						d405 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d404.Reg}
 						ctx.BindReg(d404.Reg, &d405)
+						ctx.BindReg(d404.Reg, &d405)
+					} else if d404.Type == tagFloat && d404.Loc == LocRegPair {
+						ctx.FreeReg(d404.Reg)
+						d405 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d404.Reg2}
+						ctx.BindReg(d404.Reg2, &d405)
+						ctx.BindReg(d404.Reg2, &d405)
 					} else {
-						ctx.EmitDivFloat64(d404.Reg, d128.Reg)
-						d405 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d404.Reg}
-						ctx.BindReg(d404.Reg, &d405)
-					}
-					if d405.Loc == LocReg && d404.Loc == LocReg && d405.Reg == d404.Reg {
-						ctx.TransferReg(d404.Reg)
-						d404.Loc = LocNone
+						d405 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d404}, 1)
+						d405.Type = tagFloat
+						ctx.BindReg(d405.Reg, &d405)
 					}
 					ctx.FreeDesc(&d404)
 					ctx.EnsureDesc(&d405)
+					ctx.EnsureDesc(&d128)
+					ctx.EnsureDescsTogether(&d405, &d128)
 					var d406 JITValueDesc
-					if d405.Loc == LocImm {
-						d406 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(math.Trunc(d405.Imm.Float()))}
+					if d405.Loc == LocImm && d128.Loc == LocImm {
+						d406 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d405.Imm.Float() / d128.Imm.Float())}
+					} else if d405.Loc == LocImm {
+						scratch := ctx.AllocRegExcept(d128.Reg)
+						_, xBits := d405.Imm.RawWords()
+						ctx.EmitMovRegImm64(scratch, xBits)
+						ctx.EmitDivFloat64(scratch, d128.Reg)
+						d406 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: scratch}
+						ctx.BindReg(scratch, &d406)
+					} else if d128.Loc == LocImm {
+						_, yBits := d128.Imm.RawWords()
+						ctx.EmitMovRegImm64(RegR11, yBits)
+						ctx.EmitDivFloat64(d405.Reg, RegR11)
+						d406 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d405.Reg}
+						ctx.BindReg(d405.Reg, &d406)
 					} else {
-						ctx.EnsureDesc(&d405)
-						var truncSrc Reg
-						if d405.Loc == LocRegPair {
-							ctx.FreeReg(d405.Reg)
-							truncSrc = d405.Reg2
-						} else {
-							truncSrc = d405.Reg
-						}
-						truncInt := ctx.AllocRegExcept(truncSrc)
-						ctx.EmitCvtFloatBitsToInt64(truncInt, truncSrc)
-						ctx.EmitCvtInt64ToFloat64(RegX0, truncInt)
-						d406 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: truncInt}
-						ctx.BindReg(truncInt, &d406)
-						ctx.BindReg(truncInt, &d406)
+						ctx.EmitDivFloat64(d405.Reg, d128.Reg)
+						d406 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d405.Reg}
+						ctx.BindReg(d405.Reg, &d406)
 					}
-					ctx.StabilizeDescForControlFlow(&d406)
+					if d406.Loc == LocReg && d405.Loc == LocReg && d406.Reg == d405.Reg {
+						ctx.TransferReg(d405.Reg)
+						d405.Loc = LocNone
+					}
 					ctx.FreeDesc(&d405)
 					ctx.EnsureDesc(&d406)
 					var d407 JITValueDesc
 					if d406.Loc == LocImm {
-						d407 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d406.Imm.Float() != d406.Imm.Float())}
+						d407 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(math.Trunc(d406.Imm.Float()))}
 					} else {
 						ctx.EnsureDesc(&d406)
-						nanSource408 := d406.Reg
+						var truncSrc Reg
 						if d406.Loc == LocRegPair {
-							nanSource408 = d406.Reg2
+							ctx.FreeReg(d406.Reg)
+							truncSrc = d406.Reg2
+						} else {
+							truncSrc = d406.Reg
 						}
-						r4 := ctx.AllocRegExcept(nanSource408)
-						ctx.EmitCmpFloat64(nanSource408, nanSource408)
-						d407 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r4, Condition: CondParity}
-						ctx.BindReg(r4, &d407)
+						truncInt := ctx.AllocRegExcept(truncSrc)
+						ctx.EmitCvtFloatBitsToInt64(truncInt, truncSrc)
+						ctx.EmitCvtInt64ToFloat64(RegX0, truncInt)
+						d407 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: truncInt}
+						ctx.BindReg(truncInt, &d407)
+						ctx.BindReg(truncInt, &d407)
 					}
-					d409 = d407
-					ctx.EnsureDesc(&d409)
-					if d409.Loc != LocImm && d409.Loc != LocFlags {
+					ctx.StabilizeDescForControlFlow(&d407)
+					ctx.FreeDesc(&d406)
+					ctx.EnsureDesc(&d407)
+					var d408 JITValueDesc
+					if d407.Loc == LocImm {
+						d408 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d407.Imm.Float() != d407.Imm.Float())}
+					} else {
+						ctx.EnsureDesc(&d407)
+						nanSource409 := d407.Reg
+						if d407.Loc == LocRegPair {
+							nanSource409 = d407.Reg2
+						}
+						r4 := ctx.AllocRegExcept(nanSource409)
+						ctx.EmitCmpFloat64(nanSource409, nanSource409)
+						d408 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r4, Condition: CondParity}
+						ctx.BindReg(r4, &d408)
+					}
+					d410 = d408
+					ctx.EnsureDesc(&d410)
+					if d410.Loc != LocImm && d410.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d409.Loc == LocImm {
-						if d409.Imm.Bool() {
+					if d410.Loc == LocImm {
+						if d410.Imm.Bool() {
 							if ps.General {
 							}
-							ps410 := PhiState{General: ps.General}
-							ps410.OverlayValues = make([]JITValueDesc, 410)
-							ps410.OverlayValues[0] = d0
-							ps410.OverlayValues[1] = d1
-							ps410.OverlayValues[2] = d2
-							ps410.OverlayValues[3] = d3
-							ps410.OverlayValues[18] = d18
-							ps410.OverlayValues[19] = d19
-							ps410.OverlayValues[20] = d20
-							ps410.OverlayValues[21] = d21
-							ps410.OverlayValues[22] = d22
-							ps410.OverlayValues[47] = d47
-							ps410.OverlayValues[48] = d48
-							ps410.OverlayValues[49] = d49
-							ps410.OverlayValues[50] = d50
-							ps410.OverlayValues[83] = d83
-							ps410.OverlayValues[84] = d84
-							ps410.OverlayValues[85] = d85
-							ps410.OverlayValues[86] = d86
-							ps410.OverlayValues[127] = d127
-							ps410.OverlayValues[128] = d128
-							ps410.OverlayValues[129] = d129
-							ps410.OverlayValues[130] = d130
-							ps410.OverlayValues[179] = d179
-							ps410.OverlayValues[180] = d180
-							ps410.OverlayValues[181] = d181
-							ps410.OverlayValues[182] = d182
-							ps410.OverlayValues[239] = d239
-							ps410.OverlayValues[240] = d240
-							ps410.OverlayValues[241] = d241
-							ps410.OverlayValues[242] = d242
-							ps410.OverlayValues[243] = d243
-							ps410.OverlayValues[244] = d244
-							ps410.OverlayValues[245] = d245
-							ps410.OverlayValues[246] = d246
-							ps410.OverlayValues[247] = d247
-							ps410.OverlayValues[322] = d322
-							ps410.OverlayValues[323] = d323
-							ps410.OverlayValues[402] = d402
-							ps410.OverlayValues[403] = d403
-							ps410.OverlayValues[404] = d404
-							ps410.OverlayValues[405] = d405
-							ps410.OverlayValues[406] = d406
-							ps410.OverlayValues[407] = d407
-							ps410.OverlayValues[409] = d409
-							return bbs[13].RenderPS(ps410)
+							ps411 := PhiState{General: ps.General}
+							ps411.OverlayValues = make([]JITValueDesc, 411)
+							ps411.OverlayValues[0] = d0
+							ps411.OverlayValues[1] = d1
+							ps411.OverlayValues[2] = d2
+							ps411.OverlayValues[3] = d3
+							ps411.OverlayValues[18] = d18
+							ps411.OverlayValues[19] = d19
+							ps411.OverlayValues[20] = d20
+							ps411.OverlayValues[21] = d21
+							ps411.OverlayValues[22] = d22
+							ps411.OverlayValues[47] = d47
+							ps411.OverlayValues[48] = d48
+							ps411.OverlayValues[49] = d49
+							ps411.OverlayValues[50] = d50
+							ps411.OverlayValues[83] = d83
+							ps411.OverlayValues[84] = d84
+							ps411.OverlayValues[85] = d85
+							ps411.OverlayValues[86] = d86
+							ps411.OverlayValues[127] = d127
+							ps411.OverlayValues[128] = d128
+							ps411.OverlayValues[129] = d129
+							ps411.OverlayValues[130] = d130
+							ps411.OverlayValues[179] = d179
+							ps411.OverlayValues[180] = d180
+							ps411.OverlayValues[181] = d181
+							ps411.OverlayValues[182] = d182
+							ps411.OverlayValues[239] = d239
+							ps411.OverlayValues[240] = d240
+							ps411.OverlayValues[241] = d241
+							ps411.OverlayValues[243] = d243
+							ps411.OverlayValues[244] = d244
+							ps411.OverlayValues[245] = d245
+							ps411.OverlayValues[246] = d246
+							ps411.OverlayValues[247] = d247
+							ps411.OverlayValues[248] = d248
+							ps411.OverlayValues[323] = d323
+							ps411.OverlayValues[324] = d324
+							ps411.OverlayValues[403] = d403
+							ps411.OverlayValues[404] = d404
+							ps411.OverlayValues[405] = d405
+							ps411.OverlayValues[406] = d406
+							ps411.OverlayValues[407] = d407
+							ps411.OverlayValues[408] = d408
+							ps411.OverlayValues[410] = d410
+							return bbs[13].RenderPS(ps411)
 						}
 						if ps.General {
 						}
-						ps411 := PhiState{General: ps.General}
-						ps411.OverlayValues = make([]JITValueDesc, 410)
-						ps411.OverlayValues[0] = d0
-						ps411.OverlayValues[1] = d1
-						ps411.OverlayValues[2] = d2
-						ps411.OverlayValues[3] = d3
-						ps411.OverlayValues[18] = d18
-						ps411.OverlayValues[19] = d19
-						ps411.OverlayValues[20] = d20
-						ps411.OverlayValues[21] = d21
-						ps411.OverlayValues[22] = d22
-						ps411.OverlayValues[47] = d47
-						ps411.OverlayValues[48] = d48
-						ps411.OverlayValues[49] = d49
-						ps411.OverlayValues[50] = d50
-						ps411.OverlayValues[83] = d83
-						ps411.OverlayValues[84] = d84
-						ps411.OverlayValues[85] = d85
-						ps411.OverlayValues[86] = d86
-						ps411.OverlayValues[127] = d127
-						ps411.OverlayValues[128] = d128
-						ps411.OverlayValues[129] = d129
-						ps411.OverlayValues[130] = d130
-						ps411.OverlayValues[179] = d179
-						ps411.OverlayValues[180] = d180
-						ps411.OverlayValues[181] = d181
-						ps411.OverlayValues[182] = d182
-						ps411.OverlayValues[239] = d239
-						ps411.OverlayValues[240] = d240
-						ps411.OverlayValues[241] = d241
-						ps411.OverlayValues[242] = d242
-						ps411.OverlayValues[243] = d243
-						ps411.OverlayValues[244] = d244
-						ps411.OverlayValues[245] = d245
-						ps411.OverlayValues[246] = d246
-						ps411.OverlayValues[247] = d247
-						ps411.OverlayValues[322] = d322
-						ps411.OverlayValues[323] = d323
-						ps411.OverlayValues[402] = d402
-						ps411.OverlayValues[403] = d403
-						ps411.OverlayValues[404] = d404
-						ps411.OverlayValues[405] = d405
-						ps411.OverlayValues[406] = d406
-						ps411.OverlayValues[407] = d407
-						ps411.OverlayValues[409] = d409
-						return bbs[16].RenderPS(ps411)
+						ps412 := PhiState{General: ps.General}
+						ps412.OverlayValues = make([]JITValueDesc, 411)
+						ps412.OverlayValues[0] = d0
+						ps412.OverlayValues[1] = d1
+						ps412.OverlayValues[2] = d2
+						ps412.OverlayValues[3] = d3
+						ps412.OverlayValues[18] = d18
+						ps412.OverlayValues[19] = d19
+						ps412.OverlayValues[20] = d20
+						ps412.OverlayValues[21] = d21
+						ps412.OverlayValues[22] = d22
+						ps412.OverlayValues[47] = d47
+						ps412.OverlayValues[48] = d48
+						ps412.OverlayValues[49] = d49
+						ps412.OverlayValues[50] = d50
+						ps412.OverlayValues[83] = d83
+						ps412.OverlayValues[84] = d84
+						ps412.OverlayValues[85] = d85
+						ps412.OverlayValues[86] = d86
+						ps412.OverlayValues[127] = d127
+						ps412.OverlayValues[128] = d128
+						ps412.OverlayValues[129] = d129
+						ps412.OverlayValues[130] = d130
+						ps412.OverlayValues[179] = d179
+						ps412.OverlayValues[180] = d180
+						ps412.OverlayValues[181] = d181
+						ps412.OverlayValues[182] = d182
+						ps412.OverlayValues[239] = d239
+						ps412.OverlayValues[240] = d240
+						ps412.OverlayValues[241] = d241
+						ps412.OverlayValues[243] = d243
+						ps412.OverlayValues[244] = d244
+						ps412.OverlayValues[245] = d245
+						ps412.OverlayValues[246] = d246
+						ps412.OverlayValues[247] = d247
+						ps412.OverlayValues[248] = d248
+						ps412.OverlayValues[323] = d323
+						ps412.OverlayValues[324] = d324
+						ps412.OverlayValues[403] = d403
+						ps412.OverlayValues[404] = d404
+						ps412.OverlayValues[405] = d405
+						ps412.OverlayValues[406] = d406
+						ps412.OverlayValues[407] = d407
+						ps412.OverlayValues[408] = d408
+						ps412.OverlayValues[410] = d410
+						return bbs[16].RenderPS(ps412)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[12].RenderPS(ps)
 					}
-					ctx.EmitJump(d409.Condition, lbl14)
+					ctx.EmitJump(d410.Condition, lbl14)
 					if bbs[16].Rendered {
 						ctx.EmitJmp(lbl17)
 					}
-					ctx.FreeDesc(&d407)
-					snap412 := d0
-					snap413 := d1
-					snap414 := d2
-					snap415 := d3
-					snap416 := d18
-					snap417 := d19
-					snap418 := d20
-					snap419 := d21
-					snap420 := d22
-					snap421 := d47
-					snap422 := d48
-					snap423 := d49
-					snap424 := d50
-					snap425 := d83
-					snap426 := d84
-					snap427 := d85
-					snap428 := d86
-					snap429 := d127
-					snap430 := d128
-					snap431 := d129
-					snap432 := d130
-					snap433 := d179
-					snap434 := d180
-					snap435 := d181
-					snap436 := d182
-					snap437 := d239
-					snap438 := d240
-					snap439 := d241
-					snap440 := d242
+					ctx.FreeDesc(&d408)
+					snap413 := d0
+					snap414 := d1
+					snap415 := d2
+					snap416 := d3
+					snap417 := d18
+					snap418 := d19
+					snap419 := d20
+					snap420 := d21
+					snap421 := d22
+					snap422 := d47
+					snap423 := d48
+					snap424 := d49
+					snap425 := d50
+					snap426 := d83
+					snap427 := d84
+					snap428 := d85
+					snap429 := d86
+					snap430 := d127
+					snap431 := d128
+					snap432 := d129
+					snap433 := d130
+					snap434 := d179
+					snap435 := d180
+					snap436 := d181
+					snap437 := d182
+					snap438 := d239
+					snap439 := d240
+					snap440 := d241
 					snap441 := d243
 					snap442 := d244
 					snap443 := d245
 					snap444 := d246
 					snap445 := d247
-					snap446 := d322
+					snap446 := d248
 					snap447 := d323
-					snap448 := d402
+					snap448 := d324
 					snap449 := d403
 					snap450 := d404
 					snap451 := d405
 					snap452 := d406
 					snap453 := d407
-					snap454 := d409
-					alloc455 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc455)
-					d0 = snap412
-					d1 = snap413
-					d2 = snap414
-					d3 = snap415
-					d18 = snap416
-					d19 = snap417
-					d20 = snap418
-					d21 = snap419
-					d22 = snap420
-					d47 = snap421
-					d48 = snap422
-					d49 = snap423
-					d50 = snap424
-					d83 = snap425
-					d84 = snap426
-					d85 = snap427
-					d86 = snap428
-					d127 = snap429
-					d128 = snap430
-					d129 = snap431
-					d130 = snap432
-					d179 = snap433
-					d180 = snap434
-					d181 = snap435
-					d182 = snap436
-					d239 = snap437
-					d240 = snap438
-					d241 = snap439
-					d242 = snap440
+					snap454 := d408
+					snap455 := d410
+					alloc456 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc456)
+					d0 = snap413
+					d1 = snap414
+					d2 = snap415
+					d3 = snap416
+					d18 = snap417
+					d19 = snap418
+					d20 = snap419
+					d21 = snap420
+					d22 = snap421
+					d47 = snap422
+					d48 = snap423
+					d49 = snap424
+					d50 = snap425
+					d83 = snap426
+					d84 = snap427
+					d85 = snap428
+					d86 = snap429
+					d127 = snap430
+					d128 = snap431
+					d129 = snap432
+					d130 = snap433
+					d179 = snap434
+					d180 = snap435
+					d181 = snap436
+					d182 = snap437
+					d239 = snap438
+					d240 = snap439
+					d241 = snap440
 					d243 = snap441
 					d244 = snap442
 					d245 = snap443
 					d246 = snap444
 					d247 = snap445
-					d322 = snap446
+					d248 = snap446
 					d323 = snap447
-					d402 = snap448
+					d324 = snap448
 					d403 = snap449
 					d404 = snap450
 					d405 = snap451
 					d406 = snap452
 					d407 = snap453
-					d409 = snap454
-					ctx.RestoreAllocState(alloc455)
-					d0 = snap412
-					d1 = snap413
-					d2 = snap414
-					d3 = snap415
-					d18 = snap416
-					d19 = snap417
-					d20 = snap418
-					d21 = snap419
-					d22 = snap420
-					d47 = snap421
-					d48 = snap422
-					d49 = snap423
-					d50 = snap424
-					d83 = snap425
-					d84 = snap426
-					d85 = snap427
-					d86 = snap428
-					d127 = snap429
-					d128 = snap430
-					d129 = snap431
-					d130 = snap432
-					d179 = snap433
-					d180 = snap434
-					d181 = snap435
-					d182 = snap436
-					d239 = snap437
-					d240 = snap438
-					d241 = snap439
-					d242 = snap440
+					d408 = snap454
+					d410 = snap455
+					ctx.RestoreAllocState(alloc456)
+					d0 = snap413
+					d1 = snap414
+					d2 = snap415
+					d3 = snap416
+					d18 = snap417
+					d19 = snap418
+					d20 = snap419
+					d21 = snap420
+					d22 = snap421
+					d47 = snap422
+					d48 = snap423
+					d49 = snap424
+					d50 = snap425
+					d83 = snap426
+					d84 = snap427
+					d85 = snap428
+					d86 = snap429
+					d127 = snap430
+					d128 = snap431
+					d129 = snap432
+					d130 = snap433
+					d179 = snap434
+					d180 = snap435
+					d181 = snap436
+					d182 = snap437
+					d239 = snap438
+					d240 = snap439
+					d241 = snap440
 					d243 = snap441
 					d244 = snap442
 					d245 = snap443
 					d246 = snap444
 					d247 = snap445
-					d322 = snap446
+					d248 = snap446
 					d323 = snap447
-					d402 = snap448
+					d324 = snap448
 					d403 = snap449
 					d404 = snap450
 					d405 = snap451
 					d406 = snap452
 					d407 = snap453
-					d409 = snap454
-					ps456 := PhiState{General: true}
-					ps456.OverlayValues = make([]JITValueDesc, 410)
-					ps456.OverlayValues[0] = d0
-					ps456.OverlayValues[1] = d1
-					ps456.OverlayValues[2] = d2
-					ps456.OverlayValues[3] = d3
-					ps456.OverlayValues[18] = d18
-					ps456.OverlayValues[19] = d19
-					ps456.OverlayValues[20] = d20
-					ps456.OverlayValues[21] = d21
-					ps456.OverlayValues[22] = d22
-					ps456.OverlayValues[47] = d47
-					ps456.OverlayValues[48] = d48
-					ps456.OverlayValues[49] = d49
-					ps456.OverlayValues[50] = d50
-					ps456.OverlayValues[83] = d83
-					ps456.OverlayValues[84] = d84
-					ps456.OverlayValues[85] = d85
-					ps456.OverlayValues[86] = d86
-					ps456.OverlayValues[127] = d127
-					ps456.OverlayValues[128] = d128
-					ps456.OverlayValues[129] = d129
-					ps456.OverlayValues[130] = d130
-					ps456.OverlayValues[179] = d179
-					ps456.OverlayValues[180] = d180
-					ps456.OverlayValues[181] = d181
-					ps456.OverlayValues[182] = d182
-					ps456.OverlayValues[239] = d239
-					ps456.OverlayValues[240] = d240
-					ps456.OverlayValues[241] = d241
-					ps456.OverlayValues[242] = d242
-					ps456.OverlayValues[243] = d243
-					ps456.OverlayValues[244] = d244
-					ps456.OverlayValues[245] = d245
-					ps456.OverlayValues[246] = d246
-					ps456.OverlayValues[247] = d247
-					ps456.OverlayValues[322] = d322
-					ps456.OverlayValues[323] = d323
-					ps456.OverlayValues[402] = d402
-					ps456.OverlayValues[403] = d403
-					ps456.OverlayValues[404] = d404
-					ps456.OverlayValues[405] = d405
-					ps456.OverlayValues[406] = d406
-					ps456.OverlayValues[407] = d407
-					ps456.OverlayValues[409] = d409
+					d408 = snap454
+					d410 = snap455
 					ps457 := PhiState{General: true}
-					ps457.OverlayValues = make([]JITValueDesc, 410)
+					ps457.OverlayValues = make([]JITValueDesc, 411)
 					ps457.OverlayValues[0] = d0
 					ps457.OverlayValues[1] = d1
 					ps457.OverlayValues[2] = d2
@@ -26910,114 +26978,159 @@ func init_alu() {
 					ps457.OverlayValues[239] = d239
 					ps457.OverlayValues[240] = d240
 					ps457.OverlayValues[241] = d241
-					ps457.OverlayValues[242] = d242
 					ps457.OverlayValues[243] = d243
 					ps457.OverlayValues[244] = d244
 					ps457.OverlayValues[245] = d245
 					ps457.OverlayValues[246] = d246
 					ps457.OverlayValues[247] = d247
-					ps457.OverlayValues[322] = d322
+					ps457.OverlayValues[248] = d248
 					ps457.OverlayValues[323] = d323
-					ps457.OverlayValues[402] = d402
+					ps457.OverlayValues[324] = d324
 					ps457.OverlayValues[403] = d403
 					ps457.OverlayValues[404] = d404
 					ps457.OverlayValues[405] = d405
 					ps457.OverlayValues[406] = d406
 					ps457.OverlayValues[407] = d407
-					ps457.OverlayValues[409] = d409
-					snap458 := d0
-					snap459 := d1
-					snap460 := d2
-					snap461 := d3
-					snap462 := d18
-					snap463 := d19
-					snap464 := d20
-					snap465 := d21
-					snap466 := d22
-					snap467 := d47
-					snap468 := d48
-					snap469 := d49
-					snap470 := d50
-					snap471 := d83
-					snap472 := d84
-					snap473 := d85
-					snap474 := d86
-					snap475 := d127
-					snap476 := d128
-					snap477 := d129
-					snap478 := d130
-					snap479 := d179
-					snap480 := d180
-					snap481 := d181
-					snap482 := d182
-					snap483 := d239
-					snap484 := d240
-					snap485 := d241
-					snap486 := d242
+					ps457.OverlayValues[408] = d408
+					ps457.OverlayValues[410] = d410
+					ps458 := PhiState{General: true}
+					ps458.OverlayValues = make([]JITValueDesc, 411)
+					ps458.OverlayValues[0] = d0
+					ps458.OverlayValues[1] = d1
+					ps458.OverlayValues[2] = d2
+					ps458.OverlayValues[3] = d3
+					ps458.OverlayValues[18] = d18
+					ps458.OverlayValues[19] = d19
+					ps458.OverlayValues[20] = d20
+					ps458.OverlayValues[21] = d21
+					ps458.OverlayValues[22] = d22
+					ps458.OverlayValues[47] = d47
+					ps458.OverlayValues[48] = d48
+					ps458.OverlayValues[49] = d49
+					ps458.OverlayValues[50] = d50
+					ps458.OverlayValues[83] = d83
+					ps458.OverlayValues[84] = d84
+					ps458.OverlayValues[85] = d85
+					ps458.OverlayValues[86] = d86
+					ps458.OverlayValues[127] = d127
+					ps458.OverlayValues[128] = d128
+					ps458.OverlayValues[129] = d129
+					ps458.OverlayValues[130] = d130
+					ps458.OverlayValues[179] = d179
+					ps458.OverlayValues[180] = d180
+					ps458.OverlayValues[181] = d181
+					ps458.OverlayValues[182] = d182
+					ps458.OverlayValues[239] = d239
+					ps458.OverlayValues[240] = d240
+					ps458.OverlayValues[241] = d241
+					ps458.OverlayValues[243] = d243
+					ps458.OverlayValues[244] = d244
+					ps458.OverlayValues[245] = d245
+					ps458.OverlayValues[246] = d246
+					ps458.OverlayValues[247] = d247
+					ps458.OverlayValues[248] = d248
+					ps458.OverlayValues[323] = d323
+					ps458.OverlayValues[324] = d324
+					ps458.OverlayValues[403] = d403
+					ps458.OverlayValues[404] = d404
+					ps458.OverlayValues[405] = d405
+					ps458.OverlayValues[406] = d406
+					ps458.OverlayValues[407] = d407
+					ps458.OverlayValues[408] = d408
+					ps458.OverlayValues[410] = d410
+					snap459 := d0
+					snap460 := d1
+					snap461 := d2
+					snap462 := d3
+					snap463 := d18
+					snap464 := d19
+					snap465 := d20
+					snap466 := d21
+					snap467 := d22
+					snap468 := d47
+					snap469 := d48
+					snap470 := d49
+					snap471 := d50
+					snap472 := d83
+					snap473 := d84
+					snap474 := d85
+					snap475 := d86
+					snap476 := d127
+					snap477 := d128
+					snap478 := d129
+					snap479 := d130
+					snap480 := d179
+					snap481 := d180
+					snap482 := d181
+					snap483 := d182
+					snap484 := d239
+					snap485 := d240
+					snap486 := d241
 					snap487 := d243
 					snap488 := d244
 					snap489 := d245
 					snap490 := d246
 					snap491 := d247
-					snap492 := d322
+					snap492 := d248
 					snap493 := d323
-					snap494 := d402
+					snap494 := d324
 					snap495 := d403
 					snap496 := d404
 					snap497 := d405
 					snap498 := d406
 					snap499 := d407
-					snap500 := d409
-					alloc501 := ctx.SnapshotAllocState()
+					snap500 := d408
+					snap501 := d410
+					alloc502 := ctx.SnapshotAllocState()
 					if !bbs[16].Rendered {
-						bbs[16].RenderPS(ps457)
+						bbs[16].RenderPS(ps458)
 					}
-					ctx.RestoreAllocState(alloc501)
-					d0 = snap458
-					d1 = snap459
-					d2 = snap460
-					d3 = snap461
-					d18 = snap462
-					d19 = snap463
-					d20 = snap464
-					d21 = snap465
-					d22 = snap466
-					d47 = snap467
-					d48 = snap468
-					d49 = snap469
-					d50 = snap470
-					d83 = snap471
-					d84 = snap472
-					d85 = snap473
-					d86 = snap474
-					d127 = snap475
-					d128 = snap476
-					d129 = snap477
-					d130 = snap478
-					d179 = snap479
-					d180 = snap480
-					d181 = snap481
-					d182 = snap482
-					d239 = snap483
-					d240 = snap484
-					d241 = snap485
-					d242 = snap486
+					ctx.RestoreAllocState(alloc502)
+					d0 = snap459
+					d1 = snap460
+					d2 = snap461
+					d3 = snap462
+					d18 = snap463
+					d19 = snap464
+					d20 = snap465
+					d21 = snap466
+					d22 = snap467
+					d47 = snap468
+					d48 = snap469
+					d49 = snap470
+					d50 = snap471
+					d83 = snap472
+					d84 = snap473
+					d85 = snap474
+					d86 = snap475
+					d127 = snap476
+					d128 = snap477
+					d129 = snap478
+					d130 = snap479
+					d179 = snap480
+					d180 = snap481
+					d181 = snap482
+					d182 = snap483
+					d239 = snap484
+					d240 = snap485
+					d241 = snap486
 					d243 = snap487
 					d244 = snap488
 					d245 = snap489
 					d246 = snap490
 					d247 = snap491
-					d322 = snap492
+					d248 = snap492
 					d323 = snap493
-					d402 = snap494
+					d324 = snap494
 					d403 = snap495
 					d404 = snap496
 					d405 = snap497
 					d406 = snap498
 					d407 = snap499
-					d409 = snap500
+					d408 = snap500
+					d410 = snap501
 					if !bbs[13].Rendered {
-						return bbs[13].RenderPS(ps456)
+						return bbs[13].RenderPS(ps457)
 					}
 					return result
 					return result
@@ -27125,9 +27238,6 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
@@ -27143,14 +27253,14 @@ func init_alu() {
 					if len(ps.OverlayValues) > 247 && ps.OverlayValues[247].Loc != LocNone {
 						d247 = ps.OverlayValues[247]
 					}
-					if len(ps.OverlayValues) > 322 && ps.OverlayValues[322].Loc != LocNone {
-						d322 = ps.OverlayValues[322]
+					if len(ps.OverlayValues) > 248 && ps.OverlayValues[248].Loc != LocNone {
+						d248 = ps.OverlayValues[248]
 					}
 					if len(ps.OverlayValues) > 323 && ps.OverlayValues[323].Loc != LocNone {
 						d323 = ps.OverlayValues[323]
 					}
-					if len(ps.OverlayValues) > 402 && ps.OverlayValues[402].Loc != LocNone {
-						d402 = ps.OverlayValues[402]
+					if len(ps.OverlayValues) > 324 && ps.OverlayValues[324].Loc != LocNone {
+						d324 = ps.OverlayValues[324]
 					}
 					if len(ps.OverlayValues) > 403 && ps.OverlayValues[403].Loc != LocNone {
 						d403 = ps.OverlayValues[403]
@@ -27167,32 +27277,35 @@ func init_alu() {
 					if len(ps.OverlayValues) > 407 && ps.OverlayValues[407].Loc != LocNone {
 						d407 = ps.OverlayValues[407]
 					}
-					if len(ps.OverlayValues) > 409 && ps.OverlayValues[409].Loc != LocNone {
-						d409 = ps.OverlayValues[409]
+					if len(ps.OverlayValues) > 408 && ps.OverlayValues[408].Loc != LocNone {
+						d408 = ps.OverlayValues[408]
+					}
+					if len(ps.OverlayValues) > 410 && ps.OverlayValues[410].Loc != LocNone {
+						d410 = ps.OverlayValues[410]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d502 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
-					ctx.SyncDesc(&d502)
-					if d502.Loc == LocRegPair || d502.Loc == LocStackPair || d502.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d502, &result)
-						result.Type = d502.Type
+					d503 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+					ctx.SyncDesc(&d503)
+					if d503.Loc == LocRegPair || d503.Loc == LocStackPair || d503.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d503, &result)
+						result.Type = d503.Type
 					} else {
-						switch d502.Type {
+						switch d503.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d502)
+							ctx.EmitMakeBool(result, d503)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d502)
+							ctx.EmitMakeInt(result, d503)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d502)
+							ctx.EmitMakeFloat(result, d503)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d502, &result)
-							result.Type = d502.Type
+							ctx.EmitMovPairToResult(&d503, &result)
+							result.Type = d503.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -27301,9 +27414,6 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
@@ -27319,14 +27429,14 @@ func init_alu() {
 					if len(ps.OverlayValues) > 247 && ps.OverlayValues[247].Loc != LocNone {
 						d247 = ps.OverlayValues[247]
 					}
-					if len(ps.OverlayValues) > 322 && ps.OverlayValues[322].Loc != LocNone {
-						d322 = ps.OverlayValues[322]
+					if len(ps.OverlayValues) > 248 && ps.OverlayValues[248].Loc != LocNone {
+						d248 = ps.OverlayValues[248]
 					}
 					if len(ps.OverlayValues) > 323 && ps.OverlayValues[323].Loc != LocNone {
 						d323 = ps.OverlayValues[323]
 					}
-					if len(ps.OverlayValues) > 402 && ps.OverlayValues[402].Loc != LocNone {
-						d402 = ps.OverlayValues[402]
+					if len(ps.OverlayValues) > 324 && ps.OverlayValues[324].Loc != LocNone {
+						d324 = ps.OverlayValues[324]
 					}
 					if len(ps.OverlayValues) > 403 && ps.OverlayValues[403].Loc != LocNone {
 						d403 = ps.OverlayValues[403]
@@ -27343,33 +27453,36 @@ func init_alu() {
 					if len(ps.OverlayValues) > 407 && ps.OverlayValues[407].Loc != LocNone {
 						d407 = ps.OverlayValues[407]
 					}
-					if len(ps.OverlayValues) > 409 && ps.OverlayValues[409].Loc != LocNone {
-						d409 = ps.OverlayValues[409]
+					if len(ps.OverlayValues) > 408 && ps.OverlayValues[408].Loc != LocNone {
+						d408 = ps.OverlayValues[408]
 					}
-					if len(ps.OverlayValues) > 502 && ps.OverlayValues[502].Loc != LocNone {
-						d502 = ps.OverlayValues[502]
+					if len(ps.OverlayValues) > 410 && ps.OverlayValues[410].Loc != LocNone {
+						d410 = ps.OverlayValues[410]
+					}
+					if len(ps.OverlayValues) > 503 && ps.OverlayValues[503].Loc != LocNone {
+						d503 = ps.OverlayValues[503]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d406)
-					ctx.EnsureDesc(&d406)
-					var d503 JITValueDesc
-					if d406.Loc == LocImm {
-						d503 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d406.Imm.Float()))}
+					ctx.EnsureDesc(&d407)
+					ctx.EnsureDesc(&d407)
+					var d504 JITValueDesc
+					if d407.Loc == LocImm {
+						d504 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d407.Imm.Float()))}
 					} else {
 						r5 := ctx.AllocReg()
-						ctx.EmitCvtFloatBitsToInt64(r5, d406.Reg)
-						d503 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5}
-						ctx.BindReg(r5, &d503)
+						ctx.EmitCvtFloatBitsToInt64(r5, d407.Reg)
+						d504 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5}
+						ctx.BindReg(r5, &d504)
 					}
-					ctx.EnsureDesc(&d503)
-					if d503.Loc == LocImm {
-						ctx.EmitMakeInt(result, d503)
-					} else {
-						ctx.EmitMovToReg(result.Reg2, d503)
-						d504 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+					ctx.EnsureDesc(&d504)
+					if d504.Loc == LocImm {
 						ctx.EmitMakeInt(result, d504)
-						if d503.Loc == LocReg && d503.Reg != result.Reg2 {
-							ctx.FreeReg(d503.Reg)
+					} else {
+						ctx.EmitMovToReg(result.Reg2, d504)
+						d505 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d505)
+						if d504.Loc == LocReg && d504.Reg != result.Reg2 {
+							ctx.FreeReg(d504.Reg)
 						}
 					}
 					result.Type = tagInt
@@ -27479,9 +27592,6 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
@@ -27497,14 +27607,14 @@ func init_alu() {
 					if len(ps.OverlayValues) > 247 && ps.OverlayValues[247].Loc != LocNone {
 						d247 = ps.OverlayValues[247]
 					}
-					if len(ps.OverlayValues) > 322 && ps.OverlayValues[322].Loc != LocNone {
-						d322 = ps.OverlayValues[322]
+					if len(ps.OverlayValues) > 248 && ps.OverlayValues[248].Loc != LocNone {
+						d248 = ps.OverlayValues[248]
 					}
 					if len(ps.OverlayValues) > 323 && ps.OverlayValues[323].Loc != LocNone {
 						d323 = ps.OverlayValues[323]
 					}
-					if len(ps.OverlayValues) > 402 && ps.OverlayValues[402].Loc != LocNone {
-						d402 = ps.OverlayValues[402]
+					if len(ps.OverlayValues) > 324 && ps.OverlayValues[324].Loc != LocNone {
+						d324 = ps.OverlayValues[324]
 					}
 					if len(ps.OverlayValues) > 403 && ps.OverlayValues[403].Loc != LocNone {
 						d403 = ps.OverlayValues[403]
@@ -27521,11 +27631,11 @@ func init_alu() {
 					if len(ps.OverlayValues) > 407 && ps.OverlayValues[407].Loc != LocNone {
 						d407 = ps.OverlayValues[407]
 					}
-					if len(ps.OverlayValues) > 409 && ps.OverlayValues[409].Loc != LocNone {
-						d409 = ps.OverlayValues[409]
+					if len(ps.OverlayValues) > 408 && ps.OverlayValues[408].Loc != LocNone {
+						d408 = ps.OverlayValues[408]
 					}
-					if len(ps.OverlayValues) > 502 && ps.OverlayValues[502].Loc != LocNone {
-						d502 = ps.OverlayValues[502]
+					if len(ps.OverlayValues) > 410 && ps.OverlayValues[410].Loc != LocNone {
+						d410 = ps.OverlayValues[410]
 					}
 					if len(ps.OverlayValues) > 503 && ps.OverlayValues[503].Loc != LocNone {
 						d503 = ps.OverlayValues[503]
@@ -27533,341 +27643,294 @@ func init_alu() {
 					if len(ps.OverlayValues) > 504 && ps.OverlayValues[504].Loc != LocNone {
 						d504 = ps.OverlayValues[504]
 					}
-					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d406)
-					var d505 JITValueDesc
-					if d406.Loc == LocImm {
-						d505 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d406.Imm.Float() >= 9.223372036854776e+18)}
-					} else {
-						r6 := ctx.AllocRegExcept(d406.Reg)
-						ctx.EmitMovRegImm64(RegR11, uint64(4890909195324358656))
-						ctx.EmitCmpFloat64Setcc(r6, d406.Reg, RegR11, CondSignedGreaterOrEqual)
-						d505 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r6}
-						ctx.BindReg(r6, &d505)
+					if len(ps.OverlayValues) > 505 && ps.OverlayValues[505].Loc != LocNone {
+						d505 = ps.OverlayValues[505]
 					}
-					d506 = d505
-					ctx.EnsureDesc(&d506)
-					if d506.Loc != LocImm && d506.Loc != LocReg {
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d407)
+					var d506 JITValueDesc
+					if d407.Loc == LocImm {
+						d506 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d407.Imm.Float() >= 9.223372036854776e+18)}
+					} else {
+						r6 := ctx.AllocRegExcept(d407.Reg)
+						ctx.EmitMovRegImm64(RegR11, uint64(4890909195324358656))
+						ctx.EmitCmpFloat64Setcc(r6, d407.Reg, RegR11, CondSignedGreaterOrEqual)
+						d506 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r6}
+						ctx.BindReg(r6, &d506)
+					}
+					d507 = d506
+					ctx.EnsureDesc(&d507)
+					if d507.Loc != LocImm && d507.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d506.Loc == LocImm {
-						if d506.Imm.Bool() {
+					if d507.Loc == LocImm {
+						if d507.Imm.Bool() {
 							if ps.General {
 							}
-							ps507 := PhiState{General: ps.General}
-							ps507.OverlayValues = make([]JITValueDesc, 507)
-							ps507.OverlayValues[0] = d0
-							ps507.OverlayValues[1] = d1
-							ps507.OverlayValues[2] = d2
-							ps507.OverlayValues[3] = d3
-							ps507.OverlayValues[18] = d18
-							ps507.OverlayValues[19] = d19
-							ps507.OverlayValues[20] = d20
-							ps507.OverlayValues[21] = d21
-							ps507.OverlayValues[22] = d22
-							ps507.OverlayValues[47] = d47
-							ps507.OverlayValues[48] = d48
-							ps507.OverlayValues[49] = d49
-							ps507.OverlayValues[50] = d50
-							ps507.OverlayValues[83] = d83
-							ps507.OverlayValues[84] = d84
-							ps507.OverlayValues[85] = d85
-							ps507.OverlayValues[86] = d86
-							ps507.OverlayValues[127] = d127
-							ps507.OverlayValues[128] = d128
-							ps507.OverlayValues[129] = d129
-							ps507.OverlayValues[130] = d130
-							ps507.OverlayValues[179] = d179
-							ps507.OverlayValues[180] = d180
-							ps507.OverlayValues[181] = d181
-							ps507.OverlayValues[182] = d182
-							ps507.OverlayValues[239] = d239
-							ps507.OverlayValues[240] = d240
-							ps507.OverlayValues[241] = d241
-							ps507.OverlayValues[242] = d242
-							ps507.OverlayValues[243] = d243
-							ps507.OverlayValues[244] = d244
-							ps507.OverlayValues[245] = d245
-							ps507.OverlayValues[246] = d246
-							ps507.OverlayValues[247] = d247
-							ps507.OverlayValues[322] = d322
-							ps507.OverlayValues[323] = d323
-							ps507.OverlayValues[402] = d402
-							ps507.OverlayValues[403] = d403
-							ps507.OverlayValues[404] = d404
-							ps507.OverlayValues[405] = d405
-							ps507.OverlayValues[406] = d406
-							ps507.OverlayValues[407] = d407
-							ps507.OverlayValues[409] = d409
-							ps507.OverlayValues[502] = d502
-							ps507.OverlayValues[503] = d503
-							ps507.OverlayValues[504] = d504
-							ps507.OverlayValues[505] = d505
-							ps507.OverlayValues[506] = d506
-							return bbs[13].RenderPS(ps507)
+							ps508 := PhiState{General: ps.General}
+							ps508.OverlayValues = make([]JITValueDesc, 508)
+							ps508.OverlayValues[0] = d0
+							ps508.OverlayValues[1] = d1
+							ps508.OverlayValues[2] = d2
+							ps508.OverlayValues[3] = d3
+							ps508.OverlayValues[18] = d18
+							ps508.OverlayValues[19] = d19
+							ps508.OverlayValues[20] = d20
+							ps508.OverlayValues[21] = d21
+							ps508.OverlayValues[22] = d22
+							ps508.OverlayValues[47] = d47
+							ps508.OverlayValues[48] = d48
+							ps508.OverlayValues[49] = d49
+							ps508.OverlayValues[50] = d50
+							ps508.OverlayValues[83] = d83
+							ps508.OverlayValues[84] = d84
+							ps508.OverlayValues[85] = d85
+							ps508.OverlayValues[86] = d86
+							ps508.OverlayValues[127] = d127
+							ps508.OverlayValues[128] = d128
+							ps508.OverlayValues[129] = d129
+							ps508.OverlayValues[130] = d130
+							ps508.OverlayValues[179] = d179
+							ps508.OverlayValues[180] = d180
+							ps508.OverlayValues[181] = d181
+							ps508.OverlayValues[182] = d182
+							ps508.OverlayValues[239] = d239
+							ps508.OverlayValues[240] = d240
+							ps508.OverlayValues[241] = d241
+							ps508.OverlayValues[243] = d243
+							ps508.OverlayValues[244] = d244
+							ps508.OverlayValues[245] = d245
+							ps508.OverlayValues[246] = d246
+							ps508.OverlayValues[247] = d247
+							ps508.OverlayValues[248] = d248
+							ps508.OverlayValues[323] = d323
+							ps508.OverlayValues[324] = d324
+							ps508.OverlayValues[403] = d403
+							ps508.OverlayValues[404] = d404
+							ps508.OverlayValues[405] = d405
+							ps508.OverlayValues[406] = d406
+							ps508.OverlayValues[407] = d407
+							ps508.OverlayValues[408] = d408
+							ps508.OverlayValues[410] = d410
+							ps508.OverlayValues[503] = d503
+							ps508.OverlayValues[504] = d504
+							ps508.OverlayValues[505] = d505
+							ps508.OverlayValues[506] = d506
+							ps508.OverlayValues[507] = d507
+							return bbs[13].RenderPS(ps508)
 						}
 						if ps.General {
 						}
-						ps508 := PhiState{General: ps.General}
-						ps508.OverlayValues = make([]JITValueDesc, 507)
-						ps508.OverlayValues[0] = d0
-						ps508.OverlayValues[1] = d1
-						ps508.OverlayValues[2] = d2
-						ps508.OverlayValues[3] = d3
-						ps508.OverlayValues[18] = d18
-						ps508.OverlayValues[19] = d19
-						ps508.OverlayValues[20] = d20
-						ps508.OverlayValues[21] = d21
-						ps508.OverlayValues[22] = d22
-						ps508.OverlayValues[47] = d47
-						ps508.OverlayValues[48] = d48
-						ps508.OverlayValues[49] = d49
-						ps508.OverlayValues[50] = d50
-						ps508.OverlayValues[83] = d83
-						ps508.OverlayValues[84] = d84
-						ps508.OverlayValues[85] = d85
-						ps508.OverlayValues[86] = d86
-						ps508.OverlayValues[127] = d127
-						ps508.OverlayValues[128] = d128
-						ps508.OverlayValues[129] = d129
-						ps508.OverlayValues[130] = d130
-						ps508.OverlayValues[179] = d179
-						ps508.OverlayValues[180] = d180
-						ps508.OverlayValues[181] = d181
-						ps508.OverlayValues[182] = d182
-						ps508.OverlayValues[239] = d239
-						ps508.OverlayValues[240] = d240
-						ps508.OverlayValues[241] = d241
-						ps508.OverlayValues[242] = d242
-						ps508.OverlayValues[243] = d243
-						ps508.OverlayValues[244] = d244
-						ps508.OverlayValues[245] = d245
-						ps508.OverlayValues[246] = d246
-						ps508.OverlayValues[247] = d247
-						ps508.OverlayValues[322] = d322
-						ps508.OverlayValues[323] = d323
-						ps508.OverlayValues[402] = d402
-						ps508.OverlayValues[403] = d403
-						ps508.OverlayValues[404] = d404
-						ps508.OverlayValues[405] = d405
-						ps508.OverlayValues[406] = d406
-						ps508.OverlayValues[407] = d407
-						ps508.OverlayValues[409] = d409
-						ps508.OverlayValues[502] = d502
-						ps508.OverlayValues[503] = d503
-						ps508.OverlayValues[504] = d504
-						ps508.OverlayValues[505] = d505
-						ps508.OverlayValues[506] = d506
-						return bbs[14].RenderPS(ps508)
+						ps509 := PhiState{General: ps.General}
+						ps509.OverlayValues = make([]JITValueDesc, 508)
+						ps509.OverlayValues[0] = d0
+						ps509.OverlayValues[1] = d1
+						ps509.OverlayValues[2] = d2
+						ps509.OverlayValues[3] = d3
+						ps509.OverlayValues[18] = d18
+						ps509.OverlayValues[19] = d19
+						ps509.OverlayValues[20] = d20
+						ps509.OverlayValues[21] = d21
+						ps509.OverlayValues[22] = d22
+						ps509.OverlayValues[47] = d47
+						ps509.OverlayValues[48] = d48
+						ps509.OverlayValues[49] = d49
+						ps509.OverlayValues[50] = d50
+						ps509.OverlayValues[83] = d83
+						ps509.OverlayValues[84] = d84
+						ps509.OverlayValues[85] = d85
+						ps509.OverlayValues[86] = d86
+						ps509.OverlayValues[127] = d127
+						ps509.OverlayValues[128] = d128
+						ps509.OverlayValues[129] = d129
+						ps509.OverlayValues[130] = d130
+						ps509.OverlayValues[179] = d179
+						ps509.OverlayValues[180] = d180
+						ps509.OverlayValues[181] = d181
+						ps509.OverlayValues[182] = d182
+						ps509.OverlayValues[239] = d239
+						ps509.OverlayValues[240] = d240
+						ps509.OverlayValues[241] = d241
+						ps509.OverlayValues[243] = d243
+						ps509.OverlayValues[244] = d244
+						ps509.OverlayValues[245] = d245
+						ps509.OverlayValues[246] = d246
+						ps509.OverlayValues[247] = d247
+						ps509.OverlayValues[248] = d248
+						ps509.OverlayValues[323] = d323
+						ps509.OverlayValues[324] = d324
+						ps509.OverlayValues[403] = d403
+						ps509.OverlayValues[404] = d404
+						ps509.OverlayValues[405] = d405
+						ps509.OverlayValues[406] = d406
+						ps509.OverlayValues[407] = d407
+						ps509.OverlayValues[408] = d408
+						ps509.OverlayValues[410] = d410
+						ps509.OverlayValues[503] = d503
+						ps509.OverlayValues[504] = d504
+						ps509.OverlayValues[505] = d505
+						ps509.OverlayValues[506] = d506
+						ps509.OverlayValues[507] = d507
+						return bbs[14].RenderPS(ps509)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[15].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d506.Reg, 0)
+					ctx.EmitCmpRegImm32(d507.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl14)
 					if bbs[14].Rendered {
 						ctx.EmitJmp(lbl15)
 					}
-					snap509 := d0
-					snap510 := d1
-					snap511 := d2
-					snap512 := d3
-					snap513 := d18
-					snap514 := d19
-					snap515 := d20
-					snap516 := d21
-					snap517 := d22
-					snap518 := d47
-					snap519 := d48
-					snap520 := d49
-					snap521 := d50
-					snap522 := d83
-					snap523 := d84
-					snap524 := d85
-					snap525 := d86
-					snap526 := d127
-					snap527 := d128
-					snap528 := d129
-					snap529 := d130
-					snap530 := d179
-					snap531 := d180
-					snap532 := d181
-					snap533 := d182
-					snap534 := d239
-					snap535 := d240
-					snap536 := d241
-					snap537 := d242
+					snap510 := d0
+					snap511 := d1
+					snap512 := d2
+					snap513 := d3
+					snap514 := d18
+					snap515 := d19
+					snap516 := d20
+					snap517 := d21
+					snap518 := d22
+					snap519 := d47
+					snap520 := d48
+					snap521 := d49
+					snap522 := d50
+					snap523 := d83
+					snap524 := d84
+					snap525 := d85
+					snap526 := d86
+					snap527 := d127
+					snap528 := d128
+					snap529 := d129
+					snap530 := d130
+					snap531 := d179
+					snap532 := d180
+					snap533 := d181
+					snap534 := d182
+					snap535 := d239
+					snap536 := d240
+					snap537 := d241
 					snap538 := d243
 					snap539 := d244
 					snap540 := d245
 					snap541 := d246
 					snap542 := d247
-					snap543 := d322
+					snap543 := d248
 					snap544 := d323
-					snap545 := d402
+					snap545 := d324
 					snap546 := d403
 					snap547 := d404
 					snap548 := d405
 					snap549 := d406
 					snap550 := d407
-					snap551 := d409
-					snap552 := d502
+					snap551 := d408
+					snap552 := d410
 					snap553 := d503
 					snap554 := d504
 					snap555 := d505
 					snap556 := d506
-					alloc557 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc557)
-					d0 = snap509
-					d1 = snap510
-					d2 = snap511
-					d3 = snap512
-					d18 = snap513
-					d19 = snap514
-					d20 = snap515
-					d21 = snap516
-					d22 = snap517
-					d47 = snap518
-					d48 = snap519
-					d49 = snap520
-					d50 = snap521
-					d83 = snap522
-					d84 = snap523
-					d85 = snap524
-					d86 = snap525
-					d127 = snap526
-					d128 = snap527
-					d129 = snap528
-					d130 = snap529
-					d179 = snap530
-					d180 = snap531
-					d181 = snap532
-					d182 = snap533
-					d239 = snap534
-					d240 = snap535
-					d241 = snap536
-					d242 = snap537
+					snap557 := d507
+					alloc558 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc558)
+					d0 = snap510
+					d1 = snap511
+					d2 = snap512
+					d3 = snap513
+					d18 = snap514
+					d19 = snap515
+					d20 = snap516
+					d21 = snap517
+					d22 = snap518
+					d47 = snap519
+					d48 = snap520
+					d49 = snap521
+					d50 = snap522
+					d83 = snap523
+					d84 = snap524
+					d85 = snap525
+					d86 = snap526
+					d127 = snap527
+					d128 = snap528
+					d129 = snap529
+					d130 = snap530
+					d179 = snap531
+					d180 = snap532
+					d181 = snap533
+					d182 = snap534
+					d239 = snap535
+					d240 = snap536
+					d241 = snap537
 					d243 = snap538
 					d244 = snap539
 					d245 = snap540
 					d246 = snap541
 					d247 = snap542
-					d322 = snap543
+					d248 = snap543
 					d323 = snap544
-					d402 = snap545
+					d324 = snap545
 					d403 = snap546
 					d404 = snap547
 					d405 = snap548
 					d406 = snap549
 					d407 = snap550
-					d409 = snap551
-					d502 = snap552
+					d408 = snap551
+					d410 = snap552
 					d503 = snap553
 					d504 = snap554
 					d505 = snap555
 					d506 = snap556
-					ctx.RestoreAllocState(alloc557)
-					d0 = snap509
-					d1 = snap510
-					d2 = snap511
-					d3 = snap512
-					d18 = snap513
-					d19 = snap514
-					d20 = snap515
-					d21 = snap516
-					d22 = snap517
-					d47 = snap518
-					d48 = snap519
-					d49 = snap520
-					d50 = snap521
-					d83 = snap522
-					d84 = snap523
-					d85 = snap524
-					d86 = snap525
-					d127 = snap526
-					d128 = snap527
-					d129 = snap528
-					d130 = snap529
-					d179 = snap530
-					d180 = snap531
-					d181 = snap532
-					d182 = snap533
-					d239 = snap534
-					d240 = snap535
-					d241 = snap536
-					d242 = snap537
+					d507 = snap557
+					ctx.RestoreAllocState(alloc558)
+					d0 = snap510
+					d1 = snap511
+					d2 = snap512
+					d3 = snap513
+					d18 = snap514
+					d19 = snap515
+					d20 = snap516
+					d21 = snap517
+					d22 = snap518
+					d47 = snap519
+					d48 = snap520
+					d49 = snap521
+					d50 = snap522
+					d83 = snap523
+					d84 = snap524
+					d85 = snap525
+					d86 = snap526
+					d127 = snap527
+					d128 = snap528
+					d129 = snap529
+					d130 = snap530
+					d179 = snap531
+					d180 = snap532
+					d181 = snap533
+					d182 = snap534
+					d239 = snap535
+					d240 = snap536
+					d241 = snap537
 					d243 = snap538
 					d244 = snap539
 					d245 = snap540
 					d246 = snap541
 					d247 = snap542
-					d322 = snap543
+					d248 = snap543
 					d323 = snap544
-					d402 = snap545
+					d324 = snap545
 					d403 = snap546
 					d404 = snap547
 					d405 = snap548
 					d406 = snap549
 					d407 = snap550
-					d409 = snap551
-					d502 = snap552
+					d408 = snap551
+					d410 = snap552
 					d503 = snap553
 					d504 = snap554
 					d505 = snap555
 					d506 = snap556
-					ps558 := PhiState{General: true}
-					ps558.OverlayValues = make([]JITValueDesc, 507)
-					ps558.OverlayValues[0] = d0
-					ps558.OverlayValues[1] = d1
-					ps558.OverlayValues[2] = d2
-					ps558.OverlayValues[3] = d3
-					ps558.OverlayValues[18] = d18
-					ps558.OverlayValues[19] = d19
-					ps558.OverlayValues[20] = d20
-					ps558.OverlayValues[21] = d21
-					ps558.OverlayValues[22] = d22
-					ps558.OverlayValues[47] = d47
-					ps558.OverlayValues[48] = d48
-					ps558.OverlayValues[49] = d49
-					ps558.OverlayValues[50] = d50
-					ps558.OverlayValues[83] = d83
-					ps558.OverlayValues[84] = d84
-					ps558.OverlayValues[85] = d85
-					ps558.OverlayValues[86] = d86
-					ps558.OverlayValues[127] = d127
-					ps558.OverlayValues[128] = d128
-					ps558.OverlayValues[129] = d129
-					ps558.OverlayValues[130] = d130
-					ps558.OverlayValues[179] = d179
-					ps558.OverlayValues[180] = d180
-					ps558.OverlayValues[181] = d181
-					ps558.OverlayValues[182] = d182
-					ps558.OverlayValues[239] = d239
-					ps558.OverlayValues[240] = d240
-					ps558.OverlayValues[241] = d241
-					ps558.OverlayValues[242] = d242
-					ps558.OverlayValues[243] = d243
-					ps558.OverlayValues[244] = d244
-					ps558.OverlayValues[245] = d245
-					ps558.OverlayValues[246] = d246
-					ps558.OverlayValues[247] = d247
-					ps558.OverlayValues[322] = d322
-					ps558.OverlayValues[323] = d323
-					ps558.OverlayValues[402] = d402
-					ps558.OverlayValues[403] = d403
-					ps558.OverlayValues[404] = d404
-					ps558.OverlayValues[405] = d405
-					ps558.OverlayValues[406] = d406
-					ps558.OverlayValues[407] = d407
-					ps558.OverlayValues[409] = d409
-					ps558.OverlayValues[502] = d502
-					ps558.OverlayValues[503] = d503
-					ps558.OverlayValues[504] = d504
-					ps558.OverlayValues[505] = d505
-					ps558.OverlayValues[506] = d506
+					d507 = snap557
 					ps559 := PhiState{General: true}
-					ps559.OverlayValues = make([]JITValueDesc, 507)
+					ps559.OverlayValues = make([]JITValueDesc, 508)
 					ps559.OverlayValues[0] = d0
 					ps559.OverlayValues[1] = d1
 					ps559.OverlayValues[2] = d2
@@ -27896,132 +27959,182 @@ func init_alu() {
 					ps559.OverlayValues[239] = d239
 					ps559.OverlayValues[240] = d240
 					ps559.OverlayValues[241] = d241
-					ps559.OverlayValues[242] = d242
 					ps559.OverlayValues[243] = d243
 					ps559.OverlayValues[244] = d244
 					ps559.OverlayValues[245] = d245
 					ps559.OverlayValues[246] = d246
 					ps559.OverlayValues[247] = d247
-					ps559.OverlayValues[322] = d322
+					ps559.OverlayValues[248] = d248
 					ps559.OverlayValues[323] = d323
-					ps559.OverlayValues[402] = d402
+					ps559.OverlayValues[324] = d324
 					ps559.OverlayValues[403] = d403
 					ps559.OverlayValues[404] = d404
 					ps559.OverlayValues[405] = d405
 					ps559.OverlayValues[406] = d406
 					ps559.OverlayValues[407] = d407
-					ps559.OverlayValues[409] = d409
-					ps559.OverlayValues[502] = d502
+					ps559.OverlayValues[408] = d408
+					ps559.OverlayValues[410] = d410
 					ps559.OverlayValues[503] = d503
 					ps559.OverlayValues[504] = d504
 					ps559.OverlayValues[505] = d505
 					ps559.OverlayValues[506] = d506
-					snap560 := d0
-					snap561 := d1
-					snap562 := d2
-					snap563 := d3
-					snap564 := d18
-					snap565 := d19
-					snap566 := d20
-					snap567 := d21
-					snap568 := d22
-					snap569 := d47
-					snap570 := d48
-					snap571 := d49
-					snap572 := d50
-					snap573 := d83
-					snap574 := d84
-					snap575 := d85
-					snap576 := d86
-					snap577 := d127
-					snap578 := d128
-					snap579 := d129
-					snap580 := d130
-					snap581 := d179
-					snap582 := d180
-					snap583 := d181
-					snap584 := d182
-					snap585 := d239
-					snap586 := d240
-					snap587 := d241
-					snap588 := d242
+					ps559.OverlayValues[507] = d507
+					ps560 := PhiState{General: true}
+					ps560.OverlayValues = make([]JITValueDesc, 508)
+					ps560.OverlayValues[0] = d0
+					ps560.OverlayValues[1] = d1
+					ps560.OverlayValues[2] = d2
+					ps560.OverlayValues[3] = d3
+					ps560.OverlayValues[18] = d18
+					ps560.OverlayValues[19] = d19
+					ps560.OverlayValues[20] = d20
+					ps560.OverlayValues[21] = d21
+					ps560.OverlayValues[22] = d22
+					ps560.OverlayValues[47] = d47
+					ps560.OverlayValues[48] = d48
+					ps560.OverlayValues[49] = d49
+					ps560.OverlayValues[50] = d50
+					ps560.OverlayValues[83] = d83
+					ps560.OverlayValues[84] = d84
+					ps560.OverlayValues[85] = d85
+					ps560.OverlayValues[86] = d86
+					ps560.OverlayValues[127] = d127
+					ps560.OverlayValues[128] = d128
+					ps560.OverlayValues[129] = d129
+					ps560.OverlayValues[130] = d130
+					ps560.OverlayValues[179] = d179
+					ps560.OverlayValues[180] = d180
+					ps560.OverlayValues[181] = d181
+					ps560.OverlayValues[182] = d182
+					ps560.OverlayValues[239] = d239
+					ps560.OverlayValues[240] = d240
+					ps560.OverlayValues[241] = d241
+					ps560.OverlayValues[243] = d243
+					ps560.OverlayValues[244] = d244
+					ps560.OverlayValues[245] = d245
+					ps560.OverlayValues[246] = d246
+					ps560.OverlayValues[247] = d247
+					ps560.OverlayValues[248] = d248
+					ps560.OverlayValues[323] = d323
+					ps560.OverlayValues[324] = d324
+					ps560.OverlayValues[403] = d403
+					ps560.OverlayValues[404] = d404
+					ps560.OverlayValues[405] = d405
+					ps560.OverlayValues[406] = d406
+					ps560.OverlayValues[407] = d407
+					ps560.OverlayValues[408] = d408
+					ps560.OverlayValues[410] = d410
+					ps560.OverlayValues[503] = d503
+					ps560.OverlayValues[504] = d504
+					ps560.OverlayValues[505] = d505
+					ps560.OverlayValues[506] = d506
+					ps560.OverlayValues[507] = d507
+					snap561 := d0
+					snap562 := d1
+					snap563 := d2
+					snap564 := d3
+					snap565 := d18
+					snap566 := d19
+					snap567 := d20
+					snap568 := d21
+					snap569 := d22
+					snap570 := d47
+					snap571 := d48
+					snap572 := d49
+					snap573 := d50
+					snap574 := d83
+					snap575 := d84
+					snap576 := d85
+					snap577 := d86
+					snap578 := d127
+					snap579 := d128
+					snap580 := d129
+					snap581 := d130
+					snap582 := d179
+					snap583 := d180
+					snap584 := d181
+					snap585 := d182
+					snap586 := d239
+					snap587 := d240
+					snap588 := d241
 					snap589 := d243
 					snap590 := d244
 					snap591 := d245
 					snap592 := d246
 					snap593 := d247
-					snap594 := d322
+					snap594 := d248
 					snap595 := d323
-					snap596 := d402
+					snap596 := d324
 					snap597 := d403
 					snap598 := d404
 					snap599 := d405
 					snap600 := d406
 					snap601 := d407
-					snap602 := d409
-					snap603 := d502
+					snap602 := d408
+					snap603 := d410
 					snap604 := d503
 					snap605 := d504
 					snap606 := d505
 					snap607 := d506
-					alloc608 := ctx.SnapshotAllocState()
+					snap608 := d507
+					alloc609 := ctx.SnapshotAllocState()
 					if !bbs[14].Rendered {
-						bbs[14].RenderPS(ps559)
+						bbs[14].RenderPS(ps560)
 					}
-					ctx.RestoreAllocState(alloc608)
-					d0 = snap560
-					d1 = snap561
-					d2 = snap562
-					d3 = snap563
-					d18 = snap564
-					d19 = snap565
-					d20 = snap566
-					d21 = snap567
-					d22 = snap568
-					d47 = snap569
-					d48 = snap570
-					d49 = snap571
-					d50 = snap572
-					d83 = snap573
-					d84 = snap574
-					d85 = snap575
-					d86 = snap576
-					d127 = snap577
-					d128 = snap578
-					d129 = snap579
-					d130 = snap580
-					d179 = snap581
-					d180 = snap582
-					d181 = snap583
-					d182 = snap584
-					d239 = snap585
-					d240 = snap586
-					d241 = snap587
-					d242 = snap588
+					ctx.RestoreAllocState(alloc609)
+					d0 = snap561
+					d1 = snap562
+					d2 = snap563
+					d3 = snap564
+					d18 = snap565
+					d19 = snap566
+					d20 = snap567
+					d21 = snap568
+					d22 = snap569
+					d47 = snap570
+					d48 = snap571
+					d49 = snap572
+					d50 = snap573
+					d83 = snap574
+					d84 = snap575
+					d85 = snap576
+					d86 = snap577
+					d127 = snap578
+					d128 = snap579
+					d129 = snap580
+					d130 = snap581
+					d179 = snap582
+					d180 = snap583
+					d181 = snap584
+					d182 = snap585
+					d239 = snap586
+					d240 = snap587
+					d241 = snap588
 					d243 = snap589
 					d244 = snap590
 					d245 = snap591
 					d246 = snap592
 					d247 = snap593
-					d322 = snap594
+					d248 = snap594
 					d323 = snap595
-					d402 = snap596
+					d324 = snap596
 					d403 = snap597
 					d404 = snap598
 					d405 = snap599
 					d406 = snap600
 					d407 = snap601
-					d409 = snap602
-					d502 = snap603
+					d408 = snap602
+					d410 = snap603
 					d503 = snap604
 					d504 = snap605
 					d505 = snap606
 					d506 = snap607
+					d507 = snap608
 					if !bbs[13].Rendered {
-						return bbs[13].RenderPS(ps558)
+						return bbs[13].RenderPS(ps559)
 					}
 					return result
-					ctx.FreeDesc(&d505)
+					ctx.FreeDesc(&d506)
 					return result
 				}
 				bbs[16].RenderPS = func(ps PhiState) JITValueDesc {
@@ -28127,9 +28240,6 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
@@ -28145,14 +28255,14 @@ func init_alu() {
 					if len(ps.OverlayValues) > 247 && ps.OverlayValues[247].Loc != LocNone {
 						d247 = ps.OverlayValues[247]
 					}
-					if len(ps.OverlayValues) > 322 && ps.OverlayValues[322].Loc != LocNone {
-						d322 = ps.OverlayValues[322]
+					if len(ps.OverlayValues) > 248 && ps.OverlayValues[248].Loc != LocNone {
+						d248 = ps.OverlayValues[248]
 					}
 					if len(ps.OverlayValues) > 323 && ps.OverlayValues[323].Loc != LocNone {
 						d323 = ps.OverlayValues[323]
 					}
-					if len(ps.OverlayValues) > 402 && ps.OverlayValues[402].Loc != LocNone {
-						d402 = ps.OverlayValues[402]
+					if len(ps.OverlayValues) > 324 && ps.OverlayValues[324].Loc != LocNone {
+						d324 = ps.OverlayValues[324]
 					}
 					if len(ps.OverlayValues) > 403 && ps.OverlayValues[403].Loc != LocNone {
 						d403 = ps.OverlayValues[403]
@@ -28169,11 +28279,11 @@ func init_alu() {
 					if len(ps.OverlayValues) > 407 && ps.OverlayValues[407].Loc != LocNone {
 						d407 = ps.OverlayValues[407]
 					}
-					if len(ps.OverlayValues) > 409 && ps.OverlayValues[409].Loc != LocNone {
-						d409 = ps.OverlayValues[409]
+					if len(ps.OverlayValues) > 408 && ps.OverlayValues[408].Loc != LocNone {
+						d408 = ps.OverlayValues[408]
 					}
-					if len(ps.OverlayValues) > 502 && ps.OverlayValues[502].Loc != LocNone {
-						d502 = ps.OverlayValues[502]
+					if len(ps.OverlayValues) > 410 && ps.OverlayValues[410].Loc != LocNone {
+						d410 = ps.OverlayValues[410]
 					}
 					if len(ps.OverlayValues) > 503 && ps.OverlayValues[503].Loc != LocNone {
 						d503 = ps.OverlayValues[503]
@@ -28187,353 +28297,304 @@ func init_alu() {
 					if len(ps.OverlayValues) > 506 && ps.OverlayValues[506].Loc != LocNone {
 						d506 = ps.OverlayValues[506]
 					}
-					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d406)
-					var d609 JITValueDesc
-					if d406.Loc == LocImm {
-						d609 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d406.Imm.Float() < -9.223372036854776e+18)}
-					} else {
-						r7 := ctx.AllocRegExcept(d406.Reg)
-						ctx.EmitMovRegImm64(RegR11, uint64(14114281232179134464))
-						ctx.EmitCmpFloat64Setcc(r7, d406.Reg, RegR11, CondSignedLess)
-						d609 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r7}
-						ctx.BindReg(r7, &d609)
+					if len(ps.OverlayValues) > 507 && ps.OverlayValues[507].Loc != LocNone {
+						d507 = ps.OverlayValues[507]
 					}
-					d610 = d609
-					ctx.EnsureDesc(&d610)
-					if d610.Loc != LocImm && d610.Loc != LocReg {
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d407)
+					var d610 JITValueDesc
+					if d407.Loc == LocImm {
+						d610 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d407.Imm.Float() < -9.223372036854776e+18)}
+					} else {
+						r7 := ctx.AllocRegExcept(d407.Reg)
+						ctx.EmitMovRegImm64(RegR11, uint64(14114281232179134464))
+						ctx.EmitCmpFloat64Setcc(r7, d407.Reg, RegR11, CondSignedLess)
+						d610 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r7}
+						ctx.BindReg(r7, &d610)
+					}
+					d611 = d610
+					ctx.EnsureDesc(&d611)
+					if d611.Loc != LocImm && d611.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d610.Loc == LocImm {
-						if d610.Imm.Bool() {
+					if d611.Loc == LocImm {
+						if d611.Imm.Bool() {
 							if ps.General {
 							}
-							ps611 := PhiState{General: ps.General}
-							ps611.OverlayValues = make([]JITValueDesc, 611)
-							ps611.OverlayValues[0] = d0
-							ps611.OverlayValues[1] = d1
-							ps611.OverlayValues[2] = d2
-							ps611.OverlayValues[3] = d3
-							ps611.OverlayValues[18] = d18
-							ps611.OverlayValues[19] = d19
-							ps611.OverlayValues[20] = d20
-							ps611.OverlayValues[21] = d21
-							ps611.OverlayValues[22] = d22
-							ps611.OverlayValues[47] = d47
-							ps611.OverlayValues[48] = d48
-							ps611.OverlayValues[49] = d49
-							ps611.OverlayValues[50] = d50
-							ps611.OverlayValues[83] = d83
-							ps611.OverlayValues[84] = d84
-							ps611.OverlayValues[85] = d85
-							ps611.OverlayValues[86] = d86
-							ps611.OverlayValues[127] = d127
-							ps611.OverlayValues[128] = d128
-							ps611.OverlayValues[129] = d129
-							ps611.OverlayValues[130] = d130
-							ps611.OverlayValues[179] = d179
-							ps611.OverlayValues[180] = d180
-							ps611.OverlayValues[181] = d181
-							ps611.OverlayValues[182] = d182
-							ps611.OverlayValues[239] = d239
-							ps611.OverlayValues[240] = d240
-							ps611.OverlayValues[241] = d241
-							ps611.OverlayValues[242] = d242
-							ps611.OverlayValues[243] = d243
-							ps611.OverlayValues[244] = d244
-							ps611.OverlayValues[245] = d245
-							ps611.OverlayValues[246] = d246
-							ps611.OverlayValues[247] = d247
-							ps611.OverlayValues[322] = d322
-							ps611.OverlayValues[323] = d323
-							ps611.OverlayValues[402] = d402
-							ps611.OverlayValues[403] = d403
-							ps611.OverlayValues[404] = d404
-							ps611.OverlayValues[405] = d405
-							ps611.OverlayValues[406] = d406
-							ps611.OverlayValues[407] = d407
-							ps611.OverlayValues[409] = d409
-							ps611.OverlayValues[502] = d502
-							ps611.OverlayValues[503] = d503
-							ps611.OverlayValues[504] = d504
-							ps611.OverlayValues[505] = d505
-							ps611.OverlayValues[506] = d506
-							ps611.OverlayValues[609] = d609
-							ps611.OverlayValues[610] = d610
-							return bbs[13].RenderPS(ps611)
+							ps612 := PhiState{General: ps.General}
+							ps612.OverlayValues = make([]JITValueDesc, 612)
+							ps612.OverlayValues[0] = d0
+							ps612.OverlayValues[1] = d1
+							ps612.OverlayValues[2] = d2
+							ps612.OverlayValues[3] = d3
+							ps612.OverlayValues[18] = d18
+							ps612.OverlayValues[19] = d19
+							ps612.OverlayValues[20] = d20
+							ps612.OverlayValues[21] = d21
+							ps612.OverlayValues[22] = d22
+							ps612.OverlayValues[47] = d47
+							ps612.OverlayValues[48] = d48
+							ps612.OverlayValues[49] = d49
+							ps612.OverlayValues[50] = d50
+							ps612.OverlayValues[83] = d83
+							ps612.OverlayValues[84] = d84
+							ps612.OverlayValues[85] = d85
+							ps612.OverlayValues[86] = d86
+							ps612.OverlayValues[127] = d127
+							ps612.OverlayValues[128] = d128
+							ps612.OverlayValues[129] = d129
+							ps612.OverlayValues[130] = d130
+							ps612.OverlayValues[179] = d179
+							ps612.OverlayValues[180] = d180
+							ps612.OverlayValues[181] = d181
+							ps612.OverlayValues[182] = d182
+							ps612.OverlayValues[239] = d239
+							ps612.OverlayValues[240] = d240
+							ps612.OverlayValues[241] = d241
+							ps612.OverlayValues[243] = d243
+							ps612.OverlayValues[244] = d244
+							ps612.OverlayValues[245] = d245
+							ps612.OverlayValues[246] = d246
+							ps612.OverlayValues[247] = d247
+							ps612.OverlayValues[248] = d248
+							ps612.OverlayValues[323] = d323
+							ps612.OverlayValues[324] = d324
+							ps612.OverlayValues[403] = d403
+							ps612.OverlayValues[404] = d404
+							ps612.OverlayValues[405] = d405
+							ps612.OverlayValues[406] = d406
+							ps612.OverlayValues[407] = d407
+							ps612.OverlayValues[408] = d408
+							ps612.OverlayValues[410] = d410
+							ps612.OverlayValues[503] = d503
+							ps612.OverlayValues[504] = d504
+							ps612.OverlayValues[505] = d505
+							ps612.OverlayValues[506] = d506
+							ps612.OverlayValues[507] = d507
+							ps612.OverlayValues[610] = d610
+							ps612.OverlayValues[611] = d611
+							return bbs[13].RenderPS(ps612)
 						}
 						if ps.General {
 						}
-						ps612 := PhiState{General: ps.General}
-						ps612.OverlayValues = make([]JITValueDesc, 611)
-						ps612.OverlayValues[0] = d0
-						ps612.OverlayValues[1] = d1
-						ps612.OverlayValues[2] = d2
-						ps612.OverlayValues[3] = d3
-						ps612.OverlayValues[18] = d18
-						ps612.OverlayValues[19] = d19
-						ps612.OverlayValues[20] = d20
-						ps612.OverlayValues[21] = d21
-						ps612.OverlayValues[22] = d22
-						ps612.OverlayValues[47] = d47
-						ps612.OverlayValues[48] = d48
-						ps612.OverlayValues[49] = d49
-						ps612.OverlayValues[50] = d50
-						ps612.OverlayValues[83] = d83
-						ps612.OverlayValues[84] = d84
-						ps612.OverlayValues[85] = d85
-						ps612.OverlayValues[86] = d86
-						ps612.OverlayValues[127] = d127
-						ps612.OverlayValues[128] = d128
-						ps612.OverlayValues[129] = d129
-						ps612.OverlayValues[130] = d130
-						ps612.OverlayValues[179] = d179
-						ps612.OverlayValues[180] = d180
-						ps612.OverlayValues[181] = d181
-						ps612.OverlayValues[182] = d182
-						ps612.OverlayValues[239] = d239
-						ps612.OverlayValues[240] = d240
-						ps612.OverlayValues[241] = d241
-						ps612.OverlayValues[242] = d242
-						ps612.OverlayValues[243] = d243
-						ps612.OverlayValues[244] = d244
-						ps612.OverlayValues[245] = d245
-						ps612.OverlayValues[246] = d246
-						ps612.OverlayValues[247] = d247
-						ps612.OverlayValues[322] = d322
-						ps612.OverlayValues[323] = d323
-						ps612.OverlayValues[402] = d402
-						ps612.OverlayValues[403] = d403
-						ps612.OverlayValues[404] = d404
-						ps612.OverlayValues[405] = d405
-						ps612.OverlayValues[406] = d406
-						ps612.OverlayValues[407] = d407
-						ps612.OverlayValues[409] = d409
-						ps612.OverlayValues[502] = d502
-						ps612.OverlayValues[503] = d503
-						ps612.OverlayValues[504] = d504
-						ps612.OverlayValues[505] = d505
-						ps612.OverlayValues[506] = d506
-						ps612.OverlayValues[609] = d609
-						ps612.OverlayValues[610] = d610
-						return bbs[15].RenderPS(ps612)
+						ps613 := PhiState{General: ps.General}
+						ps613.OverlayValues = make([]JITValueDesc, 612)
+						ps613.OverlayValues[0] = d0
+						ps613.OverlayValues[1] = d1
+						ps613.OverlayValues[2] = d2
+						ps613.OverlayValues[3] = d3
+						ps613.OverlayValues[18] = d18
+						ps613.OverlayValues[19] = d19
+						ps613.OverlayValues[20] = d20
+						ps613.OverlayValues[21] = d21
+						ps613.OverlayValues[22] = d22
+						ps613.OverlayValues[47] = d47
+						ps613.OverlayValues[48] = d48
+						ps613.OverlayValues[49] = d49
+						ps613.OverlayValues[50] = d50
+						ps613.OverlayValues[83] = d83
+						ps613.OverlayValues[84] = d84
+						ps613.OverlayValues[85] = d85
+						ps613.OverlayValues[86] = d86
+						ps613.OverlayValues[127] = d127
+						ps613.OverlayValues[128] = d128
+						ps613.OverlayValues[129] = d129
+						ps613.OverlayValues[130] = d130
+						ps613.OverlayValues[179] = d179
+						ps613.OverlayValues[180] = d180
+						ps613.OverlayValues[181] = d181
+						ps613.OverlayValues[182] = d182
+						ps613.OverlayValues[239] = d239
+						ps613.OverlayValues[240] = d240
+						ps613.OverlayValues[241] = d241
+						ps613.OverlayValues[243] = d243
+						ps613.OverlayValues[244] = d244
+						ps613.OverlayValues[245] = d245
+						ps613.OverlayValues[246] = d246
+						ps613.OverlayValues[247] = d247
+						ps613.OverlayValues[248] = d248
+						ps613.OverlayValues[323] = d323
+						ps613.OverlayValues[324] = d324
+						ps613.OverlayValues[403] = d403
+						ps613.OverlayValues[404] = d404
+						ps613.OverlayValues[405] = d405
+						ps613.OverlayValues[406] = d406
+						ps613.OverlayValues[407] = d407
+						ps613.OverlayValues[408] = d408
+						ps613.OverlayValues[410] = d410
+						ps613.OverlayValues[503] = d503
+						ps613.OverlayValues[504] = d504
+						ps613.OverlayValues[505] = d505
+						ps613.OverlayValues[506] = d506
+						ps613.OverlayValues[507] = d507
+						ps613.OverlayValues[610] = d610
+						ps613.OverlayValues[611] = d611
+						return bbs[15].RenderPS(ps613)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[16].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d610.Reg, 0)
+					ctx.EmitCmpRegImm32(d611.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl14)
 					if bbs[15].Rendered {
 						ctx.EmitJmp(lbl16)
 					}
-					snap613 := d0
-					snap614 := d1
-					snap615 := d2
-					snap616 := d3
-					snap617 := d18
-					snap618 := d19
-					snap619 := d20
-					snap620 := d21
-					snap621 := d22
-					snap622 := d47
-					snap623 := d48
-					snap624 := d49
-					snap625 := d50
-					snap626 := d83
-					snap627 := d84
-					snap628 := d85
-					snap629 := d86
-					snap630 := d127
-					snap631 := d128
-					snap632 := d129
-					snap633 := d130
-					snap634 := d179
-					snap635 := d180
-					snap636 := d181
-					snap637 := d182
-					snap638 := d239
-					snap639 := d240
-					snap640 := d241
-					snap641 := d242
+					snap614 := d0
+					snap615 := d1
+					snap616 := d2
+					snap617 := d3
+					snap618 := d18
+					snap619 := d19
+					snap620 := d20
+					snap621 := d21
+					snap622 := d22
+					snap623 := d47
+					snap624 := d48
+					snap625 := d49
+					snap626 := d50
+					snap627 := d83
+					snap628 := d84
+					snap629 := d85
+					snap630 := d86
+					snap631 := d127
+					snap632 := d128
+					snap633 := d129
+					snap634 := d130
+					snap635 := d179
+					snap636 := d180
+					snap637 := d181
+					snap638 := d182
+					snap639 := d239
+					snap640 := d240
+					snap641 := d241
 					snap642 := d243
 					snap643 := d244
 					snap644 := d245
 					snap645 := d246
 					snap646 := d247
-					snap647 := d322
+					snap647 := d248
 					snap648 := d323
-					snap649 := d402
+					snap649 := d324
 					snap650 := d403
 					snap651 := d404
 					snap652 := d405
 					snap653 := d406
 					snap654 := d407
-					snap655 := d409
-					snap656 := d502
+					snap655 := d408
+					snap656 := d410
 					snap657 := d503
 					snap658 := d504
 					snap659 := d505
 					snap660 := d506
-					snap661 := d609
+					snap661 := d507
 					snap662 := d610
-					alloc663 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc663)
-					d0 = snap613
-					d1 = snap614
-					d2 = snap615
-					d3 = snap616
-					d18 = snap617
-					d19 = snap618
-					d20 = snap619
-					d21 = snap620
-					d22 = snap621
-					d47 = snap622
-					d48 = snap623
-					d49 = snap624
-					d50 = snap625
-					d83 = snap626
-					d84 = snap627
-					d85 = snap628
-					d86 = snap629
-					d127 = snap630
-					d128 = snap631
-					d129 = snap632
-					d130 = snap633
-					d179 = snap634
-					d180 = snap635
-					d181 = snap636
-					d182 = snap637
-					d239 = snap638
-					d240 = snap639
-					d241 = snap640
-					d242 = snap641
+					snap663 := d611
+					alloc664 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc664)
+					d0 = snap614
+					d1 = snap615
+					d2 = snap616
+					d3 = snap617
+					d18 = snap618
+					d19 = snap619
+					d20 = snap620
+					d21 = snap621
+					d22 = snap622
+					d47 = snap623
+					d48 = snap624
+					d49 = snap625
+					d50 = snap626
+					d83 = snap627
+					d84 = snap628
+					d85 = snap629
+					d86 = snap630
+					d127 = snap631
+					d128 = snap632
+					d129 = snap633
+					d130 = snap634
+					d179 = snap635
+					d180 = snap636
+					d181 = snap637
+					d182 = snap638
+					d239 = snap639
+					d240 = snap640
+					d241 = snap641
 					d243 = snap642
 					d244 = snap643
 					d245 = snap644
 					d246 = snap645
 					d247 = snap646
-					d322 = snap647
+					d248 = snap647
 					d323 = snap648
-					d402 = snap649
+					d324 = snap649
 					d403 = snap650
 					d404 = snap651
 					d405 = snap652
 					d406 = snap653
 					d407 = snap654
-					d409 = snap655
-					d502 = snap656
+					d408 = snap655
+					d410 = snap656
 					d503 = snap657
 					d504 = snap658
 					d505 = snap659
 					d506 = snap660
-					d609 = snap661
+					d507 = snap661
 					d610 = snap662
-					ctx.RestoreAllocState(alloc663)
-					d0 = snap613
-					d1 = snap614
-					d2 = snap615
-					d3 = snap616
-					d18 = snap617
-					d19 = snap618
-					d20 = snap619
-					d21 = snap620
-					d22 = snap621
-					d47 = snap622
-					d48 = snap623
-					d49 = snap624
-					d50 = snap625
-					d83 = snap626
-					d84 = snap627
-					d85 = snap628
-					d86 = snap629
-					d127 = snap630
-					d128 = snap631
-					d129 = snap632
-					d130 = snap633
-					d179 = snap634
-					d180 = snap635
-					d181 = snap636
-					d182 = snap637
-					d239 = snap638
-					d240 = snap639
-					d241 = snap640
-					d242 = snap641
+					d611 = snap663
+					ctx.RestoreAllocState(alloc664)
+					d0 = snap614
+					d1 = snap615
+					d2 = snap616
+					d3 = snap617
+					d18 = snap618
+					d19 = snap619
+					d20 = snap620
+					d21 = snap621
+					d22 = snap622
+					d47 = snap623
+					d48 = snap624
+					d49 = snap625
+					d50 = snap626
+					d83 = snap627
+					d84 = snap628
+					d85 = snap629
+					d86 = snap630
+					d127 = snap631
+					d128 = snap632
+					d129 = snap633
+					d130 = snap634
+					d179 = snap635
+					d180 = snap636
+					d181 = snap637
+					d182 = snap638
+					d239 = snap639
+					d240 = snap640
+					d241 = snap641
 					d243 = snap642
 					d244 = snap643
 					d245 = snap644
 					d246 = snap645
 					d247 = snap646
-					d322 = snap647
+					d248 = snap647
 					d323 = snap648
-					d402 = snap649
+					d324 = snap649
 					d403 = snap650
 					d404 = snap651
 					d405 = snap652
 					d406 = snap653
 					d407 = snap654
-					d409 = snap655
-					d502 = snap656
+					d408 = snap655
+					d410 = snap656
 					d503 = snap657
 					d504 = snap658
 					d505 = snap659
 					d506 = snap660
-					d609 = snap661
+					d507 = snap661
 					d610 = snap662
-					ps664 := PhiState{General: true}
-					ps664.OverlayValues = make([]JITValueDesc, 611)
-					ps664.OverlayValues[0] = d0
-					ps664.OverlayValues[1] = d1
-					ps664.OverlayValues[2] = d2
-					ps664.OverlayValues[3] = d3
-					ps664.OverlayValues[18] = d18
-					ps664.OverlayValues[19] = d19
-					ps664.OverlayValues[20] = d20
-					ps664.OverlayValues[21] = d21
-					ps664.OverlayValues[22] = d22
-					ps664.OverlayValues[47] = d47
-					ps664.OverlayValues[48] = d48
-					ps664.OverlayValues[49] = d49
-					ps664.OverlayValues[50] = d50
-					ps664.OverlayValues[83] = d83
-					ps664.OverlayValues[84] = d84
-					ps664.OverlayValues[85] = d85
-					ps664.OverlayValues[86] = d86
-					ps664.OverlayValues[127] = d127
-					ps664.OverlayValues[128] = d128
-					ps664.OverlayValues[129] = d129
-					ps664.OverlayValues[130] = d130
-					ps664.OverlayValues[179] = d179
-					ps664.OverlayValues[180] = d180
-					ps664.OverlayValues[181] = d181
-					ps664.OverlayValues[182] = d182
-					ps664.OverlayValues[239] = d239
-					ps664.OverlayValues[240] = d240
-					ps664.OverlayValues[241] = d241
-					ps664.OverlayValues[242] = d242
-					ps664.OverlayValues[243] = d243
-					ps664.OverlayValues[244] = d244
-					ps664.OverlayValues[245] = d245
-					ps664.OverlayValues[246] = d246
-					ps664.OverlayValues[247] = d247
-					ps664.OverlayValues[322] = d322
-					ps664.OverlayValues[323] = d323
-					ps664.OverlayValues[402] = d402
-					ps664.OverlayValues[403] = d403
-					ps664.OverlayValues[404] = d404
-					ps664.OverlayValues[405] = d405
-					ps664.OverlayValues[406] = d406
-					ps664.OverlayValues[407] = d407
-					ps664.OverlayValues[409] = d409
-					ps664.OverlayValues[502] = d502
-					ps664.OverlayValues[503] = d503
-					ps664.OverlayValues[504] = d504
-					ps664.OverlayValues[505] = d505
-					ps664.OverlayValues[506] = d506
-					ps664.OverlayValues[609] = d609
-					ps664.OverlayValues[610] = d610
+					d611 = snap663
 					ps665 := PhiState{General: true}
-					ps665.OverlayValues = make([]JITValueDesc, 611)
+					ps665.OverlayValues = make([]JITValueDesc, 612)
 					ps665.OverlayValues[0] = d0
 					ps665.OverlayValues[1] = d1
 					ps665.OverlayValues[2] = d2
@@ -28562,142 +28623,194 @@ func init_alu() {
 					ps665.OverlayValues[239] = d239
 					ps665.OverlayValues[240] = d240
 					ps665.OverlayValues[241] = d241
-					ps665.OverlayValues[242] = d242
 					ps665.OverlayValues[243] = d243
 					ps665.OverlayValues[244] = d244
 					ps665.OverlayValues[245] = d245
 					ps665.OverlayValues[246] = d246
 					ps665.OverlayValues[247] = d247
-					ps665.OverlayValues[322] = d322
+					ps665.OverlayValues[248] = d248
 					ps665.OverlayValues[323] = d323
-					ps665.OverlayValues[402] = d402
+					ps665.OverlayValues[324] = d324
 					ps665.OverlayValues[403] = d403
 					ps665.OverlayValues[404] = d404
 					ps665.OverlayValues[405] = d405
 					ps665.OverlayValues[406] = d406
 					ps665.OverlayValues[407] = d407
-					ps665.OverlayValues[409] = d409
-					ps665.OverlayValues[502] = d502
+					ps665.OverlayValues[408] = d408
+					ps665.OverlayValues[410] = d410
 					ps665.OverlayValues[503] = d503
 					ps665.OverlayValues[504] = d504
 					ps665.OverlayValues[505] = d505
 					ps665.OverlayValues[506] = d506
-					ps665.OverlayValues[609] = d609
+					ps665.OverlayValues[507] = d507
 					ps665.OverlayValues[610] = d610
-					snap666 := d0
-					snap667 := d1
-					snap668 := d2
-					snap669 := d3
-					snap670 := d18
-					snap671 := d19
-					snap672 := d20
-					snap673 := d21
-					snap674 := d22
-					snap675 := d47
-					snap676 := d48
-					snap677 := d49
-					snap678 := d50
-					snap679 := d83
-					snap680 := d84
-					snap681 := d85
-					snap682 := d86
-					snap683 := d127
-					snap684 := d128
-					snap685 := d129
-					snap686 := d130
-					snap687 := d179
-					snap688 := d180
-					snap689 := d181
-					snap690 := d182
-					snap691 := d239
-					snap692 := d240
-					snap693 := d241
-					snap694 := d242
+					ps665.OverlayValues[611] = d611
+					ps666 := PhiState{General: true}
+					ps666.OverlayValues = make([]JITValueDesc, 612)
+					ps666.OverlayValues[0] = d0
+					ps666.OverlayValues[1] = d1
+					ps666.OverlayValues[2] = d2
+					ps666.OverlayValues[3] = d3
+					ps666.OverlayValues[18] = d18
+					ps666.OverlayValues[19] = d19
+					ps666.OverlayValues[20] = d20
+					ps666.OverlayValues[21] = d21
+					ps666.OverlayValues[22] = d22
+					ps666.OverlayValues[47] = d47
+					ps666.OverlayValues[48] = d48
+					ps666.OverlayValues[49] = d49
+					ps666.OverlayValues[50] = d50
+					ps666.OverlayValues[83] = d83
+					ps666.OverlayValues[84] = d84
+					ps666.OverlayValues[85] = d85
+					ps666.OverlayValues[86] = d86
+					ps666.OverlayValues[127] = d127
+					ps666.OverlayValues[128] = d128
+					ps666.OverlayValues[129] = d129
+					ps666.OverlayValues[130] = d130
+					ps666.OverlayValues[179] = d179
+					ps666.OverlayValues[180] = d180
+					ps666.OverlayValues[181] = d181
+					ps666.OverlayValues[182] = d182
+					ps666.OverlayValues[239] = d239
+					ps666.OverlayValues[240] = d240
+					ps666.OverlayValues[241] = d241
+					ps666.OverlayValues[243] = d243
+					ps666.OverlayValues[244] = d244
+					ps666.OverlayValues[245] = d245
+					ps666.OverlayValues[246] = d246
+					ps666.OverlayValues[247] = d247
+					ps666.OverlayValues[248] = d248
+					ps666.OverlayValues[323] = d323
+					ps666.OverlayValues[324] = d324
+					ps666.OverlayValues[403] = d403
+					ps666.OverlayValues[404] = d404
+					ps666.OverlayValues[405] = d405
+					ps666.OverlayValues[406] = d406
+					ps666.OverlayValues[407] = d407
+					ps666.OverlayValues[408] = d408
+					ps666.OverlayValues[410] = d410
+					ps666.OverlayValues[503] = d503
+					ps666.OverlayValues[504] = d504
+					ps666.OverlayValues[505] = d505
+					ps666.OverlayValues[506] = d506
+					ps666.OverlayValues[507] = d507
+					ps666.OverlayValues[610] = d610
+					ps666.OverlayValues[611] = d611
+					snap667 := d0
+					snap668 := d1
+					snap669 := d2
+					snap670 := d3
+					snap671 := d18
+					snap672 := d19
+					snap673 := d20
+					snap674 := d21
+					snap675 := d22
+					snap676 := d47
+					snap677 := d48
+					snap678 := d49
+					snap679 := d50
+					snap680 := d83
+					snap681 := d84
+					snap682 := d85
+					snap683 := d86
+					snap684 := d127
+					snap685 := d128
+					snap686 := d129
+					snap687 := d130
+					snap688 := d179
+					snap689 := d180
+					snap690 := d181
+					snap691 := d182
+					snap692 := d239
+					snap693 := d240
+					snap694 := d241
 					snap695 := d243
 					snap696 := d244
 					snap697 := d245
 					snap698 := d246
 					snap699 := d247
-					snap700 := d322
+					snap700 := d248
 					snap701 := d323
-					snap702 := d402
+					snap702 := d324
 					snap703 := d403
 					snap704 := d404
 					snap705 := d405
 					snap706 := d406
 					snap707 := d407
-					snap708 := d409
-					snap709 := d502
+					snap708 := d408
+					snap709 := d410
 					snap710 := d503
 					snap711 := d504
 					snap712 := d505
 					snap713 := d506
-					snap714 := d609
+					snap714 := d507
 					snap715 := d610
-					alloc716 := ctx.SnapshotAllocState()
+					snap716 := d611
+					alloc717 := ctx.SnapshotAllocState()
 					if !bbs[15].Rendered {
-						bbs[15].RenderPS(ps665)
+						bbs[15].RenderPS(ps666)
 					}
-					ctx.RestoreAllocState(alloc716)
-					d0 = snap666
-					d1 = snap667
-					d2 = snap668
-					d3 = snap669
-					d18 = snap670
-					d19 = snap671
-					d20 = snap672
-					d21 = snap673
-					d22 = snap674
-					d47 = snap675
-					d48 = snap676
-					d49 = snap677
-					d50 = snap678
-					d83 = snap679
-					d84 = snap680
-					d85 = snap681
-					d86 = snap682
-					d127 = snap683
-					d128 = snap684
-					d129 = snap685
-					d130 = snap686
-					d179 = snap687
-					d180 = snap688
-					d181 = snap689
-					d182 = snap690
-					d239 = snap691
-					d240 = snap692
-					d241 = snap693
-					d242 = snap694
+					ctx.RestoreAllocState(alloc717)
+					d0 = snap667
+					d1 = snap668
+					d2 = snap669
+					d3 = snap670
+					d18 = snap671
+					d19 = snap672
+					d20 = snap673
+					d21 = snap674
+					d22 = snap675
+					d47 = snap676
+					d48 = snap677
+					d49 = snap678
+					d50 = snap679
+					d83 = snap680
+					d84 = snap681
+					d85 = snap682
+					d86 = snap683
+					d127 = snap684
+					d128 = snap685
+					d129 = snap686
+					d130 = snap687
+					d179 = snap688
+					d180 = snap689
+					d181 = snap690
+					d182 = snap691
+					d239 = snap692
+					d240 = snap693
+					d241 = snap694
 					d243 = snap695
 					d244 = snap696
 					d245 = snap697
 					d246 = snap698
 					d247 = snap699
-					d322 = snap700
+					d248 = snap700
 					d323 = snap701
-					d402 = snap702
+					d324 = snap702
 					d403 = snap703
 					d404 = snap704
 					d405 = snap705
 					d406 = snap706
 					d407 = snap707
-					d409 = snap708
-					d502 = snap709
+					d408 = snap708
+					d410 = snap709
 					d503 = snap710
 					d504 = snap711
 					d505 = snap712
 					d506 = snap713
-					d609 = snap714
+					d507 = snap714
 					d610 = snap715
+					d611 = snap716
 					if !bbs[13].Rendered {
-						return bbs[13].RenderPS(ps664)
+						return bbs[13].RenderPS(ps665)
 					}
 					return result
-					ctx.FreeDesc(&d609)
+					ctx.FreeDesc(&d610)
 					return result
 				}
-				ps717 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps717)
+				ps718 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps718)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -28799,8 +28912,6 @@ func init_alu() {
 				_ = d240
 				var d241 JITValueDesc
 				_ = d241
-				var d242 JITValueDesc
-				_ = d242
 				var d243 JITValueDesc
 				_ = d243
 				var d244 JITValueDesc
@@ -28819,6 +28930,8 @@ func init_alu() {
 				_ = d250
 				var d251 JITValueDesc
 				_ = d251
+				var d252 JITValueDesc
+				_ = d252
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				var bbs [11]BBDescriptor
 				for i := range args {
@@ -30663,28 +30776,30 @@ func init_alu() {
 					}
 					ctx.FreeDesc(&d240)
 					ctx.EnsureDesc(&d241)
+					resultTarget242 := false
+					_ = resultTarget242
 					ctx.EnsureDesc(&d84)
 					ctx.EnsureDescsTogether(&d241, &d84)
-					var d242 JITValueDesc
+					var d243 JITValueDesc
 					if d241.Loc == LocImm && d84.Loc == LocImm {
-						d242 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d241.Imm.Int() % d84.Imm.Int())}
+						d243 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d241.Imm.Int() % d84.Imm.Int())}
 					} else {
-						d242 = ctx.EmitGoCallScalar(GoFuncAddr(JITIntRem), []JITValueDesc{d241, d84}, 1)
+						d243 = ctx.EmitGoCallScalar(GoFuncAddr(JITIntRem), []JITValueDesc{d241, d84}, 1)
 					}
-					if d242.Loc == LocReg && d241.Loc == LocReg && d242.Reg == d241.Reg {
+					if d243.Loc == LocReg && d241.Loc == LocReg && d243.Reg == d241.Reg {
 						ctx.TransferReg(d241.Reg)
 						d241.Loc = LocNone
 					}
 					ctx.FreeDesc(&d241)
-					ctx.EnsureDesc(&d242)
-					if d242.Loc == LocImm {
-						ctx.EmitMakeInt(result, d242)
-					} else {
-						ctx.EmitMovToReg(result.Reg2, d242)
-						d243 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+					ctx.EnsureDesc(&d243)
+					if d243.Loc == LocImm {
 						ctx.EmitMakeInt(result, d243)
-						if d242.Loc == LocReg && d242.Reg != result.Reg2 {
-							ctx.FreeReg(d242.Reg)
+					} else {
+						ctx.EmitMovToReg(result.Reg2, d243)
+						d244 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d244)
+						if d243.Loc == LocReg && d243.Reg != result.Reg2 {
+							ctx.FreeReg(d243.Reg)
 						}
 					}
 					result.Type = tagInt
@@ -30794,35 +30909,35 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
+					if len(ps.OverlayValues) > 244 && ps.OverlayValues[244].Loc != LocNone {
+						d244 = ps.OverlayValues[244]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d244 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
-					ctx.SyncDesc(&d244)
-					if d244.Loc == LocRegPair || d244.Loc == LocStackPair || d244.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d244, &result)
-						result.Type = d244.Type
+					d245 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+					ctx.SyncDesc(&d245)
+					if d245.Loc == LocRegPair || d245.Loc == LocStackPair || d245.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d245, &result)
+						result.Type = d245.Type
 					} else {
-						switch d244.Type {
+						switch d245.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d244)
+							ctx.EmitMakeBool(result, d245)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d244)
+							ctx.EmitMakeInt(result, d245)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d244)
+							ctx.EmitMakeFloat(result, d245)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d244, &result)
-							result.Type = d244.Type
+							ctx.EmitMovPairToResult(&d245, &result)
+							result.Type = d245.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -30931,104 +31046,105 @@ func init_alu() {
 					if len(ps.OverlayValues) > 241 && ps.OverlayValues[241].Loc != LocNone {
 						d241 = ps.OverlayValues[241]
 					}
-					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
-						d242 = ps.OverlayValues[242]
-					}
 					if len(ps.OverlayValues) > 243 && ps.OverlayValues[243].Loc != LocNone {
 						d243 = ps.OverlayValues[243]
 					}
 					if len(ps.OverlayValues) > 244 && ps.OverlayValues[244].Loc != LocNone {
 						d244 = ps.OverlayValues[244]
 					}
-					ctx.ReclaimUntrackedRegs()
-					d245 = args[0]
-					d245.ID = 0
-					var d246 JITValueDesc
-					if d245.Loc == LocImm {
-						d246 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d245.Imm.Float())}
-					} else if d245.Type == tagFloat && d245.Loc == LocReg {
-						d246 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d245.Reg}
-						ctx.BindReg(d245.Reg, &d246)
-						ctx.BindReg(d245.Reg, &d246)
-					} else if d245.Type == tagFloat && d245.Loc == LocRegPair {
-						ctx.FreeReg(d245.Reg)
-						d246 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d245.Reg2}
-						ctx.BindReg(d245.Reg2, &d246)
-						ctx.BindReg(d245.Reg2, &d246)
-					} else {
-						d246 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d245}, 1)
-						d246.Type = tagFloat
-						ctx.BindReg(d246.Reg, &d246)
+					if len(ps.OverlayValues) > 245 && ps.OverlayValues[245].Loc != LocNone {
+						d245 = ps.OverlayValues[245]
 					}
-					ctx.FreeDesc(&d245)
-					ctx.EnsureDesc(&d246)
-					ctx.EnsureDesc(&d246)
+					ctx.ReclaimUntrackedRegs()
+					d246 = args[0]
+					d246.ID = 0
 					var d247 JITValueDesc
 					if d246.Loc == LocImm {
-						d247 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d246.Imm.Float()))}
+						d247 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d246.Imm.Float())}
+					} else if d246.Type == tagFloat && d246.Loc == LocReg {
+						d247 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d246.Reg}
+						ctx.BindReg(d246.Reg, &d247)
+						ctx.BindReg(d246.Reg, &d247)
+					} else if d246.Type == tagFloat && d246.Loc == LocRegPair {
+						ctx.FreeReg(d246.Reg)
+						d247 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d246.Reg2}
+						ctx.BindReg(d246.Reg2, &d247)
+						ctx.BindReg(d246.Reg2, &d247)
 					} else {
-						r2 := ctx.AllocReg()
-						ctx.EmitCvtFloatBitsToInt64(r2, d246.Reg)
-						d247 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r2}
-						ctx.BindReg(r2, &d247)
+						d247 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d246}, 1)
+						d247.Type = tagFloat
+						ctx.BindReg(d247.Reg, &d247)
 					}
 					ctx.FreeDesc(&d246)
-					ctx.EnsureDesc(&d128)
-					ctx.EnsureDesc(&d128)
+					ctx.EnsureDesc(&d247)
+					ctx.EnsureDesc(&d247)
 					var d248 JITValueDesc
+					if d247.Loc == LocImm {
+						d248 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d247.Imm.Float()))}
+					} else {
+						r2 := ctx.AllocReg()
+						ctx.EmitCvtFloatBitsToInt64(r2, d247.Reg)
+						d248 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r2}
+						ctx.BindReg(r2, &d248)
+					}
+					ctx.FreeDesc(&d247)
+					ctx.EnsureDesc(&d128)
+					ctx.EnsureDesc(&d128)
+					var d249 JITValueDesc
 					if d128.Loc == LocImm {
-						d248 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d128.Imm.Float()))}
+						d249 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d128.Imm.Float()))}
 					} else {
 						r3 := ctx.AllocReg()
 						ctx.EmitCvtFloatBitsToInt64(r3, d128.Reg)
-						d248 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3}
-						ctx.BindReg(r3, &d248)
+						d249 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3}
+						ctx.BindReg(r3, &d249)
 					}
-					ctx.EnsureDesc(&d247)
 					ctx.EnsureDesc(&d248)
-					ctx.EnsureDescsTogether(&d247, &d248)
-					var d249 JITValueDesc
-					if d247.Loc == LocImm && d248.Loc == LocImm {
-						d249 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d247.Imm.Int() % d248.Imm.Int())}
-					} else {
-						d249 = ctx.EmitGoCallScalar(GoFuncAddr(JITIntRem), []JITValueDesc{d247, d248}, 1)
-					}
-					if d249.Loc == LocReg && d247.Loc == LocReg && d249.Reg == d247.Reg {
-						ctx.TransferReg(d247.Reg)
-						d247.Loc = LocNone
-					}
-					ctx.FreeDesc(&d247)
-					ctx.FreeDesc(&d248)
 					ctx.EnsureDesc(&d249)
-					ctx.EnsureDesc(&d249)
+					ctx.EnsureDescsTogether(&d248, &d249)
 					var d250 JITValueDesc
-					if d249.Loc == LocImm {
-						d250 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d249.Imm.Int()))}
+					if d248.Loc == LocImm && d249.Loc == LocImm {
+						d250 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d248.Imm.Int() % d249.Imm.Int())}
 					} else {
-						r4 := ctx.AllocRegExcept(d249.Reg)
-						ctx.EmitMovRegReg(r4, d249.Reg)
-						ctx.EmitCvtInt64ToFloat64(RegX0, r4)
-						d250 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r4}
-						ctx.BindReg(r4, &d250)
+						d250 = ctx.EmitGoCallScalar(GoFuncAddr(JITIntRem), []JITValueDesc{d248, d249}, 1)
 					}
+					if d250.Loc == LocReg && d248.Loc == LocReg && d250.Reg == d248.Reg {
+						ctx.TransferReg(d248.Reg)
+						d248.Loc = LocNone
+					}
+					ctx.FreeDesc(&d248)
 					ctx.FreeDesc(&d249)
 					ctx.EnsureDesc(&d250)
+					ctx.EnsureDesc(&d250)
+					var d251 JITValueDesc
 					if d250.Loc == LocImm {
-						ctx.EmitMakeFloat(result, d250)
+						d251 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d250.Imm.Int()))}
 					} else {
-						ctx.EmitMovToReg(result.Reg2, d250)
-						d251 := JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: result.Reg2, ID: 0}
+						var r4 Reg
+						r4 = d250.Reg
+						d250.Loc = LocNone
+						ctx.EmitCvtInt64ToFloat64(RegX0, r4)
+						d251 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r4}
+						ctx.BindReg(r4, &d251)
+					}
+					ctx.FreeDesc(&d250)
+					ctx.EnsureDesc(&d251)
+					if d251.Loc == LocImm {
 						ctx.EmitMakeFloat(result, d251)
-						if d250.Loc == LocReg && d250.Reg != result.Reg2 {
-							ctx.FreeReg(d250.Reg)
+					} else {
+						ctx.EmitMovToReg(result.Reg2, d251)
+						d252 := JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeFloat(result, d252)
+						if d251.Loc == LocReg && d251.Reg != result.Reg2 {
+							ctx.FreeReg(d251.Reg)
 						}
 					}
 					result.Type = tagFloat
 					ctx.EmitJmp(lbl0)
 					return result
 				}
-				ps252 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps252)
+				ps253 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps253)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -31330,15 +31446,10 @@ func init_alu() {
 					d19.ID = 0
 					d20 = args[0]
 					d20.ID = 0
-					d19 = JITPrepareScmerGoArg(ctx, d19)
-					d20 = JITPrepareScmerGoArg(ctx, d20)
-					ctx.SyncDesc(&d19)
-					ctx.SyncDesc(&d20)
-					d21 = ctx.EmitGoCallScalar(GoFuncAddr(Less), []JITValueDesc{d19, d20}, 1)
-					d21.NoHeapPointer = true
-					ctx.EmitAndRegImm32(d21.Reg, 1)
+					ctx.EnsureDesc(&d19)
+					ctx.EnsureDesc(&d20)
+					d21 = jitEmitLess(ctx, []JITValueDesc{d19, d20}, JITValueDesc{Loc: LocAny})
 					d21.Type = tagBool
-					ctx.BindReg(d21.Reg, &d21)
 					ctx.FreeDesc(&d19)
 					ctx.FreeDesc(&d20)
 					ctx.EnsureDesc(&d21)
@@ -31664,14 +31775,16 @@ func init_alu() {
 				_ = d21
 				var d22 JITValueDesc
 				_ = d22
-				var d23 JITValueDesc
-				_ = d23
 				var d24 JITValueDesc
 				_ = d24
 				var d25 JITValueDesc
 				_ = d25
 				var d26 JITValueDesc
 				_ = d26
+				var d27 JITValueDesc
+				_ = d27
+				var d28 JITValueDesc
+				_ = d28
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				var bbs [4]BBDescriptor
 				for i := range args {
@@ -31911,15 +32024,15 @@ func init_alu() {
 					d19.ID = 0
 					d20 = args[1]
 					d20.ID = 0
-					d19 = JITPrepareScmerGoArg(ctx, d19)
-					d20 = JITPrepareScmerGoArg(ctx, d20)
-					ctx.SyncDesc(&d19)
-					ctx.SyncDesc(&d20)
-					d21 = ctx.EmitGoCallScalar(GoFuncAddr(Less), []JITValueDesc{d19, d20}, 1)
-					d21.NoHeapPointer = true
-					ctx.EmitAndRegImm32(d21.Reg, 1)
+					ctx.EnsureDesc(&d19)
+					ctx.EnsureDesc(&d20)
+					d22 = JITValueDesc{Loc: LocAny}
+					resultTarget23 := result.Loc == LocRegPair
+					if resultTarget23 {
+						d22 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
+					}
+					d21 = jitEmitLess(ctx, []JITValueDesc{d19, d20}, d22)
 					d21.Type = tagBool
-					ctx.BindReg(d21.Reg, &d21)
 					ctx.FreeDesc(&d19)
 					ctx.FreeDesc(&d20)
 					ctx.EnsureDesc(&d21)
@@ -31927,8 +32040,8 @@ func init_alu() {
 						ctx.EmitMakeBool(result, d21)
 					} else {
 						ctx.EmitMovToReg(result.Reg2, d21)
-						d22 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeBool(result, d22)
+						d24 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeBool(result, d24)
 						if d21.Loc == LocReg && d21.Reg != result.Reg2 {
 							ctx.FreeReg(d21.Reg)
 						}
@@ -31983,179 +32096,191 @@ func init_alu() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d23 = args[1]
-					d23.ID = 0
-					d25 = d23
+					d25 = args[1]
 					d25.ID = 0
-					d24 = ctx.EmitTagEqualsBorrowed(&d25, tagNil, JITValueDesc{Loc: LocAny})
-					ctx.FreeDesc(&d23)
-					d26 = d24
-					ctx.EnsureDesc(&d26)
-					if d26.Loc != LocImm && d26.Loc != LocReg {
+					d27 = d25
+					d27.ID = 0
+					d26 = ctx.EmitTagEqualsBorrowed(&d27, tagNil, JITValueDesc{Loc: LocAny})
+					ctx.FreeDesc(&d25)
+					d28 = d26
+					ctx.EnsureDesc(&d28)
+					if d28.Loc != LocImm && d28.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d26.Loc == LocImm {
-						if d26.Imm.Bool() {
+					if d28.Loc == LocImm {
+						if d28.Imm.Bool() {
 							if ps.General {
 							}
-							ps27 := PhiState{General: ps.General}
-							ps27.OverlayValues = make([]JITValueDesc, 27)
-							ps27.OverlayValues[0] = d0
-							ps27.OverlayValues[1] = d1
-							ps27.OverlayValues[2] = d2
-							ps27.OverlayValues[3] = d3
-							ps27.OverlayValues[18] = d18
-							ps27.OverlayValues[19] = d19
-							ps27.OverlayValues[20] = d20
-							ps27.OverlayValues[21] = d21
-							ps27.OverlayValues[22] = d22
-							ps27.OverlayValues[23] = d23
-							ps27.OverlayValues[24] = d24
-							ps27.OverlayValues[25] = d25
-							ps27.OverlayValues[26] = d26
-							return bbs[1].RenderPS(ps27)
+							ps29 := PhiState{General: ps.General}
+							ps29.OverlayValues = make([]JITValueDesc, 29)
+							ps29.OverlayValues[0] = d0
+							ps29.OverlayValues[1] = d1
+							ps29.OverlayValues[2] = d2
+							ps29.OverlayValues[3] = d3
+							ps29.OverlayValues[18] = d18
+							ps29.OverlayValues[19] = d19
+							ps29.OverlayValues[20] = d20
+							ps29.OverlayValues[21] = d21
+							ps29.OverlayValues[22] = d22
+							ps29.OverlayValues[24] = d24
+							ps29.OverlayValues[25] = d25
+							ps29.OverlayValues[26] = d26
+							ps29.OverlayValues[27] = d27
+							ps29.OverlayValues[28] = d28
+							return bbs[1].RenderPS(ps29)
 						}
 						if ps.General {
 						}
-						ps28 := PhiState{General: ps.General}
-						ps28.OverlayValues = make([]JITValueDesc, 27)
-						ps28.OverlayValues[0] = d0
-						ps28.OverlayValues[1] = d1
-						ps28.OverlayValues[2] = d2
-						ps28.OverlayValues[3] = d3
-						ps28.OverlayValues[18] = d18
-						ps28.OverlayValues[19] = d19
-						ps28.OverlayValues[20] = d20
-						ps28.OverlayValues[21] = d21
-						ps28.OverlayValues[22] = d22
-						ps28.OverlayValues[23] = d23
-						ps28.OverlayValues[24] = d24
-						ps28.OverlayValues[25] = d25
-						ps28.OverlayValues[26] = d26
-						return bbs[2].RenderPS(ps28)
+						ps30 := PhiState{General: ps.General}
+						ps30.OverlayValues = make([]JITValueDesc, 29)
+						ps30.OverlayValues[0] = d0
+						ps30.OverlayValues[1] = d1
+						ps30.OverlayValues[2] = d2
+						ps30.OverlayValues[3] = d3
+						ps30.OverlayValues[18] = d18
+						ps30.OverlayValues[19] = d19
+						ps30.OverlayValues[20] = d20
+						ps30.OverlayValues[21] = d21
+						ps30.OverlayValues[22] = d22
+						ps30.OverlayValues[24] = d24
+						ps30.OverlayValues[25] = d25
+						ps30.OverlayValues[26] = d26
+						ps30.OverlayValues[27] = d27
+						ps30.OverlayValues[28] = d28
+						return bbs[2].RenderPS(ps30)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[3].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d26.Reg, 0)
+					ctx.EmitCmpRegImm32(d28.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl2)
 					if bbs[2].Rendered {
 						ctx.EmitJmp(lbl3)
 					}
-					snap29 := d0
-					snap30 := d1
-					snap31 := d2
-					snap32 := d3
-					snap33 := d18
-					snap34 := d19
-					snap35 := d20
-					snap36 := d21
-					snap37 := d22
-					snap38 := d23
-					snap39 := d24
-					snap40 := d25
-					snap41 := d26
-					alloc42 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc42)
-					d0 = snap29
-					d1 = snap30
-					d2 = snap31
-					d3 = snap32
-					d18 = snap33
-					d19 = snap34
-					d20 = snap35
-					d21 = snap36
-					d22 = snap37
-					d23 = snap38
-					d24 = snap39
-					d25 = snap40
-					d26 = snap41
-					ctx.RestoreAllocState(alloc42)
-					d0 = snap29
-					d1 = snap30
-					d2 = snap31
-					d3 = snap32
-					d18 = snap33
-					d19 = snap34
-					d20 = snap35
-					d21 = snap36
-					d22 = snap37
-					d23 = snap38
-					d24 = snap39
-					d25 = snap40
-					d26 = snap41
-					ps43 := PhiState{General: true}
-					ps43.OverlayValues = make([]JITValueDesc, 27)
-					ps43.OverlayValues[0] = d0
-					ps43.OverlayValues[1] = d1
-					ps43.OverlayValues[2] = d2
-					ps43.OverlayValues[3] = d3
-					ps43.OverlayValues[18] = d18
-					ps43.OverlayValues[19] = d19
-					ps43.OverlayValues[20] = d20
-					ps43.OverlayValues[21] = d21
-					ps43.OverlayValues[22] = d22
-					ps43.OverlayValues[23] = d23
-					ps43.OverlayValues[24] = d24
-					ps43.OverlayValues[25] = d25
-					ps43.OverlayValues[26] = d26
-					ps44 := PhiState{General: true}
-					ps44.OverlayValues = make([]JITValueDesc, 27)
-					ps44.OverlayValues[0] = d0
-					ps44.OverlayValues[1] = d1
-					ps44.OverlayValues[2] = d2
-					ps44.OverlayValues[3] = d3
-					ps44.OverlayValues[18] = d18
-					ps44.OverlayValues[19] = d19
-					ps44.OverlayValues[20] = d20
-					ps44.OverlayValues[21] = d21
-					ps44.OverlayValues[22] = d22
-					ps44.OverlayValues[23] = d23
-					ps44.OverlayValues[24] = d24
-					ps44.OverlayValues[25] = d25
-					ps44.OverlayValues[26] = d26
-					snap45 := d0
-					snap46 := d1
-					snap47 := d2
-					snap48 := d3
-					snap49 := d18
-					snap50 := d19
-					snap51 := d20
-					snap52 := d21
-					snap53 := d22
-					snap54 := d23
-					snap55 := d24
-					snap56 := d25
-					snap57 := d26
-					alloc58 := ctx.SnapshotAllocState()
+					snap31 := d0
+					snap32 := d1
+					snap33 := d2
+					snap34 := d3
+					snap35 := d18
+					snap36 := d19
+					snap37 := d20
+					snap38 := d21
+					snap39 := d22
+					snap40 := d24
+					snap41 := d25
+					snap42 := d26
+					snap43 := d27
+					snap44 := d28
+					alloc45 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc45)
+					d0 = snap31
+					d1 = snap32
+					d2 = snap33
+					d3 = snap34
+					d18 = snap35
+					d19 = snap36
+					d20 = snap37
+					d21 = snap38
+					d22 = snap39
+					d24 = snap40
+					d25 = snap41
+					d26 = snap42
+					d27 = snap43
+					d28 = snap44
+					ctx.RestoreAllocState(alloc45)
+					d0 = snap31
+					d1 = snap32
+					d2 = snap33
+					d3 = snap34
+					d18 = snap35
+					d19 = snap36
+					d20 = snap37
+					d21 = snap38
+					d22 = snap39
+					d24 = snap40
+					d25 = snap41
+					d26 = snap42
+					d27 = snap43
+					d28 = snap44
+					ps46 := PhiState{General: true}
+					ps46.OverlayValues = make([]JITValueDesc, 29)
+					ps46.OverlayValues[0] = d0
+					ps46.OverlayValues[1] = d1
+					ps46.OverlayValues[2] = d2
+					ps46.OverlayValues[3] = d3
+					ps46.OverlayValues[18] = d18
+					ps46.OverlayValues[19] = d19
+					ps46.OverlayValues[20] = d20
+					ps46.OverlayValues[21] = d21
+					ps46.OverlayValues[22] = d22
+					ps46.OverlayValues[24] = d24
+					ps46.OverlayValues[25] = d25
+					ps46.OverlayValues[26] = d26
+					ps46.OverlayValues[27] = d27
+					ps46.OverlayValues[28] = d28
+					ps47 := PhiState{General: true}
+					ps47.OverlayValues = make([]JITValueDesc, 29)
+					ps47.OverlayValues[0] = d0
+					ps47.OverlayValues[1] = d1
+					ps47.OverlayValues[2] = d2
+					ps47.OverlayValues[3] = d3
+					ps47.OverlayValues[18] = d18
+					ps47.OverlayValues[19] = d19
+					ps47.OverlayValues[20] = d20
+					ps47.OverlayValues[21] = d21
+					ps47.OverlayValues[22] = d22
+					ps47.OverlayValues[24] = d24
+					ps47.OverlayValues[25] = d25
+					ps47.OverlayValues[26] = d26
+					ps47.OverlayValues[27] = d27
+					ps47.OverlayValues[28] = d28
+					snap48 := d0
+					snap49 := d1
+					snap50 := d2
+					snap51 := d3
+					snap52 := d18
+					snap53 := d19
+					snap54 := d20
+					snap55 := d21
+					snap56 := d22
+					snap57 := d24
+					snap58 := d25
+					snap59 := d26
+					snap60 := d27
+					snap61 := d28
+					alloc62 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps44)
+						bbs[2].RenderPS(ps47)
 					}
-					ctx.RestoreAllocState(alloc58)
-					d0 = snap45
-					d1 = snap46
-					d2 = snap47
-					d3 = snap48
-					d18 = snap49
-					d19 = snap50
-					d20 = snap51
-					d21 = snap52
-					d22 = snap53
-					d23 = snap54
-					d24 = snap55
-					d25 = snap56
-					d26 = snap57
+					ctx.RestoreAllocState(alloc62)
+					d0 = snap48
+					d1 = snap49
+					d2 = snap50
+					d3 = snap51
+					d18 = snap52
+					d19 = snap53
+					d20 = snap54
+					d21 = snap55
+					d22 = snap56
+					d24 = snap57
+					d25 = snap58
+					d26 = snap59
+					d27 = snap60
+					d28 = snap61
 					if !bbs[1].Rendered {
-						return bbs[1].RenderPS(ps43)
+						return bbs[1].RenderPS(ps46)
 					}
 					return result
-					ctx.FreeDesc(&d24)
+					ctx.FreeDesc(&d26)
 					return result
 				}
-				ps59 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps59)
+				ps63 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps63)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -32208,14 +32333,16 @@ func init_alu() {
 				_ = d21
 				var d22 JITValueDesc
 				_ = d22
-				var d23 JITValueDesc
-				_ = d23
 				var d24 JITValueDesc
 				_ = d24
 				var d25 JITValueDesc
 				_ = d25
 				var d26 JITValueDesc
 				_ = d26
+				var d27 JITValueDesc
+				_ = d27
+				var d28 JITValueDesc
+				_ = d28
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				var bbs [4]BBDescriptor
 				for i := range args {
@@ -32455,15 +32582,15 @@ func init_alu() {
 					d19.ID = 0
 					d20 = args[0]
 					d20.ID = 0
-					d19 = JITPrepareScmerGoArg(ctx, d19)
-					d20 = JITPrepareScmerGoArg(ctx, d20)
-					ctx.SyncDesc(&d19)
-					ctx.SyncDesc(&d20)
-					d21 = ctx.EmitGoCallScalar(GoFuncAddr(Less), []JITValueDesc{d19, d20}, 1)
-					d21.NoHeapPointer = true
-					ctx.EmitAndRegImm32(d21.Reg, 1)
+					ctx.EnsureDesc(&d19)
+					ctx.EnsureDesc(&d20)
+					d22 = JITValueDesc{Loc: LocAny}
+					resultTarget23 := result.Loc == LocRegPair
+					if resultTarget23 {
+						d22 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
+					}
+					d21 = jitEmitLess(ctx, []JITValueDesc{d19, d20}, d22)
 					d21.Type = tagBool
-					ctx.BindReg(d21.Reg, &d21)
 					ctx.FreeDesc(&d19)
 					ctx.FreeDesc(&d20)
 					ctx.EnsureDesc(&d21)
@@ -32471,8 +32598,8 @@ func init_alu() {
 						ctx.EmitMakeBool(result, d21)
 					} else {
 						ctx.EmitMovToReg(result.Reg2, d21)
-						d22 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeBool(result, d22)
+						d24 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeBool(result, d24)
 						if d21.Loc == LocReg && d21.Reg != result.Reg2 {
 							ctx.FreeReg(d21.Reg)
 						}
@@ -32527,179 +32654,191 @@ func init_alu() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d23 = args[1]
-					d23.ID = 0
-					d25 = d23
+					d25 = args[1]
 					d25.ID = 0
-					d24 = ctx.EmitTagEqualsBorrowed(&d25, tagNil, JITValueDesc{Loc: LocAny})
-					ctx.FreeDesc(&d23)
-					d26 = d24
-					ctx.EnsureDesc(&d26)
-					if d26.Loc != LocImm && d26.Loc != LocReg {
+					d27 = d25
+					d27.ID = 0
+					d26 = ctx.EmitTagEqualsBorrowed(&d27, tagNil, JITValueDesc{Loc: LocAny})
+					ctx.FreeDesc(&d25)
+					d28 = d26
+					ctx.EnsureDesc(&d28)
+					if d28.Loc != LocImm && d28.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d26.Loc == LocImm {
-						if d26.Imm.Bool() {
+					if d28.Loc == LocImm {
+						if d28.Imm.Bool() {
 							if ps.General {
 							}
-							ps27 := PhiState{General: ps.General}
-							ps27.OverlayValues = make([]JITValueDesc, 27)
-							ps27.OverlayValues[0] = d0
-							ps27.OverlayValues[1] = d1
-							ps27.OverlayValues[2] = d2
-							ps27.OverlayValues[3] = d3
-							ps27.OverlayValues[18] = d18
-							ps27.OverlayValues[19] = d19
-							ps27.OverlayValues[20] = d20
-							ps27.OverlayValues[21] = d21
-							ps27.OverlayValues[22] = d22
-							ps27.OverlayValues[23] = d23
-							ps27.OverlayValues[24] = d24
-							ps27.OverlayValues[25] = d25
-							ps27.OverlayValues[26] = d26
-							return bbs[1].RenderPS(ps27)
+							ps29 := PhiState{General: ps.General}
+							ps29.OverlayValues = make([]JITValueDesc, 29)
+							ps29.OverlayValues[0] = d0
+							ps29.OverlayValues[1] = d1
+							ps29.OverlayValues[2] = d2
+							ps29.OverlayValues[3] = d3
+							ps29.OverlayValues[18] = d18
+							ps29.OverlayValues[19] = d19
+							ps29.OverlayValues[20] = d20
+							ps29.OverlayValues[21] = d21
+							ps29.OverlayValues[22] = d22
+							ps29.OverlayValues[24] = d24
+							ps29.OverlayValues[25] = d25
+							ps29.OverlayValues[26] = d26
+							ps29.OverlayValues[27] = d27
+							ps29.OverlayValues[28] = d28
+							return bbs[1].RenderPS(ps29)
 						}
 						if ps.General {
 						}
-						ps28 := PhiState{General: ps.General}
-						ps28.OverlayValues = make([]JITValueDesc, 27)
-						ps28.OverlayValues[0] = d0
-						ps28.OverlayValues[1] = d1
-						ps28.OverlayValues[2] = d2
-						ps28.OverlayValues[3] = d3
-						ps28.OverlayValues[18] = d18
-						ps28.OverlayValues[19] = d19
-						ps28.OverlayValues[20] = d20
-						ps28.OverlayValues[21] = d21
-						ps28.OverlayValues[22] = d22
-						ps28.OverlayValues[23] = d23
-						ps28.OverlayValues[24] = d24
-						ps28.OverlayValues[25] = d25
-						ps28.OverlayValues[26] = d26
-						return bbs[2].RenderPS(ps28)
+						ps30 := PhiState{General: ps.General}
+						ps30.OverlayValues = make([]JITValueDesc, 29)
+						ps30.OverlayValues[0] = d0
+						ps30.OverlayValues[1] = d1
+						ps30.OverlayValues[2] = d2
+						ps30.OverlayValues[3] = d3
+						ps30.OverlayValues[18] = d18
+						ps30.OverlayValues[19] = d19
+						ps30.OverlayValues[20] = d20
+						ps30.OverlayValues[21] = d21
+						ps30.OverlayValues[22] = d22
+						ps30.OverlayValues[24] = d24
+						ps30.OverlayValues[25] = d25
+						ps30.OverlayValues[26] = d26
+						ps30.OverlayValues[27] = d27
+						ps30.OverlayValues[28] = d28
+						return bbs[2].RenderPS(ps30)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[3].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d26.Reg, 0)
+					ctx.EmitCmpRegImm32(d28.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl2)
 					if bbs[2].Rendered {
 						ctx.EmitJmp(lbl3)
 					}
-					snap29 := d0
-					snap30 := d1
-					snap31 := d2
-					snap32 := d3
-					snap33 := d18
-					snap34 := d19
-					snap35 := d20
-					snap36 := d21
-					snap37 := d22
-					snap38 := d23
-					snap39 := d24
-					snap40 := d25
-					snap41 := d26
-					alloc42 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc42)
-					d0 = snap29
-					d1 = snap30
-					d2 = snap31
-					d3 = snap32
-					d18 = snap33
-					d19 = snap34
-					d20 = snap35
-					d21 = snap36
-					d22 = snap37
-					d23 = snap38
-					d24 = snap39
-					d25 = snap40
-					d26 = snap41
-					ctx.RestoreAllocState(alloc42)
-					d0 = snap29
-					d1 = snap30
-					d2 = snap31
-					d3 = snap32
-					d18 = snap33
-					d19 = snap34
-					d20 = snap35
-					d21 = snap36
-					d22 = snap37
-					d23 = snap38
-					d24 = snap39
-					d25 = snap40
-					d26 = snap41
-					ps43 := PhiState{General: true}
-					ps43.OverlayValues = make([]JITValueDesc, 27)
-					ps43.OverlayValues[0] = d0
-					ps43.OverlayValues[1] = d1
-					ps43.OverlayValues[2] = d2
-					ps43.OverlayValues[3] = d3
-					ps43.OverlayValues[18] = d18
-					ps43.OverlayValues[19] = d19
-					ps43.OverlayValues[20] = d20
-					ps43.OverlayValues[21] = d21
-					ps43.OverlayValues[22] = d22
-					ps43.OverlayValues[23] = d23
-					ps43.OverlayValues[24] = d24
-					ps43.OverlayValues[25] = d25
-					ps43.OverlayValues[26] = d26
-					ps44 := PhiState{General: true}
-					ps44.OverlayValues = make([]JITValueDesc, 27)
-					ps44.OverlayValues[0] = d0
-					ps44.OverlayValues[1] = d1
-					ps44.OverlayValues[2] = d2
-					ps44.OverlayValues[3] = d3
-					ps44.OverlayValues[18] = d18
-					ps44.OverlayValues[19] = d19
-					ps44.OverlayValues[20] = d20
-					ps44.OverlayValues[21] = d21
-					ps44.OverlayValues[22] = d22
-					ps44.OverlayValues[23] = d23
-					ps44.OverlayValues[24] = d24
-					ps44.OverlayValues[25] = d25
-					ps44.OverlayValues[26] = d26
-					snap45 := d0
-					snap46 := d1
-					snap47 := d2
-					snap48 := d3
-					snap49 := d18
-					snap50 := d19
-					snap51 := d20
-					snap52 := d21
-					snap53 := d22
-					snap54 := d23
-					snap55 := d24
-					snap56 := d25
-					snap57 := d26
-					alloc58 := ctx.SnapshotAllocState()
+					snap31 := d0
+					snap32 := d1
+					snap33 := d2
+					snap34 := d3
+					snap35 := d18
+					snap36 := d19
+					snap37 := d20
+					snap38 := d21
+					snap39 := d22
+					snap40 := d24
+					snap41 := d25
+					snap42 := d26
+					snap43 := d27
+					snap44 := d28
+					alloc45 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc45)
+					d0 = snap31
+					d1 = snap32
+					d2 = snap33
+					d3 = snap34
+					d18 = snap35
+					d19 = snap36
+					d20 = snap37
+					d21 = snap38
+					d22 = snap39
+					d24 = snap40
+					d25 = snap41
+					d26 = snap42
+					d27 = snap43
+					d28 = snap44
+					ctx.RestoreAllocState(alloc45)
+					d0 = snap31
+					d1 = snap32
+					d2 = snap33
+					d3 = snap34
+					d18 = snap35
+					d19 = snap36
+					d20 = snap37
+					d21 = snap38
+					d22 = snap39
+					d24 = snap40
+					d25 = snap41
+					d26 = snap42
+					d27 = snap43
+					d28 = snap44
+					ps46 := PhiState{General: true}
+					ps46.OverlayValues = make([]JITValueDesc, 29)
+					ps46.OverlayValues[0] = d0
+					ps46.OverlayValues[1] = d1
+					ps46.OverlayValues[2] = d2
+					ps46.OverlayValues[3] = d3
+					ps46.OverlayValues[18] = d18
+					ps46.OverlayValues[19] = d19
+					ps46.OverlayValues[20] = d20
+					ps46.OverlayValues[21] = d21
+					ps46.OverlayValues[22] = d22
+					ps46.OverlayValues[24] = d24
+					ps46.OverlayValues[25] = d25
+					ps46.OverlayValues[26] = d26
+					ps46.OverlayValues[27] = d27
+					ps46.OverlayValues[28] = d28
+					ps47 := PhiState{General: true}
+					ps47.OverlayValues = make([]JITValueDesc, 29)
+					ps47.OverlayValues[0] = d0
+					ps47.OverlayValues[1] = d1
+					ps47.OverlayValues[2] = d2
+					ps47.OverlayValues[3] = d3
+					ps47.OverlayValues[18] = d18
+					ps47.OverlayValues[19] = d19
+					ps47.OverlayValues[20] = d20
+					ps47.OverlayValues[21] = d21
+					ps47.OverlayValues[22] = d22
+					ps47.OverlayValues[24] = d24
+					ps47.OverlayValues[25] = d25
+					ps47.OverlayValues[26] = d26
+					ps47.OverlayValues[27] = d27
+					ps47.OverlayValues[28] = d28
+					snap48 := d0
+					snap49 := d1
+					snap50 := d2
+					snap51 := d3
+					snap52 := d18
+					snap53 := d19
+					snap54 := d20
+					snap55 := d21
+					snap56 := d22
+					snap57 := d24
+					snap58 := d25
+					snap59 := d26
+					snap60 := d27
+					snap61 := d28
+					alloc62 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps44)
+						bbs[2].RenderPS(ps47)
 					}
-					ctx.RestoreAllocState(alloc58)
-					d0 = snap45
-					d1 = snap46
-					d2 = snap47
-					d3 = snap48
-					d18 = snap49
-					d19 = snap50
-					d20 = snap51
-					d21 = snap52
-					d22 = snap53
-					d23 = snap54
-					d24 = snap55
-					d25 = snap56
-					d26 = snap57
+					ctx.RestoreAllocState(alloc62)
+					d0 = snap48
+					d1 = snap49
+					d2 = snap50
+					d3 = snap51
+					d18 = snap52
+					d19 = snap53
+					d20 = snap54
+					d21 = snap55
+					d22 = snap56
+					d24 = snap57
+					d25 = snap58
+					d26 = snap59
+					d27 = snap60
+					d28 = snap61
 					if !bbs[1].Rendered {
-						return bbs[1].RenderPS(ps43)
+						return bbs[1].RenderPS(ps46)
 					}
 					return result
-					ctx.FreeDesc(&d24)
+					ctx.FreeDesc(&d26)
 					return result
 				}
-				ps59 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps59)
+				ps63 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps63)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -33001,15 +33140,10 @@ func init_alu() {
 					d19.ID = 0
 					d20 = args[1]
 					d20.ID = 0
-					d19 = JITPrepareScmerGoArg(ctx, d19)
-					d20 = JITPrepareScmerGoArg(ctx, d20)
-					ctx.SyncDesc(&d19)
-					ctx.SyncDesc(&d20)
-					d21 = ctx.EmitGoCallScalar(GoFuncAddr(Less), []JITValueDesc{d19, d20}, 1)
-					d21.NoHeapPointer = true
-					ctx.EmitAndRegImm32(d21.Reg, 1)
+					ctx.EnsureDesc(&d19)
+					ctx.EnsureDesc(&d20)
+					d21 = jitEmitLess(ctx, []JITValueDesc{d19, d20}, JITValueDesc{Loc: LocAny})
 					d21.Type = tagBool
-					ctx.BindReg(d21.Reg, &d21)
 					ctx.FreeDesc(&d19)
 					ctx.FreeDesc(&d20)
 					ctx.EnsureDesc(&d21)
@@ -33825,64 +33959,68 @@ func init_alu() {
 				_ = d27
 				var d28 JITValueDesc
 				_ = d28
-				var d65 JITValueDesc
-				_ = d65
-				var d66 JITValueDesc
-				_ = d66
-				var d67 JITValueDesc
-				_ = d67
-				var d68 JITValueDesc
-				_ = d68
-				var d113 JITValueDesc
-				_ = d113
-				var d114 JITValueDesc
-				_ = d114
-				var d115 JITValueDesc
-				_ = d115
-				var d116 JITValueDesc
-				_ = d116
-				var d117 JITValueDesc
-				_ = d117
-				var d118 JITValueDesc
-				_ = d118
-				var d119 JITValueDesc
-				_ = d119
-				var d120 JITValueDesc
-				_ = d120
-				var d121 JITValueDesc
-				_ = d121
-				var d122 JITValueDesc
-				_ = d122
+				var d29 JITValueDesc
+				_ = d29
+				var d30 JITValueDesc
+				_ = d30
+				var d71 JITValueDesc
+				_ = d71
+				var d72 JITValueDesc
+				_ = d72
+				var d73 JITValueDesc
+				_ = d73
+				var d74 JITValueDesc
+				_ = d74
 				var d123 JITValueDesc
 				_ = d123
 				var d124 JITValueDesc
 				_ = d124
-				var d193 JITValueDesc
-				_ = d193
-				var d194 JITValueDesc
-				_ = d194
-				var d195 JITValueDesc
-				_ = d195
-				var d196 JITValueDesc
-				_ = d196
-				var d197 JITValueDesc
-				_ = d197
-				var d276 JITValueDesc
-				_ = d276
-				var d277 JITValueDesc
-				_ = d277
-				var d360 JITValueDesc
-				_ = d360
-				var d361 JITValueDesc
-				_ = d361
-				var d448 JITValueDesc
-				_ = d448
-				var d449 JITValueDesc
-				_ = d449
-				var d450 JITValueDesc
-				_ = d450
-				var d451 JITValueDesc
-				_ = d451
+				var d125 JITValueDesc
+				_ = d125
+				var d126 JITValueDesc
+				_ = d126
+				var d127 JITValueDesc
+				_ = d127
+				var d128 JITValueDesc
+				_ = d128
+				var d129 JITValueDesc
+				_ = d129
+				var d130 JITValueDesc
+				_ = d130
+				var d131 JITValueDesc
+				_ = d131
+				var d132 JITValueDesc
+				_ = d132
+				var d133 JITValueDesc
+				_ = d133
+				var d134 JITValueDesc
+				_ = d134
+				var d207 JITValueDesc
+				_ = d207
+				var d208 JITValueDesc
+				_ = d208
+				var d209 JITValueDesc
+				_ = d209
+				var d210 JITValueDesc
+				_ = d210
+				var d211 JITValueDesc
+				_ = d211
+				var d294 JITValueDesc
+				_ = d294
+				var d295 JITValueDesc
+				_ = d295
+				var d382 JITValueDesc
+				_ = d382
+				var d383 JITValueDesc
+				_ = d383
+				var d474 JITValueDesc
+				_ = d474
+				var d475 JITValueDesc
+				_ = d475
+				var d476 JITValueDesc
+				_ = d476
+				var d477 JITValueDesc
+				_ = d477
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				var bbs [11]BBDescriptor
 				for i := range args {
@@ -34199,201 +34337,223 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d22)
 					d23 = args[0]
 					d23.ID = 0
-					d24 = ctx.EmitGetTagDesc(&d23, JITValueDesc{Loc: LocAny})
-					ctx.StabilizeDescForControlFlow(&d24)
+					d24 = d23
+					d24.ID = 0
+					d25 = ctx.EmitGetTagDesc(&d24, JITValueDesc{Loc: LocAny})
+					ctx.StabilizeDescForControlFlow(&d25)
 					ctx.FreeDesc(&d23)
-					d25 = args[1]
-					d25.ID = 0
-					d26 = ctx.EmitGetTagDesc(&d25, JITValueDesc{Loc: LocAny})
-					ctx.StabilizeDescForControlFlow(&d26)
-					ctx.FreeDesc(&d25)
-					ctx.EnsureDesc(&d24)
-					var d27 JITValueDesc
-					if d24.Loc == LocImm {
-						d27 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d24.Imm.Int()) == uint64(0x1))}
+					d26 = args[1]
+					d26.ID = 0
+					d27 = d26
+					d27.ID = 0
+					d28 = ctx.EmitGetTagDesc(&d27, JITValueDesc{Loc: LocAny})
+					ctx.StabilizeDescForControlFlow(&d28)
+					ctx.FreeDesc(&d26)
+					ctx.EnsureDesc(&d25)
+					var d29 JITValueDesc
+					if d25.Loc == LocImm {
+						d29 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d25.Imm.Int()) == uint64(0x1))}
 					} else {
-						r0 := ctx.AllocRegExcept(d24.Reg)
-						ctx.EmitCmpRegImm32(d24.Reg, 1)
-						d27 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
-						ctx.BindReg(r0, &d27)
+						r0 := ctx.AllocRegExcept(d25.Reg)
+						ctx.EmitCmpRegImm32(d25.Reg, 1)
+						d29 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
+						ctx.BindReg(r0, &d29)
 					}
-					d28 = d27
-					ctx.EnsureDesc(&d28)
-					if d28.Loc != LocImm && d28.Loc != LocFlags {
+					d30 = d29
+					ctx.EnsureDesc(&d30)
+					if d30.Loc != LocImm && d30.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d28.Loc == LocImm {
-						if d28.Imm.Bool() {
+					if d30.Loc == LocImm {
+						if d30.Imm.Bool() {
 							if ps.General {
 							}
-							ps29 := PhiState{General: ps.General}
-							ps29.OverlayValues = make([]JITValueDesc, 29)
-							ps29.OverlayValues[0] = d0
-							ps29.OverlayValues[1] = d1
-							ps29.OverlayValues[2] = d2
-							ps29.OverlayValues[3] = d3
-							ps29.OverlayValues[18] = d18
-							ps29.OverlayValues[19] = d19
-							ps29.OverlayValues[20] = d20
-							ps29.OverlayValues[21] = d21
-							ps29.OverlayValues[22] = d22
-							ps29.OverlayValues[23] = d23
-							ps29.OverlayValues[24] = d24
-							ps29.OverlayValues[25] = d25
-							ps29.OverlayValues[26] = d26
-							ps29.OverlayValues[27] = d27
-							ps29.OverlayValues[28] = d28
-							return bbs[6].RenderPS(ps29)
+							ps31 := PhiState{General: ps.General}
+							ps31.OverlayValues = make([]JITValueDesc, 31)
+							ps31.OverlayValues[0] = d0
+							ps31.OverlayValues[1] = d1
+							ps31.OverlayValues[2] = d2
+							ps31.OverlayValues[3] = d3
+							ps31.OverlayValues[18] = d18
+							ps31.OverlayValues[19] = d19
+							ps31.OverlayValues[20] = d20
+							ps31.OverlayValues[21] = d21
+							ps31.OverlayValues[22] = d22
+							ps31.OverlayValues[23] = d23
+							ps31.OverlayValues[24] = d24
+							ps31.OverlayValues[25] = d25
+							ps31.OverlayValues[26] = d26
+							ps31.OverlayValues[27] = d27
+							ps31.OverlayValues[28] = d28
+							ps31.OverlayValues[29] = d29
+							ps31.OverlayValues[30] = d30
+							return bbs[6].RenderPS(ps31)
 						}
 						if ps.General {
 						}
-						ps30 := PhiState{General: ps.General}
-						ps30.OverlayValues = make([]JITValueDesc, 29)
-						ps30.OverlayValues[0] = d0
-						ps30.OverlayValues[1] = d1
-						ps30.OverlayValues[2] = d2
-						ps30.OverlayValues[3] = d3
-						ps30.OverlayValues[18] = d18
-						ps30.OverlayValues[19] = d19
-						ps30.OverlayValues[20] = d20
-						ps30.OverlayValues[21] = d21
-						ps30.OverlayValues[22] = d22
-						ps30.OverlayValues[23] = d23
-						ps30.OverlayValues[24] = d24
-						ps30.OverlayValues[25] = d25
-						ps30.OverlayValues[26] = d26
-						ps30.OverlayValues[27] = d27
-						ps30.OverlayValues[28] = d28
-						return bbs[7].RenderPS(ps30)
+						ps32 := PhiState{General: ps.General}
+						ps32.OverlayValues = make([]JITValueDesc, 31)
+						ps32.OverlayValues[0] = d0
+						ps32.OverlayValues[1] = d1
+						ps32.OverlayValues[2] = d2
+						ps32.OverlayValues[3] = d3
+						ps32.OverlayValues[18] = d18
+						ps32.OverlayValues[19] = d19
+						ps32.OverlayValues[20] = d20
+						ps32.OverlayValues[21] = d21
+						ps32.OverlayValues[22] = d22
+						ps32.OverlayValues[23] = d23
+						ps32.OverlayValues[24] = d24
+						ps32.OverlayValues[25] = d25
+						ps32.OverlayValues[26] = d26
+						ps32.OverlayValues[27] = d27
+						ps32.OverlayValues[28] = d28
+						ps32.OverlayValues[29] = d29
+						ps32.OverlayValues[30] = d30
+						return bbs[7].RenderPS(ps32)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[2].RenderPS(ps)
 					}
-					ctx.EmitJump(d28.Condition, lbl7)
+					ctx.EmitJump(d30.Condition, lbl7)
 					if bbs[7].Rendered {
 						ctx.EmitJmp(lbl8)
 					}
-					ctx.FreeDesc(&d27)
-					snap31 := d0
-					snap32 := d1
-					snap33 := d2
-					snap34 := d3
-					snap35 := d18
-					snap36 := d19
-					snap37 := d20
-					snap38 := d21
-					snap39 := d22
-					snap40 := d23
-					snap41 := d24
-					snap42 := d25
-					snap43 := d26
-					snap44 := d27
-					snap45 := d28
-					alloc46 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc46)
-					d0 = snap31
-					d1 = snap32
-					d2 = snap33
-					d3 = snap34
-					d18 = snap35
-					d19 = snap36
-					d20 = snap37
-					d21 = snap38
-					d22 = snap39
-					d23 = snap40
-					d24 = snap41
-					d25 = snap42
-					d26 = snap43
-					d27 = snap44
-					d28 = snap45
-					ctx.RestoreAllocState(alloc46)
-					d0 = snap31
-					d1 = snap32
-					d2 = snap33
-					d3 = snap34
-					d18 = snap35
-					d19 = snap36
-					d20 = snap37
-					d21 = snap38
-					d22 = snap39
-					d23 = snap40
-					d24 = snap41
-					d25 = snap42
-					d26 = snap43
-					d27 = snap44
-					d28 = snap45
-					ps47 := PhiState{General: true}
-					ps47.OverlayValues = make([]JITValueDesc, 29)
-					ps47.OverlayValues[0] = d0
-					ps47.OverlayValues[1] = d1
-					ps47.OverlayValues[2] = d2
-					ps47.OverlayValues[3] = d3
-					ps47.OverlayValues[18] = d18
-					ps47.OverlayValues[19] = d19
-					ps47.OverlayValues[20] = d20
-					ps47.OverlayValues[21] = d21
-					ps47.OverlayValues[22] = d22
-					ps47.OverlayValues[23] = d23
-					ps47.OverlayValues[24] = d24
-					ps47.OverlayValues[25] = d25
-					ps47.OverlayValues[26] = d26
-					ps47.OverlayValues[27] = d27
-					ps47.OverlayValues[28] = d28
-					ps48 := PhiState{General: true}
-					ps48.OverlayValues = make([]JITValueDesc, 29)
-					ps48.OverlayValues[0] = d0
-					ps48.OverlayValues[1] = d1
-					ps48.OverlayValues[2] = d2
-					ps48.OverlayValues[3] = d3
-					ps48.OverlayValues[18] = d18
-					ps48.OverlayValues[19] = d19
-					ps48.OverlayValues[20] = d20
-					ps48.OverlayValues[21] = d21
-					ps48.OverlayValues[22] = d22
-					ps48.OverlayValues[23] = d23
-					ps48.OverlayValues[24] = d24
-					ps48.OverlayValues[25] = d25
-					ps48.OverlayValues[26] = d26
-					ps48.OverlayValues[27] = d27
-					ps48.OverlayValues[28] = d28
-					snap49 := d0
-					snap50 := d1
-					snap51 := d2
-					snap52 := d3
-					snap53 := d18
-					snap54 := d19
-					snap55 := d20
-					snap56 := d21
-					snap57 := d22
-					snap58 := d23
-					snap59 := d24
-					snap60 := d25
-					snap61 := d26
-					snap62 := d27
-					snap63 := d28
-					alloc64 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d29)
+					snap33 := d0
+					snap34 := d1
+					snap35 := d2
+					snap36 := d3
+					snap37 := d18
+					snap38 := d19
+					snap39 := d20
+					snap40 := d21
+					snap41 := d22
+					snap42 := d23
+					snap43 := d24
+					snap44 := d25
+					snap45 := d26
+					snap46 := d27
+					snap47 := d28
+					snap48 := d29
+					snap49 := d30
+					alloc50 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc50)
+					d0 = snap33
+					d1 = snap34
+					d2 = snap35
+					d3 = snap36
+					d18 = snap37
+					d19 = snap38
+					d20 = snap39
+					d21 = snap40
+					d22 = snap41
+					d23 = snap42
+					d24 = snap43
+					d25 = snap44
+					d26 = snap45
+					d27 = snap46
+					d28 = snap47
+					d29 = snap48
+					d30 = snap49
+					ctx.RestoreAllocState(alloc50)
+					d0 = snap33
+					d1 = snap34
+					d2 = snap35
+					d3 = snap36
+					d18 = snap37
+					d19 = snap38
+					d20 = snap39
+					d21 = snap40
+					d22 = snap41
+					d23 = snap42
+					d24 = snap43
+					d25 = snap44
+					d26 = snap45
+					d27 = snap46
+					d28 = snap47
+					d29 = snap48
+					d30 = snap49
+					ps51 := PhiState{General: true}
+					ps51.OverlayValues = make([]JITValueDesc, 31)
+					ps51.OverlayValues[0] = d0
+					ps51.OverlayValues[1] = d1
+					ps51.OverlayValues[2] = d2
+					ps51.OverlayValues[3] = d3
+					ps51.OverlayValues[18] = d18
+					ps51.OverlayValues[19] = d19
+					ps51.OverlayValues[20] = d20
+					ps51.OverlayValues[21] = d21
+					ps51.OverlayValues[22] = d22
+					ps51.OverlayValues[23] = d23
+					ps51.OverlayValues[24] = d24
+					ps51.OverlayValues[25] = d25
+					ps51.OverlayValues[26] = d26
+					ps51.OverlayValues[27] = d27
+					ps51.OverlayValues[28] = d28
+					ps51.OverlayValues[29] = d29
+					ps51.OverlayValues[30] = d30
+					ps52 := PhiState{General: true}
+					ps52.OverlayValues = make([]JITValueDesc, 31)
+					ps52.OverlayValues[0] = d0
+					ps52.OverlayValues[1] = d1
+					ps52.OverlayValues[2] = d2
+					ps52.OverlayValues[3] = d3
+					ps52.OverlayValues[18] = d18
+					ps52.OverlayValues[19] = d19
+					ps52.OverlayValues[20] = d20
+					ps52.OverlayValues[21] = d21
+					ps52.OverlayValues[22] = d22
+					ps52.OverlayValues[23] = d23
+					ps52.OverlayValues[24] = d24
+					ps52.OverlayValues[25] = d25
+					ps52.OverlayValues[26] = d26
+					ps52.OverlayValues[27] = d27
+					ps52.OverlayValues[28] = d28
+					ps52.OverlayValues[29] = d29
+					ps52.OverlayValues[30] = d30
+					snap53 := d0
+					snap54 := d1
+					snap55 := d2
+					snap56 := d3
+					snap57 := d18
+					snap58 := d19
+					snap59 := d20
+					snap60 := d21
+					snap61 := d22
+					snap62 := d23
+					snap63 := d24
+					snap64 := d25
+					snap65 := d26
+					snap66 := d27
+					snap67 := d28
+					snap68 := d29
+					snap69 := d30
+					alloc70 := ctx.SnapshotAllocState()
 					if !bbs[7].Rendered {
-						bbs[7].RenderPS(ps48)
+						bbs[7].RenderPS(ps52)
 					}
-					ctx.RestoreAllocState(alloc64)
-					d0 = snap49
-					d1 = snap50
-					d2 = snap51
-					d3 = snap52
-					d18 = snap53
-					d19 = snap54
-					d20 = snap55
-					d21 = snap56
-					d22 = snap57
-					d23 = snap58
-					d24 = snap59
-					d25 = snap60
-					d26 = snap61
-					d27 = snap62
-					d28 = snap63
+					ctx.RestoreAllocState(alloc70)
+					d0 = snap53
+					d1 = snap54
+					d2 = snap55
+					d3 = snap56
+					d18 = snap57
+					d19 = snap58
+					d20 = snap59
+					d21 = snap60
+					d22 = snap61
+					d23 = snap62
+					d24 = snap63
+					d25 = snap64
+					d26 = snap65
+					d27 = snap66
+					d28 = snap67
+					d29 = snap68
+					d30 = snap69
 					if !bbs[6].Rendered {
-						return bbs[6].RenderPS(ps47)
+						return bbs[6].RenderPS(ps51)
 					}
 					return result
 					return result
@@ -34462,229 +34622,253 @@ func init_alu() {
 					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
 						d28 = ps.OverlayValues[28]
 					}
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
+					}
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d65 = args[1]
-					d65.ID = 0
-					d67 = d65
-					d67.ID = 0
-					d66 = ctx.EmitTagEqualsBorrowed(&d67, tagNil, JITValueDesc{Loc: LocAny})
-					ctx.FreeDesc(&d65)
-					d68 = d66
-					ctx.EnsureDesc(&d68)
-					if d68.Loc != LocImm && d68.Loc != LocReg {
+					d71 = args[1]
+					d71.ID = 0
+					d73 = d71
+					d73.ID = 0
+					d72 = ctx.EmitTagEqualsBorrowed(&d73, tagNil, JITValueDesc{Loc: LocAny})
+					ctx.FreeDesc(&d71)
+					d74 = d72
+					ctx.EnsureDesc(&d74)
+					if d74.Loc != LocImm && d74.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d68.Loc == LocImm {
-						if d68.Imm.Bool() {
+					if d74.Loc == LocImm {
+						if d74.Imm.Bool() {
 							if ps.General {
 							}
-							ps69 := PhiState{General: ps.General}
-							ps69.OverlayValues = make([]JITValueDesc, 69)
-							ps69.OverlayValues[0] = d0
-							ps69.OverlayValues[1] = d1
-							ps69.OverlayValues[2] = d2
-							ps69.OverlayValues[3] = d3
-							ps69.OverlayValues[18] = d18
-							ps69.OverlayValues[19] = d19
-							ps69.OverlayValues[20] = d20
-							ps69.OverlayValues[21] = d21
-							ps69.OverlayValues[22] = d22
-							ps69.OverlayValues[23] = d23
-							ps69.OverlayValues[24] = d24
-							ps69.OverlayValues[25] = d25
-							ps69.OverlayValues[26] = d26
-							ps69.OverlayValues[27] = d27
-							ps69.OverlayValues[28] = d28
-							ps69.OverlayValues[65] = d65
-							ps69.OverlayValues[66] = d66
-							ps69.OverlayValues[67] = d67
-							ps69.OverlayValues[68] = d68
-							return bbs[1].RenderPS(ps69)
+							ps75 := PhiState{General: ps.General}
+							ps75.OverlayValues = make([]JITValueDesc, 75)
+							ps75.OverlayValues[0] = d0
+							ps75.OverlayValues[1] = d1
+							ps75.OverlayValues[2] = d2
+							ps75.OverlayValues[3] = d3
+							ps75.OverlayValues[18] = d18
+							ps75.OverlayValues[19] = d19
+							ps75.OverlayValues[20] = d20
+							ps75.OverlayValues[21] = d21
+							ps75.OverlayValues[22] = d22
+							ps75.OverlayValues[23] = d23
+							ps75.OverlayValues[24] = d24
+							ps75.OverlayValues[25] = d25
+							ps75.OverlayValues[26] = d26
+							ps75.OverlayValues[27] = d27
+							ps75.OverlayValues[28] = d28
+							ps75.OverlayValues[29] = d29
+							ps75.OverlayValues[30] = d30
+							ps75.OverlayValues[71] = d71
+							ps75.OverlayValues[72] = d72
+							ps75.OverlayValues[73] = d73
+							ps75.OverlayValues[74] = d74
+							return bbs[1].RenderPS(ps75)
 						}
 						if ps.General {
 						}
-						ps70 := PhiState{General: ps.General}
-						ps70.OverlayValues = make([]JITValueDesc, 69)
-						ps70.OverlayValues[0] = d0
-						ps70.OverlayValues[1] = d1
-						ps70.OverlayValues[2] = d2
-						ps70.OverlayValues[3] = d3
-						ps70.OverlayValues[18] = d18
-						ps70.OverlayValues[19] = d19
-						ps70.OverlayValues[20] = d20
-						ps70.OverlayValues[21] = d21
-						ps70.OverlayValues[22] = d22
-						ps70.OverlayValues[23] = d23
-						ps70.OverlayValues[24] = d24
-						ps70.OverlayValues[25] = d25
-						ps70.OverlayValues[26] = d26
-						ps70.OverlayValues[27] = d27
-						ps70.OverlayValues[28] = d28
-						ps70.OverlayValues[65] = d65
-						ps70.OverlayValues[66] = d66
-						ps70.OverlayValues[67] = d67
-						ps70.OverlayValues[68] = d68
-						return bbs[2].RenderPS(ps70)
+						ps76 := PhiState{General: ps.General}
+						ps76.OverlayValues = make([]JITValueDesc, 75)
+						ps76.OverlayValues[0] = d0
+						ps76.OverlayValues[1] = d1
+						ps76.OverlayValues[2] = d2
+						ps76.OverlayValues[3] = d3
+						ps76.OverlayValues[18] = d18
+						ps76.OverlayValues[19] = d19
+						ps76.OverlayValues[20] = d20
+						ps76.OverlayValues[21] = d21
+						ps76.OverlayValues[22] = d22
+						ps76.OverlayValues[23] = d23
+						ps76.OverlayValues[24] = d24
+						ps76.OverlayValues[25] = d25
+						ps76.OverlayValues[26] = d26
+						ps76.OverlayValues[27] = d27
+						ps76.OverlayValues[28] = d28
+						ps76.OverlayValues[29] = d29
+						ps76.OverlayValues[30] = d30
+						ps76.OverlayValues[71] = d71
+						ps76.OverlayValues[72] = d72
+						ps76.OverlayValues[73] = d73
+						ps76.OverlayValues[74] = d74
+						return bbs[2].RenderPS(ps76)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[3].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d68.Reg, 0)
+					ctx.EmitCmpRegImm32(d74.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl2)
 					if bbs[2].Rendered {
 						ctx.EmitJmp(lbl3)
 					}
-					snap71 := d0
-					snap72 := d1
-					snap73 := d2
-					snap74 := d3
-					snap75 := d18
-					snap76 := d19
-					snap77 := d20
-					snap78 := d21
-					snap79 := d22
-					snap80 := d23
-					snap81 := d24
-					snap82 := d25
-					snap83 := d26
-					snap84 := d27
-					snap85 := d28
-					snap86 := d65
-					snap87 := d66
-					snap88 := d67
-					snap89 := d68
-					alloc90 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc90)
-					d0 = snap71
-					d1 = snap72
-					d2 = snap73
-					d3 = snap74
-					d18 = snap75
-					d19 = snap76
-					d20 = snap77
-					d21 = snap78
-					d22 = snap79
-					d23 = snap80
-					d24 = snap81
-					d25 = snap82
-					d26 = snap83
-					d27 = snap84
-					d28 = snap85
-					d65 = snap86
-					d66 = snap87
-					d67 = snap88
-					d68 = snap89
-					ctx.RestoreAllocState(alloc90)
-					d0 = snap71
-					d1 = snap72
-					d2 = snap73
-					d3 = snap74
-					d18 = snap75
-					d19 = snap76
-					d20 = snap77
-					d21 = snap78
-					d22 = snap79
-					d23 = snap80
-					d24 = snap81
-					d25 = snap82
-					d26 = snap83
-					d27 = snap84
-					d28 = snap85
-					d65 = snap86
-					d66 = snap87
-					d67 = snap88
-					d68 = snap89
-					ps91 := PhiState{General: true}
-					ps91.OverlayValues = make([]JITValueDesc, 69)
-					ps91.OverlayValues[0] = d0
-					ps91.OverlayValues[1] = d1
-					ps91.OverlayValues[2] = d2
-					ps91.OverlayValues[3] = d3
-					ps91.OverlayValues[18] = d18
-					ps91.OverlayValues[19] = d19
-					ps91.OverlayValues[20] = d20
-					ps91.OverlayValues[21] = d21
-					ps91.OverlayValues[22] = d22
-					ps91.OverlayValues[23] = d23
-					ps91.OverlayValues[24] = d24
-					ps91.OverlayValues[25] = d25
-					ps91.OverlayValues[26] = d26
-					ps91.OverlayValues[27] = d27
-					ps91.OverlayValues[28] = d28
-					ps91.OverlayValues[65] = d65
-					ps91.OverlayValues[66] = d66
-					ps91.OverlayValues[67] = d67
-					ps91.OverlayValues[68] = d68
-					ps92 := PhiState{General: true}
-					ps92.OverlayValues = make([]JITValueDesc, 69)
-					ps92.OverlayValues[0] = d0
-					ps92.OverlayValues[1] = d1
-					ps92.OverlayValues[2] = d2
-					ps92.OverlayValues[3] = d3
-					ps92.OverlayValues[18] = d18
-					ps92.OverlayValues[19] = d19
-					ps92.OverlayValues[20] = d20
-					ps92.OverlayValues[21] = d21
-					ps92.OverlayValues[22] = d22
-					ps92.OverlayValues[23] = d23
-					ps92.OverlayValues[24] = d24
-					ps92.OverlayValues[25] = d25
-					ps92.OverlayValues[26] = d26
-					ps92.OverlayValues[27] = d27
-					ps92.OverlayValues[28] = d28
-					ps92.OverlayValues[65] = d65
-					ps92.OverlayValues[66] = d66
-					ps92.OverlayValues[67] = d67
-					ps92.OverlayValues[68] = d68
-					snap93 := d0
-					snap94 := d1
-					snap95 := d2
-					snap96 := d3
-					snap97 := d18
-					snap98 := d19
-					snap99 := d20
-					snap100 := d21
-					snap101 := d22
-					snap102 := d23
-					snap103 := d24
-					snap104 := d25
-					snap105 := d26
-					snap106 := d27
-					snap107 := d28
-					snap108 := d65
-					snap109 := d66
-					snap110 := d67
-					snap111 := d68
-					alloc112 := ctx.SnapshotAllocState()
+					snap77 := d0
+					snap78 := d1
+					snap79 := d2
+					snap80 := d3
+					snap81 := d18
+					snap82 := d19
+					snap83 := d20
+					snap84 := d21
+					snap85 := d22
+					snap86 := d23
+					snap87 := d24
+					snap88 := d25
+					snap89 := d26
+					snap90 := d27
+					snap91 := d28
+					snap92 := d29
+					snap93 := d30
+					snap94 := d71
+					snap95 := d72
+					snap96 := d73
+					snap97 := d74
+					alloc98 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc98)
+					d0 = snap77
+					d1 = snap78
+					d2 = snap79
+					d3 = snap80
+					d18 = snap81
+					d19 = snap82
+					d20 = snap83
+					d21 = snap84
+					d22 = snap85
+					d23 = snap86
+					d24 = snap87
+					d25 = snap88
+					d26 = snap89
+					d27 = snap90
+					d28 = snap91
+					d29 = snap92
+					d30 = snap93
+					d71 = snap94
+					d72 = snap95
+					d73 = snap96
+					d74 = snap97
+					ctx.RestoreAllocState(alloc98)
+					d0 = snap77
+					d1 = snap78
+					d2 = snap79
+					d3 = snap80
+					d18 = snap81
+					d19 = snap82
+					d20 = snap83
+					d21 = snap84
+					d22 = snap85
+					d23 = snap86
+					d24 = snap87
+					d25 = snap88
+					d26 = snap89
+					d27 = snap90
+					d28 = snap91
+					d29 = snap92
+					d30 = snap93
+					d71 = snap94
+					d72 = snap95
+					d73 = snap96
+					d74 = snap97
+					ps99 := PhiState{General: true}
+					ps99.OverlayValues = make([]JITValueDesc, 75)
+					ps99.OverlayValues[0] = d0
+					ps99.OverlayValues[1] = d1
+					ps99.OverlayValues[2] = d2
+					ps99.OverlayValues[3] = d3
+					ps99.OverlayValues[18] = d18
+					ps99.OverlayValues[19] = d19
+					ps99.OverlayValues[20] = d20
+					ps99.OverlayValues[21] = d21
+					ps99.OverlayValues[22] = d22
+					ps99.OverlayValues[23] = d23
+					ps99.OverlayValues[24] = d24
+					ps99.OverlayValues[25] = d25
+					ps99.OverlayValues[26] = d26
+					ps99.OverlayValues[27] = d27
+					ps99.OverlayValues[28] = d28
+					ps99.OverlayValues[29] = d29
+					ps99.OverlayValues[30] = d30
+					ps99.OverlayValues[71] = d71
+					ps99.OverlayValues[72] = d72
+					ps99.OverlayValues[73] = d73
+					ps99.OverlayValues[74] = d74
+					ps100 := PhiState{General: true}
+					ps100.OverlayValues = make([]JITValueDesc, 75)
+					ps100.OverlayValues[0] = d0
+					ps100.OverlayValues[1] = d1
+					ps100.OverlayValues[2] = d2
+					ps100.OverlayValues[3] = d3
+					ps100.OverlayValues[18] = d18
+					ps100.OverlayValues[19] = d19
+					ps100.OverlayValues[20] = d20
+					ps100.OverlayValues[21] = d21
+					ps100.OverlayValues[22] = d22
+					ps100.OverlayValues[23] = d23
+					ps100.OverlayValues[24] = d24
+					ps100.OverlayValues[25] = d25
+					ps100.OverlayValues[26] = d26
+					ps100.OverlayValues[27] = d27
+					ps100.OverlayValues[28] = d28
+					ps100.OverlayValues[29] = d29
+					ps100.OverlayValues[30] = d30
+					ps100.OverlayValues[71] = d71
+					ps100.OverlayValues[72] = d72
+					ps100.OverlayValues[73] = d73
+					ps100.OverlayValues[74] = d74
+					snap101 := d0
+					snap102 := d1
+					snap103 := d2
+					snap104 := d3
+					snap105 := d18
+					snap106 := d19
+					snap107 := d20
+					snap108 := d21
+					snap109 := d22
+					snap110 := d23
+					snap111 := d24
+					snap112 := d25
+					snap113 := d26
+					snap114 := d27
+					snap115 := d28
+					snap116 := d29
+					snap117 := d30
+					snap118 := d71
+					snap119 := d72
+					snap120 := d73
+					snap121 := d74
+					alloc122 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps92)
+						bbs[2].RenderPS(ps100)
 					}
-					ctx.RestoreAllocState(alloc112)
-					d0 = snap93
-					d1 = snap94
-					d2 = snap95
-					d3 = snap96
-					d18 = snap97
-					d19 = snap98
-					d20 = snap99
-					d21 = snap100
-					d22 = snap101
-					d23 = snap102
-					d24 = snap103
-					d25 = snap104
-					d26 = snap105
-					d27 = snap106
-					d28 = snap107
-					d65 = snap108
-					d66 = snap109
-					d67 = snap110
-					d68 = snap111
+					ctx.RestoreAllocState(alloc122)
+					d0 = snap101
+					d1 = snap102
+					d2 = snap103
+					d3 = snap104
+					d18 = snap105
+					d19 = snap106
+					d20 = snap107
+					d21 = snap108
+					d22 = snap109
+					d23 = snap110
+					d24 = snap111
+					d25 = snap112
+					d26 = snap113
+					d27 = snap114
+					d28 = snap115
+					d29 = snap116
+					d30 = snap117
+					d71 = snap118
+					d72 = snap119
+					d73 = snap120
+					d74 = snap121
 					if !bbs[1].Rendered {
-						return bbs[1].RenderPS(ps91)
+						return bbs[1].RenderPS(ps99)
 					}
 					return result
-					ctx.FreeDesc(&d66)
+					ctx.FreeDesc(&d72)
 					return result
 				}
 				bbs[4].RenderPS = func(ps PhiState) JITValueDesc {
@@ -34751,65 +34935,71 @@ func init_alu() {
 					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
 						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
-						d65 = ps.OverlayValues[65]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
-						d66 = ps.OverlayValues[66]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
 					}
-					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
-						d67 = ps.OverlayValues[67]
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
-					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
-						d68 = ps.OverlayValues[68]
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
+					}
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
+					}
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d113 = args[0]
-					d113.ID = 0
-					d115 = d113
-					ctx.SyncDesc(&d115)
-					if d115.Loc == LocMem {
-						tmpScalar := JITValueDesc{Loc: LocReg, Type: d115.Type, Reg: ctx.AllocReg()}
+					d123 = args[0]
+					d123.ID = 0
+					d125 = d123
+					ctx.SyncDesc(&d125)
+					if d125.Loc == LocMem {
+						tmpScalar := JITValueDesc{Loc: LocReg, Type: d125.Type, Reg: ctx.AllocReg()}
 						scratch := ctx.AllocRegExcept(tmpScalar.Reg)
-						ctx.EmitMovRegImm64(scratch, uint64(d115.MemPtr))
+						ctx.EmitMovRegImm64(scratch, uint64(d125.MemPtr))
 						ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
 						ctx.FreeReg(scratch)
 						ctx.BindReg(tmpScalar.Reg, &tmpScalar)
-						d115 = tmpScalar
+						d125 = tmpScalar
 					}
-					d115 = JITPrepareScmerGoArg(ctx, d115)
-					if d115.Loc != LocRegPair && d115.Loc != LocStackPair && d115.Loc != LocInputPair {
+					d125 = JITPrepareScmerGoArg(ctx, d125)
+					if d125.Loc != LocRegPair && d125.Loc != LocStackPair && d125.Loc != LocInputPair {
 						panic("jit: Scmer.String receiver not materialized as pair")
 					}
-					d114 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d115}, 2)
-					ctx.StabilizeDescForControlFlow(&d114)
-					ctx.FreeDesc(&d113)
-					d116 = args[1]
-					d116.ID = 0
-					d118 = d116
-					ctx.SyncDesc(&d118)
-					if d118.Loc == LocMem {
-						tmpScalar := JITValueDesc{Loc: LocReg, Type: d118.Type, Reg: ctx.AllocReg()}
+					d124 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d125}, 2)
+					ctx.StabilizeDescForControlFlow(&d124)
+					ctx.FreeDesc(&d123)
+					d126 = args[1]
+					d126.ID = 0
+					d128 = d126
+					ctx.SyncDesc(&d128)
+					if d128.Loc == LocMem {
+						tmpScalar := JITValueDesc{Loc: LocReg, Type: d128.Type, Reg: ctx.AllocReg()}
 						scratch := ctx.AllocRegExcept(tmpScalar.Reg)
-						ctx.EmitMovRegImm64(scratch, uint64(d118.MemPtr))
+						ctx.EmitMovRegImm64(scratch, uint64(d128.MemPtr))
 						ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
 						ctx.FreeReg(scratch)
 						ctx.BindReg(tmpScalar.Reg, &tmpScalar)
-						d118 = tmpScalar
+						d128 = tmpScalar
 					}
-					d118 = JITPrepareScmerGoArg(ctx, d118)
-					if d118.Loc != LocRegPair && d118.Loc != LocStackPair && d118.Loc != LocInputPair {
+					d128 = JITPrepareScmerGoArg(ctx, d128)
+					if d128.Loc != LocRegPair && d128.Loc != LocStackPair && d128.Loc != LocInputPair {
 						panic("jit: Scmer.String receiver not materialized as pair")
 					}
-					d117 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d118}, 2)
-					ctx.StabilizeDescForControlFlow(&d117)
-					ctx.FreeDesc(&d116)
+					d127 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d128}, 2)
+					ctx.StabilizeDescForControlFlow(&d127)
+					ctx.FreeDesc(&d126)
 					ctx.EnsureDesc(&d22)
-					d119 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("_ci")}
-					d120 = d22
-					_ = d120
-					d121 = d119
-					_ = d121
+					d129 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("_ci")}
+					d130 = d22
+					_ = d130
+					d131 = d129
+					_ = d131
 					bbpos_1_0 := int32(-1)
 					_ = bbpos_1_0
 					lbl12 := ctx.ReserveLabel()
@@ -34819,403 +35009,421 @@ func init_alu() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d120)
-					if d120.Loc == LocImm {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d120.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.TrackImm(d120.Imm)
-						ptrWord, _ := d120.Imm.RawWords()
+					ctx.EnsureDesc(&d130)
+					if d130.Loc == LocImm {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d130.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.TrackImm(d130.Imm)
+						ptrWord, _ := d130.Imm.RawWords()
 						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d120.Imm.String())))
-						d120 = tmpPair
-					} else if d120.Loc == LocReg {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d120.Type, Reg: ctx.AllocRegExcept(d120.Reg), Reg2: ctx.AllocRegExcept(d120.Reg)}
-						switch d120.Type {
+						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d130.Imm.String())))
+						d130 = tmpPair
+					} else if d130.Loc == LocReg {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d130.Type, Reg: ctx.AllocRegExcept(d130.Reg), Reg2: ctx.AllocRegExcept(d130.Reg)}
+						switch d130.Type {
 						case tagBool:
-							ctx.EmitMakeBool(tmpPair, d120)
+							ctx.EmitMakeBool(tmpPair, d130)
 						case tagInt:
-							ctx.EmitMakeInt(tmpPair, d120)
+							ctx.EmitMakeInt(tmpPair, d130)
 						case tagFloat:
-							ctx.EmitMakeFloat(tmpPair, d120)
+							ctx.EmitMakeFloat(tmpPair, d130)
 						default:
 							panic("jit: generic call arg scalar type unknown for 2-word value")
 						}
-						ctx.FreeDesc(&d120)
-						d120 = tmpPair
+						ctx.FreeDesc(&d130)
+						d130 = tmpPair
 					}
-					if d120.Loc != LocRegPair && d120.Loc != LocStackPair && d120.Loc != LocInputPair {
+					if d130.Loc != LocRegPair && d130.Loc != LocStackPair && d130.Loc != LocInputPair {
 						panic("jit: generic call arg expects 2-word value (strings.Index arg0)")
 					}
-					ctx.EnsureDesc(&d121)
-					if d121.Loc == LocImm {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d121.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.TrackImm(d121.Imm)
-						ptrWord, _ := d121.Imm.RawWords()
+					ctx.EnsureDesc(&d131)
+					if d131.Loc == LocImm {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d131.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.TrackImm(d131.Imm)
+						ptrWord, _ := d131.Imm.RawWords()
 						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d121.Imm.String())))
-						d121 = tmpPair
-					} else if d121.Loc == LocReg {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d121.Type, Reg: ctx.AllocRegExcept(d121.Reg), Reg2: ctx.AllocRegExcept(d121.Reg)}
-						switch d121.Type {
+						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d131.Imm.String())))
+						d131 = tmpPair
+					} else if d131.Loc == LocReg {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d131.Type, Reg: ctx.AllocRegExcept(d131.Reg), Reg2: ctx.AllocRegExcept(d131.Reg)}
+						switch d131.Type {
 						case tagBool:
-							ctx.EmitMakeBool(tmpPair, d121)
+							ctx.EmitMakeBool(tmpPair, d131)
 						case tagInt:
-							ctx.EmitMakeInt(tmpPair, d121)
+							ctx.EmitMakeInt(tmpPair, d131)
 						case tagFloat:
-							ctx.EmitMakeFloat(tmpPair, d121)
+							ctx.EmitMakeFloat(tmpPair, d131)
 						default:
 							panic("jit: generic call arg scalar type unknown for 2-word value")
 						}
-						ctx.FreeDesc(&d121)
-						d121 = tmpPair
+						ctx.FreeDesc(&d131)
+						d131 = tmpPair
 					}
-					if d121.Loc != LocRegPair && d121.Loc != LocStackPair && d121.Loc != LocInputPair {
+					if d131.Loc != LocRegPair && d131.Loc != LocStackPair && d131.Loc != LocInputPair {
 						panic("jit: generic call arg expects 2-word value (strings.Index arg1)")
 					}
-					ctx.SyncDesc(&d120)
-					ctx.SyncDesc(&d121)
-					d122 = ctx.EmitGoCallScalar(GoFuncAddr(strings.Index), []JITValueDesc{d120, d121}, 1)
-					d122.NoHeapPointer = true
-					ctx.BindReg(d122.Reg, &d122)
-					ctx.FreeDesc(&d121)
+					ctx.SyncDesc(&d130)
+					ctx.SyncDesc(&d131)
+					d132 = ctx.EmitGoCallScalar(GoFuncAddr(strings.Index), []JITValueDesc{d130, d131}, 1)
+					d132.NoHeapPointer = true
+					ctx.BindReg(d132.Reg, &d132)
+					ctx.FreeDesc(&d131)
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d122)
-					var d123 JITValueDesc
-					if d122.Loc == LocImm {
-						d123 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d122.Imm.Int() >= 0)}
+					ctx.EnsureDesc(&d132)
+					var d133 JITValueDesc
+					if d132.Loc == LocImm {
+						d133 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d132.Imm.Int() >= 0)}
 					} else {
-						ctx.EmitCmpRegImm32(d122.Reg, 0)
-						r1 := ctx.AllocReg()
+						ctx.EmitCmpRegImm32(d132.Reg, 0)
+						r1 := ctx.AllocRegExcept(d132.Reg)
 						ctx.EmitSetcc(r1, CondSignedGreaterOrEqual)
-						d123 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
-						ctx.BindReg(r1, &d123)
+						d133 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
+						ctx.BindReg(r1, &d133)
 					}
-					ctx.FreeDesc(&d122)
+					ctx.FreeDesc(&d132)
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d123)
-					d124 = d123
-					ctx.EnsureDesc(&d124)
-					if d124.Loc != LocImm && d124.Loc != LocReg {
+					ctx.EnsureDesc(&d133)
+					d134 = d133
+					ctx.EnsureDesc(&d134)
+					if d134.Loc != LocImm && d134.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d124.Loc == LocImm {
-						if d124.Imm.Bool() {
+					if d134.Loc == LocImm {
+						if d134.Imm.Bool() {
 							if ps.General {
 							}
-							ps125 := PhiState{General: ps.General}
-							ps125.OverlayValues = make([]JITValueDesc, 125)
-							ps125.OverlayValues[0] = d0
-							ps125.OverlayValues[1] = d1
-							ps125.OverlayValues[2] = d2
-							ps125.OverlayValues[3] = d3
-							ps125.OverlayValues[18] = d18
-							ps125.OverlayValues[19] = d19
-							ps125.OverlayValues[20] = d20
-							ps125.OverlayValues[21] = d21
-							ps125.OverlayValues[22] = d22
-							ps125.OverlayValues[23] = d23
-							ps125.OverlayValues[24] = d24
-							ps125.OverlayValues[25] = d25
-							ps125.OverlayValues[26] = d26
-							ps125.OverlayValues[27] = d27
-							ps125.OverlayValues[28] = d28
-							ps125.OverlayValues[65] = d65
-							ps125.OverlayValues[66] = d66
-							ps125.OverlayValues[67] = d67
-							ps125.OverlayValues[68] = d68
-							ps125.OverlayValues[113] = d113
-							ps125.OverlayValues[114] = d114
-							ps125.OverlayValues[115] = d115
-							ps125.OverlayValues[116] = d116
-							ps125.OverlayValues[117] = d117
-							ps125.OverlayValues[118] = d118
-							ps125.OverlayValues[119] = d119
-							ps125.OverlayValues[120] = d120
-							ps125.OverlayValues[121] = d121
-							ps125.OverlayValues[122] = d122
-							ps125.OverlayValues[123] = d123
-							ps125.OverlayValues[124] = d124
-							return bbs[9].RenderPS(ps125)
+							ps135 := PhiState{General: ps.General}
+							ps135.OverlayValues = make([]JITValueDesc, 135)
+							ps135.OverlayValues[0] = d0
+							ps135.OverlayValues[1] = d1
+							ps135.OverlayValues[2] = d2
+							ps135.OverlayValues[3] = d3
+							ps135.OverlayValues[18] = d18
+							ps135.OverlayValues[19] = d19
+							ps135.OverlayValues[20] = d20
+							ps135.OverlayValues[21] = d21
+							ps135.OverlayValues[22] = d22
+							ps135.OverlayValues[23] = d23
+							ps135.OverlayValues[24] = d24
+							ps135.OverlayValues[25] = d25
+							ps135.OverlayValues[26] = d26
+							ps135.OverlayValues[27] = d27
+							ps135.OverlayValues[28] = d28
+							ps135.OverlayValues[29] = d29
+							ps135.OverlayValues[30] = d30
+							ps135.OverlayValues[71] = d71
+							ps135.OverlayValues[72] = d72
+							ps135.OverlayValues[73] = d73
+							ps135.OverlayValues[74] = d74
+							ps135.OverlayValues[123] = d123
+							ps135.OverlayValues[124] = d124
+							ps135.OverlayValues[125] = d125
+							ps135.OverlayValues[126] = d126
+							ps135.OverlayValues[127] = d127
+							ps135.OverlayValues[128] = d128
+							ps135.OverlayValues[129] = d129
+							ps135.OverlayValues[130] = d130
+							ps135.OverlayValues[131] = d131
+							ps135.OverlayValues[132] = d132
+							ps135.OverlayValues[133] = d133
+							ps135.OverlayValues[134] = d134
+							return bbs[9].RenderPS(ps135)
 						}
 						if ps.General {
 						}
-						ps126 := PhiState{General: ps.General}
-						ps126.OverlayValues = make([]JITValueDesc, 125)
-						ps126.OverlayValues[0] = d0
-						ps126.OverlayValues[1] = d1
-						ps126.OverlayValues[2] = d2
-						ps126.OverlayValues[3] = d3
-						ps126.OverlayValues[18] = d18
-						ps126.OverlayValues[19] = d19
-						ps126.OverlayValues[20] = d20
-						ps126.OverlayValues[21] = d21
-						ps126.OverlayValues[22] = d22
-						ps126.OverlayValues[23] = d23
-						ps126.OverlayValues[24] = d24
-						ps126.OverlayValues[25] = d25
-						ps126.OverlayValues[26] = d26
-						ps126.OverlayValues[27] = d27
-						ps126.OverlayValues[28] = d28
-						ps126.OverlayValues[65] = d65
-						ps126.OverlayValues[66] = d66
-						ps126.OverlayValues[67] = d67
-						ps126.OverlayValues[68] = d68
-						ps126.OverlayValues[113] = d113
-						ps126.OverlayValues[114] = d114
-						ps126.OverlayValues[115] = d115
-						ps126.OverlayValues[116] = d116
-						ps126.OverlayValues[117] = d117
-						ps126.OverlayValues[118] = d118
-						ps126.OverlayValues[119] = d119
-						ps126.OverlayValues[120] = d120
-						ps126.OverlayValues[121] = d121
-						ps126.OverlayValues[122] = d122
-						ps126.OverlayValues[123] = d123
-						ps126.OverlayValues[124] = d124
-						return bbs[10].RenderPS(ps126)
+						ps136 := PhiState{General: ps.General}
+						ps136.OverlayValues = make([]JITValueDesc, 135)
+						ps136.OverlayValues[0] = d0
+						ps136.OverlayValues[1] = d1
+						ps136.OverlayValues[2] = d2
+						ps136.OverlayValues[3] = d3
+						ps136.OverlayValues[18] = d18
+						ps136.OverlayValues[19] = d19
+						ps136.OverlayValues[20] = d20
+						ps136.OverlayValues[21] = d21
+						ps136.OverlayValues[22] = d22
+						ps136.OverlayValues[23] = d23
+						ps136.OverlayValues[24] = d24
+						ps136.OverlayValues[25] = d25
+						ps136.OverlayValues[26] = d26
+						ps136.OverlayValues[27] = d27
+						ps136.OverlayValues[28] = d28
+						ps136.OverlayValues[29] = d29
+						ps136.OverlayValues[30] = d30
+						ps136.OverlayValues[71] = d71
+						ps136.OverlayValues[72] = d72
+						ps136.OverlayValues[73] = d73
+						ps136.OverlayValues[74] = d74
+						ps136.OverlayValues[123] = d123
+						ps136.OverlayValues[124] = d124
+						ps136.OverlayValues[125] = d125
+						ps136.OverlayValues[126] = d126
+						ps136.OverlayValues[127] = d127
+						ps136.OverlayValues[128] = d128
+						ps136.OverlayValues[129] = d129
+						ps136.OverlayValues[130] = d130
+						ps136.OverlayValues[131] = d131
+						ps136.OverlayValues[132] = d132
+						ps136.OverlayValues[133] = d133
+						ps136.OverlayValues[134] = d134
+						return bbs[10].RenderPS(ps136)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[4].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d124.Reg, 0)
+					ctx.EmitCmpRegImm32(d134.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl10)
 					if bbs[10].Rendered {
 						ctx.EmitJmp(lbl11)
 					}
-					snap127 := d0
-					snap128 := d1
-					snap129 := d2
-					snap130 := d3
-					snap131 := d18
-					snap132 := d19
-					snap133 := d20
-					snap134 := d21
-					snap135 := d22
-					snap136 := d23
-					snap137 := d24
-					snap138 := d25
-					snap139 := d26
-					snap140 := d27
-					snap141 := d28
-					snap142 := d65
-					snap143 := d66
-					snap144 := d67
-					snap145 := d68
-					snap146 := d113
-					snap147 := d114
-					snap148 := d115
-					snap149 := d116
-					snap150 := d117
-					snap151 := d118
-					snap152 := d119
-					snap153 := d120
-					snap154 := d121
-					snap155 := d122
-					snap156 := d123
-					snap157 := d124
-					alloc158 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc158)
-					d0 = snap127
-					d1 = snap128
-					d2 = snap129
-					d3 = snap130
-					d18 = snap131
-					d19 = snap132
-					d20 = snap133
-					d21 = snap134
-					d22 = snap135
-					d23 = snap136
-					d24 = snap137
-					d25 = snap138
-					d26 = snap139
-					d27 = snap140
-					d28 = snap141
-					d65 = snap142
-					d66 = snap143
-					d67 = snap144
-					d68 = snap145
-					d113 = snap146
-					d114 = snap147
-					d115 = snap148
-					d116 = snap149
-					d117 = snap150
-					d118 = snap151
-					d119 = snap152
-					d120 = snap153
-					d121 = snap154
-					d122 = snap155
-					d123 = snap156
-					d124 = snap157
-					ctx.RestoreAllocState(alloc158)
-					d0 = snap127
-					d1 = snap128
-					d2 = snap129
-					d3 = snap130
-					d18 = snap131
-					d19 = snap132
-					d20 = snap133
-					d21 = snap134
-					d22 = snap135
-					d23 = snap136
-					d24 = snap137
-					d25 = snap138
-					d26 = snap139
-					d27 = snap140
-					d28 = snap141
-					d65 = snap142
-					d66 = snap143
-					d67 = snap144
-					d68 = snap145
-					d113 = snap146
-					d114 = snap147
-					d115 = snap148
-					d116 = snap149
-					d117 = snap150
-					d118 = snap151
-					d119 = snap152
-					d120 = snap153
-					d121 = snap154
-					d122 = snap155
-					d123 = snap156
-					d124 = snap157
-					ps159 := PhiState{General: true}
-					ps159.OverlayValues = make([]JITValueDesc, 125)
-					ps159.OverlayValues[0] = d0
-					ps159.OverlayValues[1] = d1
-					ps159.OverlayValues[2] = d2
-					ps159.OverlayValues[3] = d3
-					ps159.OverlayValues[18] = d18
-					ps159.OverlayValues[19] = d19
-					ps159.OverlayValues[20] = d20
-					ps159.OverlayValues[21] = d21
-					ps159.OverlayValues[22] = d22
-					ps159.OverlayValues[23] = d23
-					ps159.OverlayValues[24] = d24
-					ps159.OverlayValues[25] = d25
-					ps159.OverlayValues[26] = d26
-					ps159.OverlayValues[27] = d27
-					ps159.OverlayValues[28] = d28
-					ps159.OverlayValues[65] = d65
-					ps159.OverlayValues[66] = d66
-					ps159.OverlayValues[67] = d67
-					ps159.OverlayValues[68] = d68
-					ps159.OverlayValues[113] = d113
-					ps159.OverlayValues[114] = d114
-					ps159.OverlayValues[115] = d115
-					ps159.OverlayValues[116] = d116
-					ps159.OverlayValues[117] = d117
-					ps159.OverlayValues[118] = d118
-					ps159.OverlayValues[119] = d119
-					ps159.OverlayValues[120] = d120
-					ps159.OverlayValues[121] = d121
-					ps159.OverlayValues[122] = d122
-					ps159.OverlayValues[123] = d123
-					ps159.OverlayValues[124] = d124
-					ps160 := PhiState{General: true}
-					ps160.OverlayValues = make([]JITValueDesc, 125)
-					ps160.OverlayValues[0] = d0
-					ps160.OverlayValues[1] = d1
-					ps160.OverlayValues[2] = d2
-					ps160.OverlayValues[3] = d3
-					ps160.OverlayValues[18] = d18
-					ps160.OverlayValues[19] = d19
-					ps160.OverlayValues[20] = d20
-					ps160.OverlayValues[21] = d21
-					ps160.OverlayValues[22] = d22
-					ps160.OverlayValues[23] = d23
-					ps160.OverlayValues[24] = d24
-					ps160.OverlayValues[25] = d25
-					ps160.OverlayValues[26] = d26
-					ps160.OverlayValues[27] = d27
-					ps160.OverlayValues[28] = d28
-					ps160.OverlayValues[65] = d65
-					ps160.OverlayValues[66] = d66
-					ps160.OverlayValues[67] = d67
-					ps160.OverlayValues[68] = d68
-					ps160.OverlayValues[113] = d113
-					ps160.OverlayValues[114] = d114
-					ps160.OverlayValues[115] = d115
-					ps160.OverlayValues[116] = d116
-					ps160.OverlayValues[117] = d117
-					ps160.OverlayValues[118] = d118
-					ps160.OverlayValues[119] = d119
-					ps160.OverlayValues[120] = d120
-					ps160.OverlayValues[121] = d121
-					ps160.OverlayValues[122] = d122
-					ps160.OverlayValues[123] = d123
-					ps160.OverlayValues[124] = d124
-					snap161 := d0
-					snap162 := d1
-					snap163 := d2
-					snap164 := d3
-					snap165 := d18
-					snap166 := d19
-					snap167 := d20
-					snap168 := d21
-					snap169 := d22
-					snap170 := d23
-					snap171 := d24
-					snap172 := d25
-					snap173 := d26
-					snap174 := d27
-					snap175 := d28
-					snap176 := d65
-					snap177 := d66
-					snap178 := d67
-					snap179 := d68
-					snap180 := d113
-					snap181 := d114
-					snap182 := d115
-					snap183 := d116
-					snap184 := d117
-					snap185 := d118
-					snap186 := d119
-					snap187 := d120
-					snap188 := d121
-					snap189 := d122
-					snap190 := d123
-					snap191 := d124
-					alloc192 := ctx.SnapshotAllocState()
+					snap137 := d0
+					snap138 := d1
+					snap139 := d2
+					snap140 := d3
+					snap141 := d18
+					snap142 := d19
+					snap143 := d20
+					snap144 := d21
+					snap145 := d22
+					snap146 := d23
+					snap147 := d24
+					snap148 := d25
+					snap149 := d26
+					snap150 := d27
+					snap151 := d28
+					snap152 := d29
+					snap153 := d30
+					snap154 := d71
+					snap155 := d72
+					snap156 := d73
+					snap157 := d74
+					snap158 := d123
+					snap159 := d124
+					snap160 := d125
+					snap161 := d126
+					snap162 := d127
+					snap163 := d128
+					snap164 := d129
+					snap165 := d130
+					snap166 := d131
+					snap167 := d132
+					snap168 := d133
+					snap169 := d134
+					alloc170 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc170)
+					d0 = snap137
+					d1 = snap138
+					d2 = snap139
+					d3 = snap140
+					d18 = snap141
+					d19 = snap142
+					d20 = snap143
+					d21 = snap144
+					d22 = snap145
+					d23 = snap146
+					d24 = snap147
+					d25 = snap148
+					d26 = snap149
+					d27 = snap150
+					d28 = snap151
+					d29 = snap152
+					d30 = snap153
+					d71 = snap154
+					d72 = snap155
+					d73 = snap156
+					d74 = snap157
+					d123 = snap158
+					d124 = snap159
+					d125 = snap160
+					d126 = snap161
+					d127 = snap162
+					d128 = snap163
+					d129 = snap164
+					d130 = snap165
+					d131 = snap166
+					d132 = snap167
+					d133 = snap168
+					d134 = snap169
+					ctx.RestoreAllocState(alloc170)
+					d0 = snap137
+					d1 = snap138
+					d2 = snap139
+					d3 = snap140
+					d18 = snap141
+					d19 = snap142
+					d20 = snap143
+					d21 = snap144
+					d22 = snap145
+					d23 = snap146
+					d24 = snap147
+					d25 = snap148
+					d26 = snap149
+					d27 = snap150
+					d28 = snap151
+					d29 = snap152
+					d30 = snap153
+					d71 = snap154
+					d72 = snap155
+					d73 = snap156
+					d74 = snap157
+					d123 = snap158
+					d124 = snap159
+					d125 = snap160
+					d126 = snap161
+					d127 = snap162
+					d128 = snap163
+					d129 = snap164
+					d130 = snap165
+					d131 = snap166
+					d132 = snap167
+					d133 = snap168
+					d134 = snap169
+					ps171 := PhiState{General: true}
+					ps171.OverlayValues = make([]JITValueDesc, 135)
+					ps171.OverlayValues[0] = d0
+					ps171.OverlayValues[1] = d1
+					ps171.OverlayValues[2] = d2
+					ps171.OverlayValues[3] = d3
+					ps171.OverlayValues[18] = d18
+					ps171.OverlayValues[19] = d19
+					ps171.OverlayValues[20] = d20
+					ps171.OverlayValues[21] = d21
+					ps171.OverlayValues[22] = d22
+					ps171.OverlayValues[23] = d23
+					ps171.OverlayValues[24] = d24
+					ps171.OverlayValues[25] = d25
+					ps171.OverlayValues[26] = d26
+					ps171.OverlayValues[27] = d27
+					ps171.OverlayValues[28] = d28
+					ps171.OverlayValues[29] = d29
+					ps171.OverlayValues[30] = d30
+					ps171.OverlayValues[71] = d71
+					ps171.OverlayValues[72] = d72
+					ps171.OverlayValues[73] = d73
+					ps171.OverlayValues[74] = d74
+					ps171.OverlayValues[123] = d123
+					ps171.OverlayValues[124] = d124
+					ps171.OverlayValues[125] = d125
+					ps171.OverlayValues[126] = d126
+					ps171.OverlayValues[127] = d127
+					ps171.OverlayValues[128] = d128
+					ps171.OverlayValues[129] = d129
+					ps171.OverlayValues[130] = d130
+					ps171.OverlayValues[131] = d131
+					ps171.OverlayValues[132] = d132
+					ps171.OverlayValues[133] = d133
+					ps171.OverlayValues[134] = d134
+					ps172 := PhiState{General: true}
+					ps172.OverlayValues = make([]JITValueDesc, 135)
+					ps172.OverlayValues[0] = d0
+					ps172.OverlayValues[1] = d1
+					ps172.OverlayValues[2] = d2
+					ps172.OverlayValues[3] = d3
+					ps172.OverlayValues[18] = d18
+					ps172.OverlayValues[19] = d19
+					ps172.OverlayValues[20] = d20
+					ps172.OverlayValues[21] = d21
+					ps172.OverlayValues[22] = d22
+					ps172.OverlayValues[23] = d23
+					ps172.OverlayValues[24] = d24
+					ps172.OverlayValues[25] = d25
+					ps172.OverlayValues[26] = d26
+					ps172.OverlayValues[27] = d27
+					ps172.OverlayValues[28] = d28
+					ps172.OverlayValues[29] = d29
+					ps172.OverlayValues[30] = d30
+					ps172.OverlayValues[71] = d71
+					ps172.OverlayValues[72] = d72
+					ps172.OverlayValues[73] = d73
+					ps172.OverlayValues[74] = d74
+					ps172.OverlayValues[123] = d123
+					ps172.OverlayValues[124] = d124
+					ps172.OverlayValues[125] = d125
+					ps172.OverlayValues[126] = d126
+					ps172.OverlayValues[127] = d127
+					ps172.OverlayValues[128] = d128
+					ps172.OverlayValues[129] = d129
+					ps172.OverlayValues[130] = d130
+					ps172.OverlayValues[131] = d131
+					ps172.OverlayValues[132] = d132
+					ps172.OverlayValues[133] = d133
+					ps172.OverlayValues[134] = d134
+					snap173 := d0
+					snap174 := d1
+					snap175 := d2
+					snap176 := d3
+					snap177 := d18
+					snap178 := d19
+					snap179 := d20
+					snap180 := d21
+					snap181 := d22
+					snap182 := d23
+					snap183 := d24
+					snap184 := d25
+					snap185 := d26
+					snap186 := d27
+					snap187 := d28
+					snap188 := d29
+					snap189 := d30
+					snap190 := d71
+					snap191 := d72
+					snap192 := d73
+					snap193 := d74
+					snap194 := d123
+					snap195 := d124
+					snap196 := d125
+					snap197 := d126
+					snap198 := d127
+					snap199 := d128
+					snap200 := d129
+					snap201 := d130
+					snap202 := d131
+					snap203 := d132
+					snap204 := d133
+					snap205 := d134
+					alloc206 := ctx.SnapshotAllocState()
 					if !bbs[10].Rendered {
-						bbs[10].RenderPS(ps160)
+						bbs[10].RenderPS(ps172)
 					}
-					ctx.RestoreAllocState(alloc192)
-					d0 = snap161
-					d1 = snap162
-					d2 = snap163
-					d3 = snap164
-					d18 = snap165
-					d19 = snap166
-					d20 = snap167
-					d21 = snap168
-					d22 = snap169
-					d23 = snap170
-					d24 = snap171
-					d25 = snap172
-					d26 = snap173
-					d27 = snap174
-					d28 = snap175
-					d65 = snap176
-					d66 = snap177
-					d67 = snap178
-					d68 = snap179
-					d113 = snap180
-					d114 = snap181
-					d115 = snap182
-					d116 = snap183
-					d117 = snap184
-					d118 = snap185
-					d119 = snap186
-					d120 = snap187
-					d121 = snap188
-					d122 = snap189
-					d123 = snap190
-					d124 = snap191
+					ctx.RestoreAllocState(alloc206)
+					d0 = snap173
+					d1 = snap174
+					d2 = snap175
+					d3 = snap176
+					d18 = snap177
+					d19 = snap178
+					d20 = snap179
+					d21 = snap180
+					d22 = snap181
+					d23 = snap182
+					d24 = snap183
+					d25 = snap184
+					d26 = snap185
+					d27 = snap186
+					d28 = snap187
+					d29 = snap188
+					d30 = snap189
+					d71 = snap190
+					d72 = snap191
+					d73 = snap192
+					d74 = snap193
+					d123 = snap194
+					d124 = snap195
+					d125 = snap196
+					d126 = snap197
+					d127 = snap198
+					d128 = snap199
+					d129 = snap200
+					d130 = snap201
+					d131 = snap202
+					d132 = snap203
+					d133 = snap204
+					d134 = snap205
 					if !bbs[9].Rendered {
-						return bbs[9].RenderPS(ps159)
+						return bbs[9].RenderPS(ps171)
 					}
 					return result
-					ctx.FreeDesc(&d123)
+					ctx.FreeDesc(&d133)
 					return result
 				}
 				bbs[5].RenderPS = func(ps PhiState) JITValueDesc {
@@ -35282,47 +35490,23 @@ func init_alu() {
 					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
 						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
-						d65 = ps.OverlayValues[65]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
-						d66 = ps.OverlayValues[66]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
 					}
-					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
-						d67 = ps.OverlayValues[67]
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
-					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
-						d68 = ps.OverlayValues[68]
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 113 && ps.OverlayValues[113].Loc != LocNone {
-						d113 = ps.OverlayValues[113]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 114 && ps.OverlayValues[114].Loc != LocNone {
-						d114 = ps.OverlayValues[114]
-					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
-					}
-					if len(ps.OverlayValues) > 116 && ps.OverlayValues[116].Loc != LocNone {
-						d116 = ps.OverlayValues[116]
-					}
-					if len(ps.OverlayValues) > 117 && ps.OverlayValues[117].Loc != LocNone {
-						d117 = ps.OverlayValues[117]
-					}
-					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
-						d118 = ps.OverlayValues[118]
-					}
-					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
-						d119 = ps.OverlayValues[119]
-					}
-					if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
-						d120 = ps.OverlayValues[120]
-					}
-					if len(ps.OverlayValues) > 121 && ps.OverlayValues[121].Loc != LocNone {
-						d121 = ps.OverlayValues[121]
-					}
-					if len(ps.OverlayValues) > 122 && ps.OverlayValues[122].Loc != LocNone {
-						d122 = ps.OverlayValues[122]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
 					if len(ps.OverlayValues) > 123 && ps.OverlayValues[123].Loc != LocNone {
 						d123 = ps.OverlayValues[123]
@@ -35330,42 +35514,72 @@ func init_alu() {
 					if len(ps.OverlayValues) > 124 && ps.OverlayValues[124].Loc != LocNone {
 						d124 = ps.OverlayValues[124]
 					}
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
+					}
+					if len(ps.OverlayValues) > 126 && ps.OverlayValues[126].Loc != LocNone {
+						d126 = ps.OverlayValues[126]
+					}
+					if len(ps.OverlayValues) > 127 && ps.OverlayValues[127].Loc != LocNone {
+						d127 = ps.OverlayValues[127]
+					}
+					if len(ps.OverlayValues) > 128 && ps.OverlayValues[128].Loc != LocNone {
+						d128 = ps.OverlayValues[128]
+					}
+					if len(ps.OverlayValues) > 129 && ps.OverlayValues[129].Loc != LocNone {
+						d129 = ps.OverlayValues[129]
+					}
+					if len(ps.OverlayValues) > 130 && ps.OverlayValues[130].Loc != LocNone {
+						d130 = ps.OverlayValues[130]
+					}
+					if len(ps.OverlayValues) > 131 && ps.OverlayValues[131].Loc != LocNone {
+						d131 = ps.OverlayValues[131]
+					}
+					if len(ps.OverlayValues) > 132 && ps.OverlayValues[132].Loc != LocNone {
+						d132 = ps.OverlayValues[132]
+					}
+					if len(ps.OverlayValues) > 133 && ps.OverlayValues[133].Loc != LocNone {
+						d133 = ps.OverlayValues[133]
+					}
+					if len(ps.OverlayValues) > 134 && ps.OverlayValues[134].Loc != LocNone {
+						d134 = ps.OverlayValues[134]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d193 = args[0]
-					d193.ID = 0
-					d194 = args[1]
-					d194.ID = 0
-					d193 = JITPrepareScmerGoArg(ctx, d193)
-					d194 = JITPrepareScmerGoArg(ctx, d194)
-					ctx.SyncDesc(&d193)
-					ctx.SyncDesc(&d194)
-					d195 = ctx.EmitGoCallScalar(GoFuncAddr(EqualSQL), []JITValueDesc{d193, d194}, 2)
-					d195.NoHeapPointer = false
-					ctx.BindReg(d195.Reg, &d195)
-					ctx.BindReg(d195.Reg2, &d195)
-					ctx.FreeDesc(&d193)
-					ctx.FreeDesc(&d194)
-					ctx.SyncDesc(&d195)
-					if d195.Loc == LocRegPair || d195.Loc == LocStackPair || d195.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d195, &result)
-						result.Type = d195.Type
+					d207 = args[0]
+					d207.ID = 0
+					d208 = args[1]
+					d208.ID = 0
+					d207 = JITPrepareScmerGoArg(ctx, d207)
+					d208 = JITPrepareScmerGoArg(ctx, d208)
+					ctx.SyncDesc(&d207)
+					ctx.SyncDesc(&d208)
+					d209 = ctx.EmitGoCallScalar(GoFuncAddr(EqualSQL), []JITValueDesc{d207, d208}, 2)
+					d209.NoHeapPointer = false
+					ctx.BindReg(d209.Reg, &d209)
+					ctx.BindReg(d209.Reg2, &d209)
+					ctx.FreeDesc(&d207)
+					ctx.FreeDesc(&d208)
+					ctx.SyncDesc(&d209)
+					if d209.Loc == LocRegPair || d209.Loc == LocStackPair || d209.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d209, &result)
+						result.Type = d209.Type
 					} else {
-						switch d195.Type {
+						switch d209.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d195)
+							ctx.EmitMakeBool(result, d209)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d195)
+							ctx.EmitMakeInt(result, d209)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d195)
+							ctx.EmitMakeFloat(result, d209)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d195, &result)
-							result.Type = d195.Type
+							ctx.EmitMovPairToResult(&d209, &result)
+							result.Type = d209.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -35435,47 +35649,23 @@ func init_alu() {
 					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
 						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
-						d65 = ps.OverlayValues[65]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
-						d66 = ps.OverlayValues[66]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
 					}
-					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
-						d67 = ps.OverlayValues[67]
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
-					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
-						d68 = ps.OverlayValues[68]
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 113 && ps.OverlayValues[113].Loc != LocNone {
-						d113 = ps.OverlayValues[113]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 114 && ps.OverlayValues[114].Loc != LocNone {
-						d114 = ps.OverlayValues[114]
-					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
-					}
-					if len(ps.OverlayValues) > 116 && ps.OverlayValues[116].Loc != LocNone {
-						d116 = ps.OverlayValues[116]
-					}
-					if len(ps.OverlayValues) > 117 && ps.OverlayValues[117].Loc != LocNone {
-						d117 = ps.OverlayValues[117]
-					}
-					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
-						d118 = ps.OverlayValues[118]
-					}
-					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
-						d119 = ps.OverlayValues[119]
-					}
-					if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
-						d120 = ps.OverlayValues[120]
-					}
-					if len(ps.OverlayValues) > 121 && ps.OverlayValues[121].Loc != LocNone {
-						d121 = ps.OverlayValues[121]
-					}
-					if len(ps.OverlayValues) > 122 && ps.OverlayValues[122].Loc != LocNone {
-						d122 = ps.OverlayValues[122]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
 					if len(ps.OverlayValues) > 123 && ps.OverlayValues[123].Loc != LocNone {
 						d123 = ps.OverlayValues[123]
@@ -35483,392 +35673,440 @@ func init_alu() {
 					if len(ps.OverlayValues) > 124 && ps.OverlayValues[124].Loc != LocNone {
 						d124 = ps.OverlayValues[124]
 					}
-					if len(ps.OverlayValues) > 193 && ps.OverlayValues[193].Loc != LocNone {
-						d193 = ps.OverlayValues[193]
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
-					if len(ps.OverlayValues) > 194 && ps.OverlayValues[194].Loc != LocNone {
-						d194 = ps.OverlayValues[194]
+					if len(ps.OverlayValues) > 126 && ps.OverlayValues[126].Loc != LocNone {
+						d126 = ps.OverlayValues[126]
 					}
-					if len(ps.OverlayValues) > 195 && ps.OverlayValues[195].Loc != LocNone {
-						d195 = ps.OverlayValues[195]
+					if len(ps.OverlayValues) > 127 && ps.OverlayValues[127].Loc != LocNone {
+						d127 = ps.OverlayValues[127]
+					}
+					if len(ps.OverlayValues) > 128 && ps.OverlayValues[128].Loc != LocNone {
+						d128 = ps.OverlayValues[128]
+					}
+					if len(ps.OverlayValues) > 129 && ps.OverlayValues[129].Loc != LocNone {
+						d129 = ps.OverlayValues[129]
+					}
+					if len(ps.OverlayValues) > 130 && ps.OverlayValues[130].Loc != LocNone {
+						d130 = ps.OverlayValues[130]
+					}
+					if len(ps.OverlayValues) > 131 && ps.OverlayValues[131].Loc != LocNone {
+						d131 = ps.OverlayValues[131]
+					}
+					if len(ps.OverlayValues) > 132 && ps.OverlayValues[132].Loc != LocNone {
+						d132 = ps.OverlayValues[132]
+					}
+					if len(ps.OverlayValues) > 133 && ps.OverlayValues[133].Loc != LocNone {
+						d133 = ps.OverlayValues[133]
+					}
+					if len(ps.OverlayValues) > 134 && ps.OverlayValues[134].Loc != LocNone {
+						d134 = ps.OverlayValues[134]
+					}
+					if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+						d207 = ps.OverlayValues[207]
+					}
+					if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+						d208 = ps.OverlayValues[208]
+					}
+					if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+						d209 = ps.OverlayValues[209]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d26)
-					var d196 JITValueDesc
-					if d26.Loc == LocImm {
-						d196 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d26.Imm.Int()) == uint64(0x1))}
+					ctx.EnsureDesc(&d28)
+					var d210 JITValueDesc
+					if d28.Loc == LocImm {
+						d210 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d28.Imm.Int()) == uint64(0x1))}
 					} else {
-						r2 := ctx.AllocRegExcept(d26.Reg)
-						ctx.EmitCmpRegImm32(d26.Reg, 1)
-						d196 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondEqual}
-						ctx.BindReg(r2, &d196)
+						r2 := ctx.AllocRegExcept(d28.Reg)
+						ctx.EmitCmpRegImm32(d28.Reg, 1)
+						d210 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondEqual}
+						ctx.BindReg(r2, &d210)
 					}
-					d197 = d196
-					ctx.EnsureDesc(&d197)
-					if d197.Loc != LocImm && d197.Loc != LocFlags {
+					d211 = d210
+					ctx.EnsureDesc(&d211)
+					if d211.Loc != LocImm && d211.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d197.Loc == LocImm {
-						if d197.Imm.Bool() {
+					if d211.Loc == LocImm {
+						if d211.Imm.Bool() {
 							if ps.General {
 							}
-							ps198 := PhiState{General: ps.General}
-							ps198.OverlayValues = make([]JITValueDesc, 198)
-							ps198.OverlayValues[0] = d0
-							ps198.OverlayValues[1] = d1
-							ps198.OverlayValues[2] = d2
-							ps198.OverlayValues[3] = d3
-							ps198.OverlayValues[18] = d18
-							ps198.OverlayValues[19] = d19
-							ps198.OverlayValues[20] = d20
-							ps198.OverlayValues[21] = d21
-							ps198.OverlayValues[22] = d22
-							ps198.OverlayValues[23] = d23
-							ps198.OverlayValues[24] = d24
-							ps198.OverlayValues[25] = d25
-							ps198.OverlayValues[26] = d26
-							ps198.OverlayValues[27] = d27
-							ps198.OverlayValues[28] = d28
-							ps198.OverlayValues[65] = d65
-							ps198.OverlayValues[66] = d66
-							ps198.OverlayValues[67] = d67
-							ps198.OverlayValues[68] = d68
-							ps198.OverlayValues[113] = d113
-							ps198.OverlayValues[114] = d114
-							ps198.OverlayValues[115] = d115
-							ps198.OverlayValues[116] = d116
-							ps198.OverlayValues[117] = d117
-							ps198.OverlayValues[118] = d118
-							ps198.OverlayValues[119] = d119
-							ps198.OverlayValues[120] = d120
-							ps198.OverlayValues[121] = d121
-							ps198.OverlayValues[122] = d122
-							ps198.OverlayValues[123] = d123
-							ps198.OverlayValues[124] = d124
-							ps198.OverlayValues[193] = d193
-							ps198.OverlayValues[194] = d194
-							ps198.OverlayValues[195] = d195
-							ps198.OverlayValues[196] = d196
-							ps198.OverlayValues[197] = d197
-							return bbs[4].RenderPS(ps198)
+							ps212 := PhiState{General: ps.General}
+							ps212.OverlayValues = make([]JITValueDesc, 212)
+							ps212.OverlayValues[0] = d0
+							ps212.OverlayValues[1] = d1
+							ps212.OverlayValues[2] = d2
+							ps212.OverlayValues[3] = d3
+							ps212.OverlayValues[18] = d18
+							ps212.OverlayValues[19] = d19
+							ps212.OverlayValues[20] = d20
+							ps212.OverlayValues[21] = d21
+							ps212.OverlayValues[22] = d22
+							ps212.OverlayValues[23] = d23
+							ps212.OverlayValues[24] = d24
+							ps212.OverlayValues[25] = d25
+							ps212.OverlayValues[26] = d26
+							ps212.OverlayValues[27] = d27
+							ps212.OverlayValues[28] = d28
+							ps212.OverlayValues[29] = d29
+							ps212.OverlayValues[30] = d30
+							ps212.OverlayValues[71] = d71
+							ps212.OverlayValues[72] = d72
+							ps212.OverlayValues[73] = d73
+							ps212.OverlayValues[74] = d74
+							ps212.OverlayValues[123] = d123
+							ps212.OverlayValues[124] = d124
+							ps212.OverlayValues[125] = d125
+							ps212.OverlayValues[126] = d126
+							ps212.OverlayValues[127] = d127
+							ps212.OverlayValues[128] = d128
+							ps212.OverlayValues[129] = d129
+							ps212.OverlayValues[130] = d130
+							ps212.OverlayValues[131] = d131
+							ps212.OverlayValues[132] = d132
+							ps212.OverlayValues[133] = d133
+							ps212.OverlayValues[134] = d134
+							ps212.OverlayValues[207] = d207
+							ps212.OverlayValues[208] = d208
+							ps212.OverlayValues[209] = d209
+							ps212.OverlayValues[210] = d210
+							ps212.OverlayValues[211] = d211
+							return bbs[4].RenderPS(ps212)
 						}
 						if ps.General {
 						}
-						ps199 := PhiState{General: ps.General}
-						ps199.OverlayValues = make([]JITValueDesc, 198)
-						ps199.OverlayValues[0] = d0
-						ps199.OverlayValues[1] = d1
-						ps199.OverlayValues[2] = d2
-						ps199.OverlayValues[3] = d3
-						ps199.OverlayValues[18] = d18
-						ps199.OverlayValues[19] = d19
-						ps199.OverlayValues[20] = d20
-						ps199.OverlayValues[21] = d21
-						ps199.OverlayValues[22] = d22
-						ps199.OverlayValues[23] = d23
-						ps199.OverlayValues[24] = d24
-						ps199.OverlayValues[25] = d25
-						ps199.OverlayValues[26] = d26
-						ps199.OverlayValues[27] = d27
-						ps199.OverlayValues[28] = d28
-						ps199.OverlayValues[65] = d65
-						ps199.OverlayValues[66] = d66
-						ps199.OverlayValues[67] = d67
-						ps199.OverlayValues[68] = d68
-						ps199.OverlayValues[113] = d113
-						ps199.OverlayValues[114] = d114
-						ps199.OverlayValues[115] = d115
-						ps199.OverlayValues[116] = d116
-						ps199.OverlayValues[117] = d117
-						ps199.OverlayValues[118] = d118
-						ps199.OverlayValues[119] = d119
-						ps199.OverlayValues[120] = d120
-						ps199.OverlayValues[121] = d121
-						ps199.OverlayValues[122] = d122
-						ps199.OverlayValues[123] = d123
-						ps199.OverlayValues[124] = d124
-						ps199.OverlayValues[193] = d193
-						ps199.OverlayValues[194] = d194
-						ps199.OverlayValues[195] = d195
-						ps199.OverlayValues[196] = d196
-						ps199.OverlayValues[197] = d197
-						return bbs[8].RenderPS(ps199)
+						ps213 := PhiState{General: ps.General}
+						ps213.OverlayValues = make([]JITValueDesc, 212)
+						ps213.OverlayValues[0] = d0
+						ps213.OverlayValues[1] = d1
+						ps213.OverlayValues[2] = d2
+						ps213.OverlayValues[3] = d3
+						ps213.OverlayValues[18] = d18
+						ps213.OverlayValues[19] = d19
+						ps213.OverlayValues[20] = d20
+						ps213.OverlayValues[21] = d21
+						ps213.OverlayValues[22] = d22
+						ps213.OverlayValues[23] = d23
+						ps213.OverlayValues[24] = d24
+						ps213.OverlayValues[25] = d25
+						ps213.OverlayValues[26] = d26
+						ps213.OverlayValues[27] = d27
+						ps213.OverlayValues[28] = d28
+						ps213.OverlayValues[29] = d29
+						ps213.OverlayValues[30] = d30
+						ps213.OverlayValues[71] = d71
+						ps213.OverlayValues[72] = d72
+						ps213.OverlayValues[73] = d73
+						ps213.OverlayValues[74] = d74
+						ps213.OverlayValues[123] = d123
+						ps213.OverlayValues[124] = d124
+						ps213.OverlayValues[125] = d125
+						ps213.OverlayValues[126] = d126
+						ps213.OverlayValues[127] = d127
+						ps213.OverlayValues[128] = d128
+						ps213.OverlayValues[129] = d129
+						ps213.OverlayValues[130] = d130
+						ps213.OverlayValues[131] = d131
+						ps213.OverlayValues[132] = d132
+						ps213.OverlayValues[133] = d133
+						ps213.OverlayValues[134] = d134
+						ps213.OverlayValues[207] = d207
+						ps213.OverlayValues[208] = d208
+						ps213.OverlayValues[209] = d209
+						ps213.OverlayValues[210] = d210
+						ps213.OverlayValues[211] = d211
+						return bbs[8].RenderPS(ps213)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[6].RenderPS(ps)
 					}
-					ctx.EmitJump(d197.Condition, lbl5)
+					ctx.EmitJump(d211.Condition, lbl5)
 					if bbs[8].Rendered {
 						ctx.EmitJmp(lbl9)
 					}
-					ctx.FreeDesc(&d196)
-					snap200 := d0
-					snap201 := d1
-					snap202 := d2
-					snap203 := d3
-					snap204 := d18
-					snap205 := d19
-					snap206 := d20
-					snap207 := d21
-					snap208 := d22
-					snap209 := d23
-					snap210 := d24
-					snap211 := d25
-					snap212 := d26
-					snap213 := d27
-					snap214 := d28
-					snap215 := d65
-					snap216 := d66
-					snap217 := d67
-					snap218 := d68
-					snap219 := d113
-					snap220 := d114
-					snap221 := d115
-					snap222 := d116
-					snap223 := d117
-					snap224 := d118
-					snap225 := d119
-					snap226 := d120
-					snap227 := d121
-					snap228 := d122
-					snap229 := d123
-					snap230 := d124
-					snap231 := d193
-					snap232 := d194
-					snap233 := d195
-					snap234 := d196
-					snap235 := d197
-					alloc236 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc236)
-					d0 = snap200
-					d1 = snap201
-					d2 = snap202
-					d3 = snap203
-					d18 = snap204
-					d19 = snap205
-					d20 = snap206
-					d21 = snap207
-					d22 = snap208
-					d23 = snap209
-					d24 = snap210
-					d25 = snap211
-					d26 = snap212
-					d27 = snap213
-					d28 = snap214
-					d65 = snap215
-					d66 = snap216
-					d67 = snap217
-					d68 = snap218
-					d113 = snap219
-					d114 = snap220
-					d115 = snap221
-					d116 = snap222
-					d117 = snap223
-					d118 = snap224
-					d119 = snap225
-					d120 = snap226
-					d121 = snap227
-					d122 = snap228
-					d123 = snap229
-					d124 = snap230
-					d193 = snap231
-					d194 = snap232
-					d195 = snap233
-					d196 = snap234
-					d197 = snap235
-					ctx.RestoreAllocState(alloc236)
-					d0 = snap200
-					d1 = snap201
-					d2 = snap202
-					d3 = snap203
-					d18 = snap204
-					d19 = snap205
-					d20 = snap206
-					d21 = snap207
-					d22 = snap208
-					d23 = snap209
-					d24 = snap210
-					d25 = snap211
-					d26 = snap212
-					d27 = snap213
-					d28 = snap214
-					d65 = snap215
-					d66 = snap216
-					d67 = snap217
-					d68 = snap218
-					d113 = snap219
-					d114 = snap220
-					d115 = snap221
-					d116 = snap222
-					d117 = snap223
-					d118 = snap224
-					d119 = snap225
-					d120 = snap226
-					d121 = snap227
-					d122 = snap228
-					d123 = snap229
-					d124 = snap230
-					d193 = snap231
-					d194 = snap232
-					d195 = snap233
-					d196 = snap234
-					d197 = snap235
-					ps237 := PhiState{General: true}
-					ps237.OverlayValues = make([]JITValueDesc, 198)
-					ps237.OverlayValues[0] = d0
-					ps237.OverlayValues[1] = d1
-					ps237.OverlayValues[2] = d2
-					ps237.OverlayValues[3] = d3
-					ps237.OverlayValues[18] = d18
-					ps237.OverlayValues[19] = d19
-					ps237.OverlayValues[20] = d20
-					ps237.OverlayValues[21] = d21
-					ps237.OverlayValues[22] = d22
-					ps237.OverlayValues[23] = d23
-					ps237.OverlayValues[24] = d24
-					ps237.OverlayValues[25] = d25
-					ps237.OverlayValues[26] = d26
-					ps237.OverlayValues[27] = d27
-					ps237.OverlayValues[28] = d28
-					ps237.OverlayValues[65] = d65
-					ps237.OverlayValues[66] = d66
-					ps237.OverlayValues[67] = d67
-					ps237.OverlayValues[68] = d68
-					ps237.OverlayValues[113] = d113
-					ps237.OverlayValues[114] = d114
-					ps237.OverlayValues[115] = d115
-					ps237.OverlayValues[116] = d116
-					ps237.OverlayValues[117] = d117
-					ps237.OverlayValues[118] = d118
-					ps237.OverlayValues[119] = d119
-					ps237.OverlayValues[120] = d120
-					ps237.OverlayValues[121] = d121
-					ps237.OverlayValues[122] = d122
-					ps237.OverlayValues[123] = d123
-					ps237.OverlayValues[124] = d124
-					ps237.OverlayValues[193] = d193
-					ps237.OverlayValues[194] = d194
-					ps237.OverlayValues[195] = d195
-					ps237.OverlayValues[196] = d196
-					ps237.OverlayValues[197] = d197
-					ps238 := PhiState{General: true}
-					ps238.OverlayValues = make([]JITValueDesc, 198)
-					ps238.OverlayValues[0] = d0
-					ps238.OverlayValues[1] = d1
-					ps238.OverlayValues[2] = d2
-					ps238.OverlayValues[3] = d3
-					ps238.OverlayValues[18] = d18
-					ps238.OverlayValues[19] = d19
-					ps238.OverlayValues[20] = d20
-					ps238.OverlayValues[21] = d21
-					ps238.OverlayValues[22] = d22
-					ps238.OverlayValues[23] = d23
-					ps238.OverlayValues[24] = d24
-					ps238.OverlayValues[25] = d25
-					ps238.OverlayValues[26] = d26
-					ps238.OverlayValues[27] = d27
-					ps238.OverlayValues[28] = d28
-					ps238.OverlayValues[65] = d65
-					ps238.OverlayValues[66] = d66
-					ps238.OverlayValues[67] = d67
-					ps238.OverlayValues[68] = d68
-					ps238.OverlayValues[113] = d113
-					ps238.OverlayValues[114] = d114
-					ps238.OverlayValues[115] = d115
-					ps238.OverlayValues[116] = d116
-					ps238.OverlayValues[117] = d117
-					ps238.OverlayValues[118] = d118
-					ps238.OverlayValues[119] = d119
-					ps238.OverlayValues[120] = d120
-					ps238.OverlayValues[121] = d121
-					ps238.OverlayValues[122] = d122
-					ps238.OverlayValues[123] = d123
-					ps238.OverlayValues[124] = d124
-					ps238.OverlayValues[193] = d193
-					ps238.OverlayValues[194] = d194
-					ps238.OverlayValues[195] = d195
-					ps238.OverlayValues[196] = d196
-					ps238.OverlayValues[197] = d197
-					snap239 := d0
-					snap240 := d1
-					snap241 := d2
-					snap242 := d3
-					snap243 := d18
-					snap244 := d19
-					snap245 := d20
-					snap246 := d21
-					snap247 := d22
-					snap248 := d23
-					snap249 := d24
-					snap250 := d25
-					snap251 := d26
-					snap252 := d27
-					snap253 := d28
-					snap254 := d65
-					snap255 := d66
-					snap256 := d67
-					snap257 := d68
-					snap258 := d113
-					snap259 := d114
-					snap260 := d115
-					snap261 := d116
-					snap262 := d117
-					snap263 := d118
-					snap264 := d119
-					snap265 := d120
-					snap266 := d121
-					snap267 := d122
-					snap268 := d123
-					snap269 := d124
-					snap270 := d193
-					snap271 := d194
-					snap272 := d195
-					snap273 := d196
-					snap274 := d197
-					alloc275 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d210)
+					snap214 := d0
+					snap215 := d1
+					snap216 := d2
+					snap217 := d3
+					snap218 := d18
+					snap219 := d19
+					snap220 := d20
+					snap221 := d21
+					snap222 := d22
+					snap223 := d23
+					snap224 := d24
+					snap225 := d25
+					snap226 := d26
+					snap227 := d27
+					snap228 := d28
+					snap229 := d29
+					snap230 := d30
+					snap231 := d71
+					snap232 := d72
+					snap233 := d73
+					snap234 := d74
+					snap235 := d123
+					snap236 := d124
+					snap237 := d125
+					snap238 := d126
+					snap239 := d127
+					snap240 := d128
+					snap241 := d129
+					snap242 := d130
+					snap243 := d131
+					snap244 := d132
+					snap245 := d133
+					snap246 := d134
+					snap247 := d207
+					snap248 := d208
+					snap249 := d209
+					snap250 := d210
+					snap251 := d211
+					alloc252 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc252)
+					d0 = snap214
+					d1 = snap215
+					d2 = snap216
+					d3 = snap217
+					d18 = snap218
+					d19 = snap219
+					d20 = snap220
+					d21 = snap221
+					d22 = snap222
+					d23 = snap223
+					d24 = snap224
+					d25 = snap225
+					d26 = snap226
+					d27 = snap227
+					d28 = snap228
+					d29 = snap229
+					d30 = snap230
+					d71 = snap231
+					d72 = snap232
+					d73 = snap233
+					d74 = snap234
+					d123 = snap235
+					d124 = snap236
+					d125 = snap237
+					d126 = snap238
+					d127 = snap239
+					d128 = snap240
+					d129 = snap241
+					d130 = snap242
+					d131 = snap243
+					d132 = snap244
+					d133 = snap245
+					d134 = snap246
+					d207 = snap247
+					d208 = snap248
+					d209 = snap249
+					d210 = snap250
+					d211 = snap251
+					ctx.RestoreAllocState(alloc252)
+					d0 = snap214
+					d1 = snap215
+					d2 = snap216
+					d3 = snap217
+					d18 = snap218
+					d19 = snap219
+					d20 = snap220
+					d21 = snap221
+					d22 = snap222
+					d23 = snap223
+					d24 = snap224
+					d25 = snap225
+					d26 = snap226
+					d27 = snap227
+					d28 = snap228
+					d29 = snap229
+					d30 = snap230
+					d71 = snap231
+					d72 = snap232
+					d73 = snap233
+					d74 = snap234
+					d123 = snap235
+					d124 = snap236
+					d125 = snap237
+					d126 = snap238
+					d127 = snap239
+					d128 = snap240
+					d129 = snap241
+					d130 = snap242
+					d131 = snap243
+					d132 = snap244
+					d133 = snap245
+					d134 = snap246
+					d207 = snap247
+					d208 = snap248
+					d209 = snap249
+					d210 = snap250
+					d211 = snap251
+					ps253 := PhiState{General: true}
+					ps253.OverlayValues = make([]JITValueDesc, 212)
+					ps253.OverlayValues[0] = d0
+					ps253.OverlayValues[1] = d1
+					ps253.OverlayValues[2] = d2
+					ps253.OverlayValues[3] = d3
+					ps253.OverlayValues[18] = d18
+					ps253.OverlayValues[19] = d19
+					ps253.OverlayValues[20] = d20
+					ps253.OverlayValues[21] = d21
+					ps253.OverlayValues[22] = d22
+					ps253.OverlayValues[23] = d23
+					ps253.OverlayValues[24] = d24
+					ps253.OverlayValues[25] = d25
+					ps253.OverlayValues[26] = d26
+					ps253.OverlayValues[27] = d27
+					ps253.OverlayValues[28] = d28
+					ps253.OverlayValues[29] = d29
+					ps253.OverlayValues[30] = d30
+					ps253.OverlayValues[71] = d71
+					ps253.OverlayValues[72] = d72
+					ps253.OverlayValues[73] = d73
+					ps253.OverlayValues[74] = d74
+					ps253.OverlayValues[123] = d123
+					ps253.OverlayValues[124] = d124
+					ps253.OverlayValues[125] = d125
+					ps253.OverlayValues[126] = d126
+					ps253.OverlayValues[127] = d127
+					ps253.OverlayValues[128] = d128
+					ps253.OverlayValues[129] = d129
+					ps253.OverlayValues[130] = d130
+					ps253.OverlayValues[131] = d131
+					ps253.OverlayValues[132] = d132
+					ps253.OverlayValues[133] = d133
+					ps253.OverlayValues[134] = d134
+					ps253.OverlayValues[207] = d207
+					ps253.OverlayValues[208] = d208
+					ps253.OverlayValues[209] = d209
+					ps253.OverlayValues[210] = d210
+					ps253.OverlayValues[211] = d211
+					ps254 := PhiState{General: true}
+					ps254.OverlayValues = make([]JITValueDesc, 212)
+					ps254.OverlayValues[0] = d0
+					ps254.OverlayValues[1] = d1
+					ps254.OverlayValues[2] = d2
+					ps254.OverlayValues[3] = d3
+					ps254.OverlayValues[18] = d18
+					ps254.OverlayValues[19] = d19
+					ps254.OverlayValues[20] = d20
+					ps254.OverlayValues[21] = d21
+					ps254.OverlayValues[22] = d22
+					ps254.OverlayValues[23] = d23
+					ps254.OverlayValues[24] = d24
+					ps254.OverlayValues[25] = d25
+					ps254.OverlayValues[26] = d26
+					ps254.OverlayValues[27] = d27
+					ps254.OverlayValues[28] = d28
+					ps254.OverlayValues[29] = d29
+					ps254.OverlayValues[30] = d30
+					ps254.OverlayValues[71] = d71
+					ps254.OverlayValues[72] = d72
+					ps254.OverlayValues[73] = d73
+					ps254.OverlayValues[74] = d74
+					ps254.OverlayValues[123] = d123
+					ps254.OverlayValues[124] = d124
+					ps254.OverlayValues[125] = d125
+					ps254.OverlayValues[126] = d126
+					ps254.OverlayValues[127] = d127
+					ps254.OverlayValues[128] = d128
+					ps254.OverlayValues[129] = d129
+					ps254.OverlayValues[130] = d130
+					ps254.OverlayValues[131] = d131
+					ps254.OverlayValues[132] = d132
+					ps254.OverlayValues[133] = d133
+					ps254.OverlayValues[134] = d134
+					ps254.OverlayValues[207] = d207
+					ps254.OverlayValues[208] = d208
+					ps254.OverlayValues[209] = d209
+					ps254.OverlayValues[210] = d210
+					ps254.OverlayValues[211] = d211
+					snap255 := d0
+					snap256 := d1
+					snap257 := d2
+					snap258 := d3
+					snap259 := d18
+					snap260 := d19
+					snap261 := d20
+					snap262 := d21
+					snap263 := d22
+					snap264 := d23
+					snap265 := d24
+					snap266 := d25
+					snap267 := d26
+					snap268 := d27
+					snap269 := d28
+					snap270 := d29
+					snap271 := d30
+					snap272 := d71
+					snap273 := d72
+					snap274 := d73
+					snap275 := d74
+					snap276 := d123
+					snap277 := d124
+					snap278 := d125
+					snap279 := d126
+					snap280 := d127
+					snap281 := d128
+					snap282 := d129
+					snap283 := d130
+					snap284 := d131
+					snap285 := d132
+					snap286 := d133
+					snap287 := d134
+					snap288 := d207
+					snap289 := d208
+					snap290 := d209
+					snap291 := d210
+					snap292 := d211
+					alloc293 := ctx.SnapshotAllocState()
 					if !bbs[8].Rendered {
-						bbs[8].RenderPS(ps238)
+						bbs[8].RenderPS(ps254)
 					}
-					ctx.RestoreAllocState(alloc275)
-					d0 = snap239
-					d1 = snap240
-					d2 = snap241
-					d3 = snap242
-					d18 = snap243
-					d19 = snap244
-					d20 = snap245
-					d21 = snap246
-					d22 = snap247
-					d23 = snap248
-					d24 = snap249
-					d25 = snap250
-					d26 = snap251
-					d27 = snap252
-					d28 = snap253
-					d65 = snap254
-					d66 = snap255
-					d67 = snap256
-					d68 = snap257
-					d113 = snap258
-					d114 = snap259
-					d115 = snap260
-					d116 = snap261
-					d117 = snap262
-					d118 = snap263
-					d119 = snap264
-					d120 = snap265
-					d121 = snap266
-					d122 = snap267
-					d123 = snap268
-					d124 = snap269
-					d193 = snap270
-					d194 = snap271
-					d195 = snap272
-					d196 = snap273
-					d197 = snap274
+					ctx.RestoreAllocState(alloc293)
+					d0 = snap255
+					d1 = snap256
+					d2 = snap257
+					d3 = snap258
+					d18 = snap259
+					d19 = snap260
+					d20 = snap261
+					d21 = snap262
+					d22 = snap263
+					d23 = snap264
+					d24 = snap265
+					d25 = snap266
+					d26 = snap267
+					d27 = snap268
+					d28 = snap269
+					d29 = snap270
+					d30 = snap271
+					d71 = snap272
+					d72 = snap273
+					d73 = snap274
+					d74 = snap275
+					d123 = snap276
+					d124 = snap277
+					d125 = snap278
+					d126 = snap279
+					d127 = snap280
+					d128 = snap281
+					d129 = snap282
+					d130 = snap283
+					d131 = snap284
+					d132 = snap285
+					d133 = snap286
+					d134 = snap287
+					d207 = snap288
+					d208 = snap289
+					d209 = snap290
+					d210 = snap291
+					d211 = snap292
 					if !bbs[4].Rendered {
-						return bbs[4].RenderPS(ps237)
+						return bbs[4].RenderPS(ps253)
 					}
 					return result
 					return result
@@ -35937,47 +36175,23 @@ func init_alu() {
 					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
 						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
-						d65 = ps.OverlayValues[65]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
-						d66 = ps.OverlayValues[66]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
 					}
-					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
-						d67 = ps.OverlayValues[67]
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
-					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
-						d68 = ps.OverlayValues[68]
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 113 && ps.OverlayValues[113].Loc != LocNone {
-						d113 = ps.OverlayValues[113]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 114 && ps.OverlayValues[114].Loc != LocNone {
-						d114 = ps.OverlayValues[114]
-					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
-					}
-					if len(ps.OverlayValues) > 116 && ps.OverlayValues[116].Loc != LocNone {
-						d116 = ps.OverlayValues[116]
-					}
-					if len(ps.OverlayValues) > 117 && ps.OverlayValues[117].Loc != LocNone {
-						d117 = ps.OverlayValues[117]
-					}
-					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
-						d118 = ps.OverlayValues[118]
-					}
-					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
-						d119 = ps.OverlayValues[119]
-					}
-					if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
-						d120 = ps.OverlayValues[120]
-					}
-					if len(ps.OverlayValues) > 121 && ps.OverlayValues[121].Loc != LocNone {
-						d121 = ps.OverlayValues[121]
-					}
-					if len(ps.OverlayValues) > 122 && ps.OverlayValues[122].Loc != LocNone {
-						d122 = ps.OverlayValues[122]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
 					if len(ps.OverlayValues) > 123 && ps.OverlayValues[123].Loc != LocNone {
 						d123 = ps.OverlayValues[123]
@@ -35985,416 +36199,464 @@ func init_alu() {
 					if len(ps.OverlayValues) > 124 && ps.OverlayValues[124].Loc != LocNone {
 						d124 = ps.OverlayValues[124]
 					}
-					if len(ps.OverlayValues) > 193 && ps.OverlayValues[193].Loc != LocNone {
-						d193 = ps.OverlayValues[193]
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
-					if len(ps.OverlayValues) > 194 && ps.OverlayValues[194].Loc != LocNone {
-						d194 = ps.OverlayValues[194]
+					if len(ps.OverlayValues) > 126 && ps.OverlayValues[126].Loc != LocNone {
+						d126 = ps.OverlayValues[126]
 					}
-					if len(ps.OverlayValues) > 195 && ps.OverlayValues[195].Loc != LocNone {
-						d195 = ps.OverlayValues[195]
+					if len(ps.OverlayValues) > 127 && ps.OverlayValues[127].Loc != LocNone {
+						d127 = ps.OverlayValues[127]
 					}
-					if len(ps.OverlayValues) > 196 && ps.OverlayValues[196].Loc != LocNone {
-						d196 = ps.OverlayValues[196]
+					if len(ps.OverlayValues) > 128 && ps.OverlayValues[128].Loc != LocNone {
+						d128 = ps.OverlayValues[128]
 					}
-					if len(ps.OverlayValues) > 197 && ps.OverlayValues[197].Loc != LocNone {
-						d197 = ps.OverlayValues[197]
+					if len(ps.OverlayValues) > 129 && ps.OverlayValues[129].Loc != LocNone {
+						d129 = ps.OverlayValues[129]
+					}
+					if len(ps.OverlayValues) > 130 && ps.OverlayValues[130].Loc != LocNone {
+						d130 = ps.OverlayValues[130]
+					}
+					if len(ps.OverlayValues) > 131 && ps.OverlayValues[131].Loc != LocNone {
+						d131 = ps.OverlayValues[131]
+					}
+					if len(ps.OverlayValues) > 132 && ps.OverlayValues[132].Loc != LocNone {
+						d132 = ps.OverlayValues[132]
+					}
+					if len(ps.OverlayValues) > 133 && ps.OverlayValues[133].Loc != LocNone {
+						d133 = ps.OverlayValues[133]
+					}
+					if len(ps.OverlayValues) > 134 && ps.OverlayValues[134].Loc != LocNone {
+						d134 = ps.OverlayValues[134]
+					}
+					if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+						d207 = ps.OverlayValues[207]
+					}
+					if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+						d208 = ps.OverlayValues[208]
+					}
+					if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+						d209 = ps.OverlayValues[209]
+					}
+					if len(ps.OverlayValues) > 210 && ps.OverlayValues[210].Loc != LocNone {
+						d210 = ps.OverlayValues[210]
+					}
+					if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+						d211 = ps.OverlayValues[211]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d24)
-					var d276 JITValueDesc
-					if d24.Loc == LocImm {
-						d276 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d24.Imm.Int()) == uint64(0x2))}
+					ctx.EnsureDesc(&d25)
+					var d294 JITValueDesc
+					if d25.Loc == LocImm {
+						d294 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d25.Imm.Int()) == uint64(0x2))}
 					} else {
-						r3 := ctx.AllocRegExcept(d24.Reg)
-						ctx.EmitCmpRegImm32(d24.Reg, 2)
-						d276 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r3, Condition: CondEqual}
-						ctx.BindReg(r3, &d276)
+						r3 := ctx.AllocRegExcept(d25.Reg)
+						ctx.EmitCmpRegImm32(d25.Reg, 2)
+						d294 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r3, Condition: CondEqual}
+						ctx.BindReg(r3, &d294)
 					}
-					d277 = d276
-					ctx.EnsureDesc(&d277)
-					if d277.Loc != LocImm && d277.Loc != LocFlags {
+					d295 = d294
+					ctx.EnsureDesc(&d295)
+					if d295.Loc != LocImm && d295.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d277.Loc == LocImm {
-						if d277.Imm.Bool() {
+					if d295.Loc == LocImm {
+						if d295.Imm.Bool() {
 							if ps.General {
 							}
-							ps278 := PhiState{General: ps.General}
-							ps278.OverlayValues = make([]JITValueDesc, 278)
-							ps278.OverlayValues[0] = d0
-							ps278.OverlayValues[1] = d1
-							ps278.OverlayValues[2] = d2
-							ps278.OverlayValues[3] = d3
-							ps278.OverlayValues[18] = d18
-							ps278.OverlayValues[19] = d19
-							ps278.OverlayValues[20] = d20
-							ps278.OverlayValues[21] = d21
-							ps278.OverlayValues[22] = d22
-							ps278.OverlayValues[23] = d23
-							ps278.OverlayValues[24] = d24
-							ps278.OverlayValues[25] = d25
-							ps278.OverlayValues[26] = d26
-							ps278.OverlayValues[27] = d27
-							ps278.OverlayValues[28] = d28
-							ps278.OverlayValues[65] = d65
-							ps278.OverlayValues[66] = d66
-							ps278.OverlayValues[67] = d67
-							ps278.OverlayValues[68] = d68
-							ps278.OverlayValues[113] = d113
-							ps278.OverlayValues[114] = d114
-							ps278.OverlayValues[115] = d115
-							ps278.OverlayValues[116] = d116
-							ps278.OverlayValues[117] = d117
-							ps278.OverlayValues[118] = d118
-							ps278.OverlayValues[119] = d119
-							ps278.OverlayValues[120] = d120
-							ps278.OverlayValues[121] = d121
-							ps278.OverlayValues[122] = d122
-							ps278.OverlayValues[123] = d123
-							ps278.OverlayValues[124] = d124
-							ps278.OverlayValues[193] = d193
-							ps278.OverlayValues[194] = d194
-							ps278.OverlayValues[195] = d195
-							ps278.OverlayValues[196] = d196
-							ps278.OverlayValues[197] = d197
-							ps278.OverlayValues[276] = d276
-							ps278.OverlayValues[277] = d277
-							return bbs[6].RenderPS(ps278)
+							ps296 := PhiState{General: ps.General}
+							ps296.OverlayValues = make([]JITValueDesc, 296)
+							ps296.OverlayValues[0] = d0
+							ps296.OverlayValues[1] = d1
+							ps296.OverlayValues[2] = d2
+							ps296.OverlayValues[3] = d3
+							ps296.OverlayValues[18] = d18
+							ps296.OverlayValues[19] = d19
+							ps296.OverlayValues[20] = d20
+							ps296.OverlayValues[21] = d21
+							ps296.OverlayValues[22] = d22
+							ps296.OverlayValues[23] = d23
+							ps296.OverlayValues[24] = d24
+							ps296.OverlayValues[25] = d25
+							ps296.OverlayValues[26] = d26
+							ps296.OverlayValues[27] = d27
+							ps296.OverlayValues[28] = d28
+							ps296.OverlayValues[29] = d29
+							ps296.OverlayValues[30] = d30
+							ps296.OverlayValues[71] = d71
+							ps296.OverlayValues[72] = d72
+							ps296.OverlayValues[73] = d73
+							ps296.OverlayValues[74] = d74
+							ps296.OverlayValues[123] = d123
+							ps296.OverlayValues[124] = d124
+							ps296.OverlayValues[125] = d125
+							ps296.OverlayValues[126] = d126
+							ps296.OverlayValues[127] = d127
+							ps296.OverlayValues[128] = d128
+							ps296.OverlayValues[129] = d129
+							ps296.OverlayValues[130] = d130
+							ps296.OverlayValues[131] = d131
+							ps296.OverlayValues[132] = d132
+							ps296.OverlayValues[133] = d133
+							ps296.OverlayValues[134] = d134
+							ps296.OverlayValues[207] = d207
+							ps296.OverlayValues[208] = d208
+							ps296.OverlayValues[209] = d209
+							ps296.OverlayValues[210] = d210
+							ps296.OverlayValues[211] = d211
+							ps296.OverlayValues[294] = d294
+							ps296.OverlayValues[295] = d295
+							return bbs[6].RenderPS(ps296)
 						}
 						if ps.General {
 						}
-						ps279 := PhiState{General: ps.General}
-						ps279.OverlayValues = make([]JITValueDesc, 278)
-						ps279.OverlayValues[0] = d0
-						ps279.OverlayValues[1] = d1
-						ps279.OverlayValues[2] = d2
-						ps279.OverlayValues[3] = d3
-						ps279.OverlayValues[18] = d18
-						ps279.OverlayValues[19] = d19
-						ps279.OverlayValues[20] = d20
-						ps279.OverlayValues[21] = d21
-						ps279.OverlayValues[22] = d22
-						ps279.OverlayValues[23] = d23
-						ps279.OverlayValues[24] = d24
-						ps279.OverlayValues[25] = d25
-						ps279.OverlayValues[26] = d26
-						ps279.OverlayValues[27] = d27
-						ps279.OverlayValues[28] = d28
-						ps279.OverlayValues[65] = d65
-						ps279.OverlayValues[66] = d66
-						ps279.OverlayValues[67] = d67
-						ps279.OverlayValues[68] = d68
-						ps279.OverlayValues[113] = d113
-						ps279.OverlayValues[114] = d114
-						ps279.OverlayValues[115] = d115
-						ps279.OverlayValues[116] = d116
-						ps279.OverlayValues[117] = d117
-						ps279.OverlayValues[118] = d118
-						ps279.OverlayValues[119] = d119
-						ps279.OverlayValues[120] = d120
-						ps279.OverlayValues[121] = d121
-						ps279.OverlayValues[122] = d122
-						ps279.OverlayValues[123] = d123
-						ps279.OverlayValues[124] = d124
-						ps279.OverlayValues[193] = d193
-						ps279.OverlayValues[194] = d194
-						ps279.OverlayValues[195] = d195
-						ps279.OverlayValues[196] = d196
-						ps279.OverlayValues[197] = d197
-						ps279.OverlayValues[276] = d276
-						ps279.OverlayValues[277] = d277
-						return bbs[5].RenderPS(ps279)
+						ps297 := PhiState{General: ps.General}
+						ps297.OverlayValues = make([]JITValueDesc, 296)
+						ps297.OverlayValues[0] = d0
+						ps297.OverlayValues[1] = d1
+						ps297.OverlayValues[2] = d2
+						ps297.OverlayValues[3] = d3
+						ps297.OverlayValues[18] = d18
+						ps297.OverlayValues[19] = d19
+						ps297.OverlayValues[20] = d20
+						ps297.OverlayValues[21] = d21
+						ps297.OverlayValues[22] = d22
+						ps297.OverlayValues[23] = d23
+						ps297.OverlayValues[24] = d24
+						ps297.OverlayValues[25] = d25
+						ps297.OverlayValues[26] = d26
+						ps297.OverlayValues[27] = d27
+						ps297.OverlayValues[28] = d28
+						ps297.OverlayValues[29] = d29
+						ps297.OverlayValues[30] = d30
+						ps297.OverlayValues[71] = d71
+						ps297.OverlayValues[72] = d72
+						ps297.OverlayValues[73] = d73
+						ps297.OverlayValues[74] = d74
+						ps297.OverlayValues[123] = d123
+						ps297.OverlayValues[124] = d124
+						ps297.OverlayValues[125] = d125
+						ps297.OverlayValues[126] = d126
+						ps297.OverlayValues[127] = d127
+						ps297.OverlayValues[128] = d128
+						ps297.OverlayValues[129] = d129
+						ps297.OverlayValues[130] = d130
+						ps297.OverlayValues[131] = d131
+						ps297.OverlayValues[132] = d132
+						ps297.OverlayValues[133] = d133
+						ps297.OverlayValues[134] = d134
+						ps297.OverlayValues[207] = d207
+						ps297.OverlayValues[208] = d208
+						ps297.OverlayValues[209] = d209
+						ps297.OverlayValues[210] = d210
+						ps297.OverlayValues[211] = d211
+						ps297.OverlayValues[294] = d294
+						ps297.OverlayValues[295] = d295
+						return bbs[5].RenderPS(ps297)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[7].RenderPS(ps)
 					}
-					ctx.EmitJump(d277.Condition, lbl7)
+					ctx.EmitJump(d295.Condition, lbl7)
 					if bbs[5].Rendered {
 						ctx.EmitJmp(lbl6)
 					}
-					ctx.FreeDesc(&d276)
-					snap280 := d0
-					snap281 := d1
-					snap282 := d2
-					snap283 := d3
-					snap284 := d18
-					snap285 := d19
-					snap286 := d20
-					snap287 := d21
-					snap288 := d22
-					snap289 := d23
-					snap290 := d24
-					snap291 := d25
-					snap292 := d26
-					snap293 := d27
-					snap294 := d28
-					snap295 := d65
-					snap296 := d66
-					snap297 := d67
-					snap298 := d68
-					snap299 := d113
-					snap300 := d114
-					snap301 := d115
-					snap302 := d116
-					snap303 := d117
-					snap304 := d118
-					snap305 := d119
-					snap306 := d120
-					snap307 := d121
-					snap308 := d122
-					snap309 := d123
-					snap310 := d124
-					snap311 := d193
-					snap312 := d194
-					snap313 := d195
-					snap314 := d196
-					snap315 := d197
-					snap316 := d276
-					snap317 := d277
-					alloc318 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc318)
-					d0 = snap280
-					d1 = snap281
-					d2 = snap282
-					d3 = snap283
-					d18 = snap284
-					d19 = snap285
-					d20 = snap286
-					d21 = snap287
-					d22 = snap288
-					d23 = snap289
-					d24 = snap290
-					d25 = snap291
-					d26 = snap292
-					d27 = snap293
-					d28 = snap294
-					d65 = snap295
-					d66 = snap296
-					d67 = snap297
-					d68 = snap298
-					d113 = snap299
-					d114 = snap300
-					d115 = snap301
-					d116 = snap302
-					d117 = snap303
-					d118 = snap304
-					d119 = snap305
-					d120 = snap306
-					d121 = snap307
-					d122 = snap308
-					d123 = snap309
-					d124 = snap310
-					d193 = snap311
-					d194 = snap312
-					d195 = snap313
-					d196 = snap314
-					d197 = snap315
-					d276 = snap316
-					d277 = snap317
-					ctx.RestoreAllocState(alloc318)
-					d0 = snap280
-					d1 = snap281
-					d2 = snap282
-					d3 = snap283
-					d18 = snap284
-					d19 = snap285
-					d20 = snap286
-					d21 = snap287
-					d22 = snap288
-					d23 = snap289
-					d24 = snap290
-					d25 = snap291
-					d26 = snap292
-					d27 = snap293
-					d28 = snap294
-					d65 = snap295
-					d66 = snap296
-					d67 = snap297
-					d68 = snap298
-					d113 = snap299
-					d114 = snap300
-					d115 = snap301
-					d116 = snap302
-					d117 = snap303
-					d118 = snap304
-					d119 = snap305
-					d120 = snap306
-					d121 = snap307
-					d122 = snap308
-					d123 = snap309
-					d124 = snap310
-					d193 = snap311
-					d194 = snap312
-					d195 = snap313
-					d196 = snap314
-					d197 = snap315
-					d276 = snap316
-					d277 = snap317
-					ps319 := PhiState{General: true}
-					ps319.OverlayValues = make([]JITValueDesc, 278)
-					ps319.OverlayValues[0] = d0
-					ps319.OverlayValues[1] = d1
-					ps319.OverlayValues[2] = d2
-					ps319.OverlayValues[3] = d3
-					ps319.OverlayValues[18] = d18
-					ps319.OverlayValues[19] = d19
-					ps319.OverlayValues[20] = d20
-					ps319.OverlayValues[21] = d21
-					ps319.OverlayValues[22] = d22
-					ps319.OverlayValues[23] = d23
-					ps319.OverlayValues[24] = d24
-					ps319.OverlayValues[25] = d25
-					ps319.OverlayValues[26] = d26
-					ps319.OverlayValues[27] = d27
-					ps319.OverlayValues[28] = d28
-					ps319.OverlayValues[65] = d65
-					ps319.OverlayValues[66] = d66
-					ps319.OverlayValues[67] = d67
-					ps319.OverlayValues[68] = d68
-					ps319.OverlayValues[113] = d113
-					ps319.OverlayValues[114] = d114
-					ps319.OverlayValues[115] = d115
-					ps319.OverlayValues[116] = d116
-					ps319.OverlayValues[117] = d117
-					ps319.OverlayValues[118] = d118
-					ps319.OverlayValues[119] = d119
-					ps319.OverlayValues[120] = d120
-					ps319.OverlayValues[121] = d121
-					ps319.OverlayValues[122] = d122
-					ps319.OverlayValues[123] = d123
-					ps319.OverlayValues[124] = d124
-					ps319.OverlayValues[193] = d193
-					ps319.OverlayValues[194] = d194
-					ps319.OverlayValues[195] = d195
-					ps319.OverlayValues[196] = d196
-					ps319.OverlayValues[197] = d197
-					ps319.OverlayValues[276] = d276
-					ps319.OverlayValues[277] = d277
-					ps320 := PhiState{General: true}
-					ps320.OverlayValues = make([]JITValueDesc, 278)
-					ps320.OverlayValues[0] = d0
-					ps320.OverlayValues[1] = d1
-					ps320.OverlayValues[2] = d2
-					ps320.OverlayValues[3] = d3
-					ps320.OverlayValues[18] = d18
-					ps320.OverlayValues[19] = d19
-					ps320.OverlayValues[20] = d20
-					ps320.OverlayValues[21] = d21
-					ps320.OverlayValues[22] = d22
-					ps320.OverlayValues[23] = d23
-					ps320.OverlayValues[24] = d24
-					ps320.OverlayValues[25] = d25
-					ps320.OverlayValues[26] = d26
-					ps320.OverlayValues[27] = d27
-					ps320.OverlayValues[28] = d28
-					ps320.OverlayValues[65] = d65
-					ps320.OverlayValues[66] = d66
-					ps320.OverlayValues[67] = d67
-					ps320.OverlayValues[68] = d68
-					ps320.OverlayValues[113] = d113
-					ps320.OverlayValues[114] = d114
-					ps320.OverlayValues[115] = d115
-					ps320.OverlayValues[116] = d116
-					ps320.OverlayValues[117] = d117
-					ps320.OverlayValues[118] = d118
-					ps320.OverlayValues[119] = d119
-					ps320.OverlayValues[120] = d120
-					ps320.OverlayValues[121] = d121
-					ps320.OverlayValues[122] = d122
-					ps320.OverlayValues[123] = d123
-					ps320.OverlayValues[124] = d124
-					ps320.OverlayValues[193] = d193
-					ps320.OverlayValues[194] = d194
-					ps320.OverlayValues[195] = d195
-					ps320.OverlayValues[196] = d196
-					ps320.OverlayValues[197] = d197
-					ps320.OverlayValues[276] = d276
-					ps320.OverlayValues[277] = d277
-					snap321 := d0
-					snap322 := d1
-					snap323 := d2
-					snap324 := d3
-					snap325 := d18
-					snap326 := d19
-					snap327 := d20
-					snap328 := d21
-					snap329 := d22
-					snap330 := d23
-					snap331 := d24
-					snap332 := d25
-					snap333 := d26
-					snap334 := d27
-					snap335 := d28
-					snap336 := d65
-					snap337 := d66
-					snap338 := d67
-					snap339 := d68
-					snap340 := d113
-					snap341 := d114
-					snap342 := d115
-					snap343 := d116
-					snap344 := d117
-					snap345 := d118
-					snap346 := d119
-					snap347 := d120
-					snap348 := d121
-					snap349 := d122
-					snap350 := d123
-					snap351 := d124
-					snap352 := d193
-					snap353 := d194
-					snap354 := d195
-					snap355 := d196
-					snap356 := d197
-					snap357 := d276
-					snap358 := d277
-					alloc359 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d294)
+					snap298 := d0
+					snap299 := d1
+					snap300 := d2
+					snap301 := d3
+					snap302 := d18
+					snap303 := d19
+					snap304 := d20
+					snap305 := d21
+					snap306 := d22
+					snap307 := d23
+					snap308 := d24
+					snap309 := d25
+					snap310 := d26
+					snap311 := d27
+					snap312 := d28
+					snap313 := d29
+					snap314 := d30
+					snap315 := d71
+					snap316 := d72
+					snap317 := d73
+					snap318 := d74
+					snap319 := d123
+					snap320 := d124
+					snap321 := d125
+					snap322 := d126
+					snap323 := d127
+					snap324 := d128
+					snap325 := d129
+					snap326 := d130
+					snap327 := d131
+					snap328 := d132
+					snap329 := d133
+					snap330 := d134
+					snap331 := d207
+					snap332 := d208
+					snap333 := d209
+					snap334 := d210
+					snap335 := d211
+					snap336 := d294
+					snap337 := d295
+					alloc338 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc338)
+					d0 = snap298
+					d1 = snap299
+					d2 = snap300
+					d3 = snap301
+					d18 = snap302
+					d19 = snap303
+					d20 = snap304
+					d21 = snap305
+					d22 = snap306
+					d23 = snap307
+					d24 = snap308
+					d25 = snap309
+					d26 = snap310
+					d27 = snap311
+					d28 = snap312
+					d29 = snap313
+					d30 = snap314
+					d71 = snap315
+					d72 = snap316
+					d73 = snap317
+					d74 = snap318
+					d123 = snap319
+					d124 = snap320
+					d125 = snap321
+					d126 = snap322
+					d127 = snap323
+					d128 = snap324
+					d129 = snap325
+					d130 = snap326
+					d131 = snap327
+					d132 = snap328
+					d133 = snap329
+					d134 = snap330
+					d207 = snap331
+					d208 = snap332
+					d209 = snap333
+					d210 = snap334
+					d211 = snap335
+					d294 = snap336
+					d295 = snap337
+					ctx.RestoreAllocState(alloc338)
+					d0 = snap298
+					d1 = snap299
+					d2 = snap300
+					d3 = snap301
+					d18 = snap302
+					d19 = snap303
+					d20 = snap304
+					d21 = snap305
+					d22 = snap306
+					d23 = snap307
+					d24 = snap308
+					d25 = snap309
+					d26 = snap310
+					d27 = snap311
+					d28 = snap312
+					d29 = snap313
+					d30 = snap314
+					d71 = snap315
+					d72 = snap316
+					d73 = snap317
+					d74 = snap318
+					d123 = snap319
+					d124 = snap320
+					d125 = snap321
+					d126 = snap322
+					d127 = snap323
+					d128 = snap324
+					d129 = snap325
+					d130 = snap326
+					d131 = snap327
+					d132 = snap328
+					d133 = snap329
+					d134 = snap330
+					d207 = snap331
+					d208 = snap332
+					d209 = snap333
+					d210 = snap334
+					d211 = snap335
+					d294 = snap336
+					d295 = snap337
+					ps339 := PhiState{General: true}
+					ps339.OverlayValues = make([]JITValueDesc, 296)
+					ps339.OverlayValues[0] = d0
+					ps339.OverlayValues[1] = d1
+					ps339.OverlayValues[2] = d2
+					ps339.OverlayValues[3] = d3
+					ps339.OverlayValues[18] = d18
+					ps339.OverlayValues[19] = d19
+					ps339.OverlayValues[20] = d20
+					ps339.OverlayValues[21] = d21
+					ps339.OverlayValues[22] = d22
+					ps339.OverlayValues[23] = d23
+					ps339.OverlayValues[24] = d24
+					ps339.OverlayValues[25] = d25
+					ps339.OverlayValues[26] = d26
+					ps339.OverlayValues[27] = d27
+					ps339.OverlayValues[28] = d28
+					ps339.OverlayValues[29] = d29
+					ps339.OverlayValues[30] = d30
+					ps339.OverlayValues[71] = d71
+					ps339.OverlayValues[72] = d72
+					ps339.OverlayValues[73] = d73
+					ps339.OverlayValues[74] = d74
+					ps339.OverlayValues[123] = d123
+					ps339.OverlayValues[124] = d124
+					ps339.OverlayValues[125] = d125
+					ps339.OverlayValues[126] = d126
+					ps339.OverlayValues[127] = d127
+					ps339.OverlayValues[128] = d128
+					ps339.OverlayValues[129] = d129
+					ps339.OverlayValues[130] = d130
+					ps339.OverlayValues[131] = d131
+					ps339.OverlayValues[132] = d132
+					ps339.OverlayValues[133] = d133
+					ps339.OverlayValues[134] = d134
+					ps339.OverlayValues[207] = d207
+					ps339.OverlayValues[208] = d208
+					ps339.OverlayValues[209] = d209
+					ps339.OverlayValues[210] = d210
+					ps339.OverlayValues[211] = d211
+					ps339.OverlayValues[294] = d294
+					ps339.OverlayValues[295] = d295
+					ps340 := PhiState{General: true}
+					ps340.OverlayValues = make([]JITValueDesc, 296)
+					ps340.OverlayValues[0] = d0
+					ps340.OverlayValues[1] = d1
+					ps340.OverlayValues[2] = d2
+					ps340.OverlayValues[3] = d3
+					ps340.OverlayValues[18] = d18
+					ps340.OverlayValues[19] = d19
+					ps340.OverlayValues[20] = d20
+					ps340.OverlayValues[21] = d21
+					ps340.OverlayValues[22] = d22
+					ps340.OverlayValues[23] = d23
+					ps340.OverlayValues[24] = d24
+					ps340.OverlayValues[25] = d25
+					ps340.OverlayValues[26] = d26
+					ps340.OverlayValues[27] = d27
+					ps340.OverlayValues[28] = d28
+					ps340.OverlayValues[29] = d29
+					ps340.OverlayValues[30] = d30
+					ps340.OverlayValues[71] = d71
+					ps340.OverlayValues[72] = d72
+					ps340.OverlayValues[73] = d73
+					ps340.OverlayValues[74] = d74
+					ps340.OverlayValues[123] = d123
+					ps340.OverlayValues[124] = d124
+					ps340.OverlayValues[125] = d125
+					ps340.OverlayValues[126] = d126
+					ps340.OverlayValues[127] = d127
+					ps340.OverlayValues[128] = d128
+					ps340.OverlayValues[129] = d129
+					ps340.OverlayValues[130] = d130
+					ps340.OverlayValues[131] = d131
+					ps340.OverlayValues[132] = d132
+					ps340.OverlayValues[133] = d133
+					ps340.OverlayValues[134] = d134
+					ps340.OverlayValues[207] = d207
+					ps340.OverlayValues[208] = d208
+					ps340.OverlayValues[209] = d209
+					ps340.OverlayValues[210] = d210
+					ps340.OverlayValues[211] = d211
+					ps340.OverlayValues[294] = d294
+					ps340.OverlayValues[295] = d295
+					snap341 := d0
+					snap342 := d1
+					snap343 := d2
+					snap344 := d3
+					snap345 := d18
+					snap346 := d19
+					snap347 := d20
+					snap348 := d21
+					snap349 := d22
+					snap350 := d23
+					snap351 := d24
+					snap352 := d25
+					snap353 := d26
+					snap354 := d27
+					snap355 := d28
+					snap356 := d29
+					snap357 := d30
+					snap358 := d71
+					snap359 := d72
+					snap360 := d73
+					snap361 := d74
+					snap362 := d123
+					snap363 := d124
+					snap364 := d125
+					snap365 := d126
+					snap366 := d127
+					snap367 := d128
+					snap368 := d129
+					snap369 := d130
+					snap370 := d131
+					snap371 := d132
+					snap372 := d133
+					snap373 := d134
+					snap374 := d207
+					snap375 := d208
+					snap376 := d209
+					snap377 := d210
+					snap378 := d211
+					snap379 := d294
+					snap380 := d295
+					alloc381 := ctx.SnapshotAllocState()
 					if !bbs[5].Rendered {
-						bbs[5].RenderPS(ps320)
+						bbs[5].RenderPS(ps340)
 					}
-					ctx.RestoreAllocState(alloc359)
-					d0 = snap321
-					d1 = snap322
-					d2 = snap323
-					d3 = snap324
-					d18 = snap325
-					d19 = snap326
-					d20 = snap327
-					d21 = snap328
-					d22 = snap329
-					d23 = snap330
-					d24 = snap331
-					d25 = snap332
-					d26 = snap333
-					d27 = snap334
-					d28 = snap335
-					d65 = snap336
-					d66 = snap337
-					d67 = snap338
-					d68 = snap339
-					d113 = snap340
-					d114 = snap341
-					d115 = snap342
-					d116 = snap343
-					d117 = snap344
-					d118 = snap345
-					d119 = snap346
-					d120 = snap347
-					d121 = snap348
-					d122 = snap349
-					d123 = snap350
-					d124 = snap351
-					d193 = snap352
-					d194 = snap353
-					d195 = snap354
-					d196 = snap355
-					d197 = snap356
-					d276 = snap357
-					d277 = snap358
+					ctx.RestoreAllocState(alloc381)
+					d0 = snap341
+					d1 = snap342
+					d2 = snap343
+					d3 = snap344
+					d18 = snap345
+					d19 = snap346
+					d20 = snap347
+					d21 = snap348
+					d22 = snap349
+					d23 = snap350
+					d24 = snap351
+					d25 = snap352
+					d26 = snap353
+					d27 = snap354
+					d28 = snap355
+					d29 = snap356
+					d30 = snap357
+					d71 = snap358
+					d72 = snap359
+					d73 = snap360
+					d74 = snap361
+					d123 = snap362
+					d124 = snap363
+					d125 = snap364
+					d126 = snap365
+					d127 = snap366
+					d128 = snap367
+					d129 = snap368
+					d130 = snap369
+					d131 = snap370
+					d132 = snap371
+					d133 = snap372
+					d134 = snap373
+					d207 = snap374
+					d208 = snap375
+					d209 = snap376
+					d210 = snap377
+					d211 = snap378
+					d294 = snap379
+					d295 = snap380
 					if !bbs[6].Rendered {
-						return bbs[6].RenderPS(ps319)
+						return bbs[6].RenderPS(ps339)
 					}
 					return result
 					return result
@@ -36463,47 +36725,23 @@ func init_alu() {
 					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
 						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
-						d65 = ps.OverlayValues[65]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
-						d66 = ps.OverlayValues[66]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
 					}
-					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
-						d67 = ps.OverlayValues[67]
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
-					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
-						d68 = ps.OverlayValues[68]
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 113 && ps.OverlayValues[113].Loc != LocNone {
-						d113 = ps.OverlayValues[113]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 114 && ps.OverlayValues[114].Loc != LocNone {
-						d114 = ps.OverlayValues[114]
-					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
-					}
-					if len(ps.OverlayValues) > 116 && ps.OverlayValues[116].Loc != LocNone {
-						d116 = ps.OverlayValues[116]
-					}
-					if len(ps.OverlayValues) > 117 && ps.OverlayValues[117].Loc != LocNone {
-						d117 = ps.OverlayValues[117]
-					}
-					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
-						d118 = ps.OverlayValues[118]
-					}
-					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
-						d119 = ps.OverlayValues[119]
-					}
-					if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
-						d120 = ps.OverlayValues[120]
-					}
-					if len(ps.OverlayValues) > 121 && ps.OverlayValues[121].Loc != LocNone {
-						d121 = ps.OverlayValues[121]
-					}
-					if len(ps.OverlayValues) > 122 && ps.OverlayValues[122].Loc != LocNone {
-						d122 = ps.OverlayValues[122]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
 					if len(ps.OverlayValues) > 123 && ps.OverlayValues[123].Loc != LocNone {
 						d123 = ps.OverlayValues[123]
@@ -36511,440 +36749,488 @@ func init_alu() {
 					if len(ps.OverlayValues) > 124 && ps.OverlayValues[124].Loc != LocNone {
 						d124 = ps.OverlayValues[124]
 					}
-					if len(ps.OverlayValues) > 193 && ps.OverlayValues[193].Loc != LocNone {
-						d193 = ps.OverlayValues[193]
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
-					if len(ps.OverlayValues) > 194 && ps.OverlayValues[194].Loc != LocNone {
-						d194 = ps.OverlayValues[194]
+					if len(ps.OverlayValues) > 126 && ps.OverlayValues[126].Loc != LocNone {
+						d126 = ps.OverlayValues[126]
 					}
-					if len(ps.OverlayValues) > 195 && ps.OverlayValues[195].Loc != LocNone {
-						d195 = ps.OverlayValues[195]
+					if len(ps.OverlayValues) > 127 && ps.OverlayValues[127].Loc != LocNone {
+						d127 = ps.OverlayValues[127]
 					}
-					if len(ps.OverlayValues) > 196 && ps.OverlayValues[196].Loc != LocNone {
-						d196 = ps.OverlayValues[196]
+					if len(ps.OverlayValues) > 128 && ps.OverlayValues[128].Loc != LocNone {
+						d128 = ps.OverlayValues[128]
 					}
-					if len(ps.OverlayValues) > 197 && ps.OverlayValues[197].Loc != LocNone {
-						d197 = ps.OverlayValues[197]
+					if len(ps.OverlayValues) > 129 && ps.OverlayValues[129].Loc != LocNone {
+						d129 = ps.OverlayValues[129]
 					}
-					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
-						d276 = ps.OverlayValues[276]
+					if len(ps.OverlayValues) > 130 && ps.OverlayValues[130].Loc != LocNone {
+						d130 = ps.OverlayValues[130]
 					}
-					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
-						d277 = ps.OverlayValues[277]
+					if len(ps.OverlayValues) > 131 && ps.OverlayValues[131].Loc != LocNone {
+						d131 = ps.OverlayValues[131]
+					}
+					if len(ps.OverlayValues) > 132 && ps.OverlayValues[132].Loc != LocNone {
+						d132 = ps.OverlayValues[132]
+					}
+					if len(ps.OverlayValues) > 133 && ps.OverlayValues[133].Loc != LocNone {
+						d133 = ps.OverlayValues[133]
+					}
+					if len(ps.OverlayValues) > 134 && ps.OverlayValues[134].Loc != LocNone {
+						d134 = ps.OverlayValues[134]
+					}
+					if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+						d207 = ps.OverlayValues[207]
+					}
+					if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+						d208 = ps.OverlayValues[208]
+					}
+					if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+						d209 = ps.OverlayValues[209]
+					}
+					if len(ps.OverlayValues) > 210 && ps.OverlayValues[210].Loc != LocNone {
+						d210 = ps.OverlayValues[210]
+					}
+					if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+						d211 = ps.OverlayValues[211]
+					}
+					if len(ps.OverlayValues) > 294 && ps.OverlayValues[294].Loc != LocNone {
+						d294 = ps.OverlayValues[294]
+					}
+					if len(ps.OverlayValues) > 295 && ps.OverlayValues[295].Loc != LocNone {
+						d295 = ps.OverlayValues[295]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d26)
-					var d360 JITValueDesc
-					if d26.Loc == LocImm {
-						d360 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d26.Imm.Int()) == uint64(0x2))}
+					ctx.EnsureDesc(&d28)
+					var d382 JITValueDesc
+					if d28.Loc == LocImm {
+						d382 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d28.Imm.Int()) == uint64(0x2))}
 					} else {
-						r4 := ctx.AllocRegExcept(d26.Reg)
-						ctx.EmitCmpRegImm32(d26.Reg, 2)
-						d360 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r4, Condition: CondEqual}
-						ctx.BindReg(r4, &d360)
+						r4 := ctx.AllocRegExcept(d28.Reg)
+						ctx.EmitCmpRegImm32(d28.Reg, 2)
+						d382 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r4, Condition: CondEqual}
+						ctx.BindReg(r4, &d382)
 					}
-					d361 = d360
-					ctx.EnsureDesc(&d361)
-					if d361.Loc != LocImm && d361.Loc != LocFlags {
+					d383 = d382
+					ctx.EnsureDesc(&d383)
+					if d383.Loc != LocImm && d383.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d361.Loc == LocImm {
-						if d361.Imm.Bool() {
+					if d383.Loc == LocImm {
+						if d383.Imm.Bool() {
 							if ps.General {
 							}
-							ps362 := PhiState{General: ps.General}
-							ps362.OverlayValues = make([]JITValueDesc, 362)
-							ps362.OverlayValues[0] = d0
-							ps362.OverlayValues[1] = d1
-							ps362.OverlayValues[2] = d2
-							ps362.OverlayValues[3] = d3
-							ps362.OverlayValues[18] = d18
-							ps362.OverlayValues[19] = d19
-							ps362.OverlayValues[20] = d20
-							ps362.OverlayValues[21] = d21
-							ps362.OverlayValues[22] = d22
-							ps362.OverlayValues[23] = d23
-							ps362.OverlayValues[24] = d24
-							ps362.OverlayValues[25] = d25
-							ps362.OverlayValues[26] = d26
-							ps362.OverlayValues[27] = d27
-							ps362.OverlayValues[28] = d28
-							ps362.OverlayValues[65] = d65
-							ps362.OverlayValues[66] = d66
-							ps362.OverlayValues[67] = d67
-							ps362.OverlayValues[68] = d68
-							ps362.OverlayValues[113] = d113
-							ps362.OverlayValues[114] = d114
-							ps362.OverlayValues[115] = d115
-							ps362.OverlayValues[116] = d116
-							ps362.OverlayValues[117] = d117
-							ps362.OverlayValues[118] = d118
-							ps362.OverlayValues[119] = d119
-							ps362.OverlayValues[120] = d120
-							ps362.OverlayValues[121] = d121
-							ps362.OverlayValues[122] = d122
-							ps362.OverlayValues[123] = d123
-							ps362.OverlayValues[124] = d124
-							ps362.OverlayValues[193] = d193
-							ps362.OverlayValues[194] = d194
-							ps362.OverlayValues[195] = d195
-							ps362.OverlayValues[196] = d196
-							ps362.OverlayValues[197] = d197
-							ps362.OverlayValues[276] = d276
-							ps362.OverlayValues[277] = d277
-							ps362.OverlayValues[360] = d360
-							ps362.OverlayValues[361] = d361
-							return bbs[4].RenderPS(ps362)
+							ps384 := PhiState{General: ps.General}
+							ps384.OverlayValues = make([]JITValueDesc, 384)
+							ps384.OverlayValues[0] = d0
+							ps384.OverlayValues[1] = d1
+							ps384.OverlayValues[2] = d2
+							ps384.OverlayValues[3] = d3
+							ps384.OverlayValues[18] = d18
+							ps384.OverlayValues[19] = d19
+							ps384.OverlayValues[20] = d20
+							ps384.OverlayValues[21] = d21
+							ps384.OverlayValues[22] = d22
+							ps384.OverlayValues[23] = d23
+							ps384.OverlayValues[24] = d24
+							ps384.OverlayValues[25] = d25
+							ps384.OverlayValues[26] = d26
+							ps384.OverlayValues[27] = d27
+							ps384.OverlayValues[28] = d28
+							ps384.OverlayValues[29] = d29
+							ps384.OverlayValues[30] = d30
+							ps384.OverlayValues[71] = d71
+							ps384.OverlayValues[72] = d72
+							ps384.OverlayValues[73] = d73
+							ps384.OverlayValues[74] = d74
+							ps384.OverlayValues[123] = d123
+							ps384.OverlayValues[124] = d124
+							ps384.OverlayValues[125] = d125
+							ps384.OverlayValues[126] = d126
+							ps384.OverlayValues[127] = d127
+							ps384.OverlayValues[128] = d128
+							ps384.OverlayValues[129] = d129
+							ps384.OverlayValues[130] = d130
+							ps384.OverlayValues[131] = d131
+							ps384.OverlayValues[132] = d132
+							ps384.OverlayValues[133] = d133
+							ps384.OverlayValues[134] = d134
+							ps384.OverlayValues[207] = d207
+							ps384.OverlayValues[208] = d208
+							ps384.OverlayValues[209] = d209
+							ps384.OverlayValues[210] = d210
+							ps384.OverlayValues[211] = d211
+							ps384.OverlayValues[294] = d294
+							ps384.OverlayValues[295] = d295
+							ps384.OverlayValues[382] = d382
+							ps384.OverlayValues[383] = d383
+							return bbs[4].RenderPS(ps384)
 						}
 						if ps.General {
 						}
-						ps363 := PhiState{General: ps.General}
-						ps363.OverlayValues = make([]JITValueDesc, 362)
-						ps363.OverlayValues[0] = d0
-						ps363.OverlayValues[1] = d1
-						ps363.OverlayValues[2] = d2
-						ps363.OverlayValues[3] = d3
-						ps363.OverlayValues[18] = d18
-						ps363.OverlayValues[19] = d19
-						ps363.OverlayValues[20] = d20
-						ps363.OverlayValues[21] = d21
-						ps363.OverlayValues[22] = d22
-						ps363.OverlayValues[23] = d23
-						ps363.OverlayValues[24] = d24
-						ps363.OverlayValues[25] = d25
-						ps363.OverlayValues[26] = d26
-						ps363.OverlayValues[27] = d27
-						ps363.OverlayValues[28] = d28
-						ps363.OverlayValues[65] = d65
-						ps363.OverlayValues[66] = d66
-						ps363.OverlayValues[67] = d67
-						ps363.OverlayValues[68] = d68
-						ps363.OverlayValues[113] = d113
-						ps363.OverlayValues[114] = d114
-						ps363.OverlayValues[115] = d115
-						ps363.OverlayValues[116] = d116
-						ps363.OverlayValues[117] = d117
-						ps363.OverlayValues[118] = d118
-						ps363.OverlayValues[119] = d119
-						ps363.OverlayValues[120] = d120
-						ps363.OverlayValues[121] = d121
-						ps363.OverlayValues[122] = d122
-						ps363.OverlayValues[123] = d123
-						ps363.OverlayValues[124] = d124
-						ps363.OverlayValues[193] = d193
-						ps363.OverlayValues[194] = d194
-						ps363.OverlayValues[195] = d195
-						ps363.OverlayValues[196] = d196
-						ps363.OverlayValues[197] = d197
-						ps363.OverlayValues[276] = d276
-						ps363.OverlayValues[277] = d277
-						ps363.OverlayValues[360] = d360
-						ps363.OverlayValues[361] = d361
-						return bbs[5].RenderPS(ps363)
+						ps385 := PhiState{General: ps.General}
+						ps385.OverlayValues = make([]JITValueDesc, 384)
+						ps385.OverlayValues[0] = d0
+						ps385.OverlayValues[1] = d1
+						ps385.OverlayValues[2] = d2
+						ps385.OverlayValues[3] = d3
+						ps385.OverlayValues[18] = d18
+						ps385.OverlayValues[19] = d19
+						ps385.OverlayValues[20] = d20
+						ps385.OverlayValues[21] = d21
+						ps385.OverlayValues[22] = d22
+						ps385.OverlayValues[23] = d23
+						ps385.OverlayValues[24] = d24
+						ps385.OverlayValues[25] = d25
+						ps385.OverlayValues[26] = d26
+						ps385.OverlayValues[27] = d27
+						ps385.OverlayValues[28] = d28
+						ps385.OverlayValues[29] = d29
+						ps385.OverlayValues[30] = d30
+						ps385.OverlayValues[71] = d71
+						ps385.OverlayValues[72] = d72
+						ps385.OverlayValues[73] = d73
+						ps385.OverlayValues[74] = d74
+						ps385.OverlayValues[123] = d123
+						ps385.OverlayValues[124] = d124
+						ps385.OverlayValues[125] = d125
+						ps385.OverlayValues[126] = d126
+						ps385.OverlayValues[127] = d127
+						ps385.OverlayValues[128] = d128
+						ps385.OverlayValues[129] = d129
+						ps385.OverlayValues[130] = d130
+						ps385.OverlayValues[131] = d131
+						ps385.OverlayValues[132] = d132
+						ps385.OverlayValues[133] = d133
+						ps385.OverlayValues[134] = d134
+						ps385.OverlayValues[207] = d207
+						ps385.OverlayValues[208] = d208
+						ps385.OverlayValues[209] = d209
+						ps385.OverlayValues[210] = d210
+						ps385.OverlayValues[211] = d211
+						ps385.OverlayValues[294] = d294
+						ps385.OverlayValues[295] = d295
+						ps385.OverlayValues[382] = d382
+						ps385.OverlayValues[383] = d383
+						return bbs[5].RenderPS(ps385)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[8].RenderPS(ps)
 					}
-					ctx.EmitJump(d361.Condition, lbl5)
+					ctx.EmitJump(d383.Condition, lbl5)
 					if bbs[5].Rendered {
 						ctx.EmitJmp(lbl6)
 					}
-					ctx.FreeDesc(&d360)
-					snap364 := d0
-					snap365 := d1
-					snap366 := d2
-					snap367 := d3
-					snap368 := d18
-					snap369 := d19
-					snap370 := d20
-					snap371 := d21
-					snap372 := d22
-					snap373 := d23
-					snap374 := d24
-					snap375 := d25
-					snap376 := d26
-					snap377 := d27
-					snap378 := d28
-					snap379 := d65
-					snap380 := d66
-					snap381 := d67
-					snap382 := d68
-					snap383 := d113
-					snap384 := d114
-					snap385 := d115
-					snap386 := d116
-					snap387 := d117
-					snap388 := d118
-					snap389 := d119
-					snap390 := d120
-					snap391 := d121
-					snap392 := d122
-					snap393 := d123
-					snap394 := d124
-					snap395 := d193
-					snap396 := d194
-					snap397 := d195
-					snap398 := d196
-					snap399 := d197
-					snap400 := d276
-					snap401 := d277
-					snap402 := d360
-					snap403 := d361
-					alloc404 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc404)
-					d0 = snap364
-					d1 = snap365
-					d2 = snap366
-					d3 = snap367
-					d18 = snap368
-					d19 = snap369
-					d20 = snap370
-					d21 = snap371
-					d22 = snap372
-					d23 = snap373
-					d24 = snap374
-					d25 = snap375
-					d26 = snap376
-					d27 = snap377
-					d28 = snap378
-					d65 = snap379
-					d66 = snap380
-					d67 = snap381
-					d68 = snap382
-					d113 = snap383
-					d114 = snap384
-					d115 = snap385
-					d116 = snap386
-					d117 = snap387
-					d118 = snap388
-					d119 = snap389
-					d120 = snap390
-					d121 = snap391
-					d122 = snap392
-					d123 = snap393
-					d124 = snap394
-					d193 = snap395
-					d194 = snap396
-					d195 = snap397
-					d196 = snap398
-					d197 = snap399
-					d276 = snap400
-					d277 = snap401
-					d360 = snap402
-					d361 = snap403
-					ctx.RestoreAllocState(alloc404)
-					d0 = snap364
-					d1 = snap365
-					d2 = snap366
-					d3 = snap367
-					d18 = snap368
-					d19 = snap369
-					d20 = snap370
-					d21 = snap371
-					d22 = snap372
-					d23 = snap373
-					d24 = snap374
-					d25 = snap375
-					d26 = snap376
-					d27 = snap377
-					d28 = snap378
-					d65 = snap379
-					d66 = snap380
-					d67 = snap381
-					d68 = snap382
-					d113 = snap383
-					d114 = snap384
-					d115 = snap385
-					d116 = snap386
-					d117 = snap387
-					d118 = snap388
-					d119 = snap389
-					d120 = snap390
-					d121 = snap391
-					d122 = snap392
-					d123 = snap393
-					d124 = snap394
-					d193 = snap395
-					d194 = snap396
-					d195 = snap397
-					d196 = snap398
-					d197 = snap399
-					d276 = snap400
-					d277 = snap401
-					d360 = snap402
-					d361 = snap403
-					ps405 := PhiState{General: true}
-					ps405.OverlayValues = make([]JITValueDesc, 362)
-					ps405.OverlayValues[0] = d0
-					ps405.OverlayValues[1] = d1
-					ps405.OverlayValues[2] = d2
-					ps405.OverlayValues[3] = d3
-					ps405.OverlayValues[18] = d18
-					ps405.OverlayValues[19] = d19
-					ps405.OverlayValues[20] = d20
-					ps405.OverlayValues[21] = d21
-					ps405.OverlayValues[22] = d22
-					ps405.OverlayValues[23] = d23
-					ps405.OverlayValues[24] = d24
-					ps405.OverlayValues[25] = d25
-					ps405.OverlayValues[26] = d26
-					ps405.OverlayValues[27] = d27
-					ps405.OverlayValues[28] = d28
-					ps405.OverlayValues[65] = d65
-					ps405.OverlayValues[66] = d66
-					ps405.OverlayValues[67] = d67
-					ps405.OverlayValues[68] = d68
-					ps405.OverlayValues[113] = d113
-					ps405.OverlayValues[114] = d114
-					ps405.OverlayValues[115] = d115
-					ps405.OverlayValues[116] = d116
-					ps405.OverlayValues[117] = d117
-					ps405.OverlayValues[118] = d118
-					ps405.OverlayValues[119] = d119
-					ps405.OverlayValues[120] = d120
-					ps405.OverlayValues[121] = d121
-					ps405.OverlayValues[122] = d122
-					ps405.OverlayValues[123] = d123
-					ps405.OverlayValues[124] = d124
-					ps405.OverlayValues[193] = d193
-					ps405.OverlayValues[194] = d194
-					ps405.OverlayValues[195] = d195
-					ps405.OverlayValues[196] = d196
-					ps405.OverlayValues[197] = d197
-					ps405.OverlayValues[276] = d276
-					ps405.OverlayValues[277] = d277
-					ps405.OverlayValues[360] = d360
-					ps405.OverlayValues[361] = d361
-					ps406 := PhiState{General: true}
-					ps406.OverlayValues = make([]JITValueDesc, 362)
-					ps406.OverlayValues[0] = d0
-					ps406.OverlayValues[1] = d1
-					ps406.OverlayValues[2] = d2
-					ps406.OverlayValues[3] = d3
-					ps406.OverlayValues[18] = d18
-					ps406.OverlayValues[19] = d19
-					ps406.OverlayValues[20] = d20
-					ps406.OverlayValues[21] = d21
-					ps406.OverlayValues[22] = d22
-					ps406.OverlayValues[23] = d23
-					ps406.OverlayValues[24] = d24
-					ps406.OverlayValues[25] = d25
-					ps406.OverlayValues[26] = d26
-					ps406.OverlayValues[27] = d27
-					ps406.OverlayValues[28] = d28
-					ps406.OverlayValues[65] = d65
-					ps406.OverlayValues[66] = d66
-					ps406.OverlayValues[67] = d67
-					ps406.OverlayValues[68] = d68
-					ps406.OverlayValues[113] = d113
-					ps406.OverlayValues[114] = d114
-					ps406.OverlayValues[115] = d115
-					ps406.OverlayValues[116] = d116
-					ps406.OverlayValues[117] = d117
-					ps406.OverlayValues[118] = d118
-					ps406.OverlayValues[119] = d119
-					ps406.OverlayValues[120] = d120
-					ps406.OverlayValues[121] = d121
-					ps406.OverlayValues[122] = d122
-					ps406.OverlayValues[123] = d123
-					ps406.OverlayValues[124] = d124
-					ps406.OverlayValues[193] = d193
-					ps406.OverlayValues[194] = d194
-					ps406.OverlayValues[195] = d195
-					ps406.OverlayValues[196] = d196
-					ps406.OverlayValues[197] = d197
-					ps406.OverlayValues[276] = d276
-					ps406.OverlayValues[277] = d277
-					ps406.OverlayValues[360] = d360
-					ps406.OverlayValues[361] = d361
-					snap407 := d0
-					snap408 := d1
-					snap409 := d2
-					snap410 := d3
-					snap411 := d18
-					snap412 := d19
-					snap413 := d20
-					snap414 := d21
-					snap415 := d22
-					snap416 := d23
-					snap417 := d24
-					snap418 := d25
-					snap419 := d26
-					snap420 := d27
-					snap421 := d28
-					snap422 := d65
-					snap423 := d66
-					snap424 := d67
-					snap425 := d68
-					snap426 := d113
-					snap427 := d114
-					snap428 := d115
-					snap429 := d116
-					snap430 := d117
-					snap431 := d118
-					snap432 := d119
-					snap433 := d120
-					snap434 := d121
-					snap435 := d122
-					snap436 := d123
-					snap437 := d124
-					snap438 := d193
-					snap439 := d194
-					snap440 := d195
-					snap441 := d196
-					snap442 := d197
-					snap443 := d276
-					snap444 := d277
-					snap445 := d360
-					snap446 := d361
-					alloc447 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d382)
+					snap386 := d0
+					snap387 := d1
+					snap388 := d2
+					snap389 := d3
+					snap390 := d18
+					snap391 := d19
+					snap392 := d20
+					snap393 := d21
+					snap394 := d22
+					snap395 := d23
+					snap396 := d24
+					snap397 := d25
+					snap398 := d26
+					snap399 := d27
+					snap400 := d28
+					snap401 := d29
+					snap402 := d30
+					snap403 := d71
+					snap404 := d72
+					snap405 := d73
+					snap406 := d74
+					snap407 := d123
+					snap408 := d124
+					snap409 := d125
+					snap410 := d126
+					snap411 := d127
+					snap412 := d128
+					snap413 := d129
+					snap414 := d130
+					snap415 := d131
+					snap416 := d132
+					snap417 := d133
+					snap418 := d134
+					snap419 := d207
+					snap420 := d208
+					snap421 := d209
+					snap422 := d210
+					snap423 := d211
+					snap424 := d294
+					snap425 := d295
+					snap426 := d382
+					snap427 := d383
+					alloc428 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc428)
+					d0 = snap386
+					d1 = snap387
+					d2 = snap388
+					d3 = snap389
+					d18 = snap390
+					d19 = snap391
+					d20 = snap392
+					d21 = snap393
+					d22 = snap394
+					d23 = snap395
+					d24 = snap396
+					d25 = snap397
+					d26 = snap398
+					d27 = snap399
+					d28 = snap400
+					d29 = snap401
+					d30 = snap402
+					d71 = snap403
+					d72 = snap404
+					d73 = snap405
+					d74 = snap406
+					d123 = snap407
+					d124 = snap408
+					d125 = snap409
+					d126 = snap410
+					d127 = snap411
+					d128 = snap412
+					d129 = snap413
+					d130 = snap414
+					d131 = snap415
+					d132 = snap416
+					d133 = snap417
+					d134 = snap418
+					d207 = snap419
+					d208 = snap420
+					d209 = snap421
+					d210 = snap422
+					d211 = snap423
+					d294 = snap424
+					d295 = snap425
+					d382 = snap426
+					d383 = snap427
+					ctx.RestoreAllocState(alloc428)
+					d0 = snap386
+					d1 = snap387
+					d2 = snap388
+					d3 = snap389
+					d18 = snap390
+					d19 = snap391
+					d20 = snap392
+					d21 = snap393
+					d22 = snap394
+					d23 = snap395
+					d24 = snap396
+					d25 = snap397
+					d26 = snap398
+					d27 = snap399
+					d28 = snap400
+					d29 = snap401
+					d30 = snap402
+					d71 = snap403
+					d72 = snap404
+					d73 = snap405
+					d74 = snap406
+					d123 = snap407
+					d124 = snap408
+					d125 = snap409
+					d126 = snap410
+					d127 = snap411
+					d128 = snap412
+					d129 = snap413
+					d130 = snap414
+					d131 = snap415
+					d132 = snap416
+					d133 = snap417
+					d134 = snap418
+					d207 = snap419
+					d208 = snap420
+					d209 = snap421
+					d210 = snap422
+					d211 = snap423
+					d294 = snap424
+					d295 = snap425
+					d382 = snap426
+					d383 = snap427
+					ps429 := PhiState{General: true}
+					ps429.OverlayValues = make([]JITValueDesc, 384)
+					ps429.OverlayValues[0] = d0
+					ps429.OverlayValues[1] = d1
+					ps429.OverlayValues[2] = d2
+					ps429.OverlayValues[3] = d3
+					ps429.OverlayValues[18] = d18
+					ps429.OverlayValues[19] = d19
+					ps429.OverlayValues[20] = d20
+					ps429.OverlayValues[21] = d21
+					ps429.OverlayValues[22] = d22
+					ps429.OverlayValues[23] = d23
+					ps429.OverlayValues[24] = d24
+					ps429.OverlayValues[25] = d25
+					ps429.OverlayValues[26] = d26
+					ps429.OverlayValues[27] = d27
+					ps429.OverlayValues[28] = d28
+					ps429.OverlayValues[29] = d29
+					ps429.OverlayValues[30] = d30
+					ps429.OverlayValues[71] = d71
+					ps429.OverlayValues[72] = d72
+					ps429.OverlayValues[73] = d73
+					ps429.OverlayValues[74] = d74
+					ps429.OverlayValues[123] = d123
+					ps429.OverlayValues[124] = d124
+					ps429.OverlayValues[125] = d125
+					ps429.OverlayValues[126] = d126
+					ps429.OverlayValues[127] = d127
+					ps429.OverlayValues[128] = d128
+					ps429.OverlayValues[129] = d129
+					ps429.OverlayValues[130] = d130
+					ps429.OverlayValues[131] = d131
+					ps429.OverlayValues[132] = d132
+					ps429.OverlayValues[133] = d133
+					ps429.OverlayValues[134] = d134
+					ps429.OverlayValues[207] = d207
+					ps429.OverlayValues[208] = d208
+					ps429.OverlayValues[209] = d209
+					ps429.OverlayValues[210] = d210
+					ps429.OverlayValues[211] = d211
+					ps429.OverlayValues[294] = d294
+					ps429.OverlayValues[295] = d295
+					ps429.OverlayValues[382] = d382
+					ps429.OverlayValues[383] = d383
+					ps430 := PhiState{General: true}
+					ps430.OverlayValues = make([]JITValueDesc, 384)
+					ps430.OverlayValues[0] = d0
+					ps430.OverlayValues[1] = d1
+					ps430.OverlayValues[2] = d2
+					ps430.OverlayValues[3] = d3
+					ps430.OverlayValues[18] = d18
+					ps430.OverlayValues[19] = d19
+					ps430.OverlayValues[20] = d20
+					ps430.OverlayValues[21] = d21
+					ps430.OverlayValues[22] = d22
+					ps430.OverlayValues[23] = d23
+					ps430.OverlayValues[24] = d24
+					ps430.OverlayValues[25] = d25
+					ps430.OverlayValues[26] = d26
+					ps430.OverlayValues[27] = d27
+					ps430.OverlayValues[28] = d28
+					ps430.OverlayValues[29] = d29
+					ps430.OverlayValues[30] = d30
+					ps430.OverlayValues[71] = d71
+					ps430.OverlayValues[72] = d72
+					ps430.OverlayValues[73] = d73
+					ps430.OverlayValues[74] = d74
+					ps430.OverlayValues[123] = d123
+					ps430.OverlayValues[124] = d124
+					ps430.OverlayValues[125] = d125
+					ps430.OverlayValues[126] = d126
+					ps430.OverlayValues[127] = d127
+					ps430.OverlayValues[128] = d128
+					ps430.OverlayValues[129] = d129
+					ps430.OverlayValues[130] = d130
+					ps430.OverlayValues[131] = d131
+					ps430.OverlayValues[132] = d132
+					ps430.OverlayValues[133] = d133
+					ps430.OverlayValues[134] = d134
+					ps430.OverlayValues[207] = d207
+					ps430.OverlayValues[208] = d208
+					ps430.OverlayValues[209] = d209
+					ps430.OverlayValues[210] = d210
+					ps430.OverlayValues[211] = d211
+					ps430.OverlayValues[294] = d294
+					ps430.OverlayValues[295] = d295
+					ps430.OverlayValues[382] = d382
+					ps430.OverlayValues[383] = d383
+					snap431 := d0
+					snap432 := d1
+					snap433 := d2
+					snap434 := d3
+					snap435 := d18
+					snap436 := d19
+					snap437 := d20
+					snap438 := d21
+					snap439 := d22
+					snap440 := d23
+					snap441 := d24
+					snap442 := d25
+					snap443 := d26
+					snap444 := d27
+					snap445 := d28
+					snap446 := d29
+					snap447 := d30
+					snap448 := d71
+					snap449 := d72
+					snap450 := d73
+					snap451 := d74
+					snap452 := d123
+					snap453 := d124
+					snap454 := d125
+					snap455 := d126
+					snap456 := d127
+					snap457 := d128
+					snap458 := d129
+					snap459 := d130
+					snap460 := d131
+					snap461 := d132
+					snap462 := d133
+					snap463 := d134
+					snap464 := d207
+					snap465 := d208
+					snap466 := d209
+					snap467 := d210
+					snap468 := d211
+					snap469 := d294
+					snap470 := d295
+					snap471 := d382
+					snap472 := d383
+					alloc473 := ctx.SnapshotAllocState()
 					if !bbs[5].Rendered {
-						bbs[5].RenderPS(ps406)
+						bbs[5].RenderPS(ps430)
 					}
-					ctx.RestoreAllocState(alloc447)
-					d0 = snap407
-					d1 = snap408
-					d2 = snap409
-					d3 = snap410
-					d18 = snap411
-					d19 = snap412
-					d20 = snap413
-					d21 = snap414
-					d22 = snap415
-					d23 = snap416
-					d24 = snap417
-					d25 = snap418
-					d26 = snap419
-					d27 = snap420
-					d28 = snap421
-					d65 = snap422
-					d66 = snap423
-					d67 = snap424
-					d68 = snap425
-					d113 = snap426
-					d114 = snap427
-					d115 = snap428
-					d116 = snap429
-					d117 = snap430
-					d118 = snap431
-					d119 = snap432
-					d120 = snap433
-					d121 = snap434
-					d122 = snap435
-					d123 = snap436
-					d124 = snap437
-					d193 = snap438
-					d194 = snap439
-					d195 = snap440
-					d196 = snap441
-					d197 = snap442
-					d276 = snap443
-					d277 = snap444
-					d360 = snap445
-					d361 = snap446
+					ctx.RestoreAllocState(alloc473)
+					d0 = snap431
+					d1 = snap432
+					d2 = snap433
+					d3 = snap434
+					d18 = snap435
+					d19 = snap436
+					d20 = snap437
+					d21 = snap438
+					d22 = snap439
+					d23 = snap440
+					d24 = snap441
+					d25 = snap442
+					d26 = snap443
+					d27 = snap444
+					d28 = snap445
+					d29 = snap446
+					d30 = snap447
+					d71 = snap448
+					d72 = snap449
+					d73 = snap450
+					d74 = snap451
+					d123 = snap452
+					d124 = snap453
+					d125 = snap454
+					d126 = snap455
+					d127 = snap456
+					d128 = snap457
+					d129 = snap458
+					d130 = snap459
+					d131 = snap460
+					d132 = snap461
+					d133 = snap462
+					d134 = snap463
+					d207 = snap464
+					d208 = snap465
+					d209 = snap466
+					d210 = snap467
+					d211 = snap468
+					d294 = snap469
+					d295 = snap470
+					d382 = snap471
+					d383 = snap472
 					if !bbs[4].Rendered {
-						return bbs[4].RenderPS(ps405)
+						return bbs[4].RenderPS(ps429)
 					}
 					return result
 					return result
@@ -37013,47 +37299,23 @@ func init_alu() {
 					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
 						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
-						d65 = ps.OverlayValues[65]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
-						d66 = ps.OverlayValues[66]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
 					}
-					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
-						d67 = ps.OverlayValues[67]
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
-					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
-						d68 = ps.OverlayValues[68]
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 113 && ps.OverlayValues[113].Loc != LocNone {
-						d113 = ps.OverlayValues[113]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 114 && ps.OverlayValues[114].Loc != LocNone {
-						d114 = ps.OverlayValues[114]
-					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
-					}
-					if len(ps.OverlayValues) > 116 && ps.OverlayValues[116].Loc != LocNone {
-						d116 = ps.OverlayValues[116]
-					}
-					if len(ps.OverlayValues) > 117 && ps.OverlayValues[117].Loc != LocNone {
-						d117 = ps.OverlayValues[117]
-					}
-					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
-						d118 = ps.OverlayValues[118]
-					}
-					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
-						d119 = ps.OverlayValues[119]
-					}
-					if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
-						d120 = ps.OverlayValues[120]
-					}
-					if len(ps.OverlayValues) > 121 && ps.OverlayValues[121].Loc != LocNone {
-						d121 = ps.OverlayValues[121]
-					}
-					if len(ps.OverlayValues) > 122 && ps.OverlayValues[122].Loc != LocNone {
-						d122 = ps.OverlayValues[122]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
 					if len(ps.OverlayValues) > 123 && ps.OverlayValues[123].Loc != LocNone {
 						d123 = ps.OverlayValues[123]
@@ -37061,102 +37323,132 @@ func init_alu() {
 					if len(ps.OverlayValues) > 124 && ps.OverlayValues[124].Loc != LocNone {
 						d124 = ps.OverlayValues[124]
 					}
-					if len(ps.OverlayValues) > 193 && ps.OverlayValues[193].Loc != LocNone {
-						d193 = ps.OverlayValues[193]
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
-					if len(ps.OverlayValues) > 194 && ps.OverlayValues[194].Loc != LocNone {
-						d194 = ps.OverlayValues[194]
+					if len(ps.OverlayValues) > 126 && ps.OverlayValues[126].Loc != LocNone {
+						d126 = ps.OverlayValues[126]
 					}
-					if len(ps.OverlayValues) > 195 && ps.OverlayValues[195].Loc != LocNone {
-						d195 = ps.OverlayValues[195]
+					if len(ps.OverlayValues) > 127 && ps.OverlayValues[127].Loc != LocNone {
+						d127 = ps.OverlayValues[127]
 					}
-					if len(ps.OverlayValues) > 196 && ps.OverlayValues[196].Loc != LocNone {
-						d196 = ps.OverlayValues[196]
+					if len(ps.OverlayValues) > 128 && ps.OverlayValues[128].Loc != LocNone {
+						d128 = ps.OverlayValues[128]
 					}
-					if len(ps.OverlayValues) > 197 && ps.OverlayValues[197].Loc != LocNone {
-						d197 = ps.OverlayValues[197]
+					if len(ps.OverlayValues) > 129 && ps.OverlayValues[129].Loc != LocNone {
+						d129 = ps.OverlayValues[129]
 					}
-					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
-						d276 = ps.OverlayValues[276]
+					if len(ps.OverlayValues) > 130 && ps.OverlayValues[130].Loc != LocNone {
+						d130 = ps.OverlayValues[130]
 					}
-					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
-						d277 = ps.OverlayValues[277]
+					if len(ps.OverlayValues) > 131 && ps.OverlayValues[131].Loc != LocNone {
+						d131 = ps.OverlayValues[131]
 					}
-					if len(ps.OverlayValues) > 360 && ps.OverlayValues[360].Loc != LocNone {
-						d360 = ps.OverlayValues[360]
+					if len(ps.OverlayValues) > 132 && ps.OverlayValues[132].Loc != LocNone {
+						d132 = ps.OverlayValues[132]
 					}
-					if len(ps.OverlayValues) > 361 && ps.OverlayValues[361].Loc != LocNone {
-						d361 = ps.OverlayValues[361]
+					if len(ps.OverlayValues) > 133 && ps.OverlayValues[133].Loc != LocNone {
+						d133 = ps.OverlayValues[133]
+					}
+					if len(ps.OverlayValues) > 134 && ps.OverlayValues[134].Loc != LocNone {
+						d134 = ps.OverlayValues[134]
+					}
+					if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+						d207 = ps.OverlayValues[207]
+					}
+					if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+						d208 = ps.OverlayValues[208]
+					}
+					if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+						d209 = ps.OverlayValues[209]
+					}
+					if len(ps.OverlayValues) > 210 && ps.OverlayValues[210].Loc != LocNone {
+						d210 = ps.OverlayValues[210]
+					}
+					if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+						d211 = ps.OverlayValues[211]
+					}
+					if len(ps.OverlayValues) > 294 && ps.OverlayValues[294].Loc != LocNone {
+						d294 = ps.OverlayValues[294]
+					}
+					if len(ps.OverlayValues) > 295 && ps.OverlayValues[295].Loc != LocNone {
+						d295 = ps.OverlayValues[295]
+					}
+					if len(ps.OverlayValues) > 382 && ps.OverlayValues[382].Loc != LocNone {
+						d382 = ps.OverlayValues[382]
+					}
+					if len(ps.OverlayValues) > 383 && ps.OverlayValues[383].Loc != LocNone {
+						d383 = ps.OverlayValues[383]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d114)
-					if d114.Loc == LocImm {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d114.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.TrackImm(d114.Imm)
-						ptrWord, _ := d114.Imm.RawWords()
+					ctx.EnsureDesc(&d124)
+					if d124.Loc == LocImm {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d124.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.TrackImm(d124.Imm)
+						ptrWord, _ := d124.Imm.RawWords()
 						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d114.Imm.String())))
-						d114 = tmpPair
-					} else if d114.Loc == LocReg {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d114.Type, Reg: ctx.AllocRegExcept(d114.Reg), Reg2: ctx.AllocRegExcept(d114.Reg)}
-						switch d114.Type {
+						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d124.Imm.String())))
+						d124 = tmpPair
+					} else if d124.Loc == LocReg {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d124.Type, Reg: ctx.AllocRegExcept(d124.Reg), Reg2: ctx.AllocRegExcept(d124.Reg)}
+						switch d124.Type {
 						case tagBool:
-							ctx.EmitMakeBool(tmpPair, d114)
+							ctx.EmitMakeBool(tmpPair, d124)
 						case tagInt:
-							ctx.EmitMakeInt(tmpPair, d114)
+							ctx.EmitMakeInt(tmpPair, d124)
 						case tagFloat:
-							ctx.EmitMakeFloat(tmpPair, d114)
+							ctx.EmitMakeFloat(tmpPair, d124)
 						default:
 							panic("jit: generic call arg scalar type unknown for 2-word value")
 						}
-						ctx.FreeDesc(&d114)
-						d114 = tmpPair
+						ctx.FreeDesc(&d124)
+						d124 = tmpPair
 					}
-					if d114.Loc != LocRegPair && d114.Loc != LocStackPair && d114.Loc != LocInputPair {
+					if d124.Loc != LocRegPair && d124.Loc != LocStackPair && d124.Loc != LocInputPair {
 						panic("jit: generic call arg expects 2-word value (strings.EqualFold arg0)")
 					}
-					ctx.EnsureDesc(&d117)
-					if d117.Loc == LocImm {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d117.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.TrackImm(d117.Imm)
-						ptrWord, _ := d117.Imm.RawWords()
+					ctx.EnsureDesc(&d127)
+					if d127.Loc == LocImm {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d127.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.TrackImm(d127.Imm)
+						ptrWord, _ := d127.Imm.RawWords()
 						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d117.Imm.String())))
-						d117 = tmpPair
-					} else if d117.Loc == LocReg {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d117.Type, Reg: ctx.AllocRegExcept(d117.Reg), Reg2: ctx.AllocRegExcept(d117.Reg)}
-						switch d117.Type {
+						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d127.Imm.String())))
+						d127 = tmpPair
+					} else if d127.Loc == LocReg {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d127.Type, Reg: ctx.AllocRegExcept(d127.Reg), Reg2: ctx.AllocRegExcept(d127.Reg)}
+						switch d127.Type {
 						case tagBool:
-							ctx.EmitMakeBool(tmpPair, d117)
+							ctx.EmitMakeBool(tmpPair, d127)
 						case tagInt:
-							ctx.EmitMakeInt(tmpPair, d117)
+							ctx.EmitMakeInt(tmpPair, d127)
 						case tagFloat:
-							ctx.EmitMakeFloat(tmpPair, d117)
+							ctx.EmitMakeFloat(tmpPair, d127)
 						default:
 							panic("jit: generic call arg scalar type unknown for 2-word value")
 						}
-						ctx.FreeDesc(&d117)
-						d117 = tmpPair
+						ctx.FreeDesc(&d127)
+						d127 = tmpPair
 					}
-					if d117.Loc != LocRegPair && d117.Loc != LocStackPair && d117.Loc != LocInputPair {
+					if d127.Loc != LocRegPair && d127.Loc != LocStackPair && d127.Loc != LocInputPair {
 						panic("jit: generic call arg expects 2-word value (strings.EqualFold arg1)")
 					}
-					ctx.SyncDesc(&d114)
-					ctx.SyncDesc(&d117)
-					d448 = ctx.EmitGoCallScalar(GoFuncAddr(strings.EqualFold), []JITValueDesc{d114, d117}, 1)
-					d448.NoHeapPointer = true
-					ctx.EmitAndRegImm32(d448.Reg, 1)
-					d448.Type = tagBool
-					ctx.BindReg(d448.Reg, &d448)
-					ctx.EnsureDesc(&d448)
-					if d448.Loc == LocImm {
-						ctx.EmitMakeBool(result, d448)
+					ctx.SyncDesc(&d124)
+					ctx.SyncDesc(&d127)
+					d474 = ctx.EmitGoCallScalar(GoFuncAddr(strings.EqualFold), []JITValueDesc{d124, d127}, 1)
+					d474.NoHeapPointer = true
+					ctx.EmitAndRegImm32(d474.Reg, 1)
+					d474.Type = tagBool
+					ctx.BindReg(d474.Reg, &d474)
+					ctx.EnsureDesc(&d474)
+					if d474.Loc == LocImm {
+						ctx.EmitMakeBool(result, d474)
 					} else {
-						ctx.EmitMovToReg(result.Reg2, d448)
-						d449 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeBool(result, d449)
-						if d448.Loc == LocReg && d448.Reg != result.Reg2 {
-							ctx.FreeReg(d448.Reg)
+						ctx.EmitMovToReg(result.Reg2, d474)
+						d475 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeBool(result, d475)
+						if d474.Loc == LocReg && d474.Reg != result.Reg2 {
+							ctx.FreeReg(d474.Reg)
 						}
 					}
 					result.Type = tagBool
@@ -37227,47 +37519,23 @@ func init_alu() {
 					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
 						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 65 && ps.OverlayValues[65].Loc != LocNone {
-						d65 = ps.OverlayValues[65]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 66 && ps.OverlayValues[66].Loc != LocNone {
-						d66 = ps.OverlayValues[66]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
 					}
-					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
-						d67 = ps.OverlayValues[67]
+					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
+						d71 = ps.OverlayValues[71]
 					}
-					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
-						d68 = ps.OverlayValues[68]
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
 					}
-					if len(ps.OverlayValues) > 113 && ps.OverlayValues[113].Loc != LocNone {
-						d113 = ps.OverlayValues[113]
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
 					}
-					if len(ps.OverlayValues) > 114 && ps.OverlayValues[114].Loc != LocNone {
-						d114 = ps.OverlayValues[114]
-					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
-					}
-					if len(ps.OverlayValues) > 116 && ps.OverlayValues[116].Loc != LocNone {
-						d116 = ps.OverlayValues[116]
-					}
-					if len(ps.OverlayValues) > 117 && ps.OverlayValues[117].Loc != LocNone {
-						d117 = ps.OverlayValues[117]
-					}
-					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
-						d118 = ps.OverlayValues[118]
-					}
-					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
-						d119 = ps.OverlayValues[119]
-					}
-					if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
-						d120 = ps.OverlayValues[120]
-					}
-					if len(ps.OverlayValues) > 121 && ps.OverlayValues[121].Loc != LocNone {
-						d121 = ps.OverlayValues[121]
-					}
-					if len(ps.OverlayValues) > 122 && ps.OverlayValues[122].Loc != LocNone {
-						d122 = ps.OverlayValues[122]
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
 					}
 					if len(ps.OverlayValues) > 123 && ps.OverlayValues[123].Loc != LocNone {
 						d123 = ps.OverlayValues[123]
@@ -37275,63 +37543,93 @@ func init_alu() {
 					if len(ps.OverlayValues) > 124 && ps.OverlayValues[124].Loc != LocNone {
 						d124 = ps.OverlayValues[124]
 					}
-					if len(ps.OverlayValues) > 193 && ps.OverlayValues[193].Loc != LocNone {
-						d193 = ps.OverlayValues[193]
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
-					if len(ps.OverlayValues) > 194 && ps.OverlayValues[194].Loc != LocNone {
-						d194 = ps.OverlayValues[194]
+					if len(ps.OverlayValues) > 126 && ps.OverlayValues[126].Loc != LocNone {
+						d126 = ps.OverlayValues[126]
 					}
-					if len(ps.OverlayValues) > 195 && ps.OverlayValues[195].Loc != LocNone {
-						d195 = ps.OverlayValues[195]
+					if len(ps.OverlayValues) > 127 && ps.OverlayValues[127].Loc != LocNone {
+						d127 = ps.OverlayValues[127]
 					}
-					if len(ps.OverlayValues) > 196 && ps.OverlayValues[196].Loc != LocNone {
-						d196 = ps.OverlayValues[196]
+					if len(ps.OverlayValues) > 128 && ps.OverlayValues[128].Loc != LocNone {
+						d128 = ps.OverlayValues[128]
 					}
-					if len(ps.OverlayValues) > 197 && ps.OverlayValues[197].Loc != LocNone {
-						d197 = ps.OverlayValues[197]
+					if len(ps.OverlayValues) > 129 && ps.OverlayValues[129].Loc != LocNone {
+						d129 = ps.OverlayValues[129]
 					}
-					if len(ps.OverlayValues) > 276 && ps.OverlayValues[276].Loc != LocNone {
-						d276 = ps.OverlayValues[276]
+					if len(ps.OverlayValues) > 130 && ps.OverlayValues[130].Loc != LocNone {
+						d130 = ps.OverlayValues[130]
 					}
-					if len(ps.OverlayValues) > 277 && ps.OverlayValues[277].Loc != LocNone {
-						d277 = ps.OverlayValues[277]
+					if len(ps.OverlayValues) > 131 && ps.OverlayValues[131].Loc != LocNone {
+						d131 = ps.OverlayValues[131]
 					}
-					if len(ps.OverlayValues) > 360 && ps.OverlayValues[360].Loc != LocNone {
-						d360 = ps.OverlayValues[360]
+					if len(ps.OverlayValues) > 132 && ps.OverlayValues[132].Loc != LocNone {
+						d132 = ps.OverlayValues[132]
 					}
-					if len(ps.OverlayValues) > 361 && ps.OverlayValues[361].Loc != LocNone {
-						d361 = ps.OverlayValues[361]
+					if len(ps.OverlayValues) > 133 && ps.OverlayValues[133].Loc != LocNone {
+						d133 = ps.OverlayValues[133]
 					}
-					if len(ps.OverlayValues) > 448 && ps.OverlayValues[448].Loc != LocNone {
-						d448 = ps.OverlayValues[448]
+					if len(ps.OverlayValues) > 134 && ps.OverlayValues[134].Loc != LocNone {
+						d134 = ps.OverlayValues[134]
 					}
-					if len(ps.OverlayValues) > 449 && ps.OverlayValues[449].Loc != LocNone {
-						d449 = ps.OverlayValues[449]
+					if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+						d207 = ps.OverlayValues[207]
+					}
+					if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+						d208 = ps.OverlayValues[208]
+					}
+					if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+						d209 = ps.OverlayValues[209]
+					}
+					if len(ps.OverlayValues) > 210 && ps.OverlayValues[210].Loc != LocNone {
+						d210 = ps.OverlayValues[210]
+					}
+					if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+						d211 = ps.OverlayValues[211]
+					}
+					if len(ps.OverlayValues) > 294 && ps.OverlayValues[294].Loc != LocNone {
+						d294 = ps.OverlayValues[294]
+					}
+					if len(ps.OverlayValues) > 295 && ps.OverlayValues[295].Loc != LocNone {
+						d295 = ps.OverlayValues[295]
+					}
+					if len(ps.OverlayValues) > 382 && ps.OverlayValues[382].Loc != LocNone {
+						d382 = ps.OverlayValues[382]
+					}
+					if len(ps.OverlayValues) > 383 && ps.OverlayValues[383].Loc != LocNone {
+						d383 = ps.OverlayValues[383]
+					}
+					if len(ps.OverlayValues) > 474 && ps.OverlayValues[474].Loc != LocNone {
+						d474 = ps.OverlayValues[474]
+					}
+					if len(ps.OverlayValues) > 475 && ps.OverlayValues[475].Loc != LocNone {
+						d475 = ps.OverlayValues[475]
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d114)
-					ctx.EnsureDesc(&d117)
-					d450 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d114, d117}, 1)
-					ctx.EmitAndRegImm32(d450.Reg, 1)
-					d450.Type = tagBool
-					ctx.BindReg(d450.Reg, &d450)
-					ctx.EnsureDesc(&d450)
-					if d450.Loc == LocImm {
-						ctx.EmitMakeBool(result, d450)
+					ctx.EnsureDesc(&d124)
+					ctx.EnsureDesc(&d127)
+					d476 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d124, d127}, 1)
+					ctx.EmitAndRegImm32(d476.Reg, 1)
+					d476.Type = tagBool
+					ctx.BindReg(d476.Reg, &d476)
+					ctx.EnsureDesc(&d476)
+					if d476.Loc == LocImm {
+						ctx.EmitMakeBool(result, d476)
 					} else {
-						ctx.EmitMovToReg(result.Reg2, d450)
-						d451 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeBool(result, d451)
-						if d450.Loc == LocReg && d450.Reg != result.Reg2 {
-							ctx.FreeReg(d450.Reg)
+						ctx.EmitMovToReg(result.Reg2, d476)
+						d477 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeBool(result, d477)
+						if d476.Loc == LocReg && d476.Reg != result.Reg2 {
+							ctx.FreeReg(d476.Reg)
 						}
 					}
 					result.Type = tagBool
 					ctx.EmitJmp(lbl0)
 					return result
 				}
-				ps452 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps452)
+				ps478 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps478)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -38951,14 +39249,14 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d9)
-						if d9.Loc == LocReg {
+						if d9.Loc == LocReg || d9.Loc == LocFPReg {
 							ctx.ProtectReg(d9.Reg)
 						} else if d9.Loc == LocRegPair {
 							ctx.ProtectReg(d9.Reg)
 							ctx.ProtectReg(d9.Reg2)
 						}
 						ctx.SyncDesc(&d44)
-						if d44.Loc == LocReg {
+						if d44.Loc == LocReg || d44.Loc == LocFPReg {
 							ctx.ProtectReg(d44.Reg)
 						} else if d44.Loc == LocRegPair {
 							ctx.ProtectReg(d44.Reg)
@@ -38987,13 +39285,13 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d89)
 						ctx.EmitStoreToStack(d89, int32(bbs[1].PhiBase)+int32(16))
-						if d9.Loc == LocReg {
+						if d9.Loc == LocReg || d9.Loc == LocFPReg {
 							ctx.UnprotectReg(d9.Reg)
 						} else if d9.Loc == LocRegPair {
 							ctx.UnprotectReg(d9.Reg)
 							ctx.UnprotectReg(d9.Reg2)
 						}
-						if d44.Loc == LocReg {
+						if d44.Loc == LocReg || d44.Loc == LocFPReg {
 							ctx.UnprotectReg(d44.Reg)
 						} else if d44.Loc == LocRegPair {
 							ctx.UnprotectReg(d44.Reg)
@@ -39127,7 +39425,7 @@ func init_alu() {
 						if d95.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d9)
-								if d9.Loc == LocReg {
+								if d9.Loc == LocReg || d9.Loc == LocFPReg {
 									ctx.ProtectReg(d9.Reg)
 								} else if d9.Loc == LocRegPair {
 									ctx.ProtectReg(d9.Reg)
@@ -39139,7 +39437,7 @@ func init_alu() {
 								}
 								ctx.EnsureDesc(&d96)
 								ctx.EmitStoreToStack(d96, int32(bbs[1].PhiBase)+int32(16))
-								if d9.Loc == LocReg {
+								if d9.Loc == LocReg || d9.Loc == LocFPReg {
 									ctx.UnprotectReg(d9.Reg)
 								} else if d9.Loc == LocRegPair {
 									ctx.UnprotectReg(d9.Reg)
@@ -39244,7 +39542,7 @@ func init_alu() {
 					alloc125 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d9)
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.ProtectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.ProtectReg(d9.Reg)
@@ -39256,7 +39554,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d126)
 					ctx.EmitStoreToStack(d126, int32(bbs[1].PhiBase)+int32(16))
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.UnprotectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.UnprotectReg(d9.Reg)
@@ -39546,14 +39844,14 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d9)
-						if d9.Loc == LocReg {
+						if d9.Loc == LocReg || d9.Loc == LocFPReg {
 							ctx.ProtectReg(d9.Reg)
 						} else if d9.Loc == LocRegPair {
 							ctx.ProtectReg(d9.Reg)
 							ctx.ProtectReg(d9.Reg2)
 						}
 						ctx.SyncDesc(&d44)
-						if d44.Loc == LocReg {
+						if d44.Loc == LocReg || d44.Loc == LocFPReg {
 							ctx.ProtectReg(d44.Reg)
 						} else if d44.Loc == LocRegPair {
 							ctx.ProtectReg(d44.Reg)
@@ -39582,13 +39880,13 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d159)
 						ctx.EmitStoreToStack(d159, int32(bbs[1].PhiBase)+int32(16))
-						if d9.Loc == LocReg {
+						if d9.Loc == LocReg || d9.Loc == LocFPReg {
 							ctx.UnprotectReg(d9.Reg)
 						} else if d9.Loc == LocRegPair {
 							ctx.UnprotectReg(d9.Reg)
 							ctx.UnprotectReg(d9.Reg2)
 						}
-						if d44.Loc == LocReg {
+						if d44.Loc == LocReg || d44.Loc == LocFPReg {
 							ctx.UnprotectReg(d44.Reg)
 						} else if d44.Loc == LocRegPair {
 							ctx.UnprotectReg(d44.Reg)
@@ -39754,15 +40052,12 @@ func init_alu() {
 					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.StabilizeDescForControlFlow(&d44)
-					d44 = JITPrepareScmerGoArg(ctx, d44)
-					d1 = JITPrepareScmerGoArg(ctx, d1)
-					ctx.SyncDesc(&d44)
-					ctx.SyncDesc(&d1)
-					d163 = ctx.EmitGoCallScalar(GoFuncAddr(Less), []JITValueDesc{d44, d1}, 1)
-					d163.NoHeapPointer = true
-					ctx.EmitAndRegImm32(d163.Reg, 1)
+					ctx.EnsureDesc(&d44)
+					ctx.StabilizeDescForControlFlow(&d44)
+					ctx.EnsureDesc(&d1)
+					ctx.StabilizeDescForControlFlow(&d1)
+					d163 = jitEmitLess(ctx, []JITValueDesc{d44, d1}, JITValueDesc{Loc: LocAny})
 					d163.Type = tagBool
-					ctx.BindReg(d163.Reg, &d163)
 					d164 = d163
 					ctx.EnsureDesc(&d164)
 					if d164.Loc != LocImm && d164.Loc != LocReg {
@@ -39811,7 +40106,7 @@ func init_alu() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d9)
-							if d9.Loc == LocReg {
+							if d9.Loc == LocReg || d9.Loc == LocFPReg {
 								ctx.ProtectReg(d9.Reg)
 							} else if d9.Loc == LocRegPair {
 								ctx.ProtectReg(d9.Reg)
@@ -39823,7 +40118,7 @@ func init_alu() {
 							}
 							ctx.EnsureDesc(&d166)
 							ctx.EmitStoreToStack(d166, int32(bbs[1].PhiBase)+int32(16))
-							if d9.Loc == LocReg {
+							if d9.Loc == LocReg || d9.Loc == LocFPReg {
 								ctx.UnprotectReg(d9.Reg)
 							} else if d9.Loc == LocRegPair {
 								ctx.UnprotectReg(d9.Reg)
@@ -39953,7 +40248,7 @@ func init_alu() {
 					d168 = snap203
 					ctx.MarkLabel(lbl12)
 					ctx.SyncDesc(&d9)
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.ProtectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.ProtectReg(d9.Reg)
@@ -39965,7 +40260,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d205)
 					ctx.EmitStoreToStack(d205, int32(bbs[1].PhiBase)+int32(16))
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.UnprotectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.UnprotectReg(d9.Reg)
@@ -41117,14 +41412,14 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d9)
-						if d9.Loc == LocReg {
+						if d9.Loc == LocReg || d9.Loc == LocFPReg {
 							ctx.ProtectReg(d9.Reg)
 						} else if d9.Loc == LocRegPair {
 							ctx.ProtectReg(d9.Reg)
 							ctx.ProtectReg(d9.Reg2)
 						}
 						ctx.SyncDesc(&d44)
-						if d44.Loc == LocReg {
+						if d44.Loc == LocReg || d44.Loc == LocFPReg {
 							ctx.ProtectReg(d44.Reg)
 						} else if d44.Loc == LocRegPair {
 							ctx.ProtectReg(d44.Reg)
@@ -41153,13 +41448,13 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d89)
 						ctx.EmitStoreToStack(d89, int32(bbs[1].PhiBase)+int32(16))
-						if d9.Loc == LocReg {
+						if d9.Loc == LocReg || d9.Loc == LocFPReg {
 							ctx.UnprotectReg(d9.Reg)
 						} else if d9.Loc == LocRegPair {
 							ctx.UnprotectReg(d9.Reg)
 							ctx.UnprotectReg(d9.Reg2)
 						}
-						if d44.Loc == LocReg {
+						if d44.Loc == LocReg || d44.Loc == LocFPReg {
 							ctx.UnprotectReg(d44.Reg)
 						} else if d44.Loc == LocRegPair {
 							ctx.UnprotectReg(d44.Reg)
@@ -41293,7 +41588,7 @@ func init_alu() {
 						if d95.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d9)
-								if d9.Loc == LocReg {
+								if d9.Loc == LocReg || d9.Loc == LocFPReg {
 									ctx.ProtectReg(d9.Reg)
 								} else if d9.Loc == LocRegPair {
 									ctx.ProtectReg(d9.Reg)
@@ -41305,7 +41600,7 @@ func init_alu() {
 								}
 								ctx.EnsureDesc(&d96)
 								ctx.EmitStoreToStack(d96, int32(bbs[1].PhiBase)+int32(16))
-								if d9.Loc == LocReg {
+								if d9.Loc == LocReg || d9.Loc == LocFPReg {
 									ctx.UnprotectReg(d9.Reg)
 								} else if d9.Loc == LocRegPair {
 									ctx.UnprotectReg(d9.Reg)
@@ -41410,7 +41705,7 @@ func init_alu() {
 					alloc125 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d9)
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.ProtectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.ProtectReg(d9.Reg)
@@ -41422,7 +41717,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d126)
 					ctx.EmitStoreToStack(d126, int32(bbs[1].PhiBase)+int32(16))
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.UnprotectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.UnprotectReg(d9.Reg)
@@ -41712,14 +42007,14 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d9)
-						if d9.Loc == LocReg {
+						if d9.Loc == LocReg || d9.Loc == LocFPReg {
 							ctx.ProtectReg(d9.Reg)
 						} else if d9.Loc == LocRegPair {
 							ctx.ProtectReg(d9.Reg)
 							ctx.ProtectReg(d9.Reg2)
 						}
 						ctx.SyncDesc(&d44)
-						if d44.Loc == LocReg {
+						if d44.Loc == LocReg || d44.Loc == LocFPReg {
 							ctx.ProtectReg(d44.Reg)
 						} else if d44.Loc == LocRegPair {
 							ctx.ProtectReg(d44.Reg)
@@ -41748,13 +42043,13 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d159)
 						ctx.EmitStoreToStack(d159, int32(bbs[1].PhiBase)+int32(16))
-						if d9.Loc == LocReg {
+						if d9.Loc == LocReg || d9.Loc == LocFPReg {
 							ctx.UnprotectReg(d9.Reg)
 						} else if d9.Loc == LocRegPair {
 							ctx.UnprotectReg(d9.Reg)
 							ctx.UnprotectReg(d9.Reg2)
 						}
-						if d44.Loc == LocReg {
+						if d44.Loc == LocReg || d44.Loc == LocFPReg {
 							ctx.UnprotectReg(d44.Reg)
 						} else if d44.Loc == LocRegPair {
 							ctx.UnprotectReg(d44.Reg)
@@ -41920,15 +42215,12 @@ func init_alu() {
 					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.StabilizeDescForControlFlow(&d44)
-					d1 = JITPrepareScmerGoArg(ctx, d1)
-					d44 = JITPrepareScmerGoArg(ctx, d44)
-					ctx.SyncDesc(&d1)
-					ctx.SyncDesc(&d44)
-					d163 = ctx.EmitGoCallScalar(GoFuncAddr(Less), []JITValueDesc{d1, d44}, 1)
-					d163.NoHeapPointer = true
-					ctx.EmitAndRegImm32(d163.Reg, 1)
+					ctx.EnsureDesc(&d1)
+					ctx.StabilizeDescForControlFlow(&d1)
+					ctx.EnsureDesc(&d44)
+					ctx.StabilizeDescForControlFlow(&d44)
+					d163 = jitEmitLess(ctx, []JITValueDesc{d1, d44}, JITValueDesc{Loc: LocAny})
 					d163.Type = tagBool
-					ctx.BindReg(d163.Reg, &d163)
 					d164 = d163
 					ctx.EnsureDesc(&d164)
 					if d164.Loc != LocImm && d164.Loc != LocReg {
@@ -41977,7 +42269,7 @@ func init_alu() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d9)
-							if d9.Loc == LocReg {
+							if d9.Loc == LocReg || d9.Loc == LocFPReg {
 								ctx.ProtectReg(d9.Reg)
 							} else if d9.Loc == LocRegPair {
 								ctx.ProtectReg(d9.Reg)
@@ -41989,7 +42281,7 @@ func init_alu() {
 							}
 							ctx.EnsureDesc(&d166)
 							ctx.EmitStoreToStack(d166, int32(bbs[1].PhiBase)+int32(16))
-							if d9.Loc == LocReg {
+							if d9.Loc == LocReg || d9.Loc == LocFPReg {
 								ctx.UnprotectReg(d9.Reg)
 							} else if d9.Loc == LocRegPair {
 								ctx.UnprotectReg(d9.Reg)
@@ -42119,7 +42411,7 @@ func init_alu() {
 					d168 = snap203
 					ctx.MarkLabel(lbl12)
 					ctx.SyncDesc(&d9)
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.ProtectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.ProtectReg(d9.Reg)
@@ -42131,7 +42423,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d205)
 					ctx.EmitStoreToStack(d205, int32(bbs[1].PhiBase)+int32(16))
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.UnprotectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.UnprotectReg(d9.Reg)
@@ -44614,7 +44906,7 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d156)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d156)
-					if d156.Loc == LocReg {
+					if d156.Loc == LocReg || d156.Loc == LocFPReg {
 						ctx.ProtectReg(d156.Reg)
 					} else if d156.Loc == LocRegPair {
 						ctx.ProtectReg(d156.Reg)
@@ -44626,7 +44918,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d161)
 					ctx.EmitStoreToStack(d161, int32(phiBase154)+int32(0))
-					if d156.Loc == LocReg {
+					if d156.Loc == LocReg || d156.Loc == LocFPReg {
 						ctx.UnprotectReg(d156.Reg)
 					} else if d156.Loc == LocRegPair {
 						ctx.UnprotectReg(d156.Reg)
@@ -45362,7 +45654,7 @@ func init_alu() {
 					ctx.FreeDesc(&d204)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d209)
-					if d209.Loc == LocReg {
+					if d209.Loc == LocReg || d209.Loc == LocFPReg {
 						ctx.ProtectReg(d209.Reg)
 					} else if d209.Loc == LocRegPair {
 						ctx.ProtectReg(d209.Reg)
@@ -45374,7 +45666,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d210)
 					ctx.EmitStoreToStack(d210, int32(phiBase184)+int32(0))
-					if d209.Loc == LocReg {
+					if d209.Loc == LocReg || d209.Loc == LocFPReg {
 						ctx.UnprotectReg(d209.Reg)
 					} else if d209.Loc == LocRegPair {
 						ctx.UnprotectReg(d209.Reg)
@@ -45424,7 +45716,7 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d211)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d211)
-					if d211.Loc == LocReg {
+					if d211.Loc == LocReg || d211.Loc == LocFPReg {
 						ctx.ProtectReg(d211.Reg)
 					} else if d211.Loc == LocRegPair {
 						ctx.ProtectReg(d211.Reg)
@@ -45436,7 +45728,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d213)
 					ctx.EmitStoreToStack(d213, int32(phiBase184)+int32(16))
-					if d211.Loc == LocReg {
+					if d211.Loc == LocReg || d211.Loc == LocFPReg {
 						ctx.UnprotectReg(d211.Reg)
 					} else if d211.Loc == LocRegPair {
 						ctx.UnprotectReg(d211.Reg)
@@ -45492,7 +45784,7 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d219)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d219)
-					if d219.Loc == LocReg {
+					if d219.Loc == LocReg || d219.Loc == LocFPReg {
 						ctx.ProtectReg(d219.Reg)
 					} else if d219.Loc == LocRegPair {
 						ctx.ProtectReg(d219.Reg)
@@ -45504,7 +45796,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d220)
 					ctx.EmitStoreToStack(d220, int32(phiBase184)+int32(0))
-					if d219.Loc == LocReg {
+					if d219.Loc == LocReg || d219.Loc == LocFPReg {
 						ctx.UnprotectReg(d219.Reg)
 					} else if d219.Loc == LocRegPair {
 						ctx.UnprotectReg(d219.Reg)
@@ -45519,7 +45811,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d182)
-					if d182.Loc == LocReg {
+					if d182.Loc == LocReg || d182.Loc == LocFPReg {
 						ctx.ProtectReg(d182.Reg)
 					} else if d182.Loc == LocRegPair {
 						ctx.ProtectReg(d182.Reg)
@@ -45531,7 +45823,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d221)
 					ctx.EmitStoreToStack(d221, int32(phiBase184)+int32(0))
-					if d182.Loc == LocReg {
+					if d182.Loc == LocReg || d182.Loc == LocFPReg {
 						ctx.UnprotectReg(d182.Reg)
 					} else if d182.Loc == LocRegPair {
 						ctx.UnprotectReg(d182.Reg)
@@ -45589,7 +45881,7 @@ func init_alu() {
 					ctx.FreeDesc(&d227)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d228)
-					if d228.Loc == LocReg {
+					if d228.Loc == LocReg || d228.Loc == LocFPReg {
 						ctx.ProtectReg(d228.Reg)
 					} else if d228.Loc == LocRegPair {
 						ctx.ProtectReg(d228.Reg)
@@ -45601,7 +45893,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d229)
 					ctx.EmitStoreToStack(d229, int32(phiBase184)+int32(0))
-					if d228.Loc == LocReg {
+					if d228.Loc == LocReg || d228.Loc == LocFPReg {
 						ctx.UnprotectReg(d228.Reg)
 					} else if d228.Loc == LocRegPair {
 						ctx.UnprotectReg(d228.Reg)
@@ -45693,7 +45985,7 @@ func init_alu() {
 					ctx.FreeDesc(&d235)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d240)
-					if d240.Loc == LocReg {
+					if d240.Loc == LocReg || d240.Loc == LocFPReg {
 						ctx.ProtectReg(d240.Reg)
 					} else if d240.Loc == LocRegPair {
 						ctx.ProtectReg(d240.Reg)
@@ -45705,7 +45997,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d241)
 					ctx.EmitStoreToStack(d241, int32(phiBase184)+int32(0))
-					if d240.Loc == LocReg {
+					if d240.Loc == LocReg || d240.Loc == LocFPReg {
 						ctx.UnprotectReg(d240.Reg)
 					} else if d240.Loc == LocRegPair {
 						ctx.UnprotectReg(d240.Reg)
@@ -46340,7 +46632,7 @@ func init_alu() {
 					ctx.FreeDesc(&d280)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d285)
-					if d285.Loc == LocReg {
+					if d285.Loc == LocReg || d285.Loc == LocFPReg {
 						ctx.ProtectReg(d285.Reg)
 					} else if d285.Loc == LocRegPair {
 						ctx.ProtectReg(d285.Reg)
@@ -46352,7 +46644,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d286)
 					ctx.EmitStoreToStack(d286, int32(phiBase260)+int32(0))
-					if d285.Loc == LocReg {
+					if d285.Loc == LocReg || d285.Loc == LocFPReg {
 						ctx.UnprotectReg(d285.Reg)
 					} else if d285.Loc == LocRegPair {
 						ctx.UnprotectReg(d285.Reg)
@@ -46402,7 +46694,7 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d287)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d287)
-					if d287.Loc == LocReg {
+					if d287.Loc == LocReg || d287.Loc == LocFPReg {
 						ctx.ProtectReg(d287.Reg)
 					} else if d287.Loc == LocRegPair {
 						ctx.ProtectReg(d287.Reg)
@@ -46414,7 +46706,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d289)
 					ctx.EmitStoreToStack(d289, int32(phiBase260)+int32(16))
-					if d287.Loc == LocReg {
+					if d287.Loc == LocReg || d287.Loc == LocFPReg {
 						ctx.UnprotectReg(d287.Reg)
 					} else if d287.Loc == LocRegPair {
 						ctx.UnprotectReg(d287.Reg)
@@ -46470,7 +46762,7 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d295)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d295)
-					if d295.Loc == LocReg {
+					if d295.Loc == LocReg || d295.Loc == LocFPReg {
 						ctx.ProtectReg(d295.Reg)
 					} else if d295.Loc == LocRegPair {
 						ctx.ProtectReg(d295.Reg)
@@ -46482,7 +46774,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d296)
 					ctx.EmitStoreToStack(d296, int32(phiBase260)+int32(0))
-					if d295.Loc == LocReg {
+					if d295.Loc == LocReg || d295.Loc == LocFPReg {
 						ctx.UnprotectReg(d295.Reg)
 					} else if d295.Loc == LocRegPair {
 						ctx.UnprotectReg(d295.Reg)
@@ -46497,7 +46789,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d258)
-					if d258.Loc == LocReg {
+					if d258.Loc == LocReg || d258.Loc == LocFPReg {
 						ctx.ProtectReg(d258.Reg)
 					} else if d258.Loc == LocRegPair {
 						ctx.ProtectReg(d258.Reg)
@@ -46509,7 +46801,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d297)
 					ctx.EmitStoreToStack(d297, int32(phiBase260)+int32(0))
-					if d258.Loc == LocReg {
+					if d258.Loc == LocReg || d258.Loc == LocFPReg {
 						ctx.UnprotectReg(d258.Reg)
 					} else if d258.Loc == LocRegPair {
 						ctx.UnprotectReg(d258.Reg)
@@ -46567,7 +46859,7 @@ func init_alu() {
 					ctx.FreeDesc(&d303)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d304)
-					if d304.Loc == LocReg {
+					if d304.Loc == LocReg || d304.Loc == LocFPReg {
 						ctx.ProtectReg(d304.Reg)
 					} else if d304.Loc == LocRegPair {
 						ctx.ProtectReg(d304.Reg)
@@ -46579,7 +46871,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d305)
 					ctx.EmitStoreToStack(d305, int32(phiBase260)+int32(0))
-					if d304.Loc == LocReg {
+					if d304.Loc == LocReg || d304.Loc == LocFPReg {
 						ctx.UnprotectReg(d304.Reg)
 					} else if d304.Loc == LocRegPair {
 						ctx.UnprotectReg(d304.Reg)
@@ -46671,7 +46963,7 @@ func init_alu() {
 					ctx.FreeDesc(&d311)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d316)
-					if d316.Loc == LocReg {
+					if d316.Loc == LocReg || d316.Loc == LocFPReg {
 						ctx.ProtectReg(d316.Reg)
 					} else if d316.Loc == LocRegPair {
 						ctx.ProtectReg(d316.Reg)
@@ -46683,7 +46975,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d317)
 					ctx.EmitStoreToStack(d317, int32(phiBase260)+int32(0))
-					if d316.Loc == LocReg {
+					if d316.Loc == LocReg || d316.Loc == LocFPReg {
 						ctx.UnprotectReg(d316.Reg)
 					} else if d316.Loc == LocRegPair {
 						ctx.UnprotectReg(d316.Reg)
@@ -46860,7 +47152,7 @@ func init_alu() {
 					if d326.Loc == LocImm && d324.Loc == LocImm {
 						d328 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d326.Imm.Float() <= d324.Imm.Float())}
 					} else if d324.Loc == LocImm {
-						r45 := ctx.AllocReg()
+						r45 := ctx.AllocRegExcept(d326.Reg)
 						_, yBits := d324.Imm.RawWords()
 						ctx.EmitMovRegImm64(RegR11, yBits)
 						ctx.EmitCmpFloat64Setcc(r45, d326.Reg, RegR11, CondSignedLessOrEqual)
@@ -46896,7 +47188,7 @@ func init_alu() {
 						} else {
 							ctx.MarkLabel(lbl112)
 							ctx.SyncDesc(&d147)
-							if d147.Loc == LocReg {
+							if d147.Loc == LocReg || d147.Loc == LocFPReg {
 								ctx.ProtectReg(d147.Reg)
 							} else if d147.Loc == LocRegPair {
 								ctx.ProtectReg(d147.Reg)
@@ -46908,7 +47200,7 @@ func init_alu() {
 							}
 							ctx.EnsureDesc(&d330)
 							ctx.EmitStoreToStack(d330, int32(phiBase144)+int32(0))
-							if d147.Loc == LocReg {
+							if d147.Loc == LocReg || d147.Loc == LocFPReg {
 								ctx.UnprotectReg(d147.Reg)
 							} else if d147.Loc == LocRegPair {
 								ctx.UnprotectReg(d147.Reg)
@@ -46924,7 +47216,7 @@ func init_alu() {
 						ctx.EmitJmp(lbl16)
 						ctx.MarkLabel(lbl112)
 						ctx.SyncDesc(&d147)
-						if d147.Loc == LocReg {
+						if d147.Loc == LocReg || d147.Loc == LocFPReg {
 							ctx.ProtectReg(d147.Reg)
 						} else if d147.Loc == LocRegPair {
 							ctx.ProtectReg(d147.Reg)
@@ -46936,7 +47228,7 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d331)
 						ctx.EmitStoreToStack(d331, int32(phiBase144)+int32(0))
-						if d147.Loc == LocReg {
+						if d147.Loc == LocReg || d147.Loc == LocFPReg {
 							ctx.UnprotectReg(d147.Reg)
 						} else if d147.Loc == LocRegPair {
 							ctx.UnprotectReg(d147.Reg)
@@ -47021,7 +47313,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d169)
-					if d169.Loc == LocReg {
+					if d169.Loc == LocReg || d169.Loc == LocFPReg {
 						ctx.ProtectReg(d169.Reg)
 					} else if d169.Loc == LocRegPair {
 						ctx.ProtectReg(d169.Reg)
@@ -47033,7 +47325,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d334)
 					ctx.EmitStoreToStack(d334, int32(phiBase144)+int32(0))
-					if d169.Loc == LocReg {
+					if d169.Loc == LocReg || d169.Loc == LocFPReg {
 						ctx.UnprotectReg(d169.Reg)
 					} else if d169.Loc == LocRegPair {
 						ctx.UnprotectReg(d169.Reg)
@@ -47824,7 +48116,7 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d342)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d342)
-					if d342.Loc == LocReg {
+					if d342.Loc == LocReg || d342.Loc == LocFPReg {
 						ctx.ProtectReg(d342.Reg)
 					} else if d342.Loc == LocRegPair {
 						ctx.ProtectReg(d342.Reg)
@@ -47836,7 +48128,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d347)
 					ctx.EmitStoreToStack(d347, int32(phiBase340)+int32(0))
-					if d342.Loc == LocReg {
+					if d342.Loc == LocReg || d342.Loc == LocFPReg {
 						ctx.UnprotectReg(d342.Reg)
 					} else if d342.Loc == LocRegPair {
 						ctx.UnprotectReg(d342.Reg)
@@ -50382,7 +50674,7 @@ func init_alu() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d24)
-							if d24.Loc == LocReg {
+							if d24.Loc == LocReg || d24.Loc == LocFPReg {
 								ctx.ProtectReg(d24.Reg)
 							} else if d24.Loc == LocRegPair {
 								ctx.ProtectReg(d24.Reg)
@@ -50394,7 +50686,7 @@ func init_alu() {
 							}
 							ctx.EnsureDesc(&d28)
 							ctx.EmitStoreToStack(d28, int32(bbs[4].PhiBase)+int32(0))
-							if d24.Loc == LocReg {
+							if d24.Loc == LocReg || d24.Loc == LocFPReg {
 								ctx.UnprotectReg(d24.Reg)
 							} else if d24.Loc == LocRegPair {
 								ctx.UnprotectReg(d24.Reg)
@@ -50455,7 +50747,7 @@ func init_alu() {
 					d30 = snap42
 					ctx.MarkLabel(lbl9)
 					ctx.SyncDesc(&d24)
-					if d24.Loc == LocReg {
+					if d24.Loc == LocReg || d24.Loc == LocFPReg {
 						ctx.ProtectReg(d24.Reg)
 					} else if d24.Loc == LocRegPair {
 						ctx.ProtectReg(d24.Reg)
@@ -50467,7 +50759,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d44)
 					ctx.EmitStoreToStack(d44, int32(bbs[4].PhiBase)+int32(0))
-					if d24.Loc == LocReg {
+					if d24.Loc == LocReg || d24.Loc == LocFPReg {
 						ctx.UnprotectReg(d24.Reg)
 					} else if d24.Loc == LocRegPair {
 						ctx.UnprotectReg(d24.Reg)
@@ -50649,7 +50941,7 @@ func init_alu() {
 					ctx.StabilizeDescForControlFlow(&d63)
 					if ps.General {
 						ctx.SyncDesc(&d63)
-						if d63.Loc == LocReg {
+						if d63.Loc == LocReg || d63.Loc == LocFPReg {
 							ctx.ProtectReg(d63.Reg)
 						} else if d63.Loc == LocRegPair {
 							ctx.ProtectReg(d63.Reg)
@@ -50661,7 +50953,7 @@ func init_alu() {
 						}
 						ctx.EnsureDesc(&d64)
 						ctx.EmitStoreToStack(d64, int32(bbs[4].PhiBase)+int32(0))
-						if d63.Loc == LocReg {
+						if d63.Loc == LocReg || d63.Loc == LocFPReg {
 							ctx.UnprotectReg(d63.Reg)
 						} else if d63.Loc == LocRegPair {
 							ctx.UnprotectReg(d63.Reg)
@@ -51521,7 +51813,7 @@ func init_alu() {
 					if d138.Loc == LocImm && d1.Loc == LocImm {
 						d139 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d138.Imm.Float() == d1.Imm.Float())}
 					} else if d1.Loc == LocImm {
-						r8 := ctx.AllocReg()
+						r8 := ctx.AllocRegExcept(d138.Reg)
 						_, yBits := d1.Imm.RawWords()
 						ctx.EmitMovRegImm64(RegR11, yBits)
 						ctx.EmitCmpFloat64Setcc(r8, d138.Reg, RegR11, CondEqual)

--- a/scm/compare.go
+++ b/scm/compare.go
@@ -543,6 +543,7 @@ func EqualSQL(a, b Scmer) Scmer {
 func LessScm(a ...Scmer) Scmer    { return NewBool(Less(a[0], a[1])) }
 func GreaterScm(a ...Scmer) Scmer { return NewBool(Less(a[1], a[0])) }
 
+//jitgen:emitter jitEmitLess
 func Less(a, b Scmer) bool {
 	ta := a.GetTag()
 	tb := b.GetTag()
@@ -569,6 +570,16 @@ func Less(a, b Scmer) bool {
 		return float64(a.Int()) < b.Float()
 	case tagFloat:
 		return a.Float() < b.Float()
+	case tagBool:
+		return a.Int() < b.Int()
+	default:
+		return lessNonNumeric(a, b, ta, tb)
+	}
+}
+
+//jitgen:noinline
+func lessNonNumeric(a, b Scmer, ta, tb uint8) bool {
+	switch ta {
 	case tagBSON:
 		switch tb {
 		case tagBSON:
@@ -604,14 +615,5526 @@ func Less(a, b Scmer) bool {
 			// Fallback: compare by string representation to avoid panics on mixed types
 			return strings.Compare(a.String(), b.String()) < 0
 		}
-	case tagBool:
-		return a.Int() < b.Int()
 	case tagFunc:
 		return uintptr(unsafe.Pointer(a.ptr)) < uintptr(unsafe.Pointer(b.ptr))
 	case tagAny:
 		return strings.Compare(a.String(), b.String()) < 0
 	default:
-		// Fallback: compare by string representation for any unsupported combos
 		return strings.Compare(a.String(), b.String()) < 0
 	}
+}
+
+// jitEmitLess is generated from Less by jitgen. It is called while a parent
+// emitter is producing machine code, so known argument tags prune Less' cold
+// comparison arms without duplicating its SSA in every generated builtin.
+func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+	var d0 JITValueDesc
+	_ = d0
+	var d1 JITValueDesc
+	_ = d1
+	var d2 JITValueDesc
+	_ = d2
+	var d3 JITValueDesc
+	_ = d3
+	var d4 JITValueDesc
+	_ = d4
+	var d5 JITValueDesc
+	_ = d5
+	var d24 JITValueDesc
+	_ = d24
+	var d25 JITValueDesc
+	_ = d25
+	var d26 JITValueDesc
+	_ = d26
+	var d51 JITValueDesc
+	_ = d51
+	var d52 JITValueDesc
+	_ = d52
+	var d81 JITValueDesc
+	_ = d81
+	var d82 JITValueDesc
+	_ = d82
+	var d83 JITValueDesc
+	_ = d83
+	var d118 JITValueDesc
+	_ = d118
+	var d119 JITValueDesc
+	_ = d119
+	var d120 JITValueDesc
+	_ = d120
+	var d161 JITValueDesc
+	_ = d161
+	var d162 JITValueDesc
+	_ = d162
+	var d207 JITValueDesc
+	_ = d207
+	var d208 JITValueDesc
+	_ = d208
+	var d209 JITValueDesc
+	_ = d209
+	var d211 JITValueDesc
+	_ = d211
+	var d212 JITValueDesc
+	_ = d212
+	var d213 JITValueDesc
+	_ = d213
+	var d270 JITValueDesc
+	_ = d270
+	var d271 JITValueDesc
+	_ = d271
+	var d273 JITValueDesc
+	_ = d273
+	var d274 JITValueDesc
+	_ = d274
+	var d275 JITValueDesc
+	_ = d275
+	var d342 JITValueDesc
+	_ = d342
+	var d343 JITValueDesc
+	_ = d343
+	var d344 JITValueDesc
+	_ = d344
+	var d346 JITValueDesc
+	_ = d346
+	var d347 JITValueDesc
+	_ = d347
+	var d348 JITValueDesc
+	_ = d348
+	var d427 JITValueDesc
+	_ = d427
+	var d429 JITValueDesc
+	_ = d429
+	var d430 JITValueDesc
+	_ = d430
+	var d431 JITValueDesc
+	_ = d431
+	var d433 JITValueDesc
+	_ = d433
+	var d434 JITValueDesc
+	_ = d434
+	var d435 JITValueDesc
+	_ = d435
+	var d528 JITValueDesc
+	_ = d528
+	var d529 JITValueDesc
+	_ = d529
+	var d531 JITValueDesc
+	_ = d531
+	var d532 JITValueDesc
+	_ = d532
+	var d533 JITValueDesc
+	_ = d533
+	var d636 JITValueDesc
+	_ = d636
+	for i := range args {
+		if args[i].Type != JITTypeUnknown {
+			continue
+		}
+		nativeArgs := [...]JITValueDesc{args[0], args[1]}
+		for j := range nativeArgs {
+			nativeArgs[j] = JITPrepareScmerGoArg(ctx, nativeArgs[j])
+		}
+		native := ctx.EmitGoCallScalar(GoFuncAddr(Less), nativeArgs[:], 1)
+		ctx.EmitAndRegImm32(native.Reg, 1)
+		native.Type = tagBool
+		if result.Loc == LocAny {
+			return native
+		}
+		ctx.EmitMovToReg(result.Reg, native)
+		result.Type = tagBool
+		return result
+	}
+	/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
+	var bbs [20]BBDescriptor
+	if result.Loc == LocAny {
+		result = JITValueDesc{Loc: LocReg, Type: JITTypeUnknown, Reg: ctx.AllocReg()}
+		ctx.BindReg(result.Reg, &result)
+	}
+	resultRegsProtected := result.Loc == LocReg
+	if resultRegsProtected {
+		ctx.ProtectReg(result.Reg)
+	}
+	lbl0 := ctx.ReserveLabel()
+	bbpos_0_0 := int32(-1)
+	_ = bbpos_0_0
+	lbl1 := ctx.ReserveLabel()
+	_ = lbl1
+	bbpos_0_1 := int32(-1)
+	_ = bbpos_0_1
+	lbl2 := ctx.ReserveLabel()
+	_ = lbl2
+	bbpos_0_2 := int32(-1)
+	_ = bbpos_0_2
+	lbl3 := ctx.ReserveLabel()
+	_ = lbl3
+	bbpos_0_3 := int32(-1)
+	_ = bbpos_0_3
+	lbl4 := ctx.ReserveLabel()
+	_ = lbl4
+	bbpos_0_4 := int32(-1)
+	_ = bbpos_0_4
+	lbl5 := ctx.ReserveLabel()
+	_ = lbl5
+	bbpos_0_5 := int32(-1)
+	_ = bbpos_0_5
+	lbl6 := ctx.ReserveLabel()
+	_ = lbl6
+	bbpos_0_6 := int32(-1)
+	_ = bbpos_0_6
+	lbl7 := ctx.ReserveLabel()
+	_ = lbl7
+	bbpos_0_7 := int32(-1)
+	_ = bbpos_0_7
+	lbl8 := ctx.ReserveLabel()
+	_ = lbl8
+	bbpos_0_8 := int32(-1)
+	_ = bbpos_0_8
+	lbl9 := ctx.ReserveLabel()
+	_ = lbl9
+	bbpos_0_9 := int32(-1)
+	_ = bbpos_0_9
+	lbl10 := ctx.ReserveLabel()
+	_ = lbl10
+	bbpos_0_10 := int32(-1)
+	_ = bbpos_0_10
+	lbl11 := ctx.ReserveLabel()
+	_ = lbl11
+	bbpos_0_11 := int32(-1)
+	_ = bbpos_0_11
+	lbl12 := ctx.ReserveLabel()
+	_ = lbl12
+	bbpos_0_12 := int32(-1)
+	_ = bbpos_0_12
+	lbl13 := ctx.ReserveLabel()
+	_ = lbl13
+	bbpos_0_13 := int32(-1)
+	_ = bbpos_0_13
+	lbl14 := ctx.ReserveLabel()
+	_ = lbl14
+	bbpos_0_14 := int32(-1)
+	_ = bbpos_0_14
+	lbl15 := ctx.ReserveLabel()
+	_ = lbl15
+	bbpos_0_15 := int32(-1)
+	_ = bbpos_0_15
+	lbl16 := ctx.ReserveLabel()
+	_ = lbl16
+	bbpos_0_16 := int32(-1)
+	_ = bbpos_0_16
+	lbl17 := ctx.ReserveLabel()
+	_ = lbl17
+	bbpos_0_17 := int32(-1)
+	_ = bbpos_0_17
+	lbl18 := ctx.ReserveLabel()
+	_ = lbl18
+	bbpos_0_18 := int32(-1)
+	_ = bbpos_0_18
+	lbl19 := ctx.ReserveLabel()
+	_ = lbl19
+	bbpos_0_19 := int32(-1)
+	_ = bbpos_0_19
+	lbl20 := ctx.ReserveLabel()
+	_ = lbl20
+	bbs[0].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[0].VisitCount >= 0 {
+				ps.General = true
+				return bbs[0].RenderPS(ps)
+			}
+		}
+		bbs[0].VisitCount++
+		if ps.General {
+			if bbs[0].Rendered {
+				ctx.EmitJmp(lbl1)
+				return result
+			}
+			bbs[0].Rendered = true
+			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_0 = bbs[0].Address
+			ctx.MarkLabel(lbl1)
+			ctx.ResolveFixups()
+		}
+		ctx.ReclaimUntrackedRegs()
+		d0 = args[0]
+		d0.ID = 0
+		d1 = ctx.EmitGetTagDesc(&d0, JITValueDesc{Loc: LocAny})
+		ctx.StabilizeDescForControlFlow(&d1)
+		d2 = args[1]
+		d2.ID = 0
+		d3 = ctx.EmitGetTagDesc(&d2, JITValueDesc{Loc: LocAny})
+		ctx.StabilizeDescForControlFlow(&d3)
+		ctx.EnsureDesc(&d1)
+		var d4 JITValueDesc
+		if d1.Loc == LocImm {
+			d4 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d1.Imm.Int()) == uint64(0x0))}
+		} else {
+			r0 := ctx.AllocRegExcept(d1.Reg)
+			ctx.EmitCmpRegImm32(d1.Reg, 0)
+			d4 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
+			ctx.BindReg(r0, &d4)
+		}
+		d5 = d4
+		ctx.EnsureDesc(&d5)
+		if d5.Loc != LocImm && d5.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d5.Loc == LocImm {
+			if d5.Imm.Bool() {
+				if ps.General {
+				}
+				ps6 := PhiState{General: ps.General}
+				ps6.OverlayValues = make([]JITValueDesc, 6)
+				ps6.OverlayValues[0] = d0
+				ps6.OverlayValues[1] = d1
+				ps6.OverlayValues[2] = d2
+				ps6.OverlayValues[3] = d3
+				ps6.OverlayValues[4] = d4
+				ps6.OverlayValues[5] = d5
+				return bbs[3].RenderPS(ps6)
+			}
+			if ps.General {
+			}
+			ps7 := PhiState{General: ps.General}
+			ps7.OverlayValues = make([]JITValueDesc, 6)
+			ps7.OverlayValues[0] = d0
+			ps7.OverlayValues[1] = d1
+			ps7.OverlayValues[2] = d2
+			ps7.OverlayValues[3] = d3
+			ps7.OverlayValues[4] = d4
+			ps7.OverlayValues[5] = d5
+			return bbs[2].RenderPS(ps7)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[0].RenderPS(ps)
+		}
+		ctx.EmitJump(d5.Condition, lbl4)
+		if bbs[2].Rendered {
+			ctx.EmitJmp(lbl3)
+		}
+		ctx.FreeDesc(&d4)
+		snap8 := d0
+		snap9 := d1
+		snap10 := d2
+		snap11 := d3
+		snap12 := d4
+		snap13 := d5
+		alloc14 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc14)
+		d0 = snap8
+		d1 = snap9
+		d2 = snap10
+		d3 = snap11
+		d4 = snap12
+		d5 = snap13
+		ctx.RestoreAllocState(alloc14)
+		d0 = snap8
+		d1 = snap9
+		d2 = snap10
+		d3 = snap11
+		d4 = snap12
+		d5 = snap13
+		ps15 := PhiState{General: true}
+		ps15.OverlayValues = make([]JITValueDesc, 6)
+		ps15.OverlayValues[0] = d0
+		ps15.OverlayValues[1] = d1
+		ps15.OverlayValues[2] = d2
+		ps15.OverlayValues[3] = d3
+		ps15.OverlayValues[4] = d4
+		ps15.OverlayValues[5] = d5
+		ps16 := PhiState{General: true}
+		ps16.OverlayValues = make([]JITValueDesc, 6)
+		ps16.OverlayValues[0] = d0
+		ps16.OverlayValues[1] = d1
+		ps16.OverlayValues[2] = d2
+		ps16.OverlayValues[3] = d3
+		ps16.OverlayValues[4] = d4
+		ps16.OverlayValues[5] = d5
+		snap17 := d0
+		snap18 := d1
+		snap19 := d2
+		snap20 := d3
+		snap21 := d4
+		snap22 := d5
+		alloc23 := ctx.SnapshotAllocState()
+		if !bbs[2].Rendered {
+			bbs[2].RenderPS(ps16)
+		}
+		ctx.RestoreAllocState(alloc23)
+		d0 = snap17
+		d1 = snap18
+		d2 = snap19
+		d3 = snap20
+		d4 = snap21
+		d5 = snap22
+		if !bbs[3].Rendered {
+			return bbs[3].RenderPS(ps15)
+		}
+		return result
+		return result
+	}
+	bbs[1].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[1].VisitCount >= 0 {
+				ps.General = true
+				return bbs[1].RenderPS(ps)
+			}
+		}
+		bbs[1].VisitCount++
+		if ps.General {
+			if bbs[1].Rendered {
+				ctx.EmitJmp(lbl2)
+				return result
+			}
+			bbs[1].Rendered = true
+			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_1 = bbs[1].Address
+			ctx.MarkLabel(lbl2)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		ctx.ReclaimUntrackedRegs()
+		d24 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+		ctx.EmitMovToReg(result.Reg, d24)
+		result.Type = d24.Type
+		ctx.EmitJmp(lbl0)
+		return result
+	}
+	bbs[2].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[2].VisitCount >= 0 {
+				ps.General = true
+				return bbs[2].RenderPS(ps)
+			}
+		}
+		bbs[2].VisitCount++
+		if ps.General {
+			if bbs[2].Rendered {
+				ctx.EmitJmp(lbl3)
+				return result
+			}
+			bbs[2].Rendered = true
+			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_2 = bbs[2].Address
+			ctx.MarkLabel(lbl3)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d1)
+		var d25 JITValueDesc
+		if d1.Loc == LocImm {
+			d25 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d1.Imm.Int()) == uint64(0x0))}
+		} else {
+			r1 := ctx.AllocRegExcept(d1.Reg)
+			ctx.EmitCmpRegImm32(d1.Reg, 0)
+			d25 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondEqual}
+			ctx.BindReg(r1, &d25)
+		}
+		d26 = d25
+		ctx.EnsureDesc(&d26)
+		if d26.Loc != LocImm && d26.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d26.Loc == LocImm {
+			if d26.Imm.Bool() {
+				if ps.General {
+				}
+				ps27 := PhiState{General: ps.General}
+				ps27.OverlayValues = make([]JITValueDesc, 27)
+				ps27.OverlayValues[0] = d0
+				ps27.OverlayValues[1] = d1
+				ps27.OverlayValues[2] = d2
+				ps27.OverlayValues[3] = d3
+				ps27.OverlayValues[4] = d4
+				ps27.OverlayValues[5] = d5
+				ps27.OverlayValues[24] = d24
+				ps27.OverlayValues[25] = d25
+				ps27.OverlayValues[26] = d26
+				return bbs[4].RenderPS(ps27)
+			}
+			if ps.General {
+			}
+			ps28 := PhiState{General: ps.General}
+			ps28.OverlayValues = make([]JITValueDesc, 27)
+			ps28.OverlayValues[0] = d0
+			ps28.OverlayValues[1] = d1
+			ps28.OverlayValues[2] = d2
+			ps28.OverlayValues[3] = d3
+			ps28.OverlayValues[4] = d4
+			ps28.OverlayValues[5] = d5
+			ps28.OverlayValues[24] = d24
+			ps28.OverlayValues[25] = d25
+			ps28.OverlayValues[26] = d26
+			return bbs[5].RenderPS(ps28)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[2].RenderPS(ps)
+		}
+		ctx.EmitJump(d26.Condition, lbl5)
+		if bbs[5].Rendered {
+			ctx.EmitJmp(lbl6)
+		}
+		ctx.FreeDesc(&d25)
+		snap29 := d0
+		snap30 := d1
+		snap31 := d2
+		snap32 := d3
+		snap33 := d4
+		snap34 := d5
+		snap35 := d24
+		snap36 := d25
+		snap37 := d26
+		alloc38 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc38)
+		d0 = snap29
+		d1 = snap30
+		d2 = snap31
+		d3 = snap32
+		d4 = snap33
+		d5 = snap34
+		d24 = snap35
+		d25 = snap36
+		d26 = snap37
+		ctx.RestoreAllocState(alloc38)
+		d0 = snap29
+		d1 = snap30
+		d2 = snap31
+		d3 = snap32
+		d4 = snap33
+		d5 = snap34
+		d24 = snap35
+		d25 = snap36
+		d26 = snap37
+		ps39 := PhiState{General: true}
+		ps39.OverlayValues = make([]JITValueDesc, 27)
+		ps39.OverlayValues[0] = d0
+		ps39.OverlayValues[1] = d1
+		ps39.OverlayValues[2] = d2
+		ps39.OverlayValues[3] = d3
+		ps39.OverlayValues[4] = d4
+		ps39.OverlayValues[5] = d5
+		ps39.OverlayValues[24] = d24
+		ps39.OverlayValues[25] = d25
+		ps39.OverlayValues[26] = d26
+		ps40 := PhiState{General: true}
+		ps40.OverlayValues = make([]JITValueDesc, 27)
+		ps40.OverlayValues[0] = d0
+		ps40.OverlayValues[1] = d1
+		ps40.OverlayValues[2] = d2
+		ps40.OverlayValues[3] = d3
+		ps40.OverlayValues[4] = d4
+		ps40.OverlayValues[5] = d5
+		ps40.OverlayValues[24] = d24
+		ps40.OverlayValues[25] = d25
+		ps40.OverlayValues[26] = d26
+		snap41 := d0
+		snap42 := d1
+		snap43 := d2
+		snap44 := d3
+		snap45 := d4
+		snap46 := d5
+		snap47 := d24
+		snap48 := d25
+		snap49 := d26
+		alloc50 := ctx.SnapshotAllocState()
+		if !bbs[5].Rendered {
+			bbs[5].RenderPS(ps40)
+		}
+		ctx.RestoreAllocState(alloc50)
+		d0 = snap41
+		d1 = snap42
+		d2 = snap43
+		d3 = snap44
+		d4 = snap45
+		d5 = snap46
+		d24 = snap47
+		d25 = snap48
+		d26 = snap49
+		if !bbs[4].Rendered {
+			return bbs[4].RenderPS(ps39)
+		}
+		return result
+		return result
+	}
+	bbs[3].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[3].VisitCount >= 0 {
+				ps.General = true
+				return bbs[3].RenderPS(ps)
+			}
+		}
+		bbs[3].VisitCount++
+		if ps.General {
+			if bbs[3].Rendered {
+				ctx.EmitJmp(lbl4)
+				return result
+			}
+			bbs[3].Rendered = true
+			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_3 = bbs[3].Address
+			ctx.MarkLabel(lbl4)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d3)
+		var d51 JITValueDesc
+		if d3.Loc == LocImm {
+			d51 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d3.Imm.Int()) == uint64(0x0))}
+		} else {
+			r2 := ctx.AllocRegExcept(d3.Reg)
+			ctx.EmitCmpRegImm32(d3.Reg, 0)
+			d51 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondEqual}
+			ctx.BindReg(r2, &d51)
+		}
+		d52 = d51
+		ctx.EnsureDesc(&d52)
+		if d52.Loc != LocImm && d52.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d52.Loc == LocImm {
+			if d52.Imm.Bool() {
+				if ps.General {
+				}
+				ps53 := PhiState{General: ps.General}
+				ps53.OverlayValues = make([]JITValueDesc, 53)
+				ps53.OverlayValues[0] = d0
+				ps53.OverlayValues[1] = d1
+				ps53.OverlayValues[2] = d2
+				ps53.OverlayValues[3] = d3
+				ps53.OverlayValues[4] = d4
+				ps53.OverlayValues[5] = d5
+				ps53.OverlayValues[24] = d24
+				ps53.OverlayValues[25] = d25
+				ps53.OverlayValues[26] = d26
+				ps53.OverlayValues[51] = d51
+				ps53.OverlayValues[52] = d52
+				return bbs[1].RenderPS(ps53)
+			}
+			if ps.General {
+			}
+			ps54 := PhiState{General: ps.General}
+			ps54.OverlayValues = make([]JITValueDesc, 53)
+			ps54.OverlayValues[0] = d0
+			ps54.OverlayValues[1] = d1
+			ps54.OverlayValues[2] = d2
+			ps54.OverlayValues[3] = d3
+			ps54.OverlayValues[4] = d4
+			ps54.OverlayValues[5] = d5
+			ps54.OverlayValues[24] = d24
+			ps54.OverlayValues[25] = d25
+			ps54.OverlayValues[26] = d26
+			ps54.OverlayValues[51] = d51
+			ps54.OverlayValues[52] = d52
+			return bbs[2].RenderPS(ps54)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[3].RenderPS(ps)
+		}
+		ctx.EmitJump(d52.Condition, lbl2)
+		if bbs[2].Rendered {
+			ctx.EmitJmp(lbl3)
+		}
+		ctx.FreeDesc(&d51)
+		snap55 := d0
+		snap56 := d1
+		snap57 := d2
+		snap58 := d3
+		snap59 := d4
+		snap60 := d5
+		snap61 := d24
+		snap62 := d25
+		snap63 := d26
+		snap64 := d51
+		snap65 := d52
+		alloc66 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc66)
+		d0 = snap55
+		d1 = snap56
+		d2 = snap57
+		d3 = snap58
+		d4 = snap59
+		d5 = snap60
+		d24 = snap61
+		d25 = snap62
+		d26 = snap63
+		d51 = snap64
+		d52 = snap65
+		ctx.RestoreAllocState(alloc66)
+		d0 = snap55
+		d1 = snap56
+		d2 = snap57
+		d3 = snap58
+		d4 = snap59
+		d5 = snap60
+		d24 = snap61
+		d25 = snap62
+		d26 = snap63
+		d51 = snap64
+		d52 = snap65
+		ps67 := PhiState{General: true}
+		ps67.OverlayValues = make([]JITValueDesc, 53)
+		ps67.OverlayValues[0] = d0
+		ps67.OverlayValues[1] = d1
+		ps67.OverlayValues[2] = d2
+		ps67.OverlayValues[3] = d3
+		ps67.OverlayValues[4] = d4
+		ps67.OverlayValues[5] = d5
+		ps67.OverlayValues[24] = d24
+		ps67.OverlayValues[25] = d25
+		ps67.OverlayValues[26] = d26
+		ps67.OverlayValues[51] = d51
+		ps67.OverlayValues[52] = d52
+		ps68 := PhiState{General: true}
+		ps68.OverlayValues = make([]JITValueDesc, 53)
+		ps68.OverlayValues[0] = d0
+		ps68.OverlayValues[1] = d1
+		ps68.OverlayValues[2] = d2
+		ps68.OverlayValues[3] = d3
+		ps68.OverlayValues[4] = d4
+		ps68.OverlayValues[5] = d5
+		ps68.OverlayValues[24] = d24
+		ps68.OverlayValues[25] = d25
+		ps68.OverlayValues[26] = d26
+		ps68.OverlayValues[51] = d51
+		ps68.OverlayValues[52] = d52
+		snap69 := d0
+		snap70 := d1
+		snap71 := d2
+		snap72 := d3
+		snap73 := d4
+		snap74 := d5
+		snap75 := d24
+		snap76 := d25
+		snap77 := d26
+		snap78 := d51
+		snap79 := d52
+		alloc80 := ctx.SnapshotAllocState()
+		if !bbs[2].Rendered {
+			bbs[2].RenderPS(ps68)
+		}
+		ctx.RestoreAllocState(alloc80)
+		d0 = snap69
+		d1 = snap70
+		d2 = snap71
+		d3 = snap72
+		d4 = snap73
+		d5 = snap74
+		d24 = snap75
+		d25 = snap76
+		d26 = snap77
+		d51 = snap78
+		d52 = snap79
+		if !bbs[1].Rendered {
+			return bbs[1].RenderPS(ps67)
+		}
+		return result
+		return result
+	}
+	bbs[4].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[4].VisitCount >= 0 {
+				ps.General = true
+				return bbs[4].RenderPS(ps)
+			}
+		}
+		bbs[4].VisitCount++
+		if ps.General {
+			if bbs[4].Rendered {
+				ctx.EmitJmp(lbl5)
+				return result
+			}
+			bbs[4].Rendered = true
+			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_4 = bbs[4].Address
+			ctx.MarkLabel(lbl5)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		ctx.ReclaimUntrackedRegs()
+		d81 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
+		ctx.EmitMovToReg(result.Reg, d81)
+		result.Type = d81.Type
+		ctx.EmitJmp(lbl0)
+		return result
+	}
+	bbs[5].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[5].VisitCount >= 0 {
+				ps.General = true
+				return bbs[5].RenderPS(ps)
+			}
+		}
+		bbs[5].VisitCount++
+		if ps.General {
+			if bbs[5].Rendered {
+				ctx.EmitJmp(lbl6)
+				return result
+			}
+			bbs[5].Rendered = true
+			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_5 = bbs[5].Address
+			ctx.MarkLabel(lbl6)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d3)
+		var d82 JITValueDesc
+		if d3.Loc == LocImm {
+			d82 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d3.Imm.Int()) == uint64(0x0))}
+		} else {
+			r3 := ctx.AllocRegExcept(d3.Reg)
+			ctx.EmitCmpRegImm32(d3.Reg, 0)
+			d82 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r3, Condition: CondEqual}
+			ctx.BindReg(r3, &d82)
+		}
+		d83 = d82
+		ctx.EnsureDesc(&d83)
+		if d83.Loc != LocImm && d83.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d83.Loc == LocImm {
+			if d83.Imm.Bool() {
+				if ps.General {
+				}
+				ps84 := PhiState{General: ps.General}
+				ps84.OverlayValues = make([]JITValueDesc, 84)
+				ps84.OverlayValues[0] = d0
+				ps84.OverlayValues[1] = d1
+				ps84.OverlayValues[2] = d2
+				ps84.OverlayValues[3] = d3
+				ps84.OverlayValues[4] = d4
+				ps84.OverlayValues[5] = d5
+				ps84.OverlayValues[24] = d24
+				ps84.OverlayValues[25] = d25
+				ps84.OverlayValues[26] = d26
+				ps84.OverlayValues[51] = d51
+				ps84.OverlayValues[52] = d52
+				ps84.OverlayValues[81] = d81
+				ps84.OverlayValues[82] = d82
+				ps84.OverlayValues[83] = d83
+				return bbs[6].RenderPS(ps84)
+			}
+			if ps.General {
+			}
+			ps85 := PhiState{General: ps.General}
+			ps85.OverlayValues = make([]JITValueDesc, 84)
+			ps85.OverlayValues[0] = d0
+			ps85.OverlayValues[1] = d1
+			ps85.OverlayValues[2] = d2
+			ps85.OverlayValues[3] = d3
+			ps85.OverlayValues[4] = d4
+			ps85.OverlayValues[5] = d5
+			ps85.OverlayValues[24] = d24
+			ps85.OverlayValues[25] = d25
+			ps85.OverlayValues[26] = d26
+			ps85.OverlayValues[51] = d51
+			ps85.OverlayValues[52] = d52
+			ps85.OverlayValues[81] = d81
+			ps85.OverlayValues[82] = d82
+			ps85.OverlayValues[83] = d83
+			return bbs[7].RenderPS(ps85)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[5].RenderPS(ps)
+		}
+		ctx.EmitJump(d83.Condition, lbl7)
+		if bbs[7].Rendered {
+			ctx.EmitJmp(lbl8)
+		}
+		ctx.FreeDesc(&d82)
+		snap86 := d0
+		snap87 := d1
+		snap88 := d2
+		snap89 := d3
+		snap90 := d4
+		snap91 := d5
+		snap92 := d24
+		snap93 := d25
+		snap94 := d26
+		snap95 := d51
+		snap96 := d52
+		snap97 := d81
+		snap98 := d82
+		snap99 := d83
+		alloc100 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc100)
+		d0 = snap86
+		d1 = snap87
+		d2 = snap88
+		d3 = snap89
+		d4 = snap90
+		d5 = snap91
+		d24 = snap92
+		d25 = snap93
+		d26 = snap94
+		d51 = snap95
+		d52 = snap96
+		d81 = snap97
+		d82 = snap98
+		d83 = snap99
+		ctx.RestoreAllocState(alloc100)
+		d0 = snap86
+		d1 = snap87
+		d2 = snap88
+		d3 = snap89
+		d4 = snap90
+		d5 = snap91
+		d24 = snap92
+		d25 = snap93
+		d26 = snap94
+		d51 = snap95
+		d52 = snap96
+		d81 = snap97
+		d82 = snap98
+		d83 = snap99
+		ps101 := PhiState{General: true}
+		ps101.OverlayValues = make([]JITValueDesc, 84)
+		ps101.OverlayValues[0] = d0
+		ps101.OverlayValues[1] = d1
+		ps101.OverlayValues[2] = d2
+		ps101.OverlayValues[3] = d3
+		ps101.OverlayValues[4] = d4
+		ps101.OverlayValues[5] = d5
+		ps101.OverlayValues[24] = d24
+		ps101.OverlayValues[25] = d25
+		ps101.OverlayValues[26] = d26
+		ps101.OverlayValues[51] = d51
+		ps101.OverlayValues[52] = d52
+		ps101.OverlayValues[81] = d81
+		ps101.OverlayValues[82] = d82
+		ps101.OverlayValues[83] = d83
+		ps102 := PhiState{General: true}
+		ps102.OverlayValues = make([]JITValueDesc, 84)
+		ps102.OverlayValues[0] = d0
+		ps102.OverlayValues[1] = d1
+		ps102.OverlayValues[2] = d2
+		ps102.OverlayValues[3] = d3
+		ps102.OverlayValues[4] = d4
+		ps102.OverlayValues[5] = d5
+		ps102.OverlayValues[24] = d24
+		ps102.OverlayValues[25] = d25
+		ps102.OverlayValues[26] = d26
+		ps102.OverlayValues[51] = d51
+		ps102.OverlayValues[52] = d52
+		ps102.OverlayValues[81] = d81
+		ps102.OverlayValues[82] = d82
+		ps102.OverlayValues[83] = d83
+		snap103 := d0
+		snap104 := d1
+		snap105 := d2
+		snap106 := d3
+		snap107 := d4
+		snap108 := d5
+		snap109 := d24
+		snap110 := d25
+		snap111 := d26
+		snap112 := d51
+		snap113 := d52
+		snap114 := d81
+		snap115 := d82
+		snap116 := d83
+		alloc117 := ctx.SnapshotAllocState()
+		if !bbs[7].Rendered {
+			bbs[7].RenderPS(ps102)
+		}
+		ctx.RestoreAllocState(alloc117)
+		d0 = snap103
+		d1 = snap104
+		d2 = snap105
+		d3 = snap106
+		d4 = snap107
+		d5 = snap108
+		d24 = snap109
+		d25 = snap110
+		d26 = snap111
+		d51 = snap112
+		d52 = snap113
+		d81 = snap114
+		d82 = snap115
+		d83 = snap116
+		if !bbs[6].Rendered {
+			return bbs[6].RenderPS(ps101)
+		}
+		return result
+		return result
+	}
+	bbs[6].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[6].VisitCount >= 0 {
+				ps.General = true
+				return bbs[6].RenderPS(ps)
+			}
+		}
+		bbs[6].VisitCount++
+		if ps.General {
+			if bbs[6].Rendered {
+				ctx.EmitJmp(lbl7)
+				return result
+			}
+			bbs[6].Rendered = true
+			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_6 = bbs[6].Address
+			ctx.MarkLabel(lbl7)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		ctx.ReclaimUntrackedRegs()
+		d118 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+		ctx.EmitMovToReg(result.Reg, d118)
+		result.Type = d118.Type
+		ctx.EmitJmp(lbl0)
+		return result
+	}
+	bbs[7].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[7].VisitCount >= 0 {
+				ps.General = true
+				return bbs[7].RenderPS(ps)
+			}
+		}
+		bbs[7].VisitCount++
+		if ps.General {
+			if bbs[7].Rendered {
+				ctx.EmitJmp(lbl8)
+				return result
+			}
+			bbs[7].Rendered = true
+			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_7 = bbs[7].Address
+			ctx.MarkLabel(lbl8)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d1)
+		var d119 JITValueDesc
+		if d1.Loc == LocImm {
+			d119 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d1.Imm.Int()) == uint64(0x10))}
+		} else {
+			r4 := ctx.AllocRegExcept(d1.Reg)
+			ctx.EmitCmpRegImm32(d1.Reg, 16)
+			d119 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r4, Condition: CondEqual}
+			ctx.BindReg(r4, &d119)
+		}
+		d120 = d119
+		ctx.EnsureDesc(&d120)
+		if d120.Loc != LocImm && d120.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d120.Loc == LocImm {
+			if d120.Imm.Bool() {
+				if ps.General {
+				}
+				ps121 := PhiState{General: ps.General}
+				ps121.OverlayValues = make([]JITValueDesc, 121)
+				ps121.OverlayValues[0] = d0
+				ps121.OverlayValues[1] = d1
+				ps121.OverlayValues[2] = d2
+				ps121.OverlayValues[3] = d3
+				ps121.OverlayValues[4] = d4
+				ps121.OverlayValues[5] = d5
+				ps121.OverlayValues[24] = d24
+				ps121.OverlayValues[25] = d25
+				ps121.OverlayValues[26] = d26
+				ps121.OverlayValues[51] = d51
+				ps121.OverlayValues[52] = d52
+				ps121.OverlayValues[81] = d81
+				ps121.OverlayValues[82] = d82
+				ps121.OverlayValues[83] = d83
+				ps121.OverlayValues[118] = d118
+				ps121.OverlayValues[119] = d119
+				ps121.OverlayValues[120] = d120
+				return bbs[8].RenderPS(ps121)
+			}
+			if ps.General {
+			}
+			ps122 := PhiState{General: ps.General}
+			ps122.OverlayValues = make([]JITValueDesc, 121)
+			ps122.OverlayValues[0] = d0
+			ps122.OverlayValues[1] = d1
+			ps122.OverlayValues[2] = d2
+			ps122.OverlayValues[3] = d3
+			ps122.OverlayValues[4] = d4
+			ps122.OverlayValues[5] = d5
+			ps122.OverlayValues[24] = d24
+			ps122.OverlayValues[25] = d25
+			ps122.OverlayValues[26] = d26
+			ps122.OverlayValues[51] = d51
+			ps122.OverlayValues[52] = d52
+			ps122.OverlayValues[81] = d81
+			ps122.OverlayValues[82] = d82
+			ps122.OverlayValues[83] = d83
+			ps122.OverlayValues[118] = d118
+			ps122.OverlayValues[119] = d119
+			ps122.OverlayValues[120] = d120
+			return bbs[10].RenderPS(ps122)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[7].RenderPS(ps)
+		}
+		ctx.EmitJump(d120.Condition, lbl9)
+		if bbs[10].Rendered {
+			ctx.EmitJmp(lbl11)
+		}
+		ctx.FreeDesc(&d119)
+		snap123 := d0
+		snap124 := d1
+		snap125 := d2
+		snap126 := d3
+		snap127 := d4
+		snap128 := d5
+		snap129 := d24
+		snap130 := d25
+		snap131 := d26
+		snap132 := d51
+		snap133 := d52
+		snap134 := d81
+		snap135 := d82
+		snap136 := d83
+		snap137 := d118
+		snap138 := d119
+		snap139 := d120
+		alloc140 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc140)
+		d0 = snap123
+		d1 = snap124
+		d2 = snap125
+		d3 = snap126
+		d4 = snap127
+		d5 = snap128
+		d24 = snap129
+		d25 = snap130
+		d26 = snap131
+		d51 = snap132
+		d52 = snap133
+		d81 = snap134
+		d82 = snap135
+		d83 = snap136
+		d118 = snap137
+		d119 = snap138
+		d120 = snap139
+		ctx.RestoreAllocState(alloc140)
+		d0 = snap123
+		d1 = snap124
+		d2 = snap125
+		d3 = snap126
+		d4 = snap127
+		d5 = snap128
+		d24 = snap129
+		d25 = snap130
+		d26 = snap131
+		d51 = snap132
+		d52 = snap133
+		d81 = snap134
+		d82 = snap135
+		d83 = snap136
+		d118 = snap137
+		d119 = snap138
+		d120 = snap139
+		ps141 := PhiState{General: true}
+		ps141.OverlayValues = make([]JITValueDesc, 121)
+		ps141.OverlayValues[0] = d0
+		ps141.OverlayValues[1] = d1
+		ps141.OverlayValues[2] = d2
+		ps141.OverlayValues[3] = d3
+		ps141.OverlayValues[4] = d4
+		ps141.OverlayValues[5] = d5
+		ps141.OverlayValues[24] = d24
+		ps141.OverlayValues[25] = d25
+		ps141.OverlayValues[26] = d26
+		ps141.OverlayValues[51] = d51
+		ps141.OverlayValues[52] = d52
+		ps141.OverlayValues[81] = d81
+		ps141.OverlayValues[82] = d82
+		ps141.OverlayValues[83] = d83
+		ps141.OverlayValues[118] = d118
+		ps141.OverlayValues[119] = d119
+		ps141.OverlayValues[120] = d120
+		ps142 := PhiState{General: true}
+		ps142.OverlayValues = make([]JITValueDesc, 121)
+		ps142.OverlayValues[0] = d0
+		ps142.OverlayValues[1] = d1
+		ps142.OverlayValues[2] = d2
+		ps142.OverlayValues[3] = d3
+		ps142.OverlayValues[4] = d4
+		ps142.OverlayValues[5] = d5
+		ps142.OverlayValues[24] = d24
+		ps142.OverlayValues[25] = d25
+		ps142.OverlayValues[26] = d26
+		ps142.OverlayValues[51] = d51
+		ps142.OverlayValues[52] = d52
+		ps142.OverlayValues[81] = d81
+		ps142.OverlayValues[82] = d82
+		ps142.OverlayValues[83] = d83
+		ps142.OverlayValues[118] = d118
+		ps142.OverlayValues[119] = d119
+		ps142.OverlayValues[120] = d120
+		snap143 := d0
+		snap144 := d1
+		snap145 := d2
+		snap146 := d3
+		snap147 := d4
+		snap148 := d5
+		snap149 := d24
+		snap150 := d25
+		snap151 := d26
+		snap152 := d51
+		snap153 := d52
+		snap154 := d81
+		snap155 := d82
+		snap156 := d83
+		snap157 := d118
+		snap158 := d119
+		snap159 := d120
+		alloc160 := ctx.SnapshotAllocState()
+		if !bbs[10].Rendered {
+			bbs[10].RenderPS(ps142)
+		}
+		ctx.RestoreAllocState(alloc160)
+		d0 = snap143
+		d1 = snap144
+		d2 = snap145
+		d3 = snap146
+		d4 = snap147
+		d5 = snap148
+		d24 = snap149
+		d25 = snap150
+		d26 = snap151
+		d51 = snap152
+		d52 = snap153
+		d81 = snap154
+		d82 = snap155
+		d83 = snap156
+		d118 = snap157
+		d119 = snap158
+		d120 = snap159
+		if !bbs[8].Rendered {
+			return bbs[8].RenderPS(ps141)
+		}
+		return result
+		return result
+	}
+	bbs[8].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[8].VisitCount >= 0 {
+				ps.General = true
+				return bbs[8].RenderPS(ps)
+			}
+		}
+		bbs[8].VisitCount++
+		if ps.General {
+			if bbs[8].Rendered {
+				ctx.EmitJmp(lbl9)
+				return result
+			}
+			bbs[8].Rendered = true
+			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_8 = bbs[8].Address
+			ctx.MarkLabel(lbl9)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d3)
+		var d161 JITValueDesc
+		if d3.Loc == LocImm {
+			d161 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d3.Imm.Int()) == uint64(0x1))}
+		} else {
+			r5 := ctx.AllocRegExcept(d3.Reg)
+			ctx.EmitCmpRegImm32(d3.Reg, 1)
+			d161 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r5, Condition: CondEqual}
+			ctx.BindReg(r5, &d161)
+		}
+		d162 = d161
+		ctx.EnsureDesc(&d162)
+		if d162.Loc != LocImm && d162.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d162.Loc == LocImm {
+			if d162.Imm.Bool() {
+				if ps.General {
+				}
+				ps163 := PhiState{General: ps.General}
+				ps163.OverlayValues = make([]JITValueDesc, 163)
+				ps163.OverlayValues[0] = d0
+				ps163.OverlayValues[1] = d1
+				ps163.OverlayValues[2] = d2
+				ps163.OverlayValues[3] = d3
+				ps163.OverlayValues[4] = d4
+				ps163.OverlayValues[5] = d5
+				ps163.OverlayValues[24] = d24
+				ps163.OverlayValues[25] = d25
+				ps163.OverlayValues[26] = d26
+				ps163.OverlayValues[51] = d51
+				ps163.OverlayValues[52] = d52
+				ps163.OverlayValues[81] = d81
+				ps163.OverlayValues[82] = d82
+				ps163.OverlayValues[83] = d83
+				ps163.OverlayValues[118] = d118
+				ps163.OverlayValues[119] = d119
+				ps163.OverlayValues[120] = d120
+				ps163.OverlayValues[161] = d161
+				ps163.OverlayValues[162] = d162
+				return bbs[11].RenderPS(ps163)
+			}
+			if ps.General {
+			}
+			ps164 := PhiState{General: ps.General}
+			ps164.OverlayValues = make([]JITValueDesc, 163)
+			ps164.OverlayValues[0] = d0
+			ps164.OverlayValues[1] = d1
+			ps164.OverlayValues[2] = d2
+			ps164.OverlayValues[3] = d3
+			ps164.OverlayValues[4] = d4
+			ps164.OverlayValues[5] = d5
+			ps164.OverlayValues[24] = d24
+			ps164.OverlayValues[25] = d25
+			ps164.OverlayValues[26] = d26
+			ps164.OverlayValues[51] = d51
+			ps164.OverlayValues[52] = d52
+			ps164.OverlayValues[81] = d81
+			ps164.OverlayValues[82] = d82
+			ps164.OverlayValues[83] = d83
+			ps164.OverlayValues[118] = d118
+			ps164.OverlayValues[119] = d119
+			ps164.OverlayValues[120] = d120
+			ps164.OverlayValues[161] = d161
+			ps164.OverlayValues[162] = d162
+			return bbs[13].RenderPS(ps164)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[8].RenderPS(ps)
+		}
+		ctx.EmitJump(d162.Condition, lbl12)
+		if bbs[13].Rendered {
+			ctx.EmitJmp(lbl14)
+		}
+		ctx.FreeDesc(&d161)
+		snap165 := d0
+		snap166 := d1
+		snap167 := d2
+		snap168 := d3
+		snap169 := d4
+		snap170 := d5
+		snap171 := d24
+		snap172 := d25
+		snap173 := d26
+		snap174 := d51
+		snap175 := d52
+		snap176 := d81
+		snap177 := d82
+		snap178 := d83
+		snap179 := d118
+		snap180 := d119
+		snap181 := d120
+		snap182 := d161
+		snap183 := d162
+		alloc184 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc184)
+		d0 = snap165
+		d1 = snap166
+		d2 = snap167
+		d3 = snap168
+		d4 = snap169
+		d5 = snap170
+		d24 = snap171
+		d25 = snap172
+		d26 = snap173
+		d51 = snap174
+		d52 = snap175
+		d81 = snap176
+		d82 = snap177
+		d83 = snap178
+		d118 = snap179
+		d119 = snap180
+		d120 = snap181
+		d161 = snap182
+		d162 = snap183
+		ctx.RestoreAllocState(alloc184)
+		d0 = snap165
+		d1 = snap166
+		d2 = snap167
+		d3 = snap168
+		d4 = snap169
+		d5 = snap170
+		d24 = snap171
+		d25 = snap172
+		d26 = snap173
+		d51 = snap174
+		d52 = snap175
+		d81 = snap176
+		d82 = snap177
+		d83 = snap178
+		d118 = snap179
+		d119 = snap180
+		d120 = snap181
+		d161 = snap182
+		d162 = snap183
+		ps185 := PhiState{General: true}
+		ps185.OverlayValues = make([]JITValueDesc, 163)
+		ps185.OverlayValues[0] = d0
+		ps185.OverlayValues[1] = d1
+		ps185.OverlayValues[2] = d2
+		ps185.OverlayValues[3] = d3
+		ps185.OverlayValues[4] = d4
+		ps185.OverlayValues[5] = d5
+		ps185.OverlayValues[24] = d24
+		ps185.OverlayValues[25] = d25
+		ps185.OverlayValues[26] = d26
+		ps185.OverlayValues[51] = d51
+		ps185.OverlayValues[52] = d52
+		ps185.OverlayValues[81] = d81
+		ps185.OverlayValues[82] = d82
+		ps185.OverlayValues[83] = d83
+		ps185.OverlayValues[118] = d118
+		ps185.OverlayValues[119] = d119
+		ps185.OverlayValues[120] = d120
+		ps185.OverlayValues[161] = d161
+		ps185.OverlayValues[162] = d162
+		ps186 := PhiState{General: true}
+		ps186.OverlayValues = make([]JITValueDesc, 163)
+		ps186.OverlayValues[0] = d0
+		ps186.OverlayValues[1] = d1
+		ps186.OverlayValues[2] = d2
+		ps186.OverlayValues[3] = d3
+		ps186.OverlayValues[4] = d4
+		ps186.OverlayValues[5] = d5
+		ps186.OverlayValues[24] = d24
+		ps186.OverlayValues[25] = d25
+		ps186.OverlayValues[26] = d26
+		ps186.OverlayValues[51] = d51
+		ps186.OverlayValues[52] = d52
+		ps186.OverlayValues[81] = d81
+		ps186.OverlayValues[82] = d82
+		ps186.OverlayValues[83] = d83
+		ps186.OverlayValues[118] = d118
+		ps186.OverlayValues[119] = d119
+		ps186.OverlayValues[120] = d120
+		ps186.OverlayValues[161] = d161
+		ps186.OverlayValues[162] = d162
+		snap187 := d0
+		snap188 := d1
+		snap189 := d2
+		snap190 := d3
+		snap191 := d4
+		snap192 := d5
+		snap193 := d24
+		snap194 := d25
+		snap195 := d26
+		snap196 := d51
+		snap197 := d52
+		snap198 := d81
+		snap199 := d82
+		snap200 := d83
+		snap201 := d118
+		snap202 := d119
+		snap203 := d120
+		snap204 := d161
+		snap205 := d162
+		alloc206 := ctx.SnapshotAllocState()
+		if !bbs[13].Rendered {
+			bbs[13].RenderPS(ps186)
+		}
+		ctx.RestoreAllocState(alloc206)
+		d0 = snap187
+		d1 = snap188
+		d2 = snap189
+		d3 = snap190
+		d4 = snap191
+		d5 = snap192
+		d24 = snap193
+		d25 = snap194
+		d26 = snap195
+		d51 = snap196
+		d52 = snap197
+		d81 = snap198
+		d82 = snap199
+		d83 = snap200
+		d118 = snap201
+		d119 = snap202
+		d120 = snap203
+		d161 = snap204
+		d162 = snap205
+		if !bbs[11].Rendered {
+			return bbs[11].RenderPS(ps185)
+		}
+		return result
+		return result
+	}
+	bbs[9].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[9].VisitCount >= 0 {
+				ps.General = true
+				return bbs[9].RenderPS(ps)
+			}
+		}
+		bbs[9].VisitCount++
+		if ps.General {
+			if bbs[9].Rendered {
+				ctx.EmitJmp(lbl10)
+				return result
+			}
+			bbs[9].Rendered = true
+			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_9 = bbs[9].Address
+			ctx.MarkLabel(lbl10)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		ctx.ReclaimUntrackedRegs()
+		var d207 JITValueDesc
+		if args[0].Loc == LocImm {
+			d207 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(args[0].Imm.Int())}
+		} else if args[0].Type == tagInt && args[0].Loc == LocRegPair {
+			ctx.FreeReg(args[0].Reg)
+			d207 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[0].Reg2}
+			ctx.BindReg(args[0].Reg2, &d207)
+		} else if args[0].Type == tagInt && args[0].Loc == LocReg {
+			d207 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[0].Reg}
+			ctx.BindReg(args[0].Reg, &d207)
+		} else {
+			d207 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{args[0]}, 1)
+			d207.Type = tagInt
+			ctx.BindReg(d207.Reg, &d207)
+		}
+		ctx.EnsureDesc(&d207)
+		ctx.EnsureDesc(&d207)
+		var d208 JITValueDesc
+		if d207.Loc == LocImm {
+			d208 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d207.Imm.Int()))}
+		} else {
+			var r6 Reg
+			r6 = d207.Reg
+			d207.Loc = LocNone
+			ctx.EmitCvtInt64ToFloat64(RegX0, r6)
+			d208 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r6}
+			ctx.BindReg(r6, &d208)
+		}
+		ctx.FreeDesc(&d207)
+		var d209 JITValueDesc
+		if args[1].Loc == LocImm {
+			d209 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(args[1].Imm.Float())}
+		} else if args[1].Type == tagFloat && args[1].Loc == LocReg {
+			d209 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg}
+			ctx.BindReg(args[1].Reg, &d209)
+		} else if args[1].Type == tagFloat && args[1].Loc == LocRegPair {
+			ctx.FreeReg(args[1].Reg)
+			d209 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg2}
+			ctx.BindReg(args[1].Reg2, &d209)
+		} else {
+			d209 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{args[1]}, 1)
+			d209.Type = tagFloat
+			ctx.BindReg(d209.Reg, &d209)
+		}
+		ctx.EnsureDesc(&d208)
+		resultTarget210 := false
+		_ = resultTarget210
+		ctx.EnsureDesc(&d209)
+		ctx.EnsureDescsTogether(&d208, &d209)
+		var d211 JITValueDesc
+		if d208.Loc == LocImm && d209.Loc == LocImm {
+			d211 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d208.Imm.Float() < d209.Imm.Float())}
+		} else if d209.Loc == LocImm {
+			var r7 Reg
+			if result.Loc == LocReg && result.Reg != d208.Reg {
+				r7 = result.Reg
+				resultTarget210 = true
+			} else {
+				r7 = ctx.AllocRegExcept(d208.Reg)
+			}
+			_, yBits := d209.Imm.RawWords()
+			ctx.EmitMovRegImm64(RegR11, yBits)
+			ctx.EmitCmpFloat64Setcc(r7, d208.Reg, RegR11, CondSignedLess)
+			d211 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r7}
+			ctx.BindReg(r7, &d211)
+		} else if d208.Loc == LocImm {
+			var r8 Reg
+			if result.Loc == LocReg && result.Reg != d209.Reg {
+				r8 = result.Reg
+				resultTarget210 = true
+			} else {
+				r8 = ctx.AllocRegExcept(d209.Reg)
+			}
+			_, xBits := d208.Imm.RawWords()
+			ctx.EmitMovRegImm64(RegR11, xBits)
+			ctx.EmitCmpFloat64Setcc(r8, RegR11, d209.Reg, CondSignedLess)
+			d211 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r8}
+			ctx.BindReg(r8, &d211)
+		} else {
+			var r9 Reg
+			if result.Loc == LocReg && result.Reg != d208.Reg && result.Reg != d209.Reg {
+				r9 = result.Reg
+				resultTarget210 = true
+			} else {
+				r9 = ctx.AllocRegExcept(d208.Reg, d209.Reg)
+			}
+			ctx.EmitCmpFloat64Setcc(r9, d208.Reg, d209.Reg, CondSignedLess)
+			d211 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r9}
+			ctx.BindReg(r9, &d211)
+		}
+		ctx.FreeDesc(&d208)
+		ctx.FreeDesc(&d209)
+		ctx.EnsureDesc(&d211)
+		ctx.EmitMovToReg(result.Reg, d211)
+		result.Type = d211.Type
+		ctx.EmitJmp(lbl0)
+		return result
+	}
+	bbs[10].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[10].VisitCount >= 0 {
+				ps.General = true
+				return bbs[10].RenderPS(ps)
+			}
+		}
+		bbs[10].VisitCount++
+		if ps.General {
+			if bbs[10].Rendered {
+				ctx.EmitJmp(lbl11)
+				return result
+			}
+			bbs[10].Rendered = true
+			bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_10 = bbs[10].Address
+			ctx.MarkLabel(lbl11)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d1)
+		var d212 JITValueDesc
+		if d1.Loc == LocImm {
+			d212 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d1.Imm.Int()) == uint64(0x4))}
+		} else {
+			r10 := ctx.AllocRegExcept(d1.Reg)
+			ctx.EmitCmpRegImm32(d1.Reg, 4)
+			d212 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r10, Condition: CondEqual}
+			ctx.BindReg(r10, &d212)
+		}
+		d213 = d212
+		ctx.EnsureDesc(&d213)
+		if d213.Loc != LocImm && d213.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d213.Loc == LocImm {
+			if d213.Imm.Bool() {
+				if ps.General {
+				}
+				ps214 := PhiState{General: ps.General}
+				ps214.OverlayValues = make([]JITValueDesc, 214)
+				ps214.OverlayValues[0] = d0
+				ps214.OverlayValues[1] = d1
+				ps214.OverlayValues[2] = d2
+				ps214.OverlayValues[3] = d3
+				ps214.OverlayValues[4] = d4
+				ps214.OverlayValues[5] = d5
+				ps214.OverlayValues[24] = d24
+				ps214.OverlayValues[25] = d25
+				ps214.OverlayValues[26] = d26
+				ps214.OverlayValues[51] = d51
+				ps214.OverlayValues[52] = d52
+				ps214.OverlayValues[81] = d81
+				ps214.OverlayValues[82] = d82
+				ps214.OverlayValues[83] = d83
+				ps214.OverlayValues[118] = d118
+				ps214.OverlayValues[119] = d119
+				ps214.OverlayValues[120] = d120
+				ps214.OverlayValues[161] = d161
+				ps214.OverlayValues[162] = d162
+				ps214.OverlayValues[207] = d207
+				ps214.OverlayValues[208] = d208
+				ps214.OverlayValues[209] = d209
+				ps214.OverlayValues[211] = d211
+				ps214.OverlayValues[212] = d212
+				ps214.OverlayValues[213] = d213
+				return bbs[9].RenderPS(ps214)
+			}
+			if ps.General {
+			}
+			ps215 := PhiState{General: ps.General}
+			ps215.OverlayValues = make([]JITValueDesc, 214)
+			ps215.OverlayValues[0] = d0
+			ps215.OverlayValues[1] = d1
+			ps215.OverlayValues[2] = d2
+			ps215.OverlayValues[3] = d3
+			ps215.OverlayValues[4] = d4
+			ps215.OverlayValues[5] = d5
+			ps215.OverlayValues[24] = d24
+			ps215.OverlayValues[25] = d25
+			ps215.OverlayValues[26] = d26
+			ps215.OverlayValues[51] = d51
+			ps215.OverlayValues[52] = d52
+			ps215.OverlayValues[81] = d81
+			ps215.OverlayValues[82] = d82
+			ps215.OverlayValues[83] = d83
+			ps215.OverlayValues[118] = d118
+			ps215.OverlayValues[119] = d119
+			ps215.OverlayValues[120] = d120
+			ps215.OverlayValues[161] = d161
+			ps215.OverlayValues[162] = d162
+			ps215.OverlayValues[207] = d207
+			ps215.OverlayValues[208] = d208
+			ps215.OverlayValues[209] = d209
+			ps215.OverlayValues[211] = d211
+			ps215.OverlayValues[212] = d212
+			ps215.OverlayValues[213] = d213
+			return bbs[16].RenderPS(ps215)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[10].RenderPS(ps)
+		}
+		ctx.EmitJump(d213.Condition, lbl10)
+		if bbs[16].Rendered {
+			ctx.EmitJmp(lbl17)
+		}
+		ctx.FreeDesc(&d212)
+		snap216 := d0
+		snap217 := d1
+		snap218 := d2
+		snap219 := d3
+		snap220 := d4
+		snap221 := d5
+		snap222 := d24
+		snap223 := d25
+		snap224 := d26
+		snap225 := d51
+		snap226 := d52
+		snap227 := d81
+		snap228 := d82
+		snap229 := d83
+		snap230 := d118
+		snap231 := d119
+		snap232 := d120
+		snap233 := d161
+		snap234 := d162
+		snap235 := d207
+		snap236 := d208
+		snap237 := d209
+		snap238 := d211
+		snap239 := d212
+		snap240 := d213
+		alloc241 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc241)
+		d0 = snap216
+		d1 = snap217
+		d2 = snap218
+		d3 = snap219
+		d4 = snap220
+		d5 = snap221
+		d24 = snap222
+		d25 = snap223
+		d26 = snap224
+		d51 = snap225
+		d52 = snap226
+		d81 = snap227
+		d82 = snap228
+		d83 = snap229
+		d118 = snap230
+		d119 = snap231
+		d120 = snap232
+		d161 = snap233
+		d162 = snap234
+		d207 = snap235
+		d208 = snap236
+		d209 = snap237
+		d211 = snap238
+		d212 = snap239
+		d213 = snap240
+		ctx.RestoreAllocState(alloc241)
+		d0 = snap216
+		d1 = snap217
+		d2 = snap218
+		d3 = snap219
+		d4 = snap220
+		d5 = snap221
+		d24 = snap222
+		d25 = snap223
+		d26 = snap224
+		d51 = snap225
+		d52 = snap226
+		d81 = snap227
+		d82 = snap228
+		d83 = snap229
+		d118 = snap230
+		d119 = snap231
+		d120 = snap232
+		d161 = snap233
+		d162 = snap234
+		d207 = snap235
+		d208 = snap236
+		d209 = snap237
+		d211 = snap238
+		d212 = snap239
+		d213 = snap240
+		ps242 := PhiState{General: true}
+		ps242.OverlayValues = make([]JITValueDesc, 214)
+		ps242.OverlayValues[0] = d0
+		ps242.OverlayValues[1] = d1
+		ps242.OverlayValues[2] = d2
+		ps242.OverlayValues[3] = d3
+		ps242.OverlayValues[4] = d4
+		ps242.OverlayValues[5] = d5
+		ps242.OverlayValues[24] = d24
+		ps242.OverlayValues[25] = d25
+		ps242.OverlayValues[26] = d26
+		ps242.OverlayValues[51] = d51
+		ps242.OverlayValues[52] = d52
+		ps242.OverlayValues[81] = d81
+		ps242.OverlayValues[82] = d82
+		ps242.OverlayValues[83] = d83
+		ps242.OverlayValues[118] = d118
+		ps242.OverlayValues[119] = d119
+		ps242.OverlayValues[120] = d120
+		ps242.OverlayValues[161] = d161
+		ps242.OverlayValues[162] = d162
+		ps242.OverlayValues[207] = d207
+		ps242.OverlayValues[208] = d208
+		ps242.OverlayValues[209] = d209
+		ps242.OverlayValues[211] = d211
+		ps242.OverlayValues[212] = d212
+		ps242.OverlayValues[213] = d213
+		ps243 := PhiState{General: true}
+		ps243.OverlayValues = make([]JITValueDesc, 214)
+		ps243.OverlayValues[0] = d0
+		ps243.OverlayValues[1] = d1
+		ps243.OverlayValues[2] = d2
+		ps243.OverlayValues[3] = d3
+		ps243.OverlayValues[4] = d4
+		ps243.OverlayValues[5] = d5
+		ps243.OverlayValues[24] = d24
+		ps243.OverlayValues[25] = d25
+		ps243.OverlayValues[26] = d26
+		ps243.OverlayValues[51] = d51
+		ps243.OverlayValues[52] = d52
+		ps243.OverlayValues[81] = d81
+		ps243.OverlayValues[82] = d82
+		ps243.OverlayValues[83] = d83
+		ps243.OverlayValues[118] = d118
+		ps243.OverlayValues[119] = d119
+		ps243.OverlayValues[120] = d120
+		ps243.OverlayValues[161] = d161
+		ps243.OverlayValues[162] = d162
+		ps243.OverlayValues[207] = d207
+		ps243.OverlayValues[208] = d208
+		ps243.OverlayValues[209] = d209
+		ps243.OverlayValues[211] = d211
+		ps243.OverlayValues[212] = d212
+		ps243.OverlayValues[213] = d213
+		snap244 := d0
+		snap245 := d1
+		snap246 := d2
+		snap247 := d3
+		snap248 := d4
+		snap249 := d5
+		snap250 := d24
+		snap251 := d25
+		snap252 := d26
+		snap253 := d51
+		snap254 := d52
+		snap255 := d81
+		snap256 := d82
+		snap257 := d83
+		snap258 := d118
+		snap259 := d119
+		snap260 := d120
+		snap261 := d161
+		snap262 := d162
+		snap263 := d207
+		snap264 := d208
+		snap265 := d209
+		snap266 := d211
+		snap267 := d212
+		snap268 := d213
+		alloc269 := ctx.SnapshotAllocState()
+		if !bbs[16].Rendered {
+			bbs[16].RenderPS(ps243)
+		}
+		ctx.RestoreAllocState(alloc269)
+		d0 = snap244
+		d1 = snap245
+		d2 = snap246
+		d3 = snap247
+		d4 = snap248
+		d5 = snap249
+		d24 = snap250
+		d25 = snap251
+		d26 = snap252
+		d51 = snap253
+		d52 = snap254
+		d81 = snap255
+		d82 = snap256
+		d83 = snap257
+		d118 = snap258
+		d119 = snap259
+		d120 = snap260
+		d161 = snap261
+		d162 = snap262
+		d207 = snap263
+		d208 = snap264
+		d209 = snap265
+		d211 = snap266
+		d212 = snap267
+		d213 = snap268
+		if !bbs[9].Rendered {
+			return bbs[9].RenderPS(ps242)
+		}
+		return result
+		return result
+	}
+	bbs[11].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[11].VisitCount >= 0 {
+				ps.General = true
+				return bbs[11].RenderPS(ps)
+			}
+		}
+		bbs[11].VisitCount++
+		if ps.General {
+			if bbs[11].Rendered {
+				ctx.EmitJmp(lbl12)
+				return result
+			}
+			bbs[11].Rendered = true
+			bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_11 = bbs[11].Address
+			ctx.MarkLabel(lbl12)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
+			d212 = ps.OverlayValues[212]
+		}
+		if len(ps.OverlayValues) > 213 && ps.OverlayValues[213].Loc != LocNone {
+			d213 = ps.OverlayValues[213]
+		}
+		ctx.ReclaimUntrackedRegs()
+		d271 = args[1]
+		ctx.SyncDesc(&d271)
+		if d271.Loc == LocMem {
+			tmpScalar := JITValueDesc{Loc: LocReg, Type: d271.Type, Reg: ctx.AllocReg()}
+			scratch := ctx.AllocRegExcept(tmpScalar.Reg)
+			ctx.EmitMovRegImm64(scratch, uint64(d271.MemPtr))
+			ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
+			ctx.FreeReg(scratch)
+			ctx.BindReg(tmpScalar.Reg, &tmpScalar)
+			d271 = tmpScalar
+		}
+		d271 = JITPrepareScmerGoArg(ctx, d271)
+		if d271.Loc != LocRegPair && d271.Loc != LocStackPair && d271.Loc != LocInputPair {
+			panic("jit: Scmer.String receiver not materialized as pair")
+		}
+		d270 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d271}, 2)
+		ctx.EnsureDesc(&d270)
+		if d270.Loc == LocImm {
+			tmpPair := JITValueDesc{Loc: LocRegPair, Type: d270.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+			ctx.TrackImm(d270.Imm)
+			ptrWord, _ := d270.Imm.RawWords()
+			ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
+			ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d270.Imm.String())))
+			d270 = tmpPair
+		} else if d270.Loc == LocReg {
+			tmpPair := JITValueDesc{Loc: LocRegPair, Type: d270.Type, Reg: ctx.AllocRegExcept(d270.Reg), Reg2: ctx.AllocRegExcept(d270.Reg)}
+			switch d270.Type {
+			case tagBool:
+				ctx.EmitMakeBool(tmpPair, d270)
+			case tagInt:
+				ctx.EmitMakeInt(tmpPair, d270)
+			case tagFloat:
+				ctx.EmitMakeFloat(tmpPair, d270)
+			default:
+				panic("jit: generic call arg scalar type unknown for 2-word value")
+			}
+			ctx.FreeDesc(&d270)
+			d270 = tmpPair
+		}
+		if d270.Loc != LocRegPair && d270.Loc != LocStackPair && d270.Loc != LocInputPair {
+			panic("jit: generic call arg expects 2-word value (ParseDateString arg0)")
+		}
+		ctx.SyncDesc(&d270)
+		callResults272 := JITEmitGoCallResults(ctx, GoFuncAddr(ParseDateString), []JITValueDesc{d270}, []uint8{1, 1}, []uint8{0, 0})
+		d273 = callResults272[0]
+		_ = d273
+		d274 = callResults272[1]
+		_ = d274
+		ctx.StabilizeDescForControlFlow(&d273)
+		d275 = d274
+		ctx.EnsureDesc(&d275)
+		if d275.Loc != LocImm && d275.Loc != LocReg {
+			panic("jit: If condition is neither LocImm nor LocReg")
+		}
+		if d275.Loc == LocImm {
+			if d275.Imm.Bool() {
+				if ps.General {
+				}
+				ps276 := PhiState{General: ps.General}
+				ps276.OverlayValues = make([]JITValueDesc, 276)
+				ps276.OverlayValues[0] = d0
+				ps276.OverlayValues[1] = d1
+				ps276.OverlayValues[2] = d2
+				ps276.OverlayValues[3] = d3
+				ps276.OverlayValues[4] = d4
+				ps276.OverlayValues[5] = d5
+				ps276.OverlayValues[24] = d24
+				ps276.OverlayValues[25] = d25
+				ps276.OverlayValues[26] = d26
+				ps276.OverlayValues[51] = d51
+				ps276.OverlayValues[52] = d52
+				ps276.OverlayValues[81] = d81
+				ps276.OverlayValues[82] = d82
+				ps276.OverlayValues[83] = d83
+				ps276.OverlayValues[118] = d118
+				ps276.OverlayValues[119] = d119
+				ps276.OverlayValues[120] = d120
+				ps276.OverlayValues[161] = d161
+				ps276.OverlayValues[162] = d162
+				ps276.OverlayValues[207] = d207
+				ps276.OverlayValues[208] = d208
+				ps276.OverlayValues[209] = d209
+				ps276.OverlayValues[211] = d211
+				ps276.OverlayValues[212] = d212
+				ps276.OverlayValues[213] = d213
+				ps276.OverlayValues[270] = d270
+				ps276.OverlayValues[271] = d271
+				ps276.OverlayValues[273] = d273
+				ps276.OverlayValues[274] = d274
+				ps276.OverlayValues[275] = d275
+				return bbs[14].RenderPS(ps276)
+			}
+			if ps.General {
+			}
+			ps277 := PhiState{General: ps.General}
+			ps277.OverlayValues = make([]JITValueDesc, 276)
+			ps277.OverlayValues[0] = d0
+			ps277.OverlayValues[1] = d1
+			ps277.OverlayValues[2] = d2
+			ps277.OverlayValues[3] = d3
+			ps277.OverlayValues[4] = d4
+			ps277.OverlayValues[5] = d5
+			ps277.OverlayValues[24] = d24
+			ps277.OverlayValues[25] = d25
+			ps277.OverlayValues[26] = d26
+			ps277.OverlayValues[51] = d51
+			ps277.OverlayValues[52] = d52
+			ps277.OverlayValues[81] = d81
+			ps277.OverlayValues[82] = d82
+			ps277.OverlayValues[83] = d83
+			ps277.OverlayValues[118] = d118
+			ps277.OverlayValues[119] = d119
+			ps277.OverlayValues[120] = d120
+			ps277.OverlayValues[161] = d161
+			ps277.OverlayValues[162] = d162
+			ps277.OverlayValues[207] = d207
+			ps277.OverlayValues[208] = d208
+			ps277.OverlayValues[209] = d209
+			ps277.OverlayValues[211] = d211
+			ps277.OverlayValues[212] = d212
+			ps277.OverlayValues[213] = d213
+			ps277.OverlayValues[270] = d270
+			ps277.OverlayValues[271] = d271
+			ps277.OverlayValues[273] = d273
+			ps277.OverlayValues[274] = d274
+			ps277.OverlayValues[275] = d275
+			return bbs[12].RenderPS(ps277)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[11].RenderPS(ps)
+		}
+		ctx.EmitCmpRegImm32(d275.Reg, 0)
+		ctx.EmitJump(CondNotEqual, lbl15)
+		if bbs[12].Rendered {
+			ctx.EmitJmp(lbl13)
+		}
+		snap278 := d0
+		snap279 := d1
+		snap280 := d2
+		snap281 := d3
+		snap282 := d4
+		snap283 := d5
+		snap284 := d24
+		snap285 := d25
+		snap286 := d26
+		snap287 := d51
+		snap288 := d52
+		snap289 := d81
+		snap290 := d82
+		snap291 := d83
+		snap292 := d118
+		snap293 := d119
+		snap294 := d120
+		snap295 := d161
+		snap296 := d162
+		snap297 := d207
+		snap298 := d208
+		snap299 := d209
+		snap300 := d211
+		snap301 := d212
+		snap302 := d213
+		snap303 := d270
+		snap304 := d271
+		snap305 := d273
+		snap306 := d274
+		snap307 := d275
+		alloc308 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc308)
+		d0 = snap278
+		d1 = snap279
+		d2 = snap280
+		d3 = snap281
+		d4 = snap282
+		d5 = snap283
+		d24 = snap284
+		d25 = snap285
+		d26 = snap286
+		d51 = snap287
+		d52 = snap288
+		d81 = snap289
+		d82 = snap290
+		d83 = snap291
+		d118 = snap292
+		d119 = snap293
+		d120 = snap294
+		d161 = snap295
+		d162 = snap296
+		d207 = snap297
+		d208 = snap298
+		d209 = snap299
+		d211 = snap300
+		d212 = snap301
+		d213 = snap302
+		d270 = snap303
+		d271 = snap304
+		d273 = snap305
+		d274 = snap306
+		d275 = snap307
+		ctx.RestoreAllocState(alloc308)
+		d0 = snap278
+		d1 = snap279
+		d2 = snap280
+		d3 = snap281
+		d4 = snap282
+		d5 = snap283
+		d24 = snap284
+		d25 = snap285
+		d26 = snap286
+		d51 = snap287
+		d52 = snap288
+		d81 = snap289
+		d82 = snap290
+		d83 = snap291
+		d118 = snap292
+		d119 = snap293
+		d120 = snap294
+		d161 = snap295
+		d162 = snap296
+		d207 = snap297
+		d208 = snap298
+		d209 = snap299
+		d211 = snap300
+		d212 = snap301
+		d213 = snap302
+		d270 = snap303
+		d271 = snap304
+		d273 = snap305
+		d274 = snap306
+		d275 = snap307
+		ps309 := PhiState{General: true}
+		ps309.OverlayValues = make([]JITValueDesc, 276)
+		ps309.OverlayValues[0] = d0
+		ps309.OverlayValues[1] = d1
+		ps309.OverlayValues[2] = d2
+		ps309.OverlayValues[3] = d3
+		ps309.OverlayValues[4] = d4
+		ps309.OverlayValues[5] = d5
+		ps309.OverlayValues[24] = d24
+		ps309.OverlayValues[25] = d25
+		ps309.OverlayValues[26] = d26
+		ps309.OverlayValues[51] = d51
+		ps309.OverlayValues[52] = d52
+		ps309.OverlayValues[81] = d81
+		ps309.OverlayValues[82] = d82
+		ps309.OverlayValues[83] = d83
+		ps309.OverlayValues[118] = d118
+		ps309.OverlayValues[119] = d119
+		ps309.OverlayValues[120] = d120
+		ps309.OverlayValues[161] = d161
+		ps309.OverlayValues[162] = d162
+		ps309.OverlayValues[207] = d207
+		ps309.OverlayValues[208] = d208
+		ps309.OverlayValues[209] = d209
+		ps309.OverlayValues[211] = d211
+		ps309.OverlayValues[212] = d212
+		ps309.OverlayValues[213] = d213
+		ps309.OverlayValues[270] = d270
+		ps309.OverlayValues[271] = d271
+		ps309.OverlayValues[273] = d273
+		ps309.OverlayValues[274] = d274
+		ps309.OverlayValues[275] = d275
+		ps310 := PhiState{General: true}
+		ps310.OverlayValues = make([]JITValueDesc, 276)
+		ps310.OverlayValues[0] = d0
+		ps310.OverlayValues[1] = d1
+		ps310.OverlayValues[2] = d2
+		ps310.OverlayValues[3] = d3
+		ps310.OverlayValues[4] = d4
+		ps310.OverlayValues[5] = d5
+		ps310.OverlayValues[24] = d24
+		ps310.OverlayValues[25] = d25
+		ps310.OverlayValues[26] = d26
+		ps310.OverlayValues[51] = d51
+		ps310.OverlayValues[52] = d52
+		ps310.OverlayValues[81] = d81
+		ps310.OverlayValues[82] = d82
+		ps310.OverlayValues[83] = d83
+		ps310.OverlayValues[118] = d118
+		ps310.OverlayValues[119] = d119
+		ps310.OverlayValues[120] = d120
+		ps310.OverlayValues[161] = d161
+		ps310.OverlayValues[162] = d162
+		ps310.OverlayValues[207] = d207
+		ps310.OverlayValues[208] = d208
+		ps310.OverlayValues[209] = d209
+		ps310.OverlayValues[211] = d211
+		ps310.OverlayValues[212] = d212
+		ps310.OverlayValues[213] = d213
+		ps310.OverlayValues[270] = d270
+		ps310.OverlayValues[271] = d271
+		ps310.OverlayValues[273] = d273
+		ps310.OverlayValues[274] = d274
+		ps310.OverlayValues[275] = d275
+		snap311 := d0
+		snap312 := d1
+		snap313 := d2
+		snap314 := d3
+		snap315 := d4
+		snap316 := d5
+		snap317 := d24
+		snap318 := d25
+		snap319 := d26
+		snap320 := d51
+		snap321 := d52
+		snap322 := d81
+		snap323 := d82
+		snap324 := d83
+		snap325 := d118
+		snap326 := d119
+		snap327 := d120
+		snap328 := d161
+		snap329 := d162
+		snap330 := d207
+		snap331 := d208
+		snap332 := d209
+		snap333 := d211
+		snap334 := d212
+		snap335 := d213
+		snap336 := d270
+		snap337 := d271
+		snap338 := d273
+		snap339 := d274
+		snap340 := d275
+		alloc341 := ctx.SnapshotAllocState()
+		if !bbs[12].Rendered {
+			bbs[12].RenderPS(ps310)
+		}
+		ctx.RestoreAllocState(alloc341)
+		d0 = snap311
+		d1 = snap312
+		d2 = snap313
+		d3 = snap314
+		d4 = snap315
+		d5 = snap316
+		d24 = snap317
+		d25 = snap318
+		d26 = snap319
+		d51 = snap320
+		d52 = snap321
+		d81 = snap322
+		d82 = snap323
+		d83 = snap324
+		d118 = snap325
+		d119 = snap326
+		d120 = snap327
+		d161 = snap328
+		d162 = snap329
+		d207 = snap330
+		d208 = snap331
+		d209 = snap332
+		d211 = snap333
+		d212 = snap334
+		d213 = snap335
+		d270 = snap336
+		d271 = snap337
+		d273 = snap338
+		d274 = snap339
+		d275 = snap340
+		if !bbs[14].Rendered {
+			return bbs[14].RenderPS(ps309)
+		}
+		return result
+		ctx.FreeDesc(&d274)
+		return result
+	}
+	bbs[12].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[12].VisitCount >= 0 {
+				ps.General = true
+				return bbs[12].RenderPS(ps)
+			}
+		}
+		bbs[12].VisitCount++
+		if ps.General {
+			if bbs[12].Rendered {
+				ctx.EmitJmp(lbl13)
+				return result
+			}
+			bbs[12].Rendered = true
+			bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_12 = bbs[12].Address
+			ctx.MarkLabel(lbl13)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
+			d212 = ps.OverlayValues[212]
+		}
+		if len(ps.OverlayValues) > 213 && ps.OverlayValues[213].Loc != LocNone {
+			d213 = ps.OverlayValues[213]
+		}
+		if len(ps.OverlayValues) > 270 && ps.OverlayValues[270].Loc != LocNone {
+			d270 = ps.OverlayValues[270]
+		}
+		if len(ps.OverlayValues) > 271 && ps.OverlayValues[271].Loc != LocNone {
+			d271 = ps.OverlayValues[271]
+		}
+		if len(ps.OverlayValues) > 273 && ps.OverlayValues[273].Loc != LocNone {
+			d273 = ps.OverlayValues[273]
+		}
+		if len(ps.OverlayValues) > 274 && ps.OverlayValues[274].Loc != LocNone {
+			d274 = ps.OverlayValues[274]
+		}
+		if len(ps.OverlayValues) > 275 && ps.OverlayValues[275].Loc != LocNone {
+			d275 = ps.OverlayValues[275]
+		}
+		ctx.ReclaimUntrackedRegs()
+		var d342 JITValueDesc
+		if args[0].Loc == LocImm {
+			d342 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(args[0].Imm.Int())}
+		} else if args[0].Type == tagInt && args[0].Loc == LocRegPair {
+			ctx.FreeReg(args[0].Reg)
+			d342 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[0].Reg2}
+			ctx.BindReg(args[0].Reg2, &d342)
+		} else if args[0].Type == tagInt && args[0].Loc == LocReg {
+			d342 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[0].Reg}
+			ctx.BindReg(args[0].Reg, &d342)
+		} else {
+			d342 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{args[0]}, 1)
+			d342.Type = tagInt
+			ctx.BindReg(d342.Reg, &d342)
+		}
+		ctx.EnsureDesc(&d342)
+		ctx.EnsureDesc(&d342)
+		var d343 JITValueDesc
+		if d342.Loc == LocImm {
+			d343 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d342.Imm.Int()))}
+		} else {
+			var r11 Reg
+			r11 = d342.Reg
+			d342.Loc = LocNone
+			ctx.EmitCvtInt64ToFloat64(RegX0, r11)
+			d343 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r11}
+			ctx.BindReg(r11, &d343)
+		}
+		ctx.FreeDesc(&d342)
+		var d344 JITValueDesc
+		if args[1].Loc == LocImm {
+			d344 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(args[1].Imm.Float())}
+		} else if args[1].Type == tagFloat && args[1].Loc == LocReg {
+			d344 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg}
+			ctx.BindReg(args[1].Reg, &d344)
+		} else if args[1].Type == tagFloat && args[1].Loc == LocRegPair {
+			ctx.FreeReg(args[1].Reg)
+			d344 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg2}
+			ctx.BindReg(args[1].Reg2, &d344)
+		} else {
+			d344 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{args[1]}, 1)
+			d344.Type = tagFloat
+			ctx.BindReg(d344.Reg, &d344)
+		}
+		ctx.EnsureDesc(&d343)
+		resultTarget345 := false
+		_ = resultTarget345
+		ctx.EnsureDesc(&d344)
+		ctx.EnsureDescsTogether(&d343, &d344)
+		var d346 JITValueDesc
+		if d343.Loc == LocImm && d344.Loc == LocImm {
+			d346 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d343.Imm.Float() < d344.Imm.Float())}
+		} else if d344.Loc == LocImm {
+			var r12 Reg
+			if result.Loc == LocReg && result.Reg != d343.Reg {
+				r12 = result.Reg
+				resultTarget345 = true
+			} else {
+				r12 = ctx.AllocRegExcept(d343.Reg)
+			}
+			_, yBits := d344.Imm.RawWords()
+			ctx.EmitMovRegImm64(RegR11, yBits)
+			ctx.EmitCmpFloat64Setcc(r12, d343.Reg, RegR11, CondSignedLess)
+			d346 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r12}
+			ctx.BindReg(r12, &d346)
+		} else if d343.Loc == LocImm {
+			var r13 Reg
+			if result.Loc == LocReg && result.Reg != d344.Reg {
+				r13 = result.Reg
+				resultTarget345 = true
+			} else {
+				r13 = ctx.AllocRegExcept(d344.Reg)
+			}
+			_, xBits := d343.Imm.RawWords()
+			ctx.EmitMovRegImm64(RegR11, xBits)
+			ctx.EmitCmpFloat64Setcc(r13, RegR11, d344.Reg, CondSignedLess)
+			d346 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r13}
+			ctx.BindReg(r13, &d346)
+		} else {
+			var r14 Reg
+			if result.Loc == LocReg && result.Reg != d343.Reg && result.Reg != d344.Reg {
+				r14 = result.Reg
+				resultTarget345 = true
+			} else {
+				r14 = ctx.AllocRegExcept(d343.Reg, d344.Reg)
+			}
+			ctx.EmitCmpFloat64Setcc(r14, d343.Reg, d344.Reg, CondSignedLess)
+			d346 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r14}
+			ctx.BindReg(r14, &d346)
+		}
+		ctx.FreeDesc(&d343)
+		ctx.FreeDesc(&d344)
+		ctx.EnsureDesc(&d346)
+		ctx.EmitMovToReg(result.Reg, d346)
+		result.Type = d346.Type
+		ctx.EmitJmp(lbl0)
+		return result
+	}
+	bbs[13].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[13].VisitCount >= 0 {
+				ps.General = true
+				return bbs[13].RenderPS(ps)
+			}
+		}
+		bbs[13].VisitCount++
+		if ps.General {
+			if bbs[13].Rendered {
+				ctx.EmitJmp(lbl14)
+				return result
+			}
+			bbs[13].Rendered = true
+			bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_13 = bbs[13].Address
+			ctx.MarkLabel(lbl14)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
+			d212 = ps.OverlayValues[212]
+		}
+		if len(ps.OverlayValues) > 213 && ps.OverlayValues[213].Loc != LocNone {
+			d213 = ps.OverlayValues[213]
+		}
+		if len(ps.OverlayValues) > 270 && ps.OverlayValues[270].Loc != LocNone {
+			d270 = ps.OverlayValues[270]
+		}
+		if len(ps.OverlayValues) > 271 && ps.OverlayValues[271].Loc != LocNone {
+			d271 = ps.OverlayValues[271]
+		}
+		if len(ps.OverlayValues) > 273 && ps.OverlayValues[273].Loc != LocNone {
+			d273 = ps.OverlayValues[273]
+		}
+		if len(ps.OverlayValues) > 274 && ps.OverlayValues[274].Loc != LocNone {
+			d274 = ps.OverlayValues[274]
+		}
+		if len(ps.OverlayValues) > 275 && ps.OverlayValues[275].Loc != LocNone {
+			d275 = ps.OverlayValues[275]
+		}
+		if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
+			d342 = ps.OverlayValues[342]
+		}
+		if len(ps.OverlayValues) > 343 && ps.OverlayValues[343].Loc != LocNone {
+			d343 = ps.OverlayValues[343]
+		}
+		if len(ps.OverlayValues) > 344 && ps.OverlayValues[344].Loc != LocNone {
+			d344 = ps.OverlayValues[344]
+		}
+		if len(ps.OverlayValues) > 346 && ps.OverlayValues[346].Loc != LocNone {
+			d346 = ps.OverlayValues[346]
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d3)
+		var d347 JITValueDesc
+		if d3.Loc == LocImm {
+			d347 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d3.Imm.Int()) == uint64(0x2))}
+		} else {
+			r15 := ctx.AllocRegExcept(d3.Reg)
+			ctx.EmitCmpRegImm32(d3.Reg, 2)
+			d347 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r15, Condition: CondEqual}
+			ctx.BindReg(r15, &d347)
+		}
+		d348 = d347
+		ctx.EnsureDesc(&d348)
+		if d348.Loc != LocImm && d348.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d348.Loc == LocImm {
+			if d348.Imm.Bool() {
+				if ps.General {
+				}
+				ps349 := PhiState{General: ps.General}
+				ps349.OverlayValues = make([]JITValueDesc, 349)
+				ps349.OverlayValues[0] = d0
+				ps349.OverlayValues[1] = d1
+				ps349.OverlayValues[2] = d2
+				ps349.OverlayValues[3] = d3
+				ps349.OverlayValues[4] = d4
+				ps349.OverlayValues[5] = d5
+				ps349.OverlayValues[24] = d24
+				ps349.OverlayValues[25] = d25
+				ps349.OverlayValues[26] = d26
+				ps349.OverlayValues[51] = d51
+				ps349.OverlayValues[52] = d52
+				ps349.OverlayValues[81] = d81
+				ps349.OverlayValues[82] = d82
+				ps349.OverlayValues[83] = d83
+				ps349.OverlayValues[118] = d118
+				ps349.OverlayValues[119] = d119
+				ps349.OverlayValues[120] = d120
+				ps349.OverlayValues[161] = d161
+				ps349.OverlayValues[162] = d162
+				ps349.OverlayValues[207] = d207
+				ps349.OverlayValues[208] = d208
+				ps349.OverlayValues[209] = d209
+				ps349.OverlayValues[211] = d211
+				ps349.OverlayValues[212] = d212
+				ps349.OverlayValues[213] = d213
+				ps349.OverlayValues[270] = d270
+				ps349.OverlayValues[271] = d271
+				ps349.OverlayValues[273] = d273
+				ps349.OverlayValues[274] = d274
+				ps349.OverlayValues[275] = d275
+				ps349.OverlayValues[342] = d342
+				ps349.OverlayValues[343] = d343
+				ps349.OverlayValues[344] = d344
+				ps349.OverlayValues[346] = d346
+				ps349.OverlayValues[347] = d347
+				ps349.OverlayValues[348] = d348
+				return bbs[11].RenderPS(ps349)
+			}
+			if ps.General {
+			}
+			ps350 := PhiState{General: ps.General}
+			ps350.OverlayValues = make([]JITValueDesc, 349)
+			ps350.OverlayValues[0] = d0
+			ps350.OverlayValues[1] = d1
+			ps350.OverlayValues[2] = d2
+			ps350.OverlayValues[3] = d3
+			ps350.OverlayValues[4] = d4
+			ps350.OverlayValues[5] = d5
+			ps350.OverlayValues[24] = d24
+			ps350.OverlayValues[25] = d25
+			ps350.OverlayValues[26] = d26
+			ps350.OverlayValues[51] = d51
+			ps350.OverlayValues[52] = d52
+			ps350.OverlayValues[81] = d81
+			ps350.OverlayValues[82] = d82
+			ps350.OverlayValues[83] = d83
+			ps350.OverlayValues[118] = d118
+			ps350.OverlayValues[119] = d119
+			ps350.OverlayValues[120] = d120
+			ps350.OverlayValues[161] = d161
+			ps350.OverlayValues[162] = d162
+			ps350.OverlayValues[207] = d207
+			ps350.OverlayValues[208] = d208
+			ps350.OverlayValues[209] = d209
+			ps350.OverlayValues[211] = d211
+			ps350.OverlayValues[212] = d212
+			ps350.OverlayValues[213] = d213
+			ps350.OverlayValues[270] = d270
+			ps350.OverlayValues[271] = d271
+			ps350.OverlayValues[273] = d273
+			ps350.OverlayValues[274] = d274
+			ps350.OverlayValues[275] = d275
+			ps350.OverlayValues[342] = d342
+			ps350.OverlayValues[343] = d343
+			ps350.OverlayValues[344] = d344
+			ps350.OverlayValues[346] = d346
+			ps350.OverlayValues[347] = d347
+			ps350.OverlayValues[348] = d348
+			return bbs[12].RenderPS(ps350)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[13].RenderPS(ps)
+		}
+		ctx.EmitJump(d348.Condition, lbl12)
+		if bbs[12].Rendered {
+			ctx.EmitJmp(lbl13)
+		}
+		ctx.FreeDesc(&d347)
+		snap351 := d0
+		snap352 := d1
+		snap353 := d2
+		snap354 := d3
+		snap355 := d4
+		snap356 := d5
+		snap357 := d24
+		snap358 := d25
+		snap359 := d26
+		snap360 := d51
+		snap361 := d52
+		snap362 := d81
+		snap363 := d82
+		snap364 := d83
+		snap365 := d118
+		snap366 := d119
+		snap367 := d120
+		snap368 := d161
+		snap369 := d162
+		snap370 := d207
+		snap371 := d208
+		snap372 := d209
+		snap373 := d211
+		snap374 := d212
+		snap375 := d213
+		snap376 := d270
+		snap377 := d271
+		snap378 := d273
+		snap379 := d274
+		snap380 := d275
+		snap381 := d342
+		snap382 := d343
+		snap383 := d344
+		snap384 := d346
+		snap385 := d347
+		snap386 := d348
+		alloc387 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc387)
+		d0 = snap351
+		d1 = snap352
+		d2 = snap353
+		d3 = snap354
+		d4 = snap355
+		d5 = snap356
+		d24 = snap357
+		d25 = snap358
+		d26 = snap359
+		d51 = snap360
+		d52 = snap361
+		d81 = snap362
+		d82 = snap363
+		d83 = snap364
+		d118 = snap365
+		d119 = snap366
+		d120 = snap367
+		d161 = snap368
+		d162 = snap369
+		d207 = snap370
+		d208 = snap371
+		d209 = snap372
+		d211 = snap373
+		d212 = snap374
+		d213 = snap375
+		d270 = snap376
+		d271 = snap377
+		d273 = snap378
+		d274 = snap379
+		d275 = snap380
+		d342 = snap381
+		d343 = snap382
+		d344 = snap383
+		d346 = snap384
+		d347 = snap385
+		d348 = snap386
+		ctx.RestoreAllocState(alloc387)
+		d0 = snap351
+		d1 = snap352
+		d2 = snap353
+		d3 = snap354
+		d4 = snap355
+		d5 = snap356
+		d24 = snap357
+		d25 = snap358
+		d26 = snap359
+		d51 = snap360
+		d52 = snap361
+		d81 = snap362
+		d82 = snap363
+		d83 = snap364
+		d118 = snap365
+		d119 = snap366
+		d120 = snap367
+		d161 = snap368
+		d162 = snap369
+		d207 = snap370
+		d208 = snap371
+		d209 = snap372
+		d211 = snap373
+		d212 = snap374
+		d213 = snap375
+		d270 = snap376
+		d271 = snap377
+		d273 = snap378
+		d274 = snap379
+		d275 = snap380
+		d342 = snap381
+		d343 = snap382
+		d344 = snap383
+		d346 = snap384
+		d347 = snap385
+		d348 = snap386
+		ps388 := PhiState{General: true}
+		ps388.OverlayValues = make([]JITValueDesc, 349)
+		ps388.OverlayValues[0] = d0
+		ps388.OverlayValues[1] = d1
+		ps388.OverlayValues[2] = d2
+		ps388.OverlayValues[3] = d3
+		ps388.OverlayValues[4] = d4
+		ps388.OverlayValues[5] = d5
+		ps388.OverlayValues[24] = d24
+		ps388.OverlayValues[25] = d25
+		ps388.OverlayValues[26] = d26
+		ps388.OverlayValues[51] = d51
+		ps388.OverlayValues[52] = d52
+		ps388.OverlayValues[81] = d81
+		ps388.OverlayValues[82] = d82
+		ps388.OverlayValues[83] = d83
+		ps388.OverlayValues[118] = d118
+		ps388.OverlayValues[119] = d119
+		ps388.OverlayValues[120] = d120
+		ps388.OverlayValues[161] = d161
+		ps388.OverlayValues[162] = d162
+		ps388.OverlayValues[207] = d207
+		ps388.OverlayValues[208] = d208
+		ps388.OverlayValues[209] = d209
+		ps388.OverlayValues[211] = d211
+		ps388.OverlayValues[212] = d212
+		ps388.OverlayValues[213] = d213
+		ps388.OverlayValues[270] = d270
+		ps388.OverlayValues[271] = d271
+		ps388.OverlayValues[273] = d273
+		ps388.OverlayValues[274] = d274
+		ps388.OverlayValues[275] = d275
+		ps388.OverlayValues[342] = d342
+		ps388.OverlayValues[343] = d343
+		ps388.OverlayValues[344] = d344
+		ps388.OverlayValues[346] = d346
+		ps388.OverlayValues[347] = d347
+		ps388.OverlayValues[348] = d348
+		ps389 := PhiState{General: true}
+		ps389.OverlayValues = make([]JITValueDesc, 349)
+		ps389.OverlayValues[0] = d0
+		ps389.OverlayValues[1] = d1
+		ps389.OverlayValues[2] = d2
+		ps389.OverlayValues[3] = d3
+		ps389.OverlayValues[4] = d4
+		ps389.OverlayValues[5] = d5
+		ps389.OverlayValues[24] = d24
+		ps389.OverlayValues[25] = d25
+		ps389.OverlayValues[26] = d26
+		ps389.OverlayValues[51] = d51
+		ps389.OverlayValues[52] = d52
+		ps389.OverlayValues[81] = d81
+		ps389.OverlayValues[82] = d82
+		ps389.OverlayValues[83] = d83
+		ps389.OverlayValues[118] = d118
+		ps389.OverlayValues[119] = d119
+		ps389.OverlayValues[120] = d120
+		ps389.OverlayValues[161] = d161
+		ps389.OverlayValues[162] = d162
+		ps389.OverlayValues[207] = d207
+		ps389.OverlayValues[208] = d208
+		ps389.OverlayValues[209] = d209
+		ps389.OverlayValues[211] = d211
+		ps389.OverlayValues[212] = d212
+		ps389.OverlayValues[213] = d213
+		ps389.OverlayValues[270] = d270
+		ps389.OverlayValues[271] = d271
+		ps389.OverlayValues[273] = d273
+		ps389.OverlayValues[274] = d274
+		ps389.OverlayValues[275] = d275
+		ps389.OverlayValues[342] = d342
+		ps389.OverlayValues[343] = d343
+		ps389.OverlayValues[344] = d344
+		ps389.OverlayValues[346] = d346
+		ps389.OverlayValues[347] = d347
+		ps389.OverlayValues[348] = d348
+		snap390 := d0
+		snap391 := d1
+		snap392 := d2
+		snap393 := d3
+		snap394 := d4
+		snap395 := d5
+		snap396 := d24
+		snap397 := d25
+		snap398 := d26
+		snap399 := d51
+		snap400 := d52
+		snap401 := d81
+		snap402 := d82
+		snap403 := d83
+		snap404 := d118
+		snap405 := d119
+		snap406 := d120
+		snap407 := d161
+		snap408 := d162
+		snap409 := d207
+		snap410 := d208
+		snap411 := d209
+		snap412 := d211
+		snap413 := d212
+		snap414 := d213
+		snap415 := d270
+		snap416 := d271
+		snap417 := d273
+		snap418 := d274
+		snap419 := d275
+		snap420 := d342
+		snap421 := d343
+		snap422 := d344
+		snap423 := d346
+		snap424 := d347
+		snap425 := d348
+		alloc426 := ctx.SnapshotAllocState()
+		if !bbs[12].Rendered {
+			bbs[12].RenderPS(ps389)
+		}
+		ctx.RestoreAllocState(alloc426)
+		d0 = snap390
+		d1 = snap391
+		d2 = snap392
+		d3 = snap393
+		d4 = snap394
+		d5 = snap395
+		d24 = snap396
+		d25 = snap397
+		d26 = snap398
+		d51 = snap399
+		d52 = snap400
+		d81 = snap401
+		d82 = snap402
+		d83 = snap403
+		d118 = snap404
+		d119 = snap405
+		d120 = snap406
+		d161 = snap407
+		d162 = snap408
+		d207 = snap409
+		d208 = snap410
+		d209 = snap411
+		d211 = snap412
+		d212 = snap413
+		d213 = snap414
+		d270 = snap415
+		d271 = snap416
+		d273 = snap417
+		d274 = snap418
+		d275 = snap419
+		d342 = snap420
+		d343 = snap421
+		d344 = snap422
+		d346 = snap423
+		d347 = snap424
+		d348 = snap425
+		if !bbs[11].Rendered {
+			return bbs[11].RenderPS(ps388)
+		}
+		return result
+		return result
+	}
+	bbs[14].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[14].VisitCount >= 0 {
+				ps.General = true
+				return bbs[14].RenderPS(ps)
+			}
+		}
+		bbs[14].VisitCount++
+		if ps.General {
+			if bbs[14].Rendered {
+				ctx.EmitJmp(lbl15)
+				return result
+			}
+			bbs[14].Rendered = true
+			bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_14 = bbs[14].Address
+			ctx.MarkLabel(lbl15)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
+			d212 = ps.OverlayValues[212]
+		}
+		if len(ps.OverlayValues) > 213 && ps.OverlayValues[213].Loc != LocNone {
+			d213 = ps.OverlayValues[213]
+		}
+		if len(ps.OverlayValues) > 270 && ps.OverlayValues[270].Loc != LocNone {
+			d270 = ps.OverlayValues[270]
+		}
+		if len(ps.OverlayValues) > 271 && ps.OverlayValues[271].Loc != LocNone {
+			d271 = ps.OverlayValues[271]
+		}
+		if len(ps.OverlayValues) > 273 && ps.OverlayValues[273].Loc != LocNone {
+			d273 = ps.OverlayValues[273]
+		}
+		if len(ps.OverlayValues) > 274 && ps.OverlayValues[274].Loc != LocNone {
+			d274 = ps.OverlayValues[274]
+		}
+		if len(ps.OverlayValues) > 275 && ps.OverlayValues[275].Loc != LocNone {
+			d275 = ps.OverlayValues[275]
+		}
+		if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
+			d342 = ps.OverlayValues[342]
+		}
+		if len(ps.OverlayValues) > 343 && ps.OverlayValues[343].Loc != LocNone {
+			d343 = ps.OverlayValues[343]
+		}
+		if len(ps.OverlayValues) > 344 && ps.OverlayValues[344].Loc != LocNone {
+			d344 = ps.OverlayValues[344]
+		}
+		if len(ps.OverlayValues) > 346 && ps.OverlayValues[346].Loc != LocNone {
+			d346 = ps.OverlayValues[346]
+		}
+		if len(ps.OverlayValues) > 347 && ps.OverlayValues[347].Loc != LocNone {
+			d347 = ps.OverlayValues[347]
+		}
+		if len(ps.OverlayValues) > 348 && ps.OverlayValues[348].Loc != LocNone {
+			d348 = ps.OverlayValues[348]
+		}
+		ctx.ReclaimUntrackedRegs()
+		var d427 JITValueDesc
+		if args[0].Loc == LocImm {
+			d427 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(args[0].Imm.Int())}
+		} else if args[0].Type == tagInt && args[0].Loc == LocRegPair {
+			ctx.FreeReg(args[0].Reg)
+			d427 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[0].Reg2}
+			ctx.BindReg(args[0].Reg2, &d427)
+		} else if args[0].Type == tagInt && args[0].Loc == LocReg {
+			d427 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[0].Reg}
+			ctx.BindReg(args[0].Reg, &d427)
+		} else {
+			d427 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{args[0]}, 1)
+			d427.Type = tagInt
+			ctx.BindReg(d427.Reg, &d427)
+		}
+		ctx.EnsureDesc(&d427)
+		resultTarget428 := false
+		_ = resultTarget428
+		ctx.EnsureDesc(&d273)
+		ctx.EnsureDescsTogether(&d427, &d273)
+		var d429 JITValueDesc
+		if d427.Loc == LocImm && d273.Loc == LocImm {
+			d429 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d427.Imm.Int() < d273.Imm.Int())}
+		} else if d273.Loc == LocImm {
+			if d273.Imm.Int() >= -2147483648 && d273.Imm.Int() <= 2147483647 {
+				ctx.EmitCmpRegImm32(d427.Reg, int32(d273.Imm.Int()))
+			} else {
+				ctx.EmitMovRegImm64(RegR11, uint64(d273.Imm.Int()))
+				ctx.EmitCmpInt64(d427.Reg, RegR11)
+			}
+			var r16 Reg
+			if result.Loc == LocReg && result.Reg != d427.Reg {
+				r16 = result.Reg
+				resultTarget428 = true
+			} else {
+				r16 = ctx.AllocRegExcept(d427.Reg)
+			}
+			ctx.EmitSetcc(r16, CondSignedLess)
+			d429 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r16}
+			ctx.BindReg(r16, &d429)
+		} else if d427.Loc == LocImm {
+			ctx.EmitMovRegImm64(RegR11, uint64(d427.Imm.Int()))
+			ctx.EmitCmpInt64(RegR11, d273.Reg)
+			var r17 Reg
+			if result.Loc == LocReg && result.Reg != d273.Reg {
+				r17 = result.Reg
+				resultTarget428 = true
+			} else {
+				r17 = ctx.AllocRegExcept(d273.Reg)
+			}
+			ctx.EmitSetcc(r17, CondSignedLess)
+			d429 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r17}
+			ctx.BindReg(r17, &d429)
+		} else {
+			ctx.EmitCmpInt64(d427.Reg, d273.Reg)
+			var r18 Reg
+			if result.Loc == LocReg && result.Reg != d427.Reg && result.Reg != d273.Reg {
+				r18 = result.Reg
+				resultTarget428 = true
+			} else {
+				r18 = ctx.AllocRegExcept(d427.Reg, d273.Reg)
+			}
+			ctx.EmitSetcc(r18, CondSignedLess)
+			d429 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r18}
+			ctx.BindReg(r18, &d429)
+		}
+		ctx.FreeDesc(&d427)
+		ctx.EnsureDesc(&d429)
+		ctx.EmitMovToReg(result.Reg, d429)
+		result.Type = d429.Type
+		ctx.EmitJmp(lbl0)
+		return result
+	}
+	bbs[15].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[15].VisitCount >= 0 {
+				ps.General = true
+				return bbs[15].RenderPS(ps)
+			}
+		}
+		bbs[15].VisitCount++
+		if ps.General {
+			if bbs[15].Rendered {
+				ctx.EmitJmp(lbl16)
+				return result
+			}
+			bbs[15].Rendered = true
+			bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_15 = bbs[15].Address
+			ctx.MarkLabel(lbl16)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
+			d212 = ps.OverlayValues[212]
+		}
+		if len(ps.OverlayValues) > 213 && ps.OverlayValues[213].Loc != LocNone {
+			d213 = ps.OverlayValues[213]
+		}
+		if len(ps.OverlayValues) > 270 && ps.OverlayValues[270].Loc != LocNone {
+			d270 = ps.OverlayValues[270]
+		}
+		if len(ps.OverlayValues) > 271 && ps.OverlayValues[271].Loc != LocNone {
+			d271 = ps.OverlayValues[271]
+		}
+		if len(ps.OverlayValues) > 273 && ps.OverlayValues[273].Loc != LocNone {
+			d273 = ps.OverlayValues[273]
+		}
+		if len(ps.OverlayValues) > 274 && ps.OverlayValues[274].Loc != LocNone {
+			d274 = ps.OverlayValues[274]
+		}
+		if len(ps.OverlayValues) > 275 && ps.OverlayValues[275].Loc != LocNone {
+			d275 = ps.OverlayValues[275]
+		}
+		if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
+			d342 = ps.OverlayValues[342]
+		}
+		if len(ps.OverlayValues) > 343 && ps.OverlayValues[343].Loc != LocNone {
+			d343 = ps.OverlayValues[343]
+		}
+		if len(ps.OverlayValues) > 344 && ps.OverlayValues[344].Loc != LocNone {
+			d344 = ps.OverlayValues[344]
+		}
+		if len(ps.OverlayValues) > 346 && ps.OverlayValues[346].Loc != LocNone {
+			d346 = ps.OverlayValues[346]
+		}
+		if len(ps.OverlayValues) > 347 && ps.OverlayValues[347].Loc != LocNone {
+			d347 = ps.OverlayValues[347]
+		}
+		if len(ps.OverlayValues) > 348 && ps.OverlayValues[348].Loc != LocNone {
+			d348 = ps.OverlayValues[348]
+		}
+		if len(ps.OverlayValues) > 427 && ps.OverlayValues[427].Loc != LocNone {
+			d427 = ps.OverlayValues[427]
+		}
+		if len(ps.OverlayValues) > 429 && ps.OverlayValues[429].Loc != LocNone {
+			d429 = ps.OverlayValues[429]
+		}
+		ctx.ReclaimUntrackedRegs()
+		var d430 JITValueDesc
+		if args[0].Loc == LocImm {
+			d430 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(args[0].Imm.Float())}
+		} else if args[0].Type == tagFloat && args[0].Loc == LocReg {
+			d430 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[0].Reg}
+			ctx.BindReg(args[0].Reg, &d430)
+		} else if args[0].Type == tagFloat && args[0].Loc == LocRegPair {
+			ctx.FreeReg(args[0].Reg)
+			d430 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[0].Reg2}
+			ctx.BindReg(args[0].Reg2, &d430)
+		} else {
+			d430 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{args[0]}, 1)
+			d430.Type = tagFloat
+			ctx.BindReg(d430.Reg, &d430)
+		}
+		var d431 JITValueDesc
+		if args[1].Loc == LocImm {
+			d431 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(args[1].Imm.Float())}
+		} else if args[1].Type == tagFloat && args[1].Loc == LocReg {
+			d431 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg}
+			ctx.BindReg(args[1].Reg, &d431)
+		} else if args[1].Type == tagFloat && args[1].Loc == LocRegPair {
+			ctx.FreeReg(args[1].Reg)
+			d431 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg2}
+			ctx.BindReg(args[1].Reg2, &d431)
+		} else {
+			d431 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{args[1]}, 1)
+			d431.Type = tagFloat
+			ctx.BindReg(d431.Reg, &d431)
+		}
+		ctx.EnsureDesc(&d430)
+		resultTarget432 := false
+		_ = resultTarget432
+		ctx.EnsureDesc(&d431)
+		ctx.EnsureDescsTogether(&d430, &d431)
+		var d433 JITValueDesc
+		if d430.Loc == LocImm && d431.Loc == LocImm {
+			d433 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d430.Imm.Float() < d431.Imm.Float())}
+		} else if d431.Loc == LocImm {
+			var r19 Reg
+			if result.Loc == LocReg && result.Reg != d430.Reg {
+				r19 = result.Reg
+				resultTarget432 = true
+			} else {
+				r19 = ctx.AllocRegExcept(d430.Reg)
+			}
+			_, yBits := d431.Imm.RawWords()
+			ctx.EmitMovRegImm64(RegR11, yBits)
+			ctx.EmitCmpFloat64Setcc(r19, d430.Reg, RegR11, CondSignedLess)
+			d433 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r19}
+			ctx.BindReg(r19, &d433)
+		} else if d430.Loc == LocImm {
+			var r20 Reg
+			if result.Loc == LocReg && result.Reg != d431.Reg {
+				r20 = result.Reg
+				resultTarget432 = true
+			} else {
+				r20 = ctx.AllocRegExcept(d431.Reg)
+			}
+			_, xBits := d430.Imm.RawWords()
+			ctx.EmitMovRegImm64(RegR11, xBits)
+			ctx.EmitCmpFloat64Setcc(r20, RegR11, d431.Reg, CondSignedLess)
+			d433 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r20}
+			ctx.BindReg(r20, &d433)
+		} else {
+			var r21 Reg
+			if result.Loc == LocReg && result.Reg != d430.Reg && result.Reg != d431.Reg {
+				r21 = result.Reg
+				resultTarget432 = true
+			} else {
+				r21 = ctx.AllocRegExcept(d430.Reg, d431.Reg)
+			}
+			ctx.EmitCmpFloat64Setcc(r21, d430.Reg, d431.Reg, CondSignedLess)
+			d433 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r21}
+			ctx.BindReg(r21, &d433)
+		}
+		ctx.FreeDesc(&d430)
+		ctx.FreeDesc(&d431)
+		ctx.EnsureDesc(&d433)
+		ctx.EmitMovToReg(result.Reg, d433)
+		result.Type = d433.Type
+		ctx.EmitJmp(lbl0)
+		return result
+	}
+	bbs[16].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[16].VisitCount >= 0 {
+				ps.General = true
+				return bbs[16].RenderPS(ps)
+			}
+		}
+		bbs[16].VisitCount++
+		if ps.General {
+			if bbs[16].Rendered {
+				ctx.EmitJmp(lbl17)
+				return result
+			}
+			bbs[16].Rendered = true
+			bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_16 = bbs[16].Address
+			ctx.MarkLabel(lbl17)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
+			d212 = ps.OverlayValues[212]
+		}
+		if len(ps.OverlayValues) > 213 && ps.OverlayValues[213].Loc != LocNone {
+			d213 = ps.OverlayValues[213]
+		}
+		if len(ps.OverlayValues) > 270 && ps.OverlayValues[270].Loc != LocNone {
+			d270 = ps.OverlayValues[270]
+		}
+		if len(ps.OverlayValues) > 271 && ps.OverlayValues[271].Loc != LocNone {
+			d271 = ps.OverlayValues[271]
+		}
+		if len(ps.OverlayValues) > 273 && ps.OverlayValues[273].Loc != LocNone {
+			d273 = ps.OverlayValues[273]
+		}
+		if len(ps.OverlayValues) > 274 && ps.OverlayValues[274].Loc != LocNone {
+			d274 = ps.OverlayValues[274]
+		}
+		if len(ps.OverlayValues) > 275 && ps.OverlayValues[275].Loc != LocNone {
+			d275 = ps.OverlayValues[275]
+		}
+		if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
+			d342 = ps.OverlayValues[342]
+		}
+		if len(ps.OverlayValues) > 343 && ps.OverlayValues[343].Loc != LocNone {
+			d343 = ps.OverlayValues[343]
+		}
+		if len(ps.OverlayValues) > 344 && ps.OverlayValues[344].Loc != LocNone {
+			d344 = ps.OverlayValues[344]
+		}
+		if len(ps.OverlayValues) > 346 && ps.OverlayValues[346].Loc != LocNone {
+			d346 = ps.OverlayValues[346]
+		}
+		if len(ps.OverlayValues) > 347 && ps.OverlayValues[347].Loc != LocNone {
+			d347 = ps.OverlayValues[347]
+		}
+		if len(ps.OverlayValues) > 348 && ps.OverlayValues[348].Loc != LocNone {
+			d348 = ps.OverlayValues[348]
+		}
+		if len(ps.OverlayValues) > 427 && ps.OverlayValues[427].Loc != LocNone {
+			d427 = ps.OverlayValues[427]
+		}
+		if len(ps.OverlayValues) > 429 && ps.OverlayValues[429].Loc != LocNone {
+			d429 = ps.OverlayValues[429]
+		}
+		if len(ps.OverlayValues) > 430 && ps.OverlayValues[430].Loc != LocNone {
+			d430 = ps.OverlayValues[430]
+		}
+		if len(ps.OverlayValues) > 431 && ps.OverlayValues[431].Loc != LocNone {
+			d431 = ps.OverlayValues[431]
+		}
+		if len(ps.OverlayValues) > 433 && ps.OverlayValues[433].Loc != LocNone {
+			d433 = ps.OverlayValues[433]
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d1)
+		var d434 JITValueDesc
+		if d1.Loc == LocImm {
+			d434 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d1.Imm.Int()) == uint64(0x3))}
+		} else {
+			r22 := ctx.AllocRegExcept(d1.Reg)
+			ctx.EmitCmpRegImm32(d1.Reg, 3)
+			d434 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r22, Condition: CondEqual}
+			ctx.BindReg(r22, &d434)
+		}
+		d435 = d434
+		ctx.EnsureDesc(&d435)
+		if d435.Loc != LocImm && d435.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d435.Loc == LocImm {
+			if d435.Imm.Bool() {
+				if ps.General {
+				}
+				ps436 := PhiState{General: ps.General}
+				ps436.OverlayValues = make([]JITValueDesc, 436)
+				ps436.OverlayValues[0] = d0
+				ps436.OverlayValues[1] = d1
+				ps436.OverlayValues[2] = d2
+				ps436.OverlayValues[3] = d3
+				ps436.OverlayValues[4] = d4
+				ps436.OverlayValues[5] = d5
+				ps436.OverlayValues[24] = d24
+				ps436.OverlayValues[25] = d25
+				ps436.OverlayValues[26] = d26
+				ps436.OverlayValues[51] = d51
+				ps436.OverlayValues[52] = d52
+				ps436.OverlayValues[81] = d81
+				ps436.OverlayValues[82] = d82
+				ps436.OverlayValues[83] = d83
+				ps436.OverlayValues[118] = d118
+				ps436.OverlayValues[119] = d119
+				ps436.OverlayValues[120] = d120
+				ps436.OverlayValues[161] = d161
+				ps436.OverlayValues[162] = d162
+				ps436.OverlayValues[207] = d207
+				ps436.OverlayValues[208] = d208
+				ps436.OverlayValues[209] = d209
+				ps436.OverlayValues[211] = d211
+				ps436.OverlayValues[212] = d212
+				ps436.OverlayValues[213] = d213
+				ps436.OverlayValues[270] = d270
+				ps436.OverlayValues[271] = d271
+				ps436.OverlayValues[273] = d273
+				ps436.OverlayValues[274] = d274
+				ps436.OverlayValues[275] = d275
+				ps436.OverlayValues[342] = d342
+				ps436.OverlayValues[343] = d343
+				ps436.OverlayValues[344] = d344
+				ps436.OverlayValues[346] = d346
+				ps436.OverlayValues[347] = d347
+				ps436.OverlayValues[348] = d348
+				ps436.OverlayValues[427] = d427
+				ps436.OverlayValues[429] = d429
+				ps436.OverlayValues[430] = d430
+				ps436.OverlayValues[431] = d431
+				ps436.OverlayValues[433] = d433
+				ps436.OverlayValues[434] = d434
+				ps436.OverlayValues[435] = d435
+				return bbs[15].RenderPS(ps436)
+			}
+			if ps.General {
+			}
+			ps437 := PhiState{General: ps.General}
+			ps437.OverlayValues = make([]JITValueDesc, 436)
+			ps437.OverlayValues[0] = d0
+			ps437.OverlayValues[1] = d1
+			ps437.OverlayValues[2] = d2
+			ps437.OverlayValues[3] = d3
+			ps437.OverlayValues[4] = d4
+			ps437.OverlayValues[5] = d5
+			ps437.OverlayValues[24] = d24
+			ps437.OverlayValues[25] = d25
+			ps437.OverlayValues[26] = d26
+			ps437.OverlayValues[51] = d51
+			ps437.OverlayValues[52] = d52
+			ps437.OverlayValues[81] = d81
+			ps437.OverlayValues[82] = d82
+			ps437.OverlayValues[83] = d83
+			ps437.OverlayValues[118] = d118
+			ps437.OverlayValues[119] = d119
+			ps437.OverlayValues[120] = d120
+			ps437.OverlayValues[161] = d161
+			ps437.OverlayValues[162] = d162
+			ps437.OverlayValues[207] = d207
+			ps437.OverlayValues[208] = d208
+			ps437.OverlayValues[209] = d209
+			ps437.OverlayValues[211] = d211
+			ps437.OverlayValues[212] = d212
+			ps437.OverlayValues[213] = d213
+			ps437.OverlayValues[270] = d270
+			ps437.OverlayValues[271] = d271
+			ps437.OverlayValues[273] = d273
+			ps437.OverlayValues[274] = d274
+			ps437.OverlayValues[275] = d275
+			ps437.OverlayValues[342] = d342
+			ps437.OverlayValues[343] = d343
+			ps437.OverlayValues[344] = d344
+			ps437.OverlayValues[346] = d346
+			ps437.OverlayValues[347] = d347
+			ps437.OverlayValues[348] = d348
+			ps437.OverlayValues[427] = d427
+			ps437.OverlayValues[429] = d429
+			ps437.OverlayValues[430] = d430
+			ps437.OverlayValues[431] = d431
+			ps437.OverlayValues[433] = d433
+			ps437.OverlayValues[434] = d434
+			ps437.OverlayValues[435] = d435
+			return bbs[18].RenderPS(ps437)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[16].RenderPS(ps)
+		}
+		ctx.EmitJump(d435.Condition, lbl16)
+		if bbs[18].Rendered {
+			ctx.EmitJmp(lbl19)
+		}
+		ctx.FreeDesc(&d434)
+		snap438 := d0
+		snap439 := d1
+		snap440 := d2
+		snap441 := d3
+		snap442 := d4
+		snap443 := d5
+		snap444 := d24
+		snap445 := d25
+		snap446 := d26
+		snap447 := d51
+		snap448 := d52
+		snap449 := d81
+		snap450 := d82
+		snap451 := d83
+		snap452 := d118
+		snap453 := d119
+		snap454 := d120
+		snap455 := d161
+		snap456 := d162
+		snap457 := d207
+		snap458 := d208
+		snap459 := d209
+		snap460 := d211
+		snap461 := d212
+		snap462 := d213
+		snap463 := d270
+		snap464 := d271
+		snap465 := d273
+		snap466 := d274
+		snap467 := d275
+		snap468 := d342
+		snap469 := d343
+		snap470 := d344
+		snap471 := d346
+		snap472 := d347
+		snap473 := d348
+		snap474 := d427
+		snap475 := d429
+		snap476 := d430
+		snap477 := d431
+		snap478 := d433
+		snap479 := d434
+		snap480 := d435
+		alloc481 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc481)
+		d0 = snap438
+		d1 = snap439
+		d2 = snap440
+		d3 = snap441
+		d4 = snap442
+		d5 = snap443
+		d24 = snap444
+		d25 = snap445
+		d26 = snap446
+		d51 = snap447
+		d52 = snap448
+		d81 = snap449
+		d82 = snap450
+		d83 = snap451
+		d118 = snap452
+		d119 = snap453
+		d120 = snap454
+		d161 = snap455
+		d162 = snap456
+		d207 = snap457
+		d208 = snap458
+		d209 = snap459
+		d211 = snap460
+		d212 = snap461
+		d213 = snap462
+		d270 = snap463
+		d271 = snap464
+		d273 = snap465
+		d274 = snap466
+		d275 = snap467
+		d342 = snap468
+		d343 = snap469
+		d344 = snap470
+		d346 = snap471
+		d347 = snap472
+		d348 = snap473
+		d427 = snap474
+		d429 = snap475
+		d430 = snap476
+		d431 = snap477
+		d433 = snap478
+		d434 = snap479
+		d435 = snap480
+		ctx.RestoreAllocState(alloc481)
+		d0 = snap438
+		d1 = snap439
+		d2 = snap440
+		d3 = snap441
+		d4 = snap442
+		d5 = snap443
+		d24 = snap444
+		d25 = snap445
+		d26 = snap446
+		d51 = snap447
+		d52 = snap448
+		d81 = snap449
+		d82 = snap450
+		d83 = snap451
+		d118 = snap452
+		d119 = snap453
+		d120 = snap454
+		d161 = snap455
+		d162 = snap456
+		d207 = snap457
+		d208 = snap458
+		d209 = snap459
+		d211 = snap460
+		d212 = snap461
+		d213 = snap462
+		d270 = snap463
+		d271 = snap464
+		d273 = snap465
+		d274 = snap466
+		d275 = snap467
+		d342 = snap468
+		d343 = snap469
+		d344 = snap470
+		d346 = snap471
+		d347 = snap472
+		d348 = snap473
+		d427 = snap474
+		d429 = snap475
+		d430 = snap476
+		d431 = snap477
+		d433 = snap478
+		d434 = snap479
+		d435 = snap480
+		ps482 := PhiState{General: true}
+		ps482.OverlayValues = make([]JITValueDesc, 436)
+		ps482.OverlayValues[0] = d0
+		ps482.OverlayValues[1] = d1
+		ps482.OverlayValues[2] = d2
+		ps482.OverlayValues[3] = d3
+		ps482.OverlayValues[4] = d4
+		ps482.OverlayValues[5] = d5
+		ps482.OverlayValues[24] = d24
+		ps482.OverlayValues[25] = d25
+		ps482.OverlayValues[26] = d26
+		ps482.OverlayValues[51] = d51
+		ps482.OverlayValues[52] = d52
+		ps482.OverlayValues[81] = d81
+		ps482.OverlayValues[82] = d82
+		ps482.OverlayValues[83] = d83
+		ps482.OverlayValues[118] = d118
+		ps482.OverlayValues[119] = d119
+		ps482.OverlayValues[120] = d120
+		ps482.OverlayValues[161] = d161
+		ps482.OverlayValues[162] = d162
+		ps482.OverlayValues[207] = d207
+		ps482.OverlayValues[208] = d208
+		ps482.OverlayValues[209] = d209
+		ps482.OverlayValues[211] = d211
+		ps482.OverlayValues[212] = d212
+		ps482.OverlayValues[213] = d213
+		ps482.OverlayValues[270] = d270
+		ps482.OverlayValues[271] = d271
+		ps482.OverlayValues[273] = d273
+		ps482.OverlayValues[274] = d274
+		ps482.OverlayValues[275] = d275
+		ps482.OverlayValues[342] = d342
+		ps482.OverlayValues[343] = d343
+		ps482.OverlayValues[344] = d344
+		ps482.OverlayValues[346] = d346
+		ps482.OverlayValues[347] = d347
+		ps482.OverlayValues[348] = d348
+		ps482.OverlayValues[427] = d427
+		ps482.OverlayValues[429] = d429
+		ps482.OverlayValues[430] = d430
+		ps482.OverlayValues[431] = d431
+		ps482.OverlayValues[433] = d433
+		ps482.OverlayValues[434] = d434
+		ps482.OverlayValues[435] = d435
+		ps483 := PhiState{General: true}
+		ps483.OverlayValues = make([]JITValueDesc, 436)
+		ps483.OverlayValues[0] = d0
+		ps483.OverlayValues[1] = d1
+		ps483.OverlayValues[2] = d2
+		ps483.OverlayValues[3] = d3
+		ps483.OverlayValues[4] = d4
+		ps483.OverlayValues[5] = d5
+		ps483.OverlayValues[24] = d24
+		ps483.OverlayValues[25] = d25
+		ps483.OverlayValues[26] = d26
+		ps483.OverlayValues[51] = d51
+		ps483.OverlayValues[52] = d52
+		ps483.OverlayValues[81] = d81
+		ps483.OverlayValues[82] = d82
+		ps483.OverlayValues[83] = d83
+		ps483.OverlayValues[118] = d118
+		ps483.OverlayValues[119] = d119
+		ps483.OverlayValues[120] = d120
+		ps483.OverlayValues[161] = d161
+		ps483.OverlayValues[162] = d162
+		ps483.OverlayValues[207] = d207
+		ps483.OverlayValues[208] = d208
+		ps483.OverlayValues[209] = d209
+		ps483.OverlayValues[211] = d211
+		ps483.OverlayValues[212] = d212
+		ps483.OverlayValues[213] = d213
+		ps483.OverlayValues[270] = d270
+		ps483.OverlayValues[271] = d271
+		ps483.OverlayValues[273] = d273
+		ps483.OverlayValues[274] = d274
+		ps483.OverlayValues[275] = d275
+		ps483.OverlayValues[342] = d342
+		ps483.OverlayValues[343] = d343
+		ps483.OverlayValues[344] = d344
+		ps483.OverlayValues[346] = d346
+		ps483.OverlayValues[347] = d347
+		ps483.OverlayValues[348] = d348
+		ps483.OverlayValues[427] = d427
+		ps483.OverlayValues[429] = d429
+		ps483.OverlayValues[430] = d430
+		ps483.OverlayValues[431] = d431
+		ps483.OverlayValues[433] = d433
+		ps483.OverlayValues[434] = d434
+		ps483.OverlayValues[435] = d435
+		snap484 := d0
+		snap485 := d1
+		snap486 := d2
+		snap487 := d3
+		snap488 := d4
+		snap489 := d5
+		snap490 := d24
+		snap491 := d25
+		snap492 := d26
+		snap493 := d51
+		snap494 := d52
+		snap495 := d81
+		snap496 := d82
+		snap497 := d83
+		snap498 := d118
+		snap499 := d119
+		snap500 := d120
+		snap501 := d161
+		snap502 := d162
+		snap503 := d207
+		snap504 := d208
+		snap505 := d209
+		snap506 := d211
+		snap507 := d212
+		snap508 := d213
+		snap509 := d270
+		snap510 := d271
+		snap511 := d273
+		snap512 := d274
+		snap513 := d275
+		snap514 := d342
+		snap515 := d343
+		snap516 := d344
+		snap517 := d346
+		snap518 := d347
+		snap519 := d348
+		snap520 := d427
+		snap521 := d429
+		snap522 := d430
+		snap523 := d431
+		snap524 := d433
+		snap525 := d434
+		snap526 := d435
+		alloc527 := ctx.SnapshotAllocState()
+		if !bbs[18].Rendered {
+			bbs[18].RenderPS(ps483)
+		}
+		ctx.RestoreAllocState(alloc527)
+		d0 = snap484
+		d1 = snap485
+		d2 = snap486
+		d3 = snap487
+		d4 = snap488
+		d5 = snap489
+		d24 = snap490
+		d25 = snap491
+		d26 = snap492
+		d51 = snap493
+		d52 = snap494
+		d81 = snap495
+		d82 = snap496
+		d83 = snap497
+		d118 = snap498
+		d119 = snap499
+		d120 = snap500
+		d161 = snap501
+		d162 = snap502
+		d207 = snap503
+		d208 = snap504
+		d209 = snap505
+		d211 = snap506
+		d212 = snap507
+		d213 = snap508
+		d270 = snap509
+		d271 = snap510
+		d273 = snap511
+		d274 = snap512
+		d275 = snap513
+		d342 = snap514
+		d343 = snap515
+		d344 = snap516
+		d346 = snap517
+		d347 = snap518
+		d348 = snap519
+		d427 = snap520
+		d429 = snap521
+		d430 = snap522
+		d431 = snap523
+		d433 = snap524
+		d434 = snap525
+		d435 = snap526
+		if !bbs[15].Rendered {
+			return bbs[15].RenderPS(ps482)
+		}
+		return result
+		return result
+	}
+	bbs[17].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[17].VisitCount >= 0 {
+				ps.General = true
+				return bbs[17].RenderPS(ps)
+			}
+		}
+		bbs[17].VisitCount++
+		if ps.General {
+			if bbs[17].Rendered {
+				ctx.EmitJmp(lbl18)
+				return result
+			}
+			bbs[17].Rendered = true
+			bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_17 = bbs[17].Address
+			ctx.MarkLabel(lbl18)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
+			d212 = ps.OverlayValues[212]
+		}
+		if len(ps.OverlayValues) > 213 && ps.OverlayValues[213].Loc != LocNone {
+			d213 = ps.OverlayValues[213]
+		}
+		if len(ps.OverlayValues) > 270 && ps.OverlayValues[270].Loc != LocNone {
+			d270 = ps.OverlayValues[270]
+		}
+		if len(ps.OverlayValues) > 271 && ps.OverlayValues[271].Loc != LocNone {
+			d271 = ps.OverlayValues[271]
+		}
+		if len(ps.OverlayValues) > 273 && ps.OverlayValues[273].Loc != LocNone {
+			d273 = ps.OverlayValues[273]
+		}
+		if len(ps.OverlayValues) > 274 && ps.OverlayValues[274].Loc != LocNone {
+			d274 = ps.OverlayValues[274]
+		}
+		if len(ps.OverlayValues) > 275 && ps.OverlayValues[275].Loc != LocNone {
+			d275 = ps.OverlayValues[275]
+		}
+		if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
+			d342 = ps.OverlayValues[342]
+		}
+		if len(ps.OverlayValues) > 343 && ps.OverlayValues[343].Loc != LocNone {
+			d343 = ps.OverlayValues[343]
+		}
+		if len(ps.OverlayValues) > 344 && ps.OverlayValues[344].Loc != LocNone {
+			d344 = ps.OverlayValues[344]
+		}
+		if len(ps.OverlayValues) > 346 && ps.OverlayValues[346].Loc != LocNone {
+			d346 = ps.OverlayValues[346]
+		}
+		if len(ps.OverlayValues) > 347 && ps.OverlayValues[347].Loc != LocNone {
+			d347 = ps.OverlayValues[347]
+		}
+		if len(ps.OverlayValues) > 348 && ps.OverlayValues[348].Loc != LocNone {
+			d348 = ps.OverlayValues[348]
+		}
+		if len(ps.OverlayValues) > 427 && ps.OverlayValues[427].Loc != LocNone {
+			d427 = ps.OverlayValues[427]
+		}
+		if len(ps.OverlayValues) > 429 && ps.OverlayValues[429].Loc != LocNone {
+			d429 = ps.OverlayValues[429]
+		}
+		if len(ps.OverlayValues) > 430 && ps.OverlayValues[430].Loc != LocNone {
+			d430 = ps.OverlayValues[430]
+		}
+		if len(ps.OverlayValues) > 431 && ps.OverlayValues[431].Loc != LocNone {
+			d431 = ps.OverlayValues[431]
+		}
+		if len(ps.OverlayValues) > 433 && ps.OverlayValues[433].Loc != LocNone {
+			d433 = ps.OverlayValues[433]
+		}
+		if len(ps.OverlayValues) > 434 && ps.OverlayValues[434].Loc != LocNone {
+			d434 = ps.OverlayValues[434]
+		}
+		if len(ps.OverlayValues) > 435 && ps.OverlayValues[435].Loc != LocNone {
+			d435 = ps.OverlayValues[435]
+		}
+		ctx.ReclaimUntrackedRegs()
+		var d528 JITValueDesc
+		if args[0].Loc == LocImm {
+			d528 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(args[0].Imm.Int())}
+		} else if args[0].Type == tagInt && args[0].Loc == LocRegPair {
+			ctx.FreeReg(args[0].Reg)
+			d528 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[0].Reg2}
+			ctx.BindReg(args[0].Reg2, &d528)
+		} else if args[0].Type == tagInt && args[0].Loc == LocReg {
+			d528 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[0].Reg}
+			ctx.BindReg(args[0].Reg, &d528)
+		} else {
+			d528 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{args[0]}, 1)
+			d528.Type = tagInt
+			ctx.BindReg(d528.Reg, &d528)
+		}
+		var d529 JITValueDesc
+		if args[1].Loc == LocImm {
+			d529 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(args[1].Imm.Int())}
+		} else if args[1].Type == tagInt && args[1].Loc == LocRegPair {
+			ctx.FreeReg(args[1].Reg)
+			d529 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[1].Reg2}
+			ctx.BindReg(args[1].Reg2, &d529)
+		} else if args[1].Type == tagInt && args[1].Loc == LocReg {
+			d529 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: args[1].Reg}
+			ctx.BindReg(args[1].Reg, &d529)
+		} else {
+			d529 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{args[1]}, 1)
+			d529.Type = tagInt
+			ctx.BindReg(d529.Reg, &d529)
+		}
+		ctx.EnsureDesc(&d528)
+		resultTarget530 := false
+		_ = resultTarget530
+		ctx.EnsureDesc(&d529)
+		ctx.EnsureDescsTogether(&d528, &d529)
+		var d531 JITValueDesc
+		if d528.Loc == LocImm && d529.Loc == LocImm {
+			d531 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d528.Imm.Int() < d529.Imm.Int())}
+		} else if d529.Loc == LocImm {
+			if d529.Imm.Int() >= -2147483648 && d529.Imm.Int() <= 2147483647 {
+				ctx.EmitCmpRegImm32(d528.Reg, int32(d529.Imm.Int()))
+			} else {
+				ctx.EmitMovRegImm64(RegR11, uint64(d529.Imm.Int()))
+				ctx.EmitCmpInt64(d528.Reg, RegR11)
+			}
+			var r23 Reg
+			if result.Loc == LocReg && result.Reg != d528.Reg {
+				r23 = result.Reg
+				resultTarget530 = true
+			} else {
+				r23 = ctx.AllocRegExcept(d528.Reg)
+			}
+			ctx.EmitSetcc(r23, CondSignedLess)
+			d531 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r23}
+			ctx.BindReg(r23, &d531)
+		} else if d528.Loc == LocImm {
+			ctx.EmitMovRegImm64(RegR11, uint64(d528.Imm.Int()))
+			ctx.EmitCmpInt64(RegR11, d529.Reg)
+			var r24 Reg
+			if result.Loc == LocReg && result.Reg != d529.Reg {
+				r24 = result.Reg
+				resultTarget530 = true
+			} else {
+				r24 = ctx.AllocRegExcept(d529.Reg)
+			}
+			ctx.EmitSetcc(r24, CondSignedLess)
+			d531 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r24}
+			ctx.BindReg(r24, &d531)
+		} else {
+			ctx.EmitCmpInt64(d528.Reg, d529.Reg)
+			var r25 Reg
+			if result.Loc == LocReg && result.Reg != d528.Reg && result.Reg != d529.Reg {
+				r25 = result.Reg
+				resultTarget530 = true
+			} else {
+				r25 = ctx.AllocRegExcept(d528.Reg, d529.Reg)
+			}
+			ctx.EmitSetcc(r25, CondSignedLess)
+			d531 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r25}
+			ctx.BindReg(r25, &d531)
+		}
+		ctx.FreeDesc(&d528)
+		ctx.FreeDesc(&d529)
+		ctx.EnsureDesc(&d531)
+		ctx.EmitMovToReg(result.Reg, d531)
+		result.Type = d531.Type
+		ctx.EmitJmp(lbl0)
+		return result
+	}
+	bbs[18].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[18].VisitCount >= 0 {
+				ps.General = true
+				return bbs[18].RenderPS(ps)
+			}
+		}
+		bbs[18].VisitCount++
+		if ps.General {
+			if bbs[18].Rendered {
+				ctx.EmitJmp(lbl19)
+				return result
+			}
+			bbs[18].Rendered = true
+			bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_18 = bbs[18].Address
+			ctx.MarkLabel(lbl19)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
+			d212 = ps.OverlayValues[212]
+		}
+		if len(ps.OverlayValues) > 213 && ps.OverlayValues[213].Loc != LocNone {
+			d213 = ps.OverlayValues[213]
+		}
+		if len(ps.OverlayValues) > 270 && ps.OverlayValues[270].Loc != LocNone {
+			d270 = ps.OverlayValues[270]
+		}
+		if len(ps.OverlayValues) > 271 && ps.OverlayValues[271].Loc != LocNone {
+			d271 = ps.OverlayValues[271]
+		}
+		if len(ps.OverlayValues) > 273 && ps.OverlayValues[273].Loc != LocNone {
+			d273 = ps.OverlayValues[273]
+		}
+		if len(ps.OverlayValues) > 274 && ps.OverlayValues[274].Loc != LocNone {
+			d274 = ps.OverlayValues[274]
+		}
+		if len(ps.OverlayValues) > 275 && ps.OverlayValues[275].Loc != LocNone {
+			d275 = ps.OverlayValues[275]
+		}
+		if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
+			d342 = ps.OverlayValues[342]
+		}
+		if len(ps.OverlayValues) > 343 && ps.OverlayValues[343].Loc != LocNone {
+			d343 = ps.OverlayValues[343]
+		}
+		if len(ps.OverlayValues) > 344 && ps.OverlayValues[344].Loc != LocNone {
+			d344 = ps.OverlayValues[344]
+		}
+		if len(ps.OverlayValues) > 346 && ps.OverlayValues[346].Loc != LocNone {
+			d346 = ps.OverlayValues[346]
+		}
+		if len(ps.OverlayValues) > 347 && ps.OverlayValues[347].Loc != LocNone {
+			d347 = ps.OverlayValues[347]
+		}
+		if len(ps.OverlayValues) > 348 && ps.OverlayValues[348].Loc != LocNone {
+			d348 = ps.OverlayValues[348]
+		}
+		if len(ps.OverlayValues) > 427 && ps.OverlayValues[427].Loc != LocNone {
+			d427 = ps.OverlayValues[427]
+		}
+		if len(ps.OverlayValues) > 429 && ps.OverlayValues[429].Loc != LocNone {
+			d429 = ps.OverlayValues[429]
+		}
+		if len(ps.OverlayValues) > 430 && ps.OverlayValues[430].Loc != LocNone {
+			d430 = ps.OverlayValues[430]
+		}
+		if len(ps.OverlayValues) > 431 && ps.OverlayValues[431].Loc != LocNone {
+			d431 = ps.OverlayValues[431]
+		}
+		if len(ps.OverlayValues) > 433 && ps.OverlayValues[433].Loc != LocNone {
+			d433 = ps.OverlayValues[433]
+		}
+		if len(ps.OverlayValues) > 434 && ps.OverlayValues[434].Loc != LocNone {
+			d434 = ps.OverlayValues[434]
+		}
+		if len(ps.OverlayValues) > 435 && ps.OverlayValues[435].Loc != LocNone {
+			d435 = ps.OverlayValues[435]
+		}
+		if len(ps.OverlayValues) > 528 && ps.OverlayValues[528].Loc != LocNone {
+			d528 = ps.OverlayValues[528]
+		}
+		if len(ps.OverlayValues) > 529 && ps.OverlayValues[529].Loc != LocNone {
+			d529 = ps.OverlayValues[529]
+		}
+		if len(ps.OverlayValues) > 531 && ps.OverlayValues[531].Loc != LocNone {
+			d531 = ps.OverlayValues[531]
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d1)
+		var d532 JITValueDesc
+		if d1.Loc == LocImm {
+			d532 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d1.Imm.Int()) == uint64(0x5))}
+		} else {
+			r26 := ctx.AllocRegExcept(d1.Reg)
+			ctx.EmitCmpRegImm32(d1.Reg, 5)
+			d532 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r26, Condition: CondEqual}
+			ctx.BindReg(r26, &d532)
+		}
+		d533 = d532
+		ctx.EnsureDesc(&d533)
+		if d533.Loc != LocImm && d533.Loc != LocFlags {
+			panic("jit: fused If condition is neither LocImm nor LocFlags")
+		}
+		if d533.Loc == LocImm {
+			if d533.Imm.Bool() {
+				if ps.General {
+				}
+				ps534 := PhiState{General: ps.General}
+				ps534.OverlayValues = make([]JITValueDesc, 534)
+				ps534.OverlayValues[0] = d0
+				ps534.OverlayValues[1] = d1
+				ps534.OverlayValues[2] = d2
+				ps534.OverlayValues[3] = d3
+				ps534.OverlayValues[4] = d4
+				ps534.OverlayValues[5] = d5
+				ps534.OverlayValues[24] = d24
+				ps534.OverlayValues[25] = d25
+				ps534.OverlayValues[26] = d26
+				ps534.OverlayValues[51] = d51
+				ps534.OverlayValues[52] = d52
+				ps534.OverlayValues[81] = d81
+				ps534.OverlayValues[82] = d82
+				ps534.OverlayValues[83] = d83
+				ps534.OverlayValues[118] = d118
+				ps534.OverlayValues[119] = d119
+				ps534.OverlayValues[120] = d120
+				ps534.OverlayValues[161] = d161
+				ps534.OverlayValues[162] = d162
+				ps534.OverlayValues[207] = d207
+				ps534.OverlayValues[208] = d208
+				ps534.OverlayValues[209] = d209
+				ps534.OverlayValues[211] = d211
+				ps534.OverlayValues[212] = d212
+				ps534.OverlayValues[213] = d213
+				ps534.OverlayValues[270] = d270
+				ps534.OverlayValues[271] = d271
+				ps534.OverlayValues[273] = d273
+				ps534.OverlayValues[274] = d274
+				ps534.OverlayValues[275] = d275
+				ps534.OverlayValues[342] = d342
+				ps534.OverlayValues[343] = d343
+				ps534.OverlayValues[344] = d344
+				ps534.OverlayValues[346] = d346
+				ps534.OverlayValues[347] = d347
+				ps534.OverlayValues[348] = d348
+				ps534.OverlayValues[427] = d427
+				ps534.OverlayValues[429] = d429
+				ps534.OverlayValues[430] = d430
+				ps534.OverlayValues[431] = d431
+				ps534.OverlayValues[433] = d433
+				ps534.OverlayValues[434] = d434
+				ps534.OverlayValues[435] = d435
+				ps534.OverlayValues[528] = d528
+				ps534.OverlayValues[529] = d529
+				ps534.OverlayValues[531] = d531
+				ps534.OverlayValues[532] = d532
+				ps534.OverlayValues[533] = d533
+				return bbs[17].RenderPS(ps534)
+			}
+			if ps.General {
+			}
+			ps535 := PhiState{General: ps.General}
+			ps535.OverlayValues = make([]JITValueDesc, 534)
+			ps535.OverlayValues[0] = d0
+			ps535.OverlayValues[1] = d1
+			ps535.OverlayValues[2] = d2
+			ps535.OverlayValues[3] = d3
+			ps535.OverlayValues[4] = d4
+			ps535.OverlayValues[5] = d5
+			ps535.OverlayValues[24] = d24
+			ps535.OverlayValues[25] = d25
+			ps535.OverlayValues[26] = d26
+			ps535.OverlayValues[51] = d51
+			ps535.OverlayValues[52] = d52
+			ps535.OverlayValues[81] = d81
+			ps535.OverlayValues[82] = d82
+			ps535.OverlayValues[83] = d83
+			ps535.OverlayValues[118] = d118
+			ps535.OverlayValues[119] = d119
+			ps535.OverlayValues[120] = d120
+			ps535.OverlayValues[161] = d161
+			ps535.OverlayValues[162] = d162
+			ps535.OverlayValues[207] = d207
+			ps535.OverlayValues[208] = d208
+			ps535.OverlayValues[209] = d209
+			ps535.OverlayValues[211] = d211
+			ps535.OverlayValues[212] = d212
+			ps535.OverlayValues[213] = d213
+			ps535.OverlayValues[270] = d270
+			ps535.OverlayValues[271] = d271
+			ps535.OverlayValues[273] = d273
+			ps535.OverlayValues[274] = d274
+			ps535.OverlayValues[275] = d275
+			ps535.OverlayValues[342] = d342
+			ps535.OverlayValues[343] = d343
+			ps535.OverlayValues[344] = d344
+			ps535.OverlayValues[346] = d346
+			ps535.OverlayValues[347] = d347
+			ps535.OverlayValues[348] = d348
+			ps535.OverlayValues[427] = d427
+			ps535.OverlayValues[429] = d429
+			ps535.OverlayValues[430] = d430
+			ps535.OverlayValues[431] = d431
+			ps535.OverlayValues[433] = d433
+			ps535.OverlayValues[434] = d434
+			ps535.OverlayValues[435] = d435
+			ps535.OverlayValues[528] = d528
+			ps535.OverlayValues[529] = d529
+			ps535.OverlayValues[531] = d531
+			ps535.OverlayValues[532] = d532
+			ps535.OverlayValues[533] = d533
+			return bbs[19].RenderPS(ps535)
+		}
+		if !ps.General {
+			ps.General = true
+			return bbs[18].RenderPS(ps)
+		}
+		ctx.EmitJump(d533.Condition, lbl18)
+		if bbs[19].Rendered {
+			ctx.EmitJmp(lbl20)
+		}
+		ctx.FreeDesc(&d532)
+		snap536 := d0
+		snap537 := d1
+		snap538 := d2
+		snap539 := d3
+		snap540 := d4
+		snap541 := d5
+		snap542 := d24
+		snap543 := d25
+		snap544 := d26
+		snap545 := d51
+		snap546 := d52
+		snap547 := d81
+		snap548 := d82
+		snap549 := d83
+		snap550 := d118
+		snap551 := d119
+		snap552 := d120
+		snap553 := d161
+		snap554 := d162
+		snap555 := d207
+		snap556 := d208
+		snap557 := d209
+		snap558 := d211
+		snap559 := d212
+		snap560 := d213
+		snap561 := d270
+		snap562 := d271
+		snap563 := d273
+		snap564 := d274
+		snap565 := d275
+		snap566 := d342
+		snap567 := d343
+		snap568 := d344
+		snap569 := d346
+		snap570 := d347
+		snap571 := d348
+		snap572 := d427
+		snap573 := d429
+		snap574 := d430
+		snap575 := d431
+		snap576 := d433
+		snap577 := d434
+		snap578 := d435
+		snap579 := d528
+		snap580 := d529
+		snap581 := d531
+		snap582 := d532
+		snap583 := d533
+		alloc584 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc584)
+		d0 = snap536
+		d1 = snap537
+		d2 = snap538
+		d3 = snap539
+		d4 = snap540
+		d5 = snap541
+		d24 = snap542
+		d25 = snap543
+		d26 = snap544
+		d51 = snap545
+		d52 = snap546
+		d81 = snap547
+		d82 = snap548
+		d83 = snap549
+		d118 = snap550
+		d119 = snap551
+		d120 = snap552
+		d161 = snap553
+		d162 = snap554
+		d207 = snap555
+		d208 = snap556
+		d209 = snap557
+		d211 = snap558
+		d212 = snap559
+		d213 = snap560
+		d270 = snap561
+		d271 = snap562
+		d273 = snap563
+		d274 = snap564
+		d275 = snap565
+		d342 = snap566
+		d343 = snap567
+		d344 = snap568
+		d346 = snap569
+		d347 = snap570
+		d348 = snap571
+		d427 = snap572
+		d429 = snap573
+		d430 = snap574
+		d431 = snap575
+		d433 = snap576
+		d434 = snap577
+		d435 = snap578
+		d528 = snap579
+		d529 = snap580
+		d531 = snap581
+		d532 = snap582
+		d533 = snap583
+		ctx.RestoreAllocState(alloc584)
+		d0 = snap536
+		d1 = snap537
+		d2 = snap538
+		d3 = snap539
+		d4 = snap540
+		d5 = snap541
+		d24 = snap542
+		d25 = snap543
+		d26 = snap544
+		d51 = snap545
+		d52 = snap546
+		d81 = snap547
+		d82 = snap548
+		d83 = snap549
+		d118 = snap550
+		d119 = snap551
+		d120 = snap552
+		d161 = snap553
+		d162 = snap554
+		d207 = snap555
+		d208 = snap556
+		d209 = snap557
+		d211 = snap558
+		d212 = snap559
+		d213 = snap560
+		d270 = snap561
+		d271 = snap562
+		d273 = snap563
+		d274 = snap564
+		d275 = snap565
+		d342 = snap566
+		d343 = snap567
+		d344 = snap568
+		d346 = snap569
+		d347 = snap570
+		d348 = snap571
+		d427 = snap572
+		d429 = snap573
+		d430 = snap574
+		d431 = snap575
+		d433 = snap576
+		d434 = snap577
+		d435 = snap578
+		d528 = snap579
+		d529 = snap580
+		d531 = snap581
+		d532 = snap582
+		d533 = snap583
+		ps585 := PhiState{General: true}
+		ps585.OverlayValues = make([]JITValueDesc, 534)
+		ps585.OverlayValues[0] = d0
+		ps585.OverlayValues[1] = d1
+		ps585.OverlayValues[2] = d2
+		ps585.OverlayValues[3] = d3
+		ps585.OverlayValues[4] = d4
+		ps585.OverlayValues[5] = d5
+		ps585.OverlayValues[24] = d24
+		ps585.OverlayValues[25] = d25
+		ps585.OverlayValues[26] = d26
+		ps585.OverlayValues[51] = d51
+		ps585.OverlayValues[52] = d52
+		ps585.OverlayValues[81] = d81
+		ps585.OverlayValues[82] = d82
+		ps585.OverlayValues[83] = d83
+		ps585.OverlayValues[118] = d118
+		ps585.OverlayValues[119] = d119
+		ps585.OverlayValues[120] = d120
+		ps585.OverlayValues[161] = d161
+		ps585.OverlayValues[162] = d162
+		ps585.OverlayValues[207] = d207
+		ps585.OverlayValues[208] = d208
+		ps585.OverlayValues[209] = d209
+		ps585.OverlayValues[211] = d211
+		ps585.OverlayValues[212] = d212
+		ps585.OverlayValues[213] = d213
+		ps585.OverlayValues[270] = d270
+		ps585.OverlayValues[271] = d271
+		ps585.OverlayValues[273] = d273
+		ps585.OverlayValues[274] = d274
+		ps585.OverlayValues[275] = d275
+		ps585.OverlayValues[342] = d342
+		ps585.OverlayValues[343] = d343
+		ps585.OverlayValues[344] = d344
+		ps585.OverlayValues[346] = d346
+		ps585.OverlayValues[347] = d347
+		ps585.OverlayValues[348] = d348
+		ps585.OverlayValues[427] = d427
+		ps585.OverlayValues[429] = d429
+		ps585.OverlayValues[430] = d430
+		ps585.OverlayValues[431] = d431
+		ps585.OverlayValues[433] = d433
+		ps585.OverlayValues[434] = d434
+		ps585.OverlayValues[435] = d435
+		ps585.OverlayValues[528] = d528
+		ps585.OverlayValues[529] = d529
+		ps585.OverlayValues[531] = d531
+		ps585.OverlayValues[532] = d532
+		ps585.OverlayValues[533] = d533
+		ps586 := PhiState{General: true}
+		ps586.OverlayValues = make([]JITValueDesc, 534)
+		ps586.OverlayValues[0] = d0
+		ps586.OverlayValues[1] = d1
+		ps586.OverlayValues[2] = d2
+		ps586.OverlayValues[3] = d3
+		ps586.OverlayValues[4] = d4
+		ps586.OverlayValues[5] = d5
+		ps586.OverlayValues[24] = d24
+		ps586.OverlayValues[25] = d25
+		ps586.OverlayValues[26] = d26
+		ps586.OverlayValues[51] = d51
+		ps586.OverlayValues[52] = d52
+		ps586.OverlayValues[81] = d81
+		ps586.OverlayValues[82] = d82
+		ps586.OverlayValues[83] = d83
+		ps586.OverlayValues[118] = d118
+		ps586.OverlayValues[119] = d119
+		ps586.OverlayValues[120] = d120
+		ps586.OverlayValues[161] = d161
+		ps586.OverlayValues[162] = d162
+		ps586.OverlayValues[207] = d207
+		ps586.OverlayValues[208] = d208
+		ps586.OverlayValues[209] = d209
+		ps586.OverlayValues[211] = d211
+		ps586.OverlayValues[212] = d212
+		ps586.OverlayValues[213] = d213
+		ps586.OverlayValues[270] = d270
+		ps586.OverlayValues[271] = d271
+		ps586.OverlayValues[273] = d273
+		ps586.OverlayValues[274] = d274
+		ps586.OverlayValues[275] = d275
+		ps586.OverlayValues[342] = d342
+		ps586.OverlayValues[343] = d343
+		ps586.OverlayValues[344] = d344
+		ps586.OverlayValues[346] = d346
+		ps586.OverlayValues[347] = d347
+		ps586.OverlayValues[348] = d348
+		ps586.OverlayValues[427] = d427
+		ps586.OverlayValues[429] = d429
+		ps586.OverlayValues[430] = d430
+		ps586.OverlayValues[431] = d431
+		ps586.OverlayValues[433] = d433
+		ps586.OverlayValues[434] = d434
+		ps586.OverlayValues[435] = d435
+		ps586.OverlayValues[528] = d528
+		ps586.OverlayValues[529] = d529
+		ps586.OverlayValues[531] = d531
+		ps586.OverlayValues[532] = d532
+		ps586.OverlayValues[533] = d533
+		snap587 := d0
+		snap588 := d1
+		snap589 := d2
+		snap590 := d3
+		snap591 := d4
+		snap592 := d5
+		snap593 := d24
+		snap594 := d25
+		snap595 := d26
+		snap596 := d51
+		snap597 := d52
+		snap598 := d81
+		snap599 := d82
+		snap600 := d83
+		snap601 := d118
+		snap602 := d119
+		snap603 := d120
+		snap604 := d161
+		snap605 := d162
+		snap606 := d207
+		snap607 := d208
+		snap608 := d209
+		snap609 := d211
+		snap610 := d212
+		snap611 := d213
+		snap612 := d270
+		snap613 := d271
+		snap614 := d273
+		snap615 := d274
+		snap616 := d275
+		snap617 := d342
+		snap618 := d343
+		snap619 := d344
+		snap620 := d346
+		snap621 := d347
+		snap622 := d348
+		snap623 := d427
+		snap624 := d429
+		snap625 := d430
+		snap626 := d431
+		snap627 := d433
+		snap628 := d434
+		snap629 := d435
+		snap630 := d528
+		snap631 := d529
+		snap632 := d531
+		snap633 := d532
+		snap634 := d533
+		alloc635 := ctx.SnapshotAllocState()
+		if !bbs[19].Rendered {
+			bbs[19].RenderPS(ps586)
+		}
+		ctx.RestoreAllocState(alloc635)
+		d0 = snap587
+		d1 = snap588
+		d2 = snap589
+		d3 = snap590
+		d4 = snap591
+		d5 = snap592
+		d24 = snap593
+		d25 = snap594
+		d26 = snap595
+		d51 = snap596
+		d52 = snap597
+		d81 = snap598
+		d82 = snap599
+		d83 = snap600
+		d118 = snap601
+		d119 = snap602
+		d120 = snap603
+		d161 = snap604
+		d162 = snap605
+		d207 = snap606
+		d208 = snap607
+		d209 = snap608
+		d211 = snap609
+		d212 = snap610
+		d213 = snap611
+		d270 = snap612
+		d271 = snap613
+		d273 = snap614
+		d274 = snap615
+		d275 = snap616
+		d342 = snap617
+		d343 = snap618
+		d344 = snap619
+		d346 = snap620
+		d347 = snap621
+		d348 = snap622
+		d427 = snap623
+		d429 = snap624
+		d430 = snap625
+		d431 = snap626
+		d433 = snap627
+		d434 = snap628
+		d435 = snap629
+		d528 = snap630
+		d529 = snap631
+		d531 = snap632
+		d532 = snap633
+		d533 = snap634
+		if !bbs[17].Rendered {
+			return bbs[17].RenderPS(ps585)
+		}
+		return result
+		return result
+	}
+	bbs[19].RenderPS = func(ps PhiState) JITValueDesc {
+		if !ps.General {
+			if bbs[19].VisitCount >= 0 {
+				ps.General = true
+				return bbs[19].RenderPS(ps)
+			}
+		}
+		bbs[19].VisitCount++
+		if ps.General {
+			if bbs[19].Rendered {
+				ctx.EmitJmp(lbl20)
+				return result
+			}
+			bbs[19].Rendered = true
+			bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+			bbpos_0_19 = bbs[19].Address
+			ctx.MarkLabel(lbl20)
+			ctx.ResolveFixups()
+		}
+		if len(ps.OverlayValues) > 0 && ps.OverlayValues[0].Loc != LocNone {
+			d0 = ps.OverlayValues[0]
+		}
+		if len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+			d1 = ps.OverlayValues[1]
+		}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+			d2 = ps.OverlayValues[2]
+		}
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+			d3 = ps.OverlayValues[3]
+		}
+		if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+			d4 = ps.OverlayValues[4]
+		}
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+			d5 = ps.OverlayValues[5]
+		}
+		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+			d24 = ps.OverlayValues[24]
+		}
+		if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+			d25 = ps.OverlayValues[25]
+		}
+		if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+			d26 = ps.OverlayValues[26]
+		}
+		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
+			d51 = ps.OverlayValues[51]
+		}
+		if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+			d52 = ps.OverlayValues[52]
+		}
+		if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+			d81 = ps.OverlayValues[81]
+		}
+		if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+			d82 = ps.OverlayValues[82]
+		}
+		if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+			d83 = ps.OverlayValues[83]
+		}
+		if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
+			d118 = ps.OverlayValues[118]
+		}
+		if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+			d119 = ps.OverlayValues[119]
+		}
+		if len(ps.OverlayValues) > 120 && ps.OverlayValues[120].Loc != LocNone {
+			d120 = ps.OverlayValues[120]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+			d161 = ps.OverlayValues[161]
+		}
+		if len(ps.OverlayValues) > 162 && ps.OverlayValues[162].Loc != LocNone {
+			d162 = ps.OverlayValues[162]
+		}
+		if len(ps.OverlayValues) > 207 && ps.OverlayValues[207].Loc != LocNone {
+			d207 = ps.OverlayValues[207]
+		}
+		if len(ps.OverlayValues) > 208 && ps.OverlayValues[208].Loc != LocNone {
+			d208 = ps.OverlayValues[208]
+		}
+		if len(ps.OverlayValues) > 209 && ps.OverlayValues[209].Loc != LocNone {
+			d209 = ps.OverlayValues[209]
+		}
+		if len(ps.OverlayValues) > 211 && ps.OverlayValues[211].Loc != LocNone {
+			d211 = ps.OverlayValues[211]
+		}
+		if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
+			d212 = ps.OverlayValues[212]
+		}
+		if len(ps.OverlayValues) > 213 && ps.OverlayValues[213].Loc != LocNone {
+			d213 = ps.OverlayValues[213]
+		}
+		if len(ps.OverlayValues) > 270 && ps.OverlayValues[270].Loc != LocNone {
+			d270 = ps.OverlayValues[270]
+		}
+		if len(ps.OverlayValues) > 271 && ps.OverlayValues[271].Loc != LocNone {
+			d271 = ps.OverlayValues[271]
+		}
+		if len(ps.OverlayValues) > 273 && ps.OverlayValues[273].Loc != LocNone {
+			d273 = ps.OverlayValues[273]
+		}
+		if len(ps.OverlayValues) > 274 && ps.OverlayValues[274].Loc != LocNone {
+			d274 = ps.OverlayValues[274]
+		}
+		if len(ps.OverlayValues) > 275 && ps.OverlayValues[275].Loc != LocNone {
+			d275 = ps.OverlayValues[275]
+		}
+		if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
+			d342 = ps.OverlayValues[342]
+		}
+		if len(ps.OverlayValues) > 343 && ps.OverlayValues[343].Loc != LocNone {
+			d343 = ps.OverlayValues[343]
+		}
+		if len(ps.OverlayValues) > 344 && ps.OverlayValues[344].Loc != LocNone {
+			d344 = ps.OverlayValues[344]
+		}
+		if len(ps.OverlayValues) > 346 && ps.OverlayValues[346].Loc != LocNone {
+			d346 = ps.OverlayValues[346]
+		}
+		if len(ps.OverlayValues) > 347 && ps.OverlayValues[347].Loc != LocNone {
+			d347 = ps.OverlayValues[347]
+		}
+		if len(ps.OverlayValues) > 348 && ps.OverlayValues[348].Loc != LocNone {
+			d348 = ps.OverlayValues[348]
+		}
+		if len(ps.OverlayValues) > 427 && ps.OverlayValues[427].Loc != LocNone {
+			d427 = ps.OverlayValues[427]
+		}
+		if len(ps.OverlayValues) > 429 && ps.OverlayValues[429].Loc != LocNone {
+			d429 = ps.OverlayValues[429]
+		}
+		if len(ps.OverlayValues) > 430 && ps.OverlayValues[430].Loc != LocNone {
+			d430 = ps.OverlayValues[430]
+		}
+		if len(ps.OverlayValues) > 431 && ps.OverlayValues[431].Loc != LocNone {
+			d431 = ps.OverlayValues[431]
+		}
+		if len(ps.OverlayValues) > 433 && ps.OverlayValues[433].Loc != LocNone {
+			d433 = ps.OverlayValues[433]
+		}
+		if len(ps.OverlayValues) > 434 && ps.OverlayValues[434].Loc != LocNone {
+			d434 = ps.OverlayValues[434]
+		}
+		if len(ps.OverlayValues) > 435 && ps.OverlayValues[435].Loc != LocNone {
+			d435 = ps.OverlayValues[435]
+		}
+		if len(ps.OverlayValues) > 528 && ps.OverlayValues[528].Loc != LocNone {
+			d528 = ps.OverlayValues[528]
+		}
+		if len(ps.OverlayValues) > 529 && ps.OverlayValues[529].Loc != LocNone {
+			d529 = ps.OverlayValues[529]
+		}
+		if len(ps.OverlayValues) > 531 && ps.OverlayValues[531].Loc != LocNone {
+			d531 = ps.OverlayValues[531]
+		}
+		if len(ps.OverlayValues) > 532 && ps.OverlayValues[532].Loc != LocNone {
+			d532 = ps.OverlayValues[532]
+		}
+		if len(ps.OverlayValues) > 533 && ps.OverlayValues[533].Loc != LocNone {
+			d533 = ps.OverlayValues[533]
+		}
+		ctx.ReclaimUntrackedRegs()
+		args[0] = JITPrepareScmerGoArg(ctx, args[0])
+		args[1] = JITPrepareScmerGoArg(ctx, args[1])
+		if d1.Loc == LocRegPair || d1.Loc == LocStackPair || d1.Loc == LocRegTriple || d1.Loc == LocStackTriple {
+			panic("jit: generic call arg expects 1-word value")
+		}
+		if d3.Loc == LocRegPair || d3.Loc == LocStackPair || d3.Loc == LocRegTriple || d3.Loc == LocStackTriple {
+			panic("jit: generic call arg expects 1-word value")
+		}
+		ctx.SyncDesc(&args[0])
+		ctx.SyncDesc(&args[1])
+		ctx.SyncDesc(&d1)
+		ctx.SyncDesc(&d3)
+		d636 = ctx.EmitGoCallScalar(GoFuncAddr(lessNonNumeric), []JITValueDesc{args[0], args[1], d1, d3}, 1)
+		d636.NoHeapPointer = true
+		ctx.EmitAndRegImm32(d636.Reg, 1)
+		d636.Type = tagBool
+		ctx.BindReg(d636.Reg, &d636)
+		ctx.FreeDesc(&args[0])
+		ctx.FreeDesc(&args[1])
+		ctx.EnsureDesc(&d636)
+		ctx.EmitMovToReg(result.Reg, d636)
+		result.Type = d636.Type
+		ctx.EmitJmp(lbl0)
+		return result
+	}
+	ps637 := PhiState{General: false}
+	_ = bbs[0].RenderPS(ps637)
+	ctx.MarkLabel(lbl0)
+	ctx.ResolveFixups()
+	if resultRegsProtected {
+		ctx.UnprotectReg(result.Reg)
+	}
+	return result
+
 }

--- a/scm/date.go
+++ b/scm/date.go
@@ -741,7 +741,7 @@ func init_date() {
 					ctx.FreeDesc(&d27)
 					if ps.General {
 						ctx.SyncDesc(&d28)
-						if d28.Loc == LocReg {
+						if d28.Loc == LocReg || d28.Loc == LocFPReg {
 							ctx.ProtectReg(d28.Reg)
 						} else if d28.Loc == LocRegPair {
 							ctx.ProtectReg(d28.Reg)
@@ -764,7 +764,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d30, int32(bbs[2].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 						}
-						if d28.Loc == LocReg {
+						if d28.Loc == LocReg || d28.Loc == LocFPReg {
 							ctx.UnprotectReg(d28.Reg)
 						} else if d28.Loc == LocRegPair {
 							ctx.UnprotectReg(d28.Reg)
@@ -906,7 +906,7 @@ func init_date() {
 						if d36.Loc != LocReg && d36.Loc != LocRegPair && d36.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r1 := ctx.AllocReg()
+						r1 := ctx.AllocRegExcept(d36.Reg)
 						ctx.EmitCmpRegImm32(d36.Reg, 0)
 						ctx.EmitSetcc(r1, CondNotEqual)
 						d37 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
@@ -945,7 +945,7 @@ func init_date() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d35)
-							if d35.Loc == LocReg {
+							if d35.Loc == LocReg || d35.Loc == LocFPReg {
 								ctx.ProtectReg(d35.Reg)
 							} else if d35.Loc == LocRegPair {
 								ctx.ProtectReg(d35.Reg)
@@ -957,7 +957,7 @@ func init_date() {
 							}
 							ctx.EnsureDesc(&d40)
 							ctx.EmitStoreToStack(d40, int32(bbs[4].PhiBase)+int32(0))
-							if d35.Loc == LocReg {
+							if d35.Loc == LocReg || d35.Loc == LocFPReg {
 								ctx.UnprotectReg(d35.Reg)
 							} else if d35.Loc == LocRegPair {
 								ctx.UnprotectReg(d35.Reg)
@@ -1046,7 +1046,7 @@ func init_date() {
 					d43 = snap63
 					ctx.MarkLabel(lbl7)
 					ctx.SyncDesc(&d35)
-					if d35.Loc == LocReg {
+					if d35.Loc == LocReg || d35.Loc == LocFPReg {
 						ctx.ProtectReg(d35.Reg)
 					} else if d35.Loc == LocRegPair {
 						ctx.ProtectReg(d35.Reg)
@@ -1058,7 +1058,7 @@ func init_date() {
 					}
 					ctx.EnsureDesc(&d65)
 					ctx.EmitStoreToStack(d65, int32(bbs[4].PhiBase)+int32(0))
-					if d35.Loc == LocReg {
+					if d35.Loc == LocReg || d35.Loc == LocFPReg {
 						ctx.UnprotectReg(d35.Reg)
 					} else if d35.Loc == LocRegPair {
 						ctx.UnprotectReg(d35.Reg)
@@ -1283,7 +1283,7 @@ func init_date() {
 					ctx.StabilizeDescForControlFlow(&d92)
 					if ps.General {
 						ctx.SyncDesc(&d92)
-						if d92.Loc == LocReg {
+						if d92.Loc == LocReg || d92.Loc == LocFPReg {
 							ctx.ProtectReg(d92.Reg)
 						} else if d92.Loc == LocRegPair {
 							ctx.ProtectReg(d92.Reg)
@@ -1295,7 +1295,7 @@ func init_date() {
 						}
 						ctx.EnsureDesc(&d93)
 						ctx.EmitStoreToStack(d93, int32(bbs[4].PhiBase)+int32(0))
-						if d92.Loc == LocReg {
+						if d92.Loc == LocReg || d92.Loc == LocFPReg {
 							ctx.UnprotectReg(d92.Reg)
 						} else if d92.Loc == LocRegPair {
 							ctx.UnprotectReg(d92.Reg)
@@ -1647,46 +1647,48 @@ func init_date() {
 				_ = d21
 				var d22 JITValueDesc
 				_ = d22
-				var d47 JITValueDesc
-				_ = d47
-				var d48 JITValueDesc
-				_ = d48
-				var d49 JITValueDesc
-				_ = d49
+				var d23 JITValueDesc
+				_ = d23
 				var d50 JITValueDesc
 				_ = d50
 				var d51 JITValueDesc
 				_ = d51
-				var d86 JITValueDesc
-				_ = d86
-				var d87 JITValueDesc
-				_ = d87
-				var d88 JITValueDesc
-				_ = d88
-				var d89 JITValueDesc
-				_ = d89
-				var d90 JITValueDesc
-				_ = d90
+				var d52 JITValueDesc
+				_ = d52
+				var d53 JITValueDesc
+				_ = d53
+				var d54 JITValueDesc
+				_ = d54
 				var d91 JITValueDesc
 				_ = d91
+				var d92 JITValueDesc
+				_ = d92
 				var d93 JITValueDesc
 				_ = d93
 				var d94 JITValueDesc
 				_ = d94
 				var d95 JITValueDesc
 				_ = d95
-				var d148 JITValueDesc
-				_ = d148
-				var d149 JITValueDesc
-				_ = d149
-				var d150 JITValueDesc
-				_ = d150
-				var d151 JITValueDesc
-				_ = d151
-				var d212 JITValueDesc
-				_ = d212
-				var d213 JITValueDesc
-				_ = d213
+				var d96 JITValueDesc
+				_ = d96
+				var d98 JITValueDesc
+				_ = d98
+				var d99 JITValueDesc
+				_ = d99
+				var d100 JITValueDesc
+				_ = d100
+				var d155 JITValueDesc
+				_ = d155
+				var d156 JITValueDesc
+				_ = d156
+				var d157 JITValueDesc
+				_ = d157
+				var d158 JITValueDesc
+				_ = d158
+				var d221 JITValueDesc
+				_ = d221
+				var d222 JITValueDesc
+				_ = d222
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				var bbs [10]BBDescriptor
 				for i := range args {
@@ -1948,142 +1950,153 @@ func init_date() {
 					ctx.ReclaimUntrackedRegs()
 					d19 = args[0]
 					d19.ID = 0
-					d20 = ctx.EmitGetTagDesc(&d19, JITValueDesc{Loc: LocAny})
+					d20 = d19
+					d20.ID = 0
+					d21 = ctx.EmitGetTagDesc(&d20, JITValueDesc{Loc: LocAny})
 					ctx.FreeDesc(&d19)
-					ctx.EnsureDesc(&d20)
-					var d21 JITValueDesc
-					if d20.Loc == LocImm {
-						d21 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d20.Imm.Int()) == uint64(0x10))}
+					ctx.EnsureDesc(&d21)
+					var d22 JITValueDesc
+					if d21.Loc == LocImm {
+						d22 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d21.Imm.Int()) == uint64(0x10))}
 					} else {
 						r0 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d20.Reg, 16)
-						d21 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
-						ctx.BindReg(r0, &d21)
+						ctx.EmitCmpRegImm32(d21.Reg, 16)
+						d22 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
+						ctx.BindReg(r0, &d22)
 					}
-					ctx.FreeDesc(&d20)
-					d22 = d21
-					ctx.EnsureDesc(&d22)
-					if d22.Loc != LocImm && d22.Loc != LocFlags {
+					ctx.FreeDesc(&d21)
+					d23 = d22
+					ctx.EnsureDesc(&d23)
+					if d23.Loc != LocImm && d23.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d22.Loc == LocImm {
-						if d22.Imm.Bool() {
+					if d23.Loc == LocImm {
+						if d23.Imm.Bool() {
 							if ps.General {
 							}
-							ps23 := PhiState{General: ps.General}
-							ps23.OverlayValues = make([]JITValueDesc, 23)
-							ps23.OverlayValues[0] = d0
-							ps23.OverlayValues[1] = d1
-							ps23.OverlayValues[2] = d2
-							ps23.OverlayValues[3] = d3
-							ps23.OverlayValues[18] = d18
-							ps23.OverlayValues[19] = d19
-							ps23.OverlayValues[20] = d20
-							ps23.OverlayValues[21] = d21
-							ps23.OverlayValues[22] = d22
-							return bbs[3].RenderPS(ps23)
+							ps24 := PhiState{General: ps.General}
+							ps24.OverlayValues = make([]JITValueDesc, 24)
+							ps24.OverlayValues[0] = d0
+							ps24.OverlayValues[1] = d1
+							ps24.OverlayValues[2] = d2
+							ps24.OverlayValues[3] = d3
+							ps24.OverlayValues[18] = d18
+							ps24.OverlayValues[19] = d19
+							ps24.OverlayValues[20] = d20
+							ps24.OverlayValues[21] = d21
+							ps24.OverlayValues[22] = d22
+							ps24.OverlayValues[23] = d23
+							return bbs[3].RenderPS(ps24)
 						}
 						if ps.General {
 						}
-						ps24 := PhiState{General: ps.General}
-						ps24.OverlayValues = make([]JITValueDesc, 23)
-						ps24.OverlayValues[0] = d0
-						ps24.OverlayValues[1] = d1
-						ps24.OverlayValues[2] = d2
-						ps24.OverlayValues[3] = d3
-						ps24.OverlayValues[18] = d18
-						ps24.OverlayValues[19] = d19
-						ps24.OverlayValues[20] = d20
-						ps24.OverlayValues[21] = d21
-						ps24.OverlayValues[22] = d22
-						return bbs[4].RenderPS(ps24)
+						ps25 := PhiState{General: ps.General}
+						ps25.OverlayValues = make([]JITValueDesc, 24)
+						ps25.OverlayValues[0] = d0
+						ps25.OverlayValues[1] = d1
+						ps25.OverlayValues[2] = d2
+						ps25.OverlayValues[3] = d3
+						ps25.OverlayValues[18] = d18
+						ps25.OverlayValues[19] = d19
+						ps25.OverlayValues[20] = d20
+						ps25.OverlayValues[21] = d21
+						ps25.OverlayValues[22] = d22
+						ps25.OverlayValues[23] = d23
+						return bbs[4].RenderPS(ps25)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[2].RenderPS(ps)
 					}
-					ctx.EmitJump(d22.Condition, lbl4)
+					ctx.EmitJump(d23.Condition, lbl4)
 					if bbs[4].Rendered {
 						ctx.EmitJmp(lbl5)
 					}
-					ctx.FreeDesc(&d21)
-					snap25 := d0
-					snap26 := d1
-					snap27 := d2
-					snap28 := d3
-					snap29 := d18
-					snap30 := d19
-					snap31 := d20
-					snap32 := d21
-					snap33 := d22
-					alloc34 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc34)
-					d0 = snap25
-					d1 = snap26
-					d2 = snap27
-					d3 = snap28
-					d18 = snap29
-					d19 = snap30
-					d20 = snap31
-					d21 = snap32
-					d22 = snap33
-					ctx.RestoreAllocState(alloc34)
-					d0 = snap25
-					d1 = snap26
-					d2 = snap27
-					d3 = snap28
-					d18 = snap29
-					d19 = snap30
-					d20 = snap31
-					d21 = snap32
-					d22 = snap33
-					ps35 := PhiState{General: true}
-					ps35.OverlayValues = make([]JITValueDesc, 23)
-					ps35.OverlayValues[0] = d0
-					ps35.OverlayValues[1] = d1
-					ps35.OverlayValues[2] = d2
-					ps35.OverlayValues[3] = d3
-					ps35.OverlayValues[18] = d18
-					ps35.OverlayValues[19] = d19
-					ps35.OverlayValues[20] = d20
-					ps35.OverlayValues[21] = d21
-					ps35.OverlayValues[22] = d22
-					ps36 := PhiState{General: true}
-					ps36.OverlayValues = make([]JITValueDesc, 23)
-					ps36.OverlayValues[0] = d0
-					ps36.OverlayValues[1] = d1
-					ps36.OverlayValues[2] = d2
-					ps36.OverlayValues[3] = d3
-					ps36.OverlayValues[18] = d18
-					ps36.OverlayValues[19] = d19
-					ps36.OverlayValues[20] = d20
-					ps36.OverlayValues[21] = d21
-					ps36.OverlayValues[22] = d22
-					snap37 := d0
-					snap38 := d1
-					snap39 := d2
-					snap40 := d3
-					snap41 := d18
-					snap42 := d19
-					snap43 := d20
-					snap44 := d21
-					snap45 := d22
-					alloc46 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d22)
+					snap26 := d0
+					snap27 := d1
+					snap28 := d2
+					snap29 := d3
+					snap30 := d18
+					snap31 := d19
+					snap32 := d20
+					snap33 := d21
+					snap34 := d22
+					snap35 := d23
+					alloc36 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc36)
+					d0 = snap26
+					d1 = snap27
+					d2 = snap28
+					d3 = snap29
+					d18 = snap30
+					d19 = snap31
+					d20 = snap32
+					d21 = snap33
+					d22 = snap34
+					d23 = snap35
+					ctx.RestoreAllocState(alloc36)
+					d0 = snap26
+					d1 = snap27
+					d2 = snap28
+					d3 = snap29
+					d18 = snap30
+					d19 = snap31
+					d20 = snap32
+					d21 = snap33
+					d22 = snap34
+					d23 = snap35
+					ps37 := PhiState{General: true}
+					ps37.OverlayValues = make([]JITValueDesc, 24)
+					ps37.OverlayValues[0] = d0
+					ps37.OverlayValues[1] = d1
+					ps37.OverlayValues[2] = d2
+					ps37.OverlayValues[3] = d3
+					ps37.OverlayValues[18] = d18
+					ps37.OverlayValues[19] = d19
+					ps37.OverlayValues[20] = d20
+					ps37.OverlayValues[21] = d21
+					ps37.OverlayValues[22] = d22
+					ps37.OverlayValues[23] = d23
+					ps38 := PhiState{General: true}
+					ps38.OverlayValues = make([]JITValueDesc, 24)
+					ps38.OverlayValues[0] = d0
+					ps38.OverlayValues[1] = d1
+					ps38.OverlayValues[2] = d2
+					ps38.OverlayValues[3] = d3
+					ps38.OverlayValues[18] = d18
+					ps38.OverlayValues[19] = d19
+					ps38.OverlayValues[20] = d20
+					ps38.OverlayValues[21] = d21
+					ps38.OverlayValues[22] = d22
+					ps38.OverlayValues[23] = d23
+					snap39 := d0
+					snap40 := d1
+					snap41 := d2
+					snap42 := d3
+					snap43 := d18
+					snap44 := d19
+					snap45 := d20
+					snap46 := d21
+					snap47 := d22
+					snap48 := d23
+					alloc49 := ctx.SnapshotAllocState()
 					if !bbs[4].Rendered {
-						bbs[4].RenderPS(ps36)
+						bbs[4].RenderPS(ps38)
 					}
-					ctx.RestoreAllocState(alloc46)
-					d0 = snap37
-					d1 = snap38
-					d2 = snap39
-					d3 = snap40
-					d18 = snap41
-					d19 = snap42
-					d20 = snap43
-					d21 = snap44
-					d22 = snap45
+					ctx.RestoreAllocState(alloc49)
+					d0 = snap39
+					d1 = snap40
+					d2 = snap41
+					d3 = snap42
+					d18 = snap43
+					d19 = snap44
+					d20 = snap45
+					d21 = snap46
+					d22 = snap47
+					d23 = snap48
 					if !bbs[3].Rendered {
-						return bbs[3].RenderPS(ps35)
+						return bbs[3].RenderPS(ps37)
 					}
 					return result
 					return result
@@ -2134,30 +2147,33 @@ func init_date() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
+					if len(ps.OverlayValues) > 23 && ps.OverlayValues[23].Loc != LocNone {
+						d23 = ps.OverlayValues[23]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d47 = args[0]
-					d47.ID = 0
-					ctx.SyncDesc(&d47)
-					if d47.Loc == LocRegPair || d47.Loc == LocStackPair || d47.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d47, &result)
-						result.Type = d47.Type
+					d50 = args[0]
+					d50.ID = 0
+					ctx.SyncDesc(&d50)
+					if d50.Loc == LocRegPair || d50.Loc == LocStackPair || d50.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d50, &result)
+						result.Type = d50.Type
 					} else {
-						switch d47.Type {
+						switch d50.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d47)
+							ctx.EmitMakeBool(result, d50)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d47)
+							ctx.EmitMakeInt(result, d50)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d47)
+							ctx.EmitMakeFloat(result, d50)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d47, &result)
-							result.Type = d47.Type
+							ctx.EmitMovPairToResult(&d50, &result)
+							result.Type = d50.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -2209,187 +2225,199 @@ func init_date() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 47 && ps.OverlayValues[47].Loc != LocNone {
-						d47 = ps.OverlayValues[47]
+					if len(ps.OverlayValues) > 23 && ps.OverlayValues[23].Loc != LocNone {
+						d23 = ps.OverlayValues[23]
+					}
+					if len(ps.OverlayValues) > 50 && ps.OverlayValues[50].Loc != LocNone {
+						d50 = ps.OverlayValues[50]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d48 = args[0]
-					d48.ID = 0
-					d50 = d48
-					d50.ID = 0
-					d49 = ctx.EmitTagEqualsBorrowed(&d50, tagInt, JITValueDesc{Loc: LocAny})
-					ctx.FreeDesc(&d48)
-					d51 = d49
-					ctx.EnsureDesc(&d51)
-					if d51.Loc != LocImm && d51.Loc != LocReg {
+					d51 = args[0]
+					d51.ID = 0
+					d53 = d51
+					d53.ID = 0
+					d52 = ctx.EmitTagEqualsBorrowed(&d53, tagInt, JITValueDesc{Loc: LocAny})
+					ctx.FreeDesc(&d51)
+					d54 = d52
+					ctx.EnsureDesc(&d54)
+					if d54.Loc != LocImm && d54.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d51.Loc == LocImm {
-						if d51.Imm.Bool() {
+					if d54.Loc == LocImm {
+						if d54.Imm.Bool() {
 							if ps.General {
 							}
-							ps52 := PhiState{General: ps.General}
-							ps52.OverlayValues = make([]JITValueDesc, 52)
-							ps52.OverlayValues[0] = d0
-							ps52.OverlayValues[1] = d1
-							ps52.OverlayValues[2] = d2
-							ps52.OverlayValues[3] = d3
-							ps52.OverlayValues[18] = d18
-							ps52.OverlayValues[19] = d19
-							ps52.OverlayValues[20] = d20
-							ps52.OverlayValues[21] = d21
-							ps52.OverlayValues[22] = d22
-							ps52.OverlayValues[47] = d47
-							ps52.OverlayValues[48] = d48
-							ps52.OverlayValues[49] = d49
-							ps52.OverlayValues[50] = d50
-							ps52.OverlayValues[51] = d51
-							return bbs[5].RenderPS(ps52)
+							ps55 := PhiState{General: ps.General}
+							ps55.OverlayValues = make([]JITValueDesc, 55)
+							ps55.OverlayValues[0] = d0
+							ps55.OverlayValues[1] = d1
+							ps55.OverlayValues[2] = d2
+							ps55.OverlayValues[3] = d3
+							ps55.OverlayValues[18] = d18
+							ps55.OverlayValues[19] = d19
+							ps55.OverlayValues[20] = d20
+							ps55.OverlayValues[21] = d21
+							ps55.OverlayValues[22] = d22
+							ps55.OverlayValues[23] = d23
+							ps55.OverlayValues[50] = d50
+							ps55.OverlayValues[51] = d51
+							ps55.OverlayValues[52] = d52
+							ps55.OverlayValues[53] = d53
+							ps55.OverlayValues[54] = d54
+							return bbs[5].RenderPS(ps55)
 						}
 						if ps.General {
 						}
-						ps53 := PhiState{General: ps.General}
-						ps53.OverlayValues = make([]JITValueDesc, 52)
-						ps53.OverlayValues[0] = d0
-						ps53.OverlayValues[1] = d1
-						ps53.OverlayValues[2] = d2
-						ps53.OverlayValues[3] = d3
-						ps53.OverlayValues[18] = d18
-						ps53.OverlayValues[19] = d19
-						ps53.OverlayValues[20] = d20
-						ps53.OverlayValues[21] = d21
-						ps53.OverlayValues[22] = d22
-						ps53.OverlayValues[47] = d47
-						ps53.OverlayValues[48] = d48
-						ps53.OverlayValues[49] = d49
-						ps53.OverlayValues[50] = d50
-						ps53.OverlayValues[51] = d51
-						return bbs[7].RenderPS(ps53)
+						ps56 := PhiState{General: ps.General}
+						ps56.OverlayValues = make([]JITValueDesc, 55)
+						ps56.OverlayValues[0] = d0
+						ps56.OverlayValues[1] = d1
+						ps56.OverlayValues[2] = d2
+						ps56.OverlayValues[3] = d3
+						ps56.OverlayValues[18] = d18
+						ps56.OverlayValues[19] = d19
+						ps56.OverlayValues[20] = d20
+						ps56.OverlayValues[21] = d21
+						ps56.OverlayValues[22] = d22
+						ps56.OverlayValues[23] = d23
+						ps56.OverlayValues[50] = d50
+						ps56.OverlayValues[51] = d51
+						ps56.OverlayValues[52] = d52
+						ps56.OverlayValues[53] = d53
+						ps56.OverlayValues[54] = d54
+						return bbs[7].RenderPS(ps56)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[4].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d51.Reg, 0)
+					ctx.EmitCmpRegImm32(d54.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl6)
 					if bbs[7].Rendered {
 						ctx.EmitJmp(lbl8)
 					}
-					snap54 := d0
-					snap55 := d1
-					snap56 := d2
-					snap57 := d3
-					snap58 := d18
-					snap59 := d19
-					snap60 := d20
-					snap61 := d21
-					snap62 := d22
-					snap63 := d47
-					snap64 := d48
-					snap65 := d49
-					snap66 := d50
-					snap67 := d51
-					alloc68 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc68)
-					d0 = snap54
-					d1 = snap55
-					d2 = snap56
-					d3 = snap57
-					d18 = snap58
-					d19 = snap59
-					d20 = snap60
-					d21 = snap61
-					d22 = snap62
-					d47 = snap63
-					d48 = snap64
-					d49 = snap65
-					d50 = snap66
-					d51 = snap67
-					ctx.RestoreAllocState(alloc68)
-					d0 = snap54
-					d1 = snap55
-					d2 = snap56
-					d3 = snap57
-					d18 = snap58
-					d19 = snap59
-					d20 = snap60
-					d21 = snap61
-					d22 = snap62
-					d47 = snap63
-					d48 = snap64
-					d49 = snap65
-					d50 = snap66
-					d51 = snap67
-					ps69 := PhiState{General: true}
-					ps69.OverlayValues = make([]JITValueDesc, 52)
-					ps69.OverlayValues[0] = d0
-					ps69.OverlayValues[1] = d1
-					ps69.OverlayValues[2] = d2
-					ps69.OverlayValues[3] = d3
-					ps69.OverlayValues[18] = d18
-					ps69.OverlayValues[19] = d19
-					ps69.OverlayValues[20] = d20
-					ps69.OverlayValues[21] = d21
-					ps69.OverlayValues[22] = d22
-					ps69.OverlayValues[47] = d47
-					ps69.OverlayValues[48] = d48
-					ps69.OverlayValues[49] = d49
-					ps69.OverlayValues[50] = d50
-					ps69.OverlayValues[51] = d51
-					ps70 := PhiState{General: true}
-					ps70.OverlayValues = make([]JITValueDesc, 52)
-					ps70.OverlayValues[0] = d0
-					ps70.OverlayValues[1] = d1
-					ps70.OverlayValues[2] = d2
-					ps70.OverlayValues[3] = d3
-					ps70.OverlayValues[18] = d18
-					ps70.OverlayValues[19] = d19
-					ps70.OverlayValues[20] = d20
-					ps70.OverlayValues[21] = d21
-					ps70.OverlayValues[22] = d22
-					ps70.OverlayValues[47] = d47
-					ps70.OverlayValues[48] = d48
-					ps70.OverlayValues[49] = d49
-					ps70.OverlayValues[50] = d50
-					ps70.OverlayValues[51] = d51
-					snap71 := d0
-					snap72 := d1
-					snap73 := d2
-					snap74 := d3
-					snap75 := d18
-					snap76 := d19
-					snap77 := d20
-					snap78 := d21
-					snap79 := d22
-					snap80 := d47
-					snap81 := d48
-					snap82 := d49
-					snap83 := d50
-					snap84 := d51
-					alloc85 := ctx.SnapshotAllocState()
+					snap57 := d0
+					snap58 := d1
+					snap59 := d2
+					snap60 := d3
+					snap61 := d18
+					snap62 := d19
+					snap63 := d20
+					snap64 := d21
+					snap65 := d22
+					snap66 := d23
+					snap67 := d50
+					snap68 := d51
+					snap69 := d52
+					snap70 := d53
+					snap71 := d54
+					alloc72 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc72)
+					d0 = snap57
+					d1 = snap58
+					d2 = snap59
+					d3 = snap60
+					d18 = snap61
+					d19 = snap62
+					d20 = snap63
+					d21 = snap64
+					d22 = snap65
+					d23 = snap66
+					d50 = snap67
+					d51 = snap68
+					d52 = snap69
+					d53 = snap70
+					d54 = snap71
+					ctx.RestoreAllocState(alloc72)
+					d0 = snap57
+					d1 = snap58
+					d2 = snap59
+					d3 = snap60
+					d18 = snap61
+					d19 = snap62
+					d20 = snap63
+					d21 = snap64
+					d22 = snap65
+					d23 = snap66
+					d50 = snap67
+					d51 = snap68
+					d52 = snap69
+					d53 = snap70
+					d54 = snap71
+					ps73 := PhiState{General: true}
+					ps73.OverlayValues = make([]JITValueDesc, 55)
+					ps73.OverlayValues[0] = d0
+					ps73.OverlayValues[1] = d1
+					ps73.OverlayValues[2] = d2
+					ps73.OverlayValues[3] = d3
+					ps73.OverlayValues[18] = d18
+					ps73.OverlayValues[19] = d19
+					ps73.OverlayValues[20] = d20
+					ps73.OverlayValues[21] = d21
+					ps73.OverlayValues[22] = d22
+					ps73.OverlayValues[23] = d23
+					ps73.OverlayValues[50] = d50
+					ps73.OverlayValues[51] = d51
+					ps73.OverlayValues[52] = d52
+					ps73.OverlayValues[53] = d53
+					ps73.OverlayValues[54] = d54
+					ps74 := PhiState{General: true}
+					ps74.OverlayValues = make([]JITValueDesc, 55)
+					ps74.OverlayValues[0] = d0
+					ps74.OverlayValues[1] = d1
+					ps74.OverlayValues[2] = d2
+					ps74.OverlayValues[3] = d3
+					ps74.OverlayValues[18] = d18
+					ps74.OverlayValues[19] = d19
+					ps74.OverlayValues[20] = d20
+					ps74.OverlayValues[21] = d21
+					ps74.OverlayValues[22] = d22
+					ps74.OverlayValues[23] = d23
+					ps74.OverlayValues[50] = d50
+					ps74.OverlayValues[51] = d51
+					ps74.OverlayValues[52] = d52
+					ps74.OverlayValues[53] = d53
+					ps74.OverlayValues[54] = d54
+					snap75 := d0
+					snap76 := d1
+					snap77 := d2
+					snap78 := d3
+					snap79 := d18
+					snap80 := d19
+					snap81 := d20
+					snap82 := d21
+					snap83 := d22
+					snap84 := d23
+					snap85 := d50
+					snap86 := d51
+					snap87 := d52
+					snap88 := d53
+					snap89 := d54
+					alloc90 := ctx.SnapshotAllocState()
 					if !bbs[7].Rendered {
-						bbs[7].RenderPS(ps70)
+						bbs[7].RenderPS(ps74)
 					}
-					ctx.RestoreAllocState(alloc85)
-					d0 = snap71
-					d1 = snap72
-					d2 = snap73
-					d3 = snap74
-					d18 = snap75
-					d19 = snap76
-					d20 = snap77
-					d21 = snap78
-					d22 = snap79
-					d47 = snap80
-					d48 = snap81
-					d49 = snap82
-					d50 = snap83
-					d51 = snap84
+					ctx.RestoreAllocState(alloc90)
+					d0 = snap75
+					d1 = snap76
+					d2 = snap77
+					d3 = snap78
+					d18 = snap79
+					d19 = snap80
+					d20 = snap81
+					d21 = snap82
+					d22 = snap83
+					d23 = snap84
+					d50 = snap85
+					d51 = snap86
+					d52 = snap87
+					d53 = snap88
+					d54 = snap89
 					if !bbs[5].Rendered {
-						return bbs[5].RenderPS(ps69)
+						return bbs[5].RenderPS(ps73)
 					}
 					return result
-					ctx.FreeDesc(&d49)
+					ctx.FreeDesc(&d52)
 					return result
 				}
 				bbs[5].RenderPS = func(ps PhiState) JITValueDesc {
@@ -2438,14 +2466,8 @@ func init_date() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 47 && ps.OverlayValues[47].Loc != LocNone {
-						d47 = ps.OverlayValues[47]
-					}
-					if len(ps.OverlayValues) > 48 && ps.OverlayValues[48].Loc != LocNone {
-						d48 = ps.OverlayValues[48]
-					}
-					if len(ps.OverlayValues) > 49 && ps.OverlayValues[49].Loc != LocNone {
-						d49 = ps.OverlayValues[49]
+					if len(ps.OverlayValues) > 23 && ps.OverlayValues[23].Loc != LocNone {
+						d23 = ps.OverlayValues[23]
 					}
 					if len(ps.OverlayValues) > 50 && ps.OverlayValues[50].Loc != LocNone {
 						d50 = ps.OverlayValues[50]
@@ -2453,57 +2475,66 @@ func init_date() {
 					if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
 						d51 = ps.OverlayValues[51]
 					}
-					ctx.ReclaimUntrackedRegs()
-					d86 = args[0]
-					d86.ID = 0
-					var d87 JITValueDesc
-					if d86.Loc == LocImm {
-						d87 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d86.Imm.Int())}
-					} else if d86.Type == tagInt && d86.Loc == LocRegPair {
-						ctx.FreeReg(d86.Reg)
-						d87 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d86.Reg2}
-						ctx.BindReg(d86.Reg2, &d87)
-						ctx.BindReg(d86.Reg2, &d87)
-					} else if d86.Type == tagInt && d86.Loc == LocReg {
-						d87 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d86.Reg}
-						ctx.BindReg(d86.Reg, &d87)
-						ctx.BindReg(d86.Reg, &d87)
-					} else {
-						d87 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{d86}, 1)
-						d87.Type = tagInt
-						ctx.BindReg(d87.Reg, &d87)
+					if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+						d52 = ps.OverlayValues[52]
 					}
-					ctx.FreeDesc(&d86)
-					if d87.Loc == LocRegPair || d87.Loc == LocStackPair || d87.Loc == LocRegTriple || d87.Loc == LocStackTriple {
+					if len(ps.OverlayValues) > 53 && ps.OverlayValues[53].Loc != LocNone {
+						d53 = ps.OverlayValues[53]
+					}
+					if len(ps.OverlayValues) > 54 && ps.OverlayValues[54].Loc != LocNone {
+						d54 = ps.OverlayValues[54]
+					}
+					ctx.ReclaimUntrackedRegs()
+					d91 = args[0]
+					d91.ID = 0
+					var d92 JITValueDesc
+					if d91.Loc == LocImm {
+						d92 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d91.Imm.Int())}
+					} else if d91.Type == tagInt && d91.Loc == LocRegPair {
+						ctx.FreeReg(d91.Reg)
+						d92 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d91.Reg2}
+						ctx.BindReg(d91.Reg2, &d92)
+						ctx.BindReg(d91.Reg2, &d92)
+					} else if d91.Type == tagInt && d91.Loc == LocReg {
+						d92 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d91.Reg}
+						ctx.BindReg(d91.Reg, &d92)
+						ctx.BindReg(d91.Reg, &d92)
+					} else {
+						d92 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{d91}, 1)
+						d92.Type = tagInt
+						ctx.BindReg(d92.Reg, &d92)
+					}
+					ctx.FreeDesc(&d91)
+					if d92.Loc == LocRegPair || d92.Loc == LocStackPair || d92.Loc == LocRegTriple || d92.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d87)
-					d88 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d87}, 2)
-					d88.NoHeapPointer = false
-					ctx.BindReg(d88.Reg, &d88)
-					ctx.BindReg(d88.Reg2, &d88)
-					ctx.FreeDesc(&d87)
-					ctx.SyncDesc(&d88)
-					if d88.Loc == LocRegPair || d88.Loc == LocStackPair || d88.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d88, &result)
-						result.Type = d88.Type
+					ctx.SyncDesc(&d92)
+					d93 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d92}, 2)
+					d93.NoHeapPointer = false
+					ctx.BindReg(d93.Reg, &d93)
+					ctx.BindReg(d93.Reg2, &d93)
+					ctx.FreeDesc(&d92)
+					ctx.SyncDesc(&d93)
+					if d93.Loc == LocRegPair || d93.Loc == LocStackPair || d93.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d93, &result)
+						result.Type = d93.Type
 					} else {
-						switch d88.Type {
+						switch d93.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d88)
+							ctx.EmitMakeBool(result, d93)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d88)
+							ctx.EmitMakeInt(result, d93)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d88)
+							ctx.EmitMakeFloat(result, d93)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d88, &result)
-							result.Type = d88.Type
+							ctx.EmitMovPairToResult(&d93, &result)
+							result.Type = d93.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -2555,14 +2586,8 @@ func init_date() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 47 && ps.OverlayValues[47].Loc != LocNone {
-						d47 = ps.OverlayValues[47]
-					}
-					if len(ps.OverlayValues) > 48 && ps.OverlayValues[48].Loc != LocNone {
-						d48 = ps.OverlayValues[48]
-					}
-					if len(ps.OverlayValues) > 49 && ps.OverlayValues[49].Loc != LocNone {
-						d49 = ps.OverlayValues[49]
+					if len(ps.OverlayValues) > 23 && ps.OverlayValues[23].Loc != LocNone {
+						d23 = ps.OverlayValues[23]
 					}
 					if len(ps.OverlayValues) > 50 && ps.OverlayValues[50].Loc != LocNone {
 						d50 = ps.OverlayValues[50]
@@ -2570,320 +2595,338 @@ func init_date() {
 					if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
 						d51 = ps.OverlayValues[51]
 					}
-					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
-						d86 = ps.OverlayValues[86]
+					if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+						d52 = ps.OverlayValues[52]
 					}
-					if len(ps.OverlayValues) > 87 && ps.OverlayValues[87].Loc != LocNone {
-						d87 = ps.OverlayValues[87]
+					if len(ps.OverlayValues) > 53 && ps.OverlayValues[53].Loc != LocNone {
+						d53 = ps.OverlayValues[53]
 					}
-					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
-						d88 = ps.OverlayValues[88]
+					if len(ps.OverlayValues) > 54 && ps.OverlayValues[54].Loc != LocNone {
+						d54 = ps.OverlayValues[54]
+					}
+					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
+						d91 = ps.OverlayValues[91]
+					}
+					if len(ps.OverlayValues) > 92 && ps.OverlayValues[92].Loc != LocNone {
+						d92 = ps.OverlayValues[92]
+					}
+					if len(ps.OverlayValues) > 93 && ps.OverlayValues[93].Loc != LocNone {
+						d93 = ps.OverlayValues[93]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d89 = args[0]
-					d89.ID = 0
-					d91 = d89
-					ctx.SyncDesc(&d91)
-					if d91.Loc == LocMem {
-						tmpScalar := JITValueDesc{Loc: LocReg, Type: d91.Type, Reg: ctx.AllocReg()}
+					d94 = args[0]
+					d94.ID = 0
+					d96 = d94
+					ctx.SyncDesc(&d96)
+					if d96.Loc == LocMem {
+						tmpScalar := JITValueDesc{Loc: LocReg, Type: d96.Type, Reg: ctx.AllocReg()}
 						scratch := ctx.AllocRegExcept(tmpScalar.Reg)
-						ctx.EmitMovRegImm64(scratch, uint64(d91.MemPtr))
+						ctx.EmitMovRegImm64(scratch, uint64(d96.MemPtr))
 						ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
 						ctx.FreeReg(scratch)
 						ctx.BindReg(tmpScalar.Reg, &tmpScalar)
-						d91 = tmpScalar
+						d96 = tmpScalar
 					}
-					d91 = JITPrepareScmerGoArg(ctx, d91)
-					if d91.Loc != LocRegPair && d91.Loc != LocStackPair && d91.Loc != LocInputPair {
+					d96 = JITPrepareScmerGoArg(ctx, d96)
+					if d96.Loc != LocRegPair && d96.Loc != LocStackPair && d96.Loc != LocInputPair {
 						panic("jit: Scmer.String receiver not materialized as pair")
 					}
-					d90 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d91}, 2)
-					ctx.FreeDesc(&d89)
-					ctx.EnsureDesc(&d90)
-					if d90.Loc == LocImm {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d90.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.TrackImm(d90.Imm)
-						ptrWord, _ := d90.Imm.RawWords()
+					d95 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d96}, 2)
+					ctx.FreeDesc(&d94)
+					ctx.EnsureDesc(&d95)
+					if d95.Loc == LocImm {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d95.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.TrackImm(d95.Imm)
+						ptrWord, _ := d95.Imm.RawWords()
 						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d90.Imm.String())))
-						d90 = tmpPair
-					} else if d90.Loc == LocReg {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d90.Type, Reg: ctx.AllocRegExcept(d90.Reg), Reg2: ctx.AllocRegExcept(d90.Reg)}
-						switch d90.Type {
+						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d95.Imm.String())))
+						d95 = tmpPair
+					} else if d95.Loc == LocReg {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d95.Type, Reg: ctx.AllocRegExcept(d95.Reg), Reg2: ctx.AllocRegExcept(d95.Reg)}
+						switch d95.Type {
 						case tagBool:
-							ctx.EmitMakeBool(tmpPair, d90)
+							ctx.EmitMakeBool(tmpPair, d95)
 						case tagInt:
-							ctx.EmitMakeInt(tmpPair, d90)
+							ctx.EmitMakeInt(tmpPair, d95)
 						case tagFloat:
-							ctx.EmitMakeFloat(tmpPair, d90)
+							ctx.EmitMakeFloat(tmpPair, d95)
 						default:
 							panic("jit: generic call arg scalar type unknown for 2-word value")
 						}
-						ctx.FreeDesc(&d90)
-						d90 = tmpPair
+						ctx.FreeDesc(&d95)
+						d95 = tmpPair
 					}
-					if d90.Loc != LocRegPair && d90.Loc != LocStackPair && d90.Loc != LocInputPair {
+					if d95.Loc != LocRegPair && d95.Loc != LocStackPair && d95.Loc != LocInputPair {
 						panic("jit: generic call arg expects 2-word value (ParseDateString arg0)")
 					}
-					ctx.SyncDesc(&d90)
-					callResults92 := JITEmitGoCallResults(ctx, GoFuncAddr(ParseDateString), []JITValueDesc{d90}, []uint8{1, 1}, []uint8{0, 0})
-					d93 = callResults92[0]
-					_ = d93
-					d94 = callResults92[1]
-					_ = d94
-					ctx.StabilizeDescForControlFlow(&d93)
-					d95 = d94
-					ctx.EnsureDesc(&d95)
-					if d95.Loc != LocImm && d95.Loc != LocReg {
+					ctx.SyncDesc(&d95)
+					callResults97 := JITEmitGoCallResults(ctx, GoFuncAddr(ParseDateString), []JITValueDesc{d95}, []uint8{1, 1}, []uint8{0, 0})
+					d98 = callResults97[0]
+					_ = d98
+					d99 = callResults97[1]
+					_ = d99
+					ctx.StabilizeDescForControlFlow(&d98)
+					d100 = d99
+					ctx.EnsureDesc(&d100)
+					if d100.Loc != LocImm && d100.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d95.Loc == LocImm {
-						if d95.Imm.Bool() {
+					if d100.Loc == LocImm {
+						if d100.Imm.Bool() {
 							if ps.General {
 							}
-							ps96 := PhiState{General: ps.General}
-							ps96.OverlayValues = make([]JITValueDesc, 96)
-							ps96.OverlayValues[0] = d0
-							ps96.OverlayValues[1] = d1
-							ps96.OverlayValues[2] = d2
-							ps96.OverlayValues[3] = d3
-							ps96.OverlayValues[18] = d18
-							ps96.OverlayValues[19] = d19
-							ps96.OverlayValues[20] = d20
-							ps96.OverlayValues[21] = d21
-							ps96.OverlayValues[22] = d22
-							ps96.OverlayValues[47] = d47
-							ps96.OverlayValues[48] = d48
-							ps96.OverlayValues[49] = d49
-							ps96.OverlayValues[50] = d50
-							ps96.OverlayValues[51] = d51
-							ps96.OverlayValues[86] = d86
-							ps96.OverlayValues[87] = d87
-							ps96.OverlayValues[88] = d88
-							ps96.OverlayValues[89] = d89
-							ps96.OverlayValues[90] = d90
-							ps96.OverlayValues[91] = d91
-							ps96.OverlayValues[93] = d93
-							ps96.OverlayValues[94] = d94
-							ps96.OverlayValues[95] = d95
-							return bbs[8].RenderPS(ps96)
+							ps101 := PhiState{General: ps.General}
+							ps101.OverlayValues = make([]JITValueDesc, 101)
+							ps101.OverlayValues[0] = d0
+							ps101.OverlayValues[1] = d1
+							ps101.OverlayValues[2] = d2
+							ps101.OverlayValues[3] = d3
+							ps101.OverlayValues[18] = d18
+							ps101.OverlayValues[19] = d19
+							ps101.OverlayValues[20] = d20
+							ps101.OverlayValues[21] = d21
+							ps101.OverlayValues[22] = d22
+							ps101.OverlayValues[23] = d23
+							ps101.OverlayValues[50] = d50
+							ps101.OverlayValues[51] = d51
+							ps101.OverlayValues[52] = d52
+							ps101.OverlayValues[53] = d53
+							ps101.OverlayValues[54] = d54
+							ps101.OverlayValues[91] = d91
+							ps101.OverlayValues[92] = d92
+							ps101.OverlayValues[93] = d93
+							ps101.OverlayValues[94] = d94
+							ps101.OverlayValues[95] = d95
+							ps101.OverlayValues[96] = d96
+							ps101.OverlayValues[98] = d98
+							ps101.OverlayValues[99] = d99
+							ps101.OverlayValues[100] = d100
+							return bbs[8].RenderPS(ps101)
 						}
 						if ps.General {
 						}
-						ps97 := PhiState{General: ps.General}
-						ps97.OverlayValues = make([]JITValueDesc, 96)
-						ps97.OverlayValues[0] = d0
-						ps97.OverlayValues[1] = d1
-						ps97.OverlayValues[2] = d2
-						ps97.OverlayValues[3] = d3
-						ps97.OverlayValues[18] = d18
-						ps97.OverlayValues[19] = d19
-						ps97.OverlayValues[20] = d20
-						ps97.OverlayValues[21] = d21
-						ps97.OverlayValues[22] = d22
-						ps97.OverlayValues[47] = d47
-						ps97.OverlayValues[48] = d48
-						ps97.OverlayValues[49] = d49
-						ps97.OverlayValues[50] = d50
-						ps97.OverlayValues[51] = d51
-						ps97.OverlayValues[86] = d86
-						ps97.OverlayValues[87] = d87
-						ps97.OverlayValues[88] = d88
-						ps97.OverlayValues[89] = d89
-						ps97.OverlayValues[90] = d90
-						ps97.OverlayValues[91] = d91
-						ps97.OverlayValues[93] = d93
-						ps97.OverlayValues[94] = d94
-						ps97.OverlayValues[95] = d95
-						return bbs[9].RenderPS(ps97)
+						ps102 := PhiState{General: ps.General}
+						ps102.OverlayValues = make([]JITValueDesc, 101)
+						ps102.OverlayValues[0] = d0
+						ps102.OverlayValues[1] = d1
+						ps102.OverlayValues[2] = d2
+						ps102.OverlayValues[3] = d3
+						ps102.OverlayValues[18] = d18
+						ps102.OverlayValues[19] = d19
+						ps102.OverlayValues[20] = d20
+						ps102.OverlayValues[21] = d21
+						ps102.OverlayValues[22] = d22
+						ps102.OverlayValues[23] = d23
+						ps102.OverlayValues[50] = d50
+						ps102.OverlayValues[51] = d51
+						ps102.OverlayValues[52] = d52
+						ps102.OverlayValues[53] = d53
+						ps102.OverlayValues[54] = d54
+						ps102.OverlayValues[91] = d91
+						ps102.OverlayValues[92] = d92
+						ps102.OverlayValues[93] = d93
+						ps102.OverlayValues[94] = d94
+						ps102.OverlayValues[95] = d95
+						ps102.OverlayValues[96] = d96
+						ps102.OverlayValues[98] = d98
+						ps102.OverlayValues[99] = d99
+						ps102.OverlayValues[100] = d100
+						return bbs[9].RenderPS(ps102)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[6].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d95.Reg, 0)
+					ctx.EmitCmpRegImm32(d100.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl9)
 					if bbs[9].Rendered {
 						ctx.EmitJmp(lbl10)
 					}
-					snap98 := d0
-					snap99 := d1
-					snap100 := d2
-					snap101 := d3
-					snap102 := d18
-					snap103 := d19
-					snap104 := d20
-					snap105 := d21
-					snap106 := d22
-					snap107 := d47
-					snap108 := d48
-					snap109 := d49
-					snap110 := d50
-					snap111 := d51
-					snap112 := d86
-					snap113 := d87
-					snap114 := d88
-					snap115 := d89
-					snap116 := d90
-					snap117 := d91
-					snap118 := d93
-					snap119 := d94
-					snap120 := d95
-					alloc121 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc121)
-					d0 = snap98
-					d1 = snap99
-					d2 = snap100
-					d3 = snap101
-					d18 = snap102
-					d19 = snap103
-					d20 = snap104
-					d21 = snap105
-					d22 = snap106
-					d47 = snap107
-					d48 = snap108
-					d49 = snap109
-					d50 = snap110
-					d51 = snap111
-					d86 = snap112
-					d87 = snap113
-					d88 = snap114
-					d89 = snap115
-					d90 = snap116
-					d91 = snap117
-					d93 = snap118
-					d94 = snap119
-					d95 = snap120
-					ctx.RestoreAllocState(alloc121)
-					d0 = snap98
-					d1 = snap99
-					d2 = snap100
-					d3 = snap101
-					d18 = snap102
-					d19 = snap103
-					d20 = snap104
-					d21 = snap105
-					d22 = snap106
-					d47 = snap107
-					d48 = snap108
-					d49 = snap109
-					d50 = snap110
-					d51 = snap111
-					d86 = snap112
-					d87 = snap113
-					d88 = snap114
-					d89 = snap115
-					d90 = snap116
-					d91 = snap117
-					d93 = snap118
-					d94 = snap119
-					d95 = snap120
-					ps122 := PhiState{General: true}
-					ps122.OverlayValues = make([]JITValueDesc, 96)
-					ps122.OverlayValues[0] = d0
-					ps122.OverlayValues[1] = d1
-					ps122.OverlayValues[2] = d2
-					ps122.OverlayValues[3] = d3
-					ps122.OverlayValues[18] = d18
-					ps122.OverlayValues[19] = d19
-					ps122.OverlayValues[20] = d20
-					ps122.OverlayValues[21] = d21
-					ps122.OverlayValues[22] = d22
-					ps122.OverlayValues[47] = d47
-					ps122.OverlayValues[48] = d48
-					ps122.OverlayValues[49] = d49
-					ps122.OverlayValues[50] = d50
-					ps122.OverlayValues[51] = d51
-					ps122.OverlayValues[86] = d86
-					ps122.OverlayValues[87] = d87
-					ps122.OverlayValues[88] = d88
-					ps122.OverlayValues[89] = d89
-					ps122.OverlayValues[90] = d90
-					ps122.OverlayValues[91] = d91
-					ps122.OverlayValues[93] = d93
-					ps122.OverlayValues[94] = d94
-					ps122.OverlayValues[95] = d95
-					ps123 := PhiState{General: true}
-					ps123.OverlayValues = make([]JITValueDesc, 96)
-					ps123.OverlayValues[0] = d0
-					ps123.OverlayValues[1] = d1
-					ps123.OverlayValues[2] = d2
-					ps123.OverlayValues[3] = d3
-					ps123.OverlayValues[18] = d18
-					ps123.OverlayValues[19] = d19
-					ps123.OverlayValues[20] = d20
-					ps123.OverlayValues[21] = d21
-					ps123.OverlayValues[22] = d22
-					ps123.OverlayValues[47] = d47
-					ps123.OverlayValues[48] = d48
-					ps123.OverlayValues[49] = d49
-					ps123.OverlayValues[50] = d50
-					ps123.OverlayValues[51] = d51
-					ps123.OverlayValues[86] = d86
-					ps123.OverlayValues[87] = d87
-					ps123.OverlayValues[88] = d88
-					ps123.OverlayValues[89] = d89
-					ps123.OverlayValues[90] = d90
-					ps123.OverlayValues[91] = d91
-					ps123.OverlayValues[93] = d93
-					ps123.OverlayValues[94] = d94
-					ps123.OverlayValues[95] = d95
-					snap124 := d0
-					snap125 := d1
-					snap126 := d2
-					snap127 := d3
-					snap128 := d18
-					snap129 := d19
-					snap130 := d20
-					snap131 := d21
-					snap132 := d22
-					snap133 := d47
-					snap134 := d48
-					snap135 := d49
-					snap136 := d50
-					snap137 := d51
-					snap138 := d86
-					snap139 := d87
-					snap140 := d88
-					snap141 := d89
-					snap142 := d90
-					snap143 := d91
-					snap144 := d93
-					snap145 := d94
-					snap146 := d95
-					alloc147 := ctx.SnapshotAllocState()
+					snap103 := d0
+					snap104 := d1
+					snap105 := d2
+					snap106 := d3
+					snap107 := d18
+					snap108 := d19
+					snap109 := d20
+					snap110 := d21
+					snap111 := d22
+					snap112 := d23
+					snap113 := d50
+					snap114 := d51
+					snap115 := d52
+					snap116 := d53
+					snap117 := d54
+					snap118 := d91
+					snap119 := d92
+					snap120 := d93
+					snap121 := d94
+					snap122 := d95
+					snap123 := d96
+					snap124 := d98
+					snap125 := d99
+					snap126 := d100
+					alloc127 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc127)
+					d0 = snap103
+					d1 = snap104
+					d2 = snap105
+					d3 = snap106
+					d18 = snap107
+					d19 = snap108
+					d20 = snap109
+					d21 = snap110
+					d22 = snap111
+					d23 = snap112
+					d50 = snap113
+					d51 = snap114
+					d52 = snap115
+					d53 = snap116
+					d54 = snap117
+					d91 = snap118
+					d92 = snap119
+					d93 = snap120
+					d94 = snap121
+					d95 = snap122
+					d96 = snap123
+					d98 = snap124
+					d99 = snap125
+					d100 = snap126
+					ctx.RestoreAllocState(alloc127)
+					d0 = snap103
+					d1 = snap104
+					d2 = snap105
+					d3 = snap106
+					d18 = snap107
+					d19 = snap108
+					d20 = snap109
+					d21 = snap110
+					d22 = snap111
+					d23 = snap112
+					d50 = snap113
+					d51 = snap114
+					d52 = snap115
+					d53 = snap116
+					d54 = snap117
+					d91 = snap118
+					d92 = snap119
+					d93 = snap120
+					d94 = snap121
+					d95 = snap122
+					d96 = snap123
+					d98 = snap124
+					d99 = snap125
+					d100 = snap126
+					ps128 := PhiState{General: true}
+					ps128.OverlayValues = make([]JITValueDesc, 101)
+					ps128.OverlayValues[0] = d0
+					ps128.OverlayValues[1] = d1
+					ps128.OverlayValues[2] = d2
+					ps128.OverlayValues[3] = d3
+					ps128.OverlayValues[18] = d18
+					ps128.OverlayValues[19] = d19
+					ps128.OverlayValues[20] = d20
+					ps128.OverlayValues[21] = d21
+					ps128.OverlayValues[22] = d22
+					ps128.OverlayValues[23] = d23
+					ps128.OverlayValues[50] = d50
+					ps128.OverlayValues[51] = d51
+					ps128.OverlayValues[52] = d52
+					ps128.OverlayValues[53] = d53
+					ps128.OverlayValues[54] = d54
+					ps128.OverlayValues[91] = d91
+					ps128.OverlayValues[92] = d92
+					ps128.OverlayValues[93] = d93
+					ps128.OverlayValues[94] = d94
+					ps128.OverlayValues[95] = d95
+					ps128.OverlayValues[96] = d96
+					ps128.OverlayValues[98] = d98
+					ps128.OverlayValues[99] = d99
+					ps128.OverlayValues[100] = d100
+					ps129 := PhiState{General: true}
+					ps129.OverlayValues = make([]JITValueDesc, 101)
+					ps129.OverlayValues[0] = d0
+					ps129.OverlayValues[1] = d1
+					ps129.OverlayValues[2] = d2
+					ps129.OverlayValues[3] = d3
+					ps129.OverlayValues[18] = d18
+					ps129.OverlayValues[19] = d19
+					ps129.OverlayValues[20] = d20
+					ps129.OverlayValues[21] = d21
+					ps129.OverlayValues[22] = d22
+					ps129.OverlayValues[23] = d23
+					ps129.OverlayValues[50] = d50
+					ps129.OverlayValues[51] = d51
+					ps129.OverlayValues[52] = d52
+					ps129.OverlayValues[53] = d53
+					ps129.OverlayValues[54] = d54
+					ps129.OverlayValues[91] = d91
+					ps129.OverlayValues[92] = d92
+					ps129.OverlayValues[93] = d93
+					ps129.OverlayValues[94] = d94
+					ps129.OverlayValues[95] = d95
+					ps129.OverlayValues[96] = d96
+					ps129.OverlayValues[98] = d98
+					ps129.OverlayValues[99] = d99
+					ps129.OverlayValues[100] = d100
+					snap130 := d0
+					snap131 := d1
+					snap132 := d2
+					snap133 := d3
+					snap134 := d18
+					snap135 := d19
+					snap136 := d20
+					snap137 := d21
+					snap138 := d22
+					snap139 := d23
+					snap140 := d50
+					snap141 := d51
+					snap142 := d52
+					snap143 := d53
+					snap144 := d54
+					snap145 := d91
+					snap146 := d92
+					snap147 := d93
+					snap148 := d94
+					snap149 := d95
+					snap150 := d96
+					snap151 := d98
+					snap152 := d99
+					snap153 := d100
+					alloc154 := ctx.SnapshotAllocState()
 					if !bbs[9].Rendered {
-						bbs[9].RenderPS(ps123)
+						bbs[9].RenderPS(ps129)
 					}
-					ctx.RestoreAllocState(alloc147)
-					d0 = snap124
-					d1 = snap125
-					d2 = snap126
-					d3 = snap127
-					d18 = snap128
-					d19 = snap129
-					d20 = snap130
-					d21 = snap131
-					d22 = snap132
-					d47 = snap133
-					d48 = snap134
-					d49 = snap135
-					d50 = snap136
-					d51 = snap137
-					d86 = snap138
-					d87 = snap139
-					d88 = snap140
-					d89 = snap141
-					d90 = snap142
-					d91 = snap143
-					d93 = snap144
-					d94 = snap145
-					d95 = snap146
+					ctx.RestoreAllocState(alloc154)
+					d0 = snap130
+					d1 = snap131
+					d2 = snap132
+					d3 = snap133
+					d18 = snap134
+					d19 = snap135
+					d20 = snap136
+					d21 = snap137
+					d22 = snap138
+					d23 = snap139
+					d50 = snap140
+					d51 = snap141
+					d52 = snap142
+					d53 = snap143
+					d54 = snap144
+					d91 = snap145
+					d92 = snap146
+					d93 = snap147
+					d94 = snap148
+					d95 = snap149
+					d96 = snap150
+					d98 = snap151
+					d99 = snap152
+					d100 = snap153
 					if !bbs[8].Rendered {
-						return bbs[8].RenderPS(ps122)
+						return bbs[8].RenderPS(ps128)
 					}
 					return result
-					ctx.FreeDesc(&d94)
+					ctx.FreeDesc(&d99)
 					return result
 				}
 				bbs[7].RenderPS = func(ps PhiState) JITValueDesc {
@@ -2932,14 +2975,8 @@ func init_date() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 47 && ps.OverlayValues[47].Loc != LocNone {
-						d47 = ps.OverlayValues[47]
-					}
-					if len(ps.OverlayValues) > 48 && ps.OverlayValues[48].Loc != LocNone {
-						d48 = ps.OverlayValues[48]
-					}
-					if len(ps.OverlayValues) > 49 && ps.OverlayValues[49].Loc != LocNone {
-						d49 = ps.OverlayValues[49]
+					if len(ps.OverlayValues) > 23 && ps.OverlayValues[23].Loc != LocNone {
+						d23 = ps.OverlayValues[23]
 					}
 					if len(ps.OverlayValues) > 50 && ps.OverlayValues[50].Loc != LocNone {
 						d50 = ps.OverlayValues[50]
@@ -2947,23 +2984,20 @@ func init_date() {
 					if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
 						d51 = ps.OverlayValues[51]
 					}
-					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
-						d86 = ps.OverlayValues[86]
+					if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+						d52 = ps.OverlayValues[52]
 					}
-					if len(ps.OverlayValues) > 87 && ps.OverlayValues[87].Loc != LocNone {
-						d87 = ps.OverlayValues[87]
+					if len(ps.OverlayValues) > 53 && ps.OverlayValues[53].Loc != LocNone {
+						d53 = ps.OverlayValues[53]
 					}
-					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
-						d88 = ps.OverlayValues[88]
-					}
-					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
-						d89 = ps.OverlayValues[89]
-					}
-					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
-						d90 = ps.OverlayValues[90]
+					if len(ps.OverlayValues) > 54 && ps.OverlayValues[54].Loc != LocNone {
+						d54 = ps.OverlayValues[54]
 					}
 					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
 						d91 = ps.OverlayValues[91]
+					}
+					if len(ps.OverlayValues) > 92 && ps.OverlayValues[92].Loc != LocNone {
+						d92 = ps.OverlayValues[92]
 					}
 					if len(ps.OverlayValues) > 93 && ps.OverlayValues[93].Loc != LocNone {
 						d93 = ps.OverlayValues[93]
@@ -2974,301 +3008,322 @@ func init_date() {
 					if len(ps.OverlayValues) > 95 && ps.OverlayValues[95].Loc != LocNone {
 						d95 = ps.OverlayValues[95]
 					}
+					if len(ps.OverlayValues) > 96 && ps.OverlayValues[96].Loc != LocNone {
+						d96 = ps.OverlayValues[96]
+					}
+					if len(ps.OverlayValues) > 98 && ps.OverlayValues[98].Loc != LocNone {
+						d98 = ps.OverlayValues[98]
+					}
+					if len(ps.OverlayValues) > 99 && ps.OverlayValues[99].Loc != LocNone {
+						d99 = ps.OverlayValues[99]
+					}
+					if len(ps.OverlayValues) > 100 && ps.OverlayValues[100].Loc != LocNone {
+						d100 = ps.OverlayValues[100]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d148 = args[0]
-					d148.ID = 0
-					d150 = d148
-					d150.ID = 0
-					d149 = ctx.EmitTagEqualsBorrowed(&d150, tagFloat, JITValueDesc{Loc: LocAny})
-					ctx.FreeDesc(&d148)
-					d151 = d149
-					ctx.EnsureDesc(&d151)
-					if d151.Loc != LocImm && d151.Loc != LocReg {
+					d155 = args[0]
+					d155.ID = 0
+					d157 = d155
+					d157.ID = 0
+					d156 = ctx.EmitTagEqualsBorrowed(&d157, tagFloat, JITValueDesc{Loc: LocAny})
+					ctx.FreeDesc(&d155)
+					d158 = d156
+					ctx.EnsureDesc(&d158)
+					if d158.Loc != LocImm && d158.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d151.Loc == LocImm {
-						if d151.Imm.Bool() {
+					if d158.Loc == LocImm {
+						if d158.Imm.Bool() {
 							if ps.General {
 							}
-							ps152 := PhiState{General: ps.General}
-							ps152.OverlayValues = make([]JITValueDesc, 152)
-							ps152.OverlayValues[0] = d0
-							ps152.OverlayValues[1] = d1
-							ps152.OverlayValues[2] = d2
-							ps152.OverlayValues[3] = d3
-							ps152.OverlayValues[18] = d18
-							ps152.OverlayValues[19] = d19
-							ps152.OverlayValues[20] = d20
-							ps152.OverlayValues[21] = d21
-							ps152.OverlayValues[22] = d22
-							ps152.OverlayValues[47] = d47
-							ps152.OverlayValues[48] = d48
-							ps152.OverlayValues[49] = d49
-							ps152.OverlayValues[50] = d50
-							ps152.OverlayValues[51] = d51
-							ps152.OverlayValues[86] = d86
-							ps152.OverlayValues[87] = d87
-							ps152.OverlayValues[88] = d88
-							ps152.OverlayValues[89] = d89
-							ps152.OverlayValues[90] = d90
-							ps152.OverlayValues[91] = d91
-							ps152.OverlayValues[93] = d93
-							ps152.OverlayValues[94] = d94
-							ps152.OverlayValues[95] = d95
-							ps152.OverlayValues[148] = d148
-							ps152.OverlayValues[149] = d149
-							ps152.OverlayValues[150] = d150
-							ps152.OverlayValues[151] = d151
-							return bbs[5].RenderPS(ps152)
+							ps159 := PhiState{General: ps.General}
+							ps159.OverlayValues = make([]JITValueDesc, 159)
+							ps159.OverlayValues[0] = d0
+							ps159.OverlayValues[1] = d1
+							ps159.OverlayValues[2] = d2
+							ps159.OverlayValues[3] = d3
+							ps159.OverlayValues[18] = d18
+							ps159.OverlayValues[19] = d19
+							ps159.OverlayValues[20] = d20
+							ps159.OverlayValues[21] = d21
+							ps159.OverlayValues[22] = d22
+							ps159.OverlayValues[23] = d23
+							ps159.OverlayValues[50] = d50
+							ps159.OverlayValues[51] = d51
+							ps159.OverlayValues[52] = d52
+							ps159.OverlayValues[53] = d53
+							ps159.OverlayValues[54] = d54
+							ps159.OverlayValues[91] = d91
+							ps159.OverlayValues[92] = d92
+							ps159.OverlayValues[93] = d93
+							ps159.OverlayValues[94] = d94
+							ps159.OverlayValues[95] = d95
+							ps159.OverlayValues[96] = d96
+							ps159.OverlayValues[98] = d98
+							ps159.OverlayValues[99] = d99
+							ps159.OverlayValues[100] = d100
+							ps159.OverlayValues[155] = d155
+							ps159.OverlayValues[156] = d156
+							ps159.OverlayValues[157] = d157
+							ps159.OverlayValues[158] = d158
+							return bbs[5].RenderPS(ps159)
 						}
 						if ps.General {
 						}
-						ps153 := PhiState{General: ps.General}
-						ps153.OverlayValues = make([]JITValueDesc, 152)
-						ps153.OverlayValues[0] = d0
-						ps153.OverlayValues[1] = d1
-						ps153.OverlayValues[2] = d2
-						ps153.OverlayValues[3] = d3
-						ps153.OverlayValues[18] = d18
-						ps153.OverlayValues[19] = d19
-						ps153.OverlayValues[20] = d20
-						ps153.OverlayValues[21] = d21
-						ps153.OverlayValues[22] = d22
-						ps153.OverlayValues[47] = d47
-						ps153.OverlayValues[48] = d48
-						ps153.OverlayValues[49] = d49
-						ps153.OverlayValues[50] = d50
-						ps153.OverlayValues[51] = d51
-						ps153.OverlayValues[86] = d86
-						ps153.OverlayValues[87] = d87
-						ps153.OverlayValues[88] = d88
-						ps153.OverlayValues[89] = d89
-						ps153.OverlayValues[90] = d90
-						ps153.OverlayValues[91] = d91
-						ps153.OverlayValues[93] = d93
-						ps153.OverlayValues[94] = d94
-						ps153.OverlayValues[95] = d95
-						ps153.OverlayValues[148] = d148
-						ps153.OverlayValues[149] = d149
-						ps153.OverlayValues[150] = d150
-						ps153.OverlayValues[151] = d151
-						return bbs[6].RenderPS(ps153)
+						ps160 := PhiState{General: ps.General}
+						ps160.OverlayValues = make([]JITValueDesc, 159)
+						ps160.OverlayValues[0] = d0
+						ps160.OverlayValues[1] = d1
+						ps160.OverlayValues[2] = d2
+						ps160.OverlayValues[3] = d3
+						ps160.OverlayValues[18] = d18
+						ps160.OverlayValues[19] = d19
+						ps160.OverlayValues[20] = d20
+						ps160.OverlayValues[21] = d21
+						ps160.OverlayValues[22] = d22
+						ps160.OverlayValues[23] = d23
+						ps160.OverlayValues[50] = d50
+						ps160.OverlayValues[51] = d51
+						ps160.OverlayValues[52] = d52
+						ps160.OverlayValues[53] = d53
+						ps160.OverlayValues[54] = d54
+						ps160.OverlayValues[91] = d91
+						ps160.OverlayValues[92] = d92
+						ps160.OverlayValues[93] = d93
+						ps160.OverlayValues[94] = d94
+						ps160.OverlayValues[95] = d95
+						ps160.OverlayValues[96] = d96
+						ps160.OverlayValues[98] = d98
+						ps160.OverlayValues[99] = d99
+						ps160.OverlayValues[100] = d100
+						ps160.OverlayValues[155] = d155
+						ps160.OverlayValues[156] = d156
+						ps160.OverlayValues[157] = d157
+						ps160.OverlayValues[158] = d158
+						return bbs[6].RenderPS(ps160)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[7].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d151.Reg, 0)
+					ctx.EmitCmpRegImm32(d158.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl6)
 					if bbs[6].Rendered {
 						ctx.EmitJmp(lbl7)
 					}
-					snap154 := d0
-					snap155 := d1
-					snap156 := d2
-					snap157 := d3
-					snap158 := d18
-					snap159 := d19
-					snap160 := d20
-					snap161 := d21
-					snap162 := d22
-					snap163 := d47
-					snap164 := d48
-					snap165 := d49
-					snap166 := d50
-					snap167 := d51
-					snap168 := d86
-					snap169 := d87
-					snap170 := d88
-					snap171 := d89
-					snap172 := d90
-					snap173 := d91
-					snap174 := d93
-					snap175 := d94
-					snap176 := d95
-					snap177 := d148
-					snap178 := d149
-					snap179 := d150
-					snap180 := d151
-					alloc181 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc181)
-					d0 = snap154
-					d1 = snap155
-					d2 = snap156
-					d3 = snap157
-					d18 = snap158
-					d19 = snap159
-					d20 = snap160
-					d21 = snap161
-					d22 = snap162
-					d47 = snap163
-					d48 = snap164
-					d49 = snap165
-					d50 = snap166
-					d51 = snap167
-					d86 = snap168
-					d87 = snap169
-					d88 = snap170
-					d89 = snap171
-					d90 = snap172
-					d91 = snap173
-					d93 = snap174
-					d94 = snap175
-					d95 = snap176
-					d148 = snap177
-					d149 = snap178
-					d150 = snap179
-					d151 = snap180
-					ctx.RestoreAllocState(alloc181)
-					d0 = snap154
-					d1 = snap155
-					d2 = snap156
-					d3 = snap157
-					d18 = snap158
-					d19 = snap159
-					d20 = snap160
-					d21 = snap161
-					d22 = snap162
-					d47 = snap163
-					d48 = snap164
-					d49 = snap165
-					d50 = snap166
-					d51 = snap167
-					d86 = snap168
-					d87 = snap169
-					d88 = snap170
-					d89 = snap171
-					d90 = snap172
-					d91 = snap173
-					d93 = snap174
-					d94 = snap175
-					d95 = snap176
-					d148 = snap177
-					d149 = snap178
-					d150 = snap179
-					d151 = snap180
-					ps182 := PhiState{General: true}
-					ps182.OverlayValues = make([]JITValueDesc, 152)
-					ps182.OverlayValues[0] = d0
-					ps182.OverlayValues[1] = d1
-					ps182.OverlayValues[2] = d2
-					ps182.OverlayValues[3] = d3
-					ps182.OverlayValues[18] = d18
-					ps182.OverlayValues[19] = d19
-					ps182.OverlayValues[20] = d20
-					ps182.OverlayValues[21] = d21
-					ps182.OverlayValues[22] = d22
-					ps182.OverlayValues[47] = d47
-					ps182.OverlayValues[48] = d48
-					ps182.OverlayValues[49] = d49
-					ps182.OverlayValues[50] = d50
-					ps182.OverlayValues[51] = d51
-					ps182.OverlayValues[86] = d86
-					ps182.OverlayValues[87] = d87
-					ps182.OverlayValues[88] = d88
-					ps182.OverlayValues[89] = d89
-					ps182.OverlayValues[90] = d90
-					ps182.OverlayValues[91] = d91
-					ps182.OverlayValues[93] = d93
-					ps182.OverlayValues[94] = d94
-					ps182.OverlayValues[95] = d95
-					ps182.OverlayValues[148] = d148
-					ps182.OverlayValues[149] = d149
-					ps182.OverlayValues[150] = d150
-					ps182.OverlayValues[151] = d151
-					ps183 := PhiState{General: true}
-					ps183.OverlayValues = make([]JITValueDesc, 152)
-					ps183.OverlayValues[0] = d0
-					ps183.OverlayValues[1] = d1
-					ps183.OverlayValues[2] = d2
-					ps183.OverlayValues[3] = d3
-					ps183.OverlayValues[18] = d18
-					ps183.OverlayValues[19] = d19
-					ps183.OverlayValues[20] = d20
-					ps183.OverlayValues[21] = d21
-					ps183.OverlayValues[22] = d22
-					ps183.OverlayValues[47] = d47
-					ps183.OverlayValues[48] = d48
-					ps183.OverlayValues[49] = d49
-					ps183.OverlayValues[50] = d50
-					ps183.OverlayValues[51] = d51
-					ps183.OverlayValues[86] = d86
-					ps183.OverlayValues[87] = d87
-					ps183.OverlayValues[88] = d88
-					ps183.OverlayValues[89] = d89
-					ps183.OverlayValues[90] = d90
-					ps183.OverlayValues[91] = d91
-					ps183.OverlayValues[93] = d93
-					ps183.OverlayValues[94] = d94
-					ps183.OverlayValues[95] = d95
-					ps183.OverlayValues[148] = d148
-					ps183.OverlayValues[149] = d149
-					ps183.OverlayValues[150] = d150
-					ps183.OverlayValues[151] = d151
-					snap184 := d0
-					snap185 := d1
-					snap186 := d2
-					snap187 := d3
-					snap188 := d18
-					snap189 := d19
-					snap190 := d20
-					snap191 := d21
-					snap192 := d22
-					snap193 := d47
-					snap194 := d48
-					snap195 := d49
-					snap196 := d50
-					snap197 := d51
-					snap198 := d86
-					snap199 := d87
-					snap200 := d88
-					snap201 := d89
-					snap202 := d90
-					snap203 := d91
-					snap204 := d93
-					snap205 := d94
-					snap206 := d95
-					snap207 := d148
-					snap208 := d149
-					snap209 := d150
-					snap210 := d151
-					alloc211 := ctx.SnapshotAllocState()
+					snap161 := d0
+					snap162 := d1
+					snap163 := d2
+					snap164 := d3
+					snap165 := d18
+					snap166 := d19
+					snap167 := d20
+					snap168 := d21
+					snap169 := d22
+					snap170 := d23
+					snap171 := d50
+					snap172 := d51
+					snap173 := d52
+					snap174 := d53
+					snap175 := d54
+					snap176 := d91
+					snap177 := d92
+					snap178 := d93
+					snap179 := d94
+					snap180 := d95
+					snap181 := d96
+					snap182 := d98
+					snap183 := d99
+					snap184 := d100
+					snap185 := d155
+					snap186 := d156
+					snap187 := d157
+					snap188 := d158
+					alloc189 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc189)
+					d0 = snap161
+					d1 = snap162
+					d2 = snap163
+					d3 = snap164
+					d18 = snap165
+					d19 = snap166
+					d20 = snap167
+					d21 = snap168
+					d22 = snap169
+					d23 = snap170
+					d50 = snap171
+					d51 = snap172
+					d52 = snap173
+					d53 = snap174
+					d54 = snap175
+					d91 = snap176
+					d92 = snap177
+					d93 = snap178
+					d94 = snap179
+					d95 = snap180
+					d96 = snap181
+					d98 = snap182
+					d99 = snap183
+					d100 = snap184
+					d155 = snap185
+					d156 = snap186
+					d157 = snap187
+					d158 = snap188
+					ctx.RestoreAllocState(alloc189)
+					d0 = snap161
+					d1 = snap162
+					d2 = snap163
+					d3 = snap164
+					d18 = snap165
+					d19 = snap166
+					d20 = snap167
+					d21 = snap168
+					d22 = snap169
+					d23 = snap170
+					d50 = snap171
+					d51 = snap172
+					d52 = snap173
+					d53 = snap174
+					d54 = snap175
+					d91 = snap176
+					d92 = snap177
+					d93 = snap178
+					d94 = snap179
+					d95 = snap180
+					d96 = snap181
+					d98 = snap182
+					d99 = snap183
+					d100 = snap184
+					d155 = snap185
+					d156 = snap186
+					d157 = snap187
+					d158 = snap188
+					ps190 := PhiState{General: true}
+					ps190.OverlayValues = make([]JITValueDesc, 159)
+					ps190.OverlayValues[0] = d0
+					ps190.OverlayValues[1] = d1
+					ps190.OverlayValues[2] = d2
+					ps190.OverlayValues[3] = d3
+					ps190.OverlayValues[18] = d18
+					ps190.OverlayValues[19] = d19
+					ps190.OverlayValues[20] = d20
+					ps190.OverlayValues[21] = d21
+					ps190.OverlayValues[22] = d22
+					ps190.OverlayValues[23] = d23
+					ps190.OverlayValues[50] = d50
+					ps190.OverlayValues[51] = d51
+					ps190.OverlayValues[52] = d52
+					ps190.OverlayValues[53] = d53
+					ps190.OverlayValues[54] = d54
+					ps190.OverlayValues[91] = d91
+					ps190.OverlayValues[92] = d92
+					ps190.OverlayValues[93] = d93
+					ps190.OverlayValues[94] = d94
+					ps190.OverlayValues[95] = d95
+					ps190.OverlayValues[96] = d96
+					ps190.OverlayValues[98] = d98
+					ps190.OverlayValues[99] = d99
+					ps190.OverlayValues[100] = d100
+					ps190.OverlayValues[155] = d155
+					ps190.OverlayValues[156] = d156
+					ps190.OverlayValues[157] = d157
+					ps190.OverlayValues[158] = d158
+					ps191 := PhiState{General: true}
+					ps191.OverlayValues = make([]JITValueDesc, 159)
+					ps191.OverlayValues[0] = d0
+					ps191.OverlayValues[1] = d1
+					ps191.OverlayValues[2] = d2
+					ps191.OverlayValues[3] = d3
+					ps191.OverlayValues[18] = d18
+					ps191.OverlayValues[19] = d19
+					ps191.OverlayValues[20] = d20
+					ps191.OverlayValues[21] = d21
+					ps191.OverlayValues[22] = d22
+					ps191.OverlayValues[23] = d23
+					ps191.OverlayValues[50] = d50
+					ps191.OverlayValues[51] = d51
+					ps191.OverlayValues[52] = d52
+					ps191.OverlayValues[53] = d53
+					ps191.OverlayValues[54] = d54
+					ps191.OverlayValues[91] = d91
+					ps191.OverlayValues[92] = d92
+					ps191.OverlayValues[93] = d93
+					ps191.OverlayValues[94] = d94
+					ps191.OverlayValues[95] = d95
+					ps191.OverlayValues[96] = d96
+					ps191.OverlayValues[98] = d98
+					ps191.OverlayValues[99] = d99
+					ps191.OverlayValues[100] = d100
+					ps191.OverlayValues[155] = d155
+					ps191.OverlayValues[156] = d156
+					ps191.OverlayValues[157] = d157
+					ps191.OverlayValues[158] = d158
+					snap192 := d0
+					snap193 := d1
+					snap194 := d2
+					snap195 := d3
+					snap196 := d18
+					snap197 := d19
+					snap198 := d20
+					snap199 := d21
+					snap200 := d22
+					snap201 := d23
+					snap202 := d50
+					snap203 := d51
+					snap204 := d52
+					snap205 := d53
+					snap206 := d54
+					snap207 := d91
+					snap208 := d92
+					snap209 := d93
+					snap210 := d94
+					snap211 := d95
+					snap212 := d96
+					snap213 := d98
+					snap214 := d99
+					snap215 := d100
+					snap216 := d155
+					snap217 := d156
+					snap218 := d157
+					snap219 := d158
+					alloc220 := ctx.SnapshotAllocState()
 					if !bbs[6].Rendered {
-						bbs[6].RenderPS(ps183)
+						bbs[6].RenderPS(ps191)
 					}
-					ctx.RestoreAllocState(alloc211)
-					d0 = snap184
-					d1 = snap185
-					d2 = snap186
-					d3 = snap187
-					d18 = snap188
-					d19 = snap189
-					d20 = snap190
-					d21 = snap191
-					d22 = snap192
-					d47 = snap193
-					d48 = snap194
-					d49 = snap195
-					d50 = snap196
-					d51 = snap197
-					d86 = snap198
-					d87 = snap199
-					d88 = snap200
-					d89 = snap201
-					d90 = snap202
-					d91 = snap203
-					d93 = snap204
-					d94 = snap205
-					d95 = snap206
-					d148 = snap207
-					d149 = snap208
-					d150 = snap209
-					d151 = snap210
+					ctx.RestoreAllocState(alloc220)
+					d0 = snap192
+					d1 = snap193
+					d2 = snap194
+					d3 = snap195
+					d18 = snap196
+					d19 = snap197
+					d20 = snap198
+					d21 = snap199
+					d22 = snap200
+					d23 = snap201
+					d50 = snap202
+					d51 = snap203
+					d52 = snap204
+					d53 = snap205
+					d54 = snap206
+					d91 = snap207
+					d92 = snap208
+					d93 = snap209
+					d94 = snap210
+					d95 = snap211
+					d96 = snap212
+					d98 = snap213
+					d99 = snap214
+					d100 = snap215
+					d155 = snap216
+					d156 = snap217
+					d157 = snap218
+					d158 = snap219
 					if !bbs[5].Rendered {
-						return bbs[5].RenderPS(ps182)
+						return bbs[5].RenderPS(ps190)
 					}
 					return result
-					ctx.FreeDesc(&d149)
+					ctx.FreeDesc(&d156)
 					return result
 				}
 				bbs[8].RenderPS = func(ps PhiState) JITValueDesc {
@@ -3317,14 +3372,8 @@ func init_date() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 47 && ps.OverlayValues[47].Loc != LocNone {
-						d47 = ps.OverlayValues[47]
-					}
-					if len(ps.OverlayValues) > 48 && ps.OverlayValues[48].Loc != LocNone {
-						d48 = ps.OverlayValues[48]
-					}
-					if len(ps.OverlayValues) > 49 && ps.OverlayValues[49].Loc != LocNone {
-						d49 = ps.OverlayValues[49]
+					if len(ps.OverlayValues) > 23 && ps.OverlayValues[23].Loc != LocNone {
+						d23 = ps.OverlayValues[23]
 					}
 					if len(ps.OverlayValues) > 50 && ps.OverlayValues[50].Loc != LocNone {
 						d50 = ps.OverlayValues[50]
@@ -3332,23 +3381,20 @@ func init_date() {
 					if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
 						d51 = ps.OverlayValues[51]
 					}
-					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
-						d86 = ps.OverlayValues[86]
+					if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+						d52 = ps.OverlayValues[52]
 					}
-					if len(ps.OverlayValues) > 87 && ps.OverlayValues[87].Loc != LocNone {
-						d87 = ps.OverlayValues[87]
+					if len(ps.OverlayValues) > 53 && ps.OverlayValues[53].Loc != LocNone {
+						d53 = ps.OverlayValues[53]
 					}
-					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
-						d88 = ps.OverlayValues[88]
-					}
-					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
-						d89 = ps.OverlayValues[89]
-					}
-					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
-						d90 = ps.OverlayValues[90]
+					if len(ps.OverlayValues) > 54 && ps.OverlayValues[54].Loc != LocNone {
+						d54 = ps.OverlayValues[54]
 					}
 					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
 						d91 = ps.OverlayValues[91]
+					}
+					if len(ps.OverlayValues) > 92 && ps.OverlayValues[92].Loc != LocNone {
+						d92 = ps.OverlayValues[92]
 					}
 					if len(ps.OverlayValues) > 93 && ps.OverlayValues[93].Loc != LocNone {
 						d93 = ps.OverlayValues[93]
@@ -3359,48 +3405,60 @@ func init_date() {
 					if len(ps.OverlayValues) > 95 && ps.OverlayValues[95].Loc != LocNone {
 						d95 = ps.OverlayValues[95]
 					}
-					if len(ps.OverlayValues) > 148 && ps.OverlayValues[148].Loc != LocNone {
-						d148 = ps.OverlayValues[148]
+					if len(ps.OverlayValues) > 96 && ps.OverlayValues[96].Loc != LocNone {
+						d96 = ps.OverlayValues[96]
 					}
-					if len(ps.OverlayValues) > 149 && ps.OverlayValues[149].Loc != LocNone {
-						d149 = ps.OverlayValues[149]
+					if len(ps.OverlayValues) > 98 && ps.OverlayValues[98].Loc != LocNone {
+						d98 = ps.OverlayValues[98]
 					}
-					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
-						d150 = ps.OverlayValues[150]
+					if len(ps.OverlayValues) > 99 && ps.OverlayValues[99].Loc != LocNone {
+						d99 = ps.OverlayValues[99]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
+					if len(ps.OverlayValues) > 100 && ps.OverlayValues[100].Loc != LocNone {
+						d100 = ps.OverlayValues[100]
+					}
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
+					}
+					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
+						d156 = ps.OverlayValues[156]
+					}
+					if len(ps.OverlayValues) > 157 && ps.OverlayValues[157].Loc != LocNone {
+						d157 = ps.OverlayValues[157]
+					}
+					if len(ps.OverlayValues) > 158 && ps.OverlayValues[158].Loc != LocNone {
+						d158 = ps.OverlayValues[158]
 					}
 					ctx.ReclaimUntrackedRegs()
-					if d93.Loc == LocRegPair || d93.Loc == LocStackPair || d93.Loc == LocRegTriple || d93.Loc == LocStackTriple {
+					if d98.Loc == LocRegPair || d98.Loc == LocStackPair || d98.Loc == LocRegTriple || d98.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d93)
-					d212 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d93}, 2)
-					d212.NoHeapPointer = false
-					ctx.BindReg(d212.Reg, &d212)
-					ctx.BindReg(d212.Reg2, &d212)
-					ctx.SyncDesc(&d212)
-					if d212.Loc == LocRegPair || d212.Loc == LocStackPair || d212.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d212, &result)
-						result.Type = d212.Type
+					ctx.SyncDesc(&d98)
+					d221 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d98}, 2)
+					d221.NoHeapPointer = false
+					ctx.BindReg(d221.Reg, &d221)
+					ctx.BindReg(d221.Reg2, &d221)
+					ctx.SyncDesc(&d221)
+					if d221.Loc == LocRegPair || d221.Loc == LocStackPair || d221.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d221, &result)
+						result.Type = d221.Type
 					} else {
-						switch d212.Type {
+						switch d221.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d212)
+							ctx.EmitMakeBool(result, d221)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d212)
+							ctx.EmitMakeInt(result, d221)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d212)
+							ctx.EmitMakeFloat(result, d221)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d212, &result)
-							result.Type = d212.Type
+							ctx.EmitMovPairToResult(&d221, &result)
+							result.Type = d221.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -3452,14 +3510,8 @@ func init_date() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
-					if len(ps.OverlayValues) > 47 && ps.OverlayValues[47].Loc != LocNone {
-						d47 = ps.OverlayValues[47]
-					}
-					if len(ps.OverlayValues) > 48 && ps.OverlayValues[48].Loc != LocNone {
-						d48 = ps.OverlayValues[48]
-					}
-					if len(ps.OverlayValues) > 49 && ps.OverlayValues[49].Loc != LocNone {
-						d49 = ps.OverlayValues[49]
+					if len(ps.OverlayValues) > 23 && ps.OverlayValues[23].Loc != LocNone {
+						d23 = ps.OverlayValues[23]
 					}
 					if len(ps.OverlayValues) > 50 && ps.OverlayValues[50].Loc != LocNone {
 						d50 = ps.OverlayValues[50]
@@ -3467,23 +3519,20 @@ func init_date() {
 					if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != LocNone {
 						d51 = ps.OverlayValues[51]
 					}
-					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
-						d86 = ps.OverlayValues[86]
+					if len(ps.OverlayValues) > 52 && ps.OverlayValues[52].Loc != LocNone {
+						d52 = ps.OverlayValues[52]
 					}
-					if len(ps.OverlayValues) > 87 && ps.OverlayValues[87].Loc != LocNone {
-						d87 = ps.OverlayValues[87]
+					if len(ps.OverlayValues) > 53 && ps.OverlayValues[53].Loc != LocNone {
+						d53 = ps.OverlayValues[53]
 					}
-					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
-						d88 = ps.OverlayValues[88]
-					}
-					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
-						d89 = ps.OverlayValues[89]
-					}
-					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
-						d90 = ps.OverlayValues[90]
+					if len(ps.OverlayValues) > 54 && ps.OverlayValues[54].Loc != LocNone {
+						d54 = ps.OverlayValues[54]
 					}
 					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
 						d91 = ps.OverlayValues[91]
+					}
+					if len(ps.OverlayValues) > 92 && ps.OverlayValues[92].Loc != LocNone {
+						d92 = ps.OverlayValues[92]
 					}
 					if len(ps.OverlayValues) > 93 && ps.OverlayValues[93].Loc != LocNone {
 						d93 = ps.OverlayValues[93]
@@ -3494,51 +3543,63 @@ func init_date() {
 					if len(ps.OverlayValues) > 95 && ps.OverlayValues[95].Loc != LocNone {
 						d95 = ps.OverlayValues[95]
 					}
-					if len(ps.OverlayValues) > 148 && ps.OverlayValues[148].Loc != LocNone {
-						d148 = ps.OverlayValues[148]
+					if len(ps.OverlayValues) > 96 && ps.OverlayValues[96].Loc != LocNone {
+						d96 = ps.OverlayValues[96]
 					}
-					if len(ps.OverlayValues) > 149 && ps.OverlayValues[149].Loc != LocNone {
-						d149 = ps.OverlayValues[149]
+					if len(ps.OverlayValues) > 98 && ps.OverlayValues[98].Loc != LocNone {
+						d98 = ps.OverlayValues[98]
 					}
-					if len(ps.OverlayValues) > 150 && ps.OverlayValues[150].Loc != LocNone {
-						d150 = ps.OverlayValues[150]
+					if len(ps.OverlayValues) > 99 && ps.OverlayValues[99].Loc != LocNone {
+						d99 = ps.OverlayValues[99]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
+					if len(ps.OverlayValues) > 100 && ps.OverlayValues[100].Loc != LocNone {
+						d100 = ps.OverlayValues[100]
 					}
-					if len(ps.OverlayValues) > 212 && ps.OverlayValues[212].Loc != LocNone {
-						d212 = ps.OverlayValues[212]
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
+					}
+					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
+						d156 = ps.OverlayValues[156]
+					}
+					if len(ps.OverlayValues) > 157 && ps.OverlayValues[157].Loc != LocNone {
+						d157 = ps.OverlayValues[157]
+					}
+					if len(ps.OverlayValues) > 158 && ps.OverlayValues[158].Loc != LocNone {
+						d158 = ps.OverlayValues[158]
+					}
+					if len(ps.OverlayValues) > 221 && ps.OverlayValues[221].Loc != LocNone {
+						d221 = ps.OverlayValues[221]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d213 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
-					ctx.SyncDesc(&d213)
-					if d213.Loc == LocRegPair || d213.Loc == LocStackPair || d213.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d213, &result)
-						result.Type = d213.Type
+					d222 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+					ctx.SyncDesc(&d222)
+					if d222.Loc == LocRegPair || d222.Loc == LocStackPair || d222.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d222, &result)
+						result.Type = d222.Type
 					} else {
-						switch d213.Type {
+						switch d222.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d213)
+							ctx.EmitMakeBool(result, d222)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d213)
+							ctx.EmitMakeInt(result, d222)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d213)
+							ctx.EmitMakeFloat(result, d222)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d213, &result)
-							result.Type = d213.Type
+							ctx.EmitMovPairToResult(&d222, &result)
+							result.Type = d222.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
 					return result
 				}
-				ps214 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps214)
+				ps223 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps223)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -4574,7 +4635,7 @@ func init_date() {
 					ctx.FreeDesc(&d104)
 					if ps.General {
 						ctx.SyncDesc(&d105)
-						if d105.Loc == LocReg {
+						if d105.Loc == LocReg || d105.Loc == LocFPReg {
 							ctx.ProtectReg(d105.Reg)
 						} else if d105.Loc == LocRegPair {
 							ctx.ProtectReg(d105.Reg)
@@ -4597,7 +4658,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d107, int32(bbs[6].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
 						}
-						if d105.Loc == LocReg {
+						if d105.Loc == LocReg || d105.Loc == LocFPReg {
 							ctx.UnprotectReg(d105.Reg)
 						} else if d105.Loc == LocRegPair {
 							ctx.UnprotectReg(d105.Reg)
@@ -4779,7 +4840,7 @@ func init_date() {
 						if d113.Loc != LocReg && d113.Loc != LocRegPair && d113.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r1 := ctx.AllocReg()
+						r1 := ctx.AllocRegExcept(d113.Reg)
 						ctx.EmitCmpRegImm32(d113.Reg, 0)
 						ctx.EmitSetcc(r1, CondNotEqual)
 						d114 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
@@ -4828,7 +4889,7 @@ func init_date() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d112)
-							if d112.Loc == LocReg {
+							if d112.Loc == LocReg || d112.Loc == LocFPReg {
 								ctx.ProtectReg(d112.Reg)
 							} else if d112.Loc == LocRegPair {
 								ctx.ProtectReg(d112.Reg)
@@ -4840,7 +4901,7 @@ func init_date() {
 							}
 							ctx.EnsureDesc(&d117)
 							ctx.EmitStoreToStack(d117, int32(bbs[8].PhiBase)+int32(0))
-							if d112.Loc == LocReg {
+							if d112.Loc == LocReg || d112.Loc == LocFPReg {
 								ctx.UnprotectReg(d112.Reg)
 							} else if d112.Loc == LocRegPair {
 								ctx.UnprotectReg(d112.Reg)
@@ -4959,7 +5020,7 @@ func init_date() {
 					d120 = snap150
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d112)
-					if d112.Loc == LocReg {
+					if d112.Loc == LocReg || d112.Loc == LocFPReg {
 						ctx.ProtectReg(d112.Reg)
 					} else if d112.Loc == LocRegPair {
 						ctx.ProtectReg(d112.Reg)
@@ -4971,7 +5032,7 @@ func init_date() {
 					}
 					ctx.EnsureDesc(&d152)
 					ctx.EmitStoreToStack(d152, int32(bbs[8].PhiBase)+int32(0))
-					if d112.Loc == LocReg {
+					if d112.Loc == LocReg || d112.Loc == LocFPReg {
 						ctx.UnprotectReg(d112.Reg)
 					} else if d112.Loc == LocRegPair {
 						ctx.UnprotectReg(d112.Reg)
@@ -5276,7 +5337,7 @@ func init_date() {
 					ctx.StabilizeDescForControlFlow(&d189)
 					if ps.General {
 						ctx.SyncDesc(&d189)
-						if d189.Loc == LocReg {
+						if d189.Loc == LocReg || d189.Loc == LocFPReg {
 							ctx.ProtectReg(d189.Reg)
 						} else if d189.Loc == LocRegPair {
 							ctx.ProtectReg(d189.Reg)
@@ -5288,7 +5349,7 @@ func init_date() {
 						}
 						ctx.EnsureDesc(&d190)
 						ctx.EmitStoreToStack(d190, int32(bbs[8].PhiBase)+int32(0))
-						if d189.Loc == LocReg {
+						if d189.Loc == LocReg || d189.Loc == LocFPReg {
 							ctx.UnprotectReg(d189.Reg)
 						} else if d189.Loc == LocRegPair {
 							ctx.UnprotectReg(d189.Reg)
@@ -5837,8 +5898,6 @@ func init_date() {
 				_ = d1493
 				var d1494 JITValueDesc
 				_ = d1494
-				var d1495 JITValueDesc
-				_ = d1495
 				var d1496 JITValueDesc
 				_ = d1496
 				var d1497 JITValueDesc
@@ -5849,8 +5908,8 @@ func init_date() {
 				_ = d1499
 				var d1500 JITValueDesc
 				_ = d1500
-				var d1727 JITValueDesc
-				_ = d1727
+				var d1501 JITValueDesc
+				_ = d1501
 				var d1728 JITValueDesc
 				_ = d1728
 				var d1729 JITValueDesc
@@ -5867,6 +5926,8 @@ func init_date() {
 				_ = d1734
 				var d1735 JITValueDesc
 				_ = d1735
+				var d1736 JITValueDesc
+				_ = d1736
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				phiBase0 := ctx.AllocStack(int32(32))
 				var bbs [29]BBDescriptor
@@ -6857,7 +6918,7 @@ func init_date() {
 					ctx.FreeDesc(&d104)
 					if ps.General {
 						ctx.SyncDesc(&d105)
-						if d105.Loc == LocReg {
+						if d105.Loc == LocReg || d105.Loc == LocFPReg {
 							ctx.ProtectReg(d105.Reg)
 						} else if d105.Loc == LocRegPair {
 							ctx.ProtectReg(d105.Reg)
@@ -6880,7 +6941,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d107, int32(bbs[6].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
 						}
-						if d105.Loc == LocReg {
+						if d105.Loc == LocReg || d105.Loc == LocFPReg {
 							ctx.UnprotectReg(d105.Reg)
 						} else if d105.Loc == LocRegPair {
 							ctx.UnprotectReg(d105.Reg)
@@ -7062,7 +7123,7 @@ func init_date() {
 						if d113.Loc != LocReg && d113.Loc != LocRegPair && d113.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r1 := ctx.AllocReg()
+						r1 := ctx.AllocRegExcept(d113.Reg)
 						ctx.EmitCmpRegImm32(d113.Reg, 0)
 						ctx.EmitSetcc(r1, CondNotEqual)
 						d114 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
@@ -7111,7 +7172,7 @@ func init_date() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d112)
-							if d112.Loc == LocReg {
+							if d112.Loc == LocReg || d112.Loc == LocFPReg {
 								ctx.ProtectReg(d112.Reg)
 							} else if d112.Loc == LocRegPair {
 								ctx.ProtectReg(d112.Reg)
@@ -7123,7 +7184,7 @@ func init_date() {
 							}
 							ctx.EnsureDesc(&d117)
 							ctx.EmitStoreToStack(d117, int32(bbs[8].PhiBase)+int32(0))
-							if d112.Loc == LocReg {
+							if d112.Loc == LocReg || d112.Loc == LocFPReg {
 								ctx.UnprotectReg(d112.Reg)
 							} else if d112.Loc == LocRegPair {
 								ctx.UnprotectReg(d112.Reg)
@@ -7242,7 +7303,7 @@ func init_date() {
 					d120 = snap150
 					ctx.MarkLabel(lbl31)
 					ctx.SyncDesc(&d112)
-					if d112.Loc == LocReg {
+					if d112.Loc == LocReg || d112.Loc == LocFPReg {
 						ctx.ProtectReg(d112.Reg)
 					} else if d112.Loc == LocRegPair {
 						ctx.ProtectReg(d112.Reg)
@@ -7254,7 +7315,7 @@ func init_date() {
 					}
 					ctx.EnsureDesc(&d152)
 					ctx.EmitStoreToStack(d152, int32(bbs[8].PhiBase)+int32(0))
-					if d112.Loc == LocReg {
+					if d112.Loc == LocReg || d112.Loc == LocFPReg {
 						ctx.UnprotectReg(d112.Reg)
 					} else if d112.Loc == LocRegPair {
 						ctx.UnprotectReg(d112.Reg)
@@ -7559,7 +7620,7 @@ func init_date() {
 					ctx.StabilizeDescForControlFlow(&d189)
 					if ps.General {
 						ctx.SyncDesc(&d189)
-						if d189.Loc == LocReg {
+						if d189.Loc == LocReg || d189.Loc == LocFPReg {
 							ctx.ProtectReg(d189.Reg)
 						} else if d189.Loc == LocRegPair {
 							ctx.ProtectReg(d189.Reg)
@@ -7571,7 +7632,7 @@ func init_date() {
 						}
 						ctx.EnsureDesc(&d190)
 						ctx.EmitStoreToStack(d190, int32(bbs[8].PhiBase)+int32(0))
-						if d189.Loc == LocReg {
+						if d189.Loc == LocReg || d189.Loc == LocFPReg {
 							ctx.UnprotectReg(d189.Reg)
 						} else if d189.Loc == LocRegPair {
 							ctx.UnprotectReg(d189.Reg)
@@ -17772,31 +17833,42 @@ func init_date() {
 					ctx.EnsureDesc(&d1493)
 					ctx.EnsureDesc(&d1493)
 					ctx.EnsureDesc(&d1493)
+					resultTarget1495 := false
+					_ = resultTarget1495
 					ctx.EnsureDesc(&d1493)
-					var d1495 JITValueDesc
+					var d1496 JITValueDesc
 					if d1493.Loc == LocImm {
-						d1495 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d1493.Imm.Int() + 1)}
+						d1496 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d1493.Imm.Int() + 1)}
 					} else {
-						scratch := ctx.AllocRegExcept(d1493.Reg)
+						var scratch Reg
+						if result.Loc == LocRegPair && result.Reg2 != d1493.Reg {
+							scratch = result.Reg2
+							resultTarget1495 = true
+						} else {
+							scratch = ctx.AllocRegExcept(d1493.Reg)
+						}
 						ctx.EmitMovRegReg(scratch, d1493.Reg)
 						ctx.EmitAddRegImm32(scratch, int32(1))
-						d1495 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-						ctx.BindReg(scratch, &d1495)
+						d1496 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d1496)
 					}
-					if d1495.Loc == LocReg && d1493.Loc == LocReg && d1495.Reg == d1493.Reg {
+					if d1496.Loc == LocReg && d1493.Loc == LocReg && d1496.Reg == d1493.Reg {
 						ctx.TransferReg(d1493.Reg)
 						d1493.Loc = LocNone
 					}
+					if resultTarget1495 && d1496.Loc == LocReg {
+						ctx.BindReg(result.Reg2, &result)
+					}
 					ctx.FreeDesc(&d1493)
-					ctx.EnsureDesc(&d1495)
-					if d1495.Loc == LocImm {
-						ctx.EmitMakeInt(result, d1495)
-					} else {
-						ctx.EmitMovToReg(result.Reg2, d1495)
-						d1496 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+					ctx.EnsureDesc(&d1496)
+					if d1496.Loc == LocImm {
 						ctx.EmitMakeInt(result, d1496)
-						if d1495.Loc == LocReg && d1495.Reg != result.Reg2 {
-							ctx.FreeReg(d1495.Reg)
+					} else {
+						ctx.EmitMovToReg(result.Reg2, d1496)
+						d1497 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d1497)
+						if d1496.Loc == LocReg && d1496.Reg != result.Reg2 {
+							ctx.FreeReg(d1496.Reg)
 						}
 					}
 					result.Type = tagInt
@@ -18136,726 +18208,614 @@ func init_date() {
 					if len(ps.OverlayValues) > 1494 && ps.OverlayValues[1494].Loc != LocNone {
 						d1494 = ps.OverlayValues[1494]
 					}
-					if len(ps.OverlayValues) > 1495 && ps.OverlayValues[1495].Loc != LocNone {
-						d1495 = ps.OverlayValues[1495]
-					}
 					if len(ps.OverlayValues) > 1496 && ps.OverlayValues[1496].Loc != LocNone {
 						d1496 = ps.OverlayValues[1496]
 					}
+					if len(ps.OverlayValues) > 1497 && ps.OverlayValues[1497].Loc != LocNone {
+						d1497 = ps.OverlayValues[1497]
+					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d198)
-					d1497 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("DAYOFWEEK")}
-					var d1498 JITValueDesc
-					if d1497.Loc == LocImm {
-						ctx.TrackImm(d1497.Imm)
-						ptrWord, _ := d1497.Imm.RawWords()
-						d1498 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.EmitMovRegImm64(d1498.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(d1498.Reg2, uint64(len(d1497.Imm.String())))
-						ctx.BindReg(d1498.Reg, &d1498)
-						ctx.BindReg(d1498.Reg2, &d1498)
+					d1498 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("DAYOFWEEK")}
+					var d1499 JITValueDesc
+					if d1498.Loc == LocImm {
+						ctx.TrackImm(d1498.Imm)
+						ptrWord, _ := d1498.Imm.RawWords()
+						d1499 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.EmitMovRegImm64(d1499.Reg, uint64(ptrWord))
+						ctx.EmitMovRegImm64(d1499.Reg2, uint64(len(d1498.Imm.String())))
+						ctx.BindReg(d1499.Reg, &d1499)
+						ctx.BindReg(d1499.Reg2, &d1499)
 					} else {
-						d1498 = d1497
+						d1499 = d1498
 					}
-					d1499 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d198, d1498}, 1)
-					ctx.EmitAndRegImm32(d1499.Reg, 1)
-					d1499.Type = tagBool
-					ctx.BindReg(d1499.Reg, &d1499)
-					d1500 = d1499
-					ctx.EnsureDesc(&d1500)
-					if d1500.Loc != LocImm && d1500.Loc != LocReg {
+					d1500 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d198, d1499}, 1)
+					ctx.EmitAndRegImm32(d1500.Reg, 1)
+					d1500.Type = tagBool
+					ctx.BindReg(d1500.Reg, &d1500)
+					d1501 = d1500
+					ctx.EnsureDesc(&d1501)
+					if d1501.Loc != LocImm && d1501.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d1500.Loc == LocImm {
-						if d1500.Imm.Bool() {
+					if d1501.Loc == LocImm {
+						if d1501.Imm.Bool() {
 							if ps.General {
 							}
-							ps1501 := PhiState{General: ps.General}
-							ps1501.OverlayValues = make([]JITValueDesc, 1501)
-							ps1501.OverlayValues[1] = d1
-							ps1501.OverlayValues[2] = d2
-							ps1501.OverlayValues[3] = d3
-							ps1501.OverlayValues[4] = d4
-							ps1501.OverlayValues[5] = d5
-							ps1501.OverlayValues[6] = d6
-							ps1501.OverlayValues[25] = d25
-							ps1501.OverlayValues[26] = d26
-							ps1501.OverlayValues[28] = d28
-							ps1501.OverlayValues[29] = d29
-							ps1501.OverlayValues[30] = d30
-							ps1501.OverlayValues[59] = d59
-							ps1501.OverlayValues[60] = d60
-							ps1501.OverlayValues[61] = d61
-							ps1501.OverlayValues[62] = d62
-							ps1501.OverlayValues[65] = d65
-							ps1501.OverlayValues[85] = d85
-							ps1501.OverlayValues[104] = d104
-							ps1501.OverlayValues[105] = d105
-							ps1501.OverlayValues[106] = d106
-							ps1501.OverlayValues[107] = d107
-							ps1501.OverlayValues[109] = d109
-							ps1501.OverlayValues[110] = d110
-							ps1501.OverlayValues[112] = d112
-							ps1501.OverlayValues[113] = d113
-							ps1501.OverlayValues[114] = d114
-							ps1501.OverlayValues[115] = d115
-							ps1501.OverlayValues[117] = d117
-							ps1501.OverlayValues[119] = d119
-							ps1501.OverlayValues[120] = d120
-							ps1501.OverlayValues[152] = d152
-							ps1501.OverlayValues[155] = d155
-							ps1501.OverlayValues[189] = d189
-							ps1501.OverlayValues[190] = d190
-							ps1501.OverlayValues[192] = d192
-							ps1501.OverlayValues[193] = d193
-							ps1501.OverlayValues[194] = d194
-							ps1501.OverlayValues[195] = d195
-							ps1501.OverlayValues[196] = d196
-							ps1501.OverlayValues[197] = d197
-							ps1501.OverlayValues[198] = d198
-							ps1501.OverlayValues[199] = d199
-							ps1501.OverlayValues[200] = d200
-							ps1501.OverlayValues[201] = d201
-							ps1501.OverlayValues[202] = d202
-							ps1501.OverlayValues[205] = d205
-							ps1501.OverlayValues[302] = d302
-							ps1501.OverlayValues[303] = d303
-							ps1501.OverlayValues[304] = d304
-							ps1501.OverlayValues[305] = d305
-							ps1501.OverlayValues[306] = d306
-							ps1501.OverlayValues[307] = d307
-							ps1501.OverlayValues[308] = d308
-							ps1501.OverlayValues[309] = d309
-							ps1501.OverlayValues[310] = d310
-							ps1501.OverlayValues[311] = d311
-							ps1501.OverlayValues[430] = d430
-							ps1501.OverlayValues[431] = d431
-							ps1501.OverlayValues[432] = d432
-							ps1501.OverlayValues[433] = d433
-							ps1501.OverlayValues[434] = d434
-							ps1501.OverlayValues[435] = d435
-							ps1501.OverlayValues[436] = d436
-							ps1501.OverlayValues[569] = d569
-							ps1501.OverlayValues[570] = d570
-							ps1501.OverlayValues[571] = d571
-							ps1501.OverlayValues[572] = d572
-							ps1501.OverlayValues[573] = d573
-							ps1501.OverlayValues[574] = d574
-							ps1501.OverlayValues[575] = d575
-							ps1501.OverlayValues[722] = d722
-							ps1501.OverlayValues[723] = d723
-							ps1501.OverlayValues[724] = d724
-							ps1501.OverlayValues[725] = d725
-							ps1501.OverlayValues[726] = d726
-							ps1501.OverlayValues[727] = d727
-							ps1501.OverlayValues[728] = d728
-							ps1501.OverlayValues[889] = d889
-							ps1501.OverlayValues[890] = d890
-							ps1501.OverlayValues[891] = d891
-							ps1501.OverlayValues[892] = d892
-							ps1501.OverlayValues[893] = d893
-							ps1501.OverlayValues[894] = d894
-							ps1501.OverlayValues[895] = d895
-							ps1501.OverlayValues[1070] = d1070
-							ps1501.OverlayValues[1071] = d1071
-							ps1501.OverlayValues[1072] = d1072
-							ps1501.OverlayValues[1073] = d1073
-							ps1501.OverlayValues[1074] = d1074
-							ps1501.OverlayValues[1075] = d1075
-							ps1501.OverlayValues[1076] = d1076
-							ps1501.OverlayValues[1077] = d1077
-							ps1501.OverlayValues[1078] = d1078
-							ps1501.OverlayValues[1079] = d1079
-							ps1501.OverlayValues[1275] = d1275
-							ps1501.OverlayValues[1276] = d1276
-							ps1501.OverlayValues[1277] = d1277
-							ps1501.OverlayValues[1278] = d1278
-							ps1501.OverlayValues[1279] = d1279
-							ps1501.OverlayValues[1280] = d1280
-							ps1501.OverlayValues[1281] = d1281
-							ps1501.OverlayValues[1282] = d1282
-							ps1501.OverlayValues[1493] = d1493
-							ps1501.OverlayValues[1494] = d1494
-							ps1501.OverlayValues[1495] = d1495
-							ps1501.OverlayValues[1496] = d1496
-							ps1501.OverlayValues[1497] = d1497
-							ps1501.OverlayValues[1498] = d1498
-							ps1501.OverlayValues[1499] = d1499
-							ps1501.OverlayValues[1500] = d1500
-							return bbs[24].RenderPS(ps1501)
+							ps1502 := PhiState{General: ps.General}
+							ps1502.OverlayValues = make([]JITValueDesc, 1502)
+							ps1502.OverlayValues[1] = d1
+							ps1502.OverlayValues[2] = d2
+							ps1502.OverlayValues[3] = d3
+							ps1502.OverlayValues[4] = d4
+							ps1502.OverlayValues[5] = d5
+							ps1502.OverlayValues[6] = d6
+							ps1502.OverlayValues[25] = d25
+							ps1502.OverlayValues[26] = d26
+							ps1502.OverlayValues[28] = d28
+							ps1502.OverlayValues[29] = d29
+							ps1502.OverlayValues[30] = d30
+							ps1502.OverlayValues[59] = d59
+							ps1502.OverlayValues[60] = d60
+							ps1502.OverlayValues[61] = d61
+							ps1502.OverlayValues[62] = d62
+							ps1502.OverlayValues[65] = d65
+							ps1502.OverlayValues[85] = d85
+							ps1502.OverlayValues[104] = d104
+							ps1502.OverlayValues[105] = d105
+							ps1502.OverlayValues[106] = d106
+							ps1502.OverlayValues[107] = d107
+							ps1502.OverlayValues[109] = d109
+							ps1502.OverlayValues[110] = d110
+							ps1502.OverlayValues[112] = d112
+							ps1502.OverlayValues[113] = d113
+							ps1502.OverlayValues[114] = d114
+							ps1502.OverlayValues[115] = d115
+							ps1502.OverlayValues[117] = d117
+							ps1502.OverlayValues[119] = d119
+							ps1502.OverlayValues[120] = d120
+							ps1502.OverlayValues[152] = d152
+							ps1502.OverlayValues[155] = d155
+							ps1502.OverlayValues[189] = d189
+							ps1502.OverlayValues[190] = d190
+							ps1502.OverlayValues[192] = d192
+							ps1502.OverlayValues[193] = d193
+							ps1502.OverlayValues[194] = d194
+							ps1502.OverlayValues[195] = d195
+							ps1502.OverlayValues[196] = d196
+							ps1502.OverlayValues[197] = d197
+							ps1502.OverlayValues[198] = d198
+							ps1502.OverlayValues[199] = d199
+							ps1502.OverlayValues[200] = d200
+							ps1502.OverlayValues[201] = d201
+							ps1502.OverlayValues[202] = d202
+							ps1502.OverlayValues[205] = d205
+							ps1502.OverlayValues[302] = d302
+							ps1502.OverlayValues[303] = d303
+							ps1502.OverlayValues[304] = d304
+							ps1502.OverlayValues[305] = d305
+							ps1502.OverlayValues[306] = d306
+							ps1502.OverlayValues[307] = d307
+							ps1502.OverlayValues[308] = d308
+							ps1502.OverlayValues[309] = d309
+							ps1502.OverlayValues[310] = d310
+							ps1502.OverlayValues[311] = d311
+							ps1502.OverlayValues[430] = d430
+							ps1502.OverlayValues[431] = d431
+							ps1502.OverlayValues[432] = d432
+							ps1502.OverlayValues[433] = d433
+							ps1502.OverlayValues[434] = d434
+							ps1502.OverlayValues[435] = d435
+							ps1502.OverlayValues[436] = d436
+							ps1502.OverlayValues[569] = d569
+							ps1502.OverlayValues[570] = d570
+							ps1502.OverlayValues[571] = d571
+							ps1502.OverlayValues[572] = d572
+							ps1502.OverlayValues[573] = d573
+							ps1502.OverlayValues[574] = d574
+							ps1502.OverlayValues[575] = d575
+							ps1502.OverlayValues[722] = d722
+							ps1502.OverlayValues[723] = d723
+							ps1502.OverlayValues[724] = d724
+							ps1502.OverlayValues[725] = d725
+							ps1502.OverlayValues[726] = d726
+							ps1502.OverlayValues[727] = d727
+							ps1502.OverlayValues[728] = d728
+							ps1502.OverlayValues[889] = d889
+							ps1502.OverlayValues[890] = d890
+							ps1502.OverlayValues[891] = d891
+							ps1502.OverlayValues[892] = d892
+							ps1502.OverlayValues[893] = d893
+							ps1502.OverlayValues[894] = d894
+							ps1502.OverlayValues[895] = d895
+							ps1502.OverlayValues[1070] = d1070
+							ps1502.OverlayValues[1071] = d1071
+							ps1502.OverlayValues[1072] = d1072
+							ps1502.OverlayValues[1073] = d1073
+							ps1502.OverlayValues[1074] = d1074
+							ps1502.OverlayValues[1075] = d1075
+							ps1502.OverlayValues[1076] = d1076
+							ps1502.OverlayValues[1077] = d1077
+							ps1502.OverlayValues[1078] = d1078
+							ps1502.OverlayValues[1079] = d1079
+							ps1502.OverlayValues[1275] = d1275
+							ps1502.OverlayValues[1276] = d1276
+							ps1502.OverlayValues[1277] = d1277
+							ps1502.OverlayValues[1278] = d1278
+							ps1502.OverlayValues[1279] = d1279
+							ps1502.OverlayValues[1280] = d1280
+							ps1502.OverlayValues[1281] = d1281
+							ps1502.OverlayValues[1282] = d1282
+							ps1502.OverlayValues[1493] = d1493
+							ps1502.OverlayValues[1494] = d1494
+							ps1502.OverlayValues[1496] = d1496
+							ps1502.OverlayValues[1497] = d1497
+							ps1502.OverlayValues[1498] = d1498
+							ps1502.OverlayValues[1499] = d1499
+							ps1502.OverlayValues[1500] = d1500
+							ps1502.OverlayValues[1501] = d1501
+							return bbs[24].RenderPS(ps1502)
 						}
 						if ps.General {
 						}
-						ps1502 := PhiState{General: ps.General}
-						ps1502.OverlayValues = make([]JITValueDesc, 1501)
-						ps1502.OverlayValues[1] = d1
-						ps1502.OverlayValues[2] = d2
-						ps1502.OverlayValues[3] = d3
-						ps1502.OverlayValues[4] = d4
-						ps1502.OverlayValues[5] = d5
-						ps1502.OverlayValues[6] = d6
-						ps1502.OverlayValues[25] = d25
-						ps1502.OverlayValues[26] = d26
-						ps1502.OverlayValues[28] = d28
-						ps1502.OverlayValues[29] = d29
-						ps1502.OverlayValues[30] = d30
-						ps1502.OverlayValues[59] = d59
-						ps1502.OverlayValues[60] = d60
-						ps1502.OverlayValues[61] = d61
-						ps1502.OverlayValues[62] = d62
-						ps1502.OverlayValues[65] = d65
-						ps1502.OverlayValues[85] = d85
-						ps1502.OverlayValues[104] = d104
-						ps1502.OverlayValues[105] = d105
-						ps1502.OverlayValues[106] = d106
-						ps1502.OverlayValues[107] = d107
-						ps1502.OverlayValues[109] = d109
-						ps1502.OverlayValues[110] = d110
-						ps1502.OverlayValues[112] = d112
-						ps1502.OverlayValues[113] = d113
-						ps1502.OverlayValues[114] = d114
-						ps1502.OverlayValues[115] = d115
-						ps1502.OverlayValues[117] = d117
-						ps1502.OverlayValues[119] = d119
-						ps1502.OverlayValues[120] = d120
-						ps1502.OverlayValues[152] = d152
-						ps1502.OverlayValues[155] = d155
-						ps1502.OverlayValues[189] = d189
-						ps1502.OverlayValues[190] = d190
-						ps1502.OverlayValues[192] = d192
-						ps1502.OverlayValues[193] = d193
-						ps1502.OverlayValues[194] = d194
-						ps1502.OverlayValues[195] = d195
-						ps1502.OverlayValues[196] = d196
-						ps1502.OverlayValues[197] = d197
-						ps1502.OverlayValues[198] = d198
-						ps1502.OverlayValues[199] = d199
-						ps1502.OverlayValues[200] = d200
-						ps1502.OverlayValues[201] = d201
-						ps1502.OverlayValues[202] = d202
-						ps1502.OverlayValues[205] = d205
-						ps1502.OverlayValues[302] = d302
-						ps1502.OverlayValues[303] = d303
-						ps1502.OverlayValues[304] = d304
-						ps1502.OverlayValues[305] = d305
-						ps1502.OverlayValues[306] = d306
-						ps1502.OverlayValues[307] = d307
-						ps1502.OverlayValues[308] = d308
-						ps1502.OverlayValues[309] = d309
-						ps1502.OverlayValues[310] = d310
-						ps1502.OverlayValues[311] = d311
-						ps1502.OverlayValues[430] = d430
-						ps1502.OverlayValues[431] = d431
-						ps1502.OverlayValues[432] = d432
-						ps1502.OverlayValues[433] = d433
-						ps1502.OverlayValues[434] = d434
-						ps1502.OverlayValues[435] = d435
-						ps1502.OverlayValues[436] = d436
-						ps1502.OverlayValues[569] = d569
-						ps1502.OverlayValues[570] = d570
-						ps1502.OverlayValues[571] = d571
-						ps1502.OverlayValues[572] = d572
-						ps1502.OverlayValues[573] = d573
-						ps1502.OverlayValues[574] = d574
-						ps1502.OverlayValues[575] = d575
-						ps1502.OverlayValues[722] = d722
-						ps1502.OverlayValues[723] = d723
-						ps1502.OverlayValues[724] = d724
-						ps1502.OverlayValues[725] = d725
-						ps1502.OverlayValues[726] = d726
-						ps1502.OverlayValues[727] = d727
-						ps1502.OverlayValues[728] = d728
-						ps1502.OverlayValues[889] = d889
-						ps1502.OverlayValues[890] = d890
-						ps1502.OverlayValues[891] = d891
-						ps1502.OverlayValues[892] = d892
-						ps1502.OverlayValues[893] = d893
-						ps1502.OverlayValues[894] = d894
-						ps1502.OverlayValues[895] = d895
-						ps1502.OverlayValues[1070] = d1070
-						ps1502.OverlayValues[1071] = d1071
-						ps1502.OverlayValues[1072] = d1072
-						ps1502.OverlayValues[1073] = d1073
-						ps1502.OverlayValues[1074] = d1074
-						ps1502.OverlayValues[1075] = d1075
-						ps1502.OverlayValues[1076] = d1076
-						ps1502.OverlayValues[1077] = d1077
-						ps1502.OverlayValues[1078] = d1078
-						ps1502.OverlayValues[1079] = d1079
-						ps1502.OverlayValues[1275] = d1275
-						ps1502.OverlayValues[1276] = d1276
-						ps1502.OverlayValues[1277] = d1277
-						ps1502.OverlayValues[1278] = d1278
-						ps1502.OverlayValues[1279] = d1279
-						ps1502.OverlayValues[1280] = d1280
-						ps1502.OverlayValues[1281] = d1281
-						ps1502.OverlayValues[1282] = d1282
-						ps1502.OverlayValues[1493] = d1493
-						ps1502.OverlayValues[1494] = d1494
-						ps1502.OverlayValues[1495] = d1495
-						ps1502.OverlayValues[1496] = d1496
-						ps1502.OverlayValues[1497] = d1497
-						ps1502.OverlayValues[1498] = d1498
-						ps1502.OverlayValues[1499] = d1499
-						ps1502.OverlayValues[1500] = d1500
-						return bbs[27].RenderPS(ps1502)
+						ps1503 := PhiState{General: ps.General}
+						ps1503.OverlayValues = make([]JITValueDesc, 1502)
+						ps1503.OverlayValues[1] = d1
+						ps1503.OverlayValues[2] = d2
+						ps1503.OverlayValues[3] = d3
+						ps1503.OverlayValues[4] = d4
+						ps1503.OverlayValues[5] = d5
+						ps1503.OverlayValues[6] = d6
+						ps1503.OverlayValues[25] = d25
+						ps1503.OverlayValues[26] = d26
+						ps1503.OverlayValues[28] = d28
+						ps1503.OverlayValues[29] = d29
+						ps1503.OverlayValues[30] = d30
+						ps1503.OverlayValues[59] = d59
+						ps1503.OverlayValues[60] = d60
+						ps1503.OverlayValues[61] = d61
+						ps1503.OverlayValues[62] = d62
+						ps1503.OverlayValues[65] = d65
+						ps1503.OverlayValues[85] = d85
+						ps1503.OverlayValues[104] = d104
+						ps1503.OverlayValues[105] = d105
+						ps1503.OverlayValues[106] = d106
+						ps1503.OverlayValues[107] = d107
+						ps1503.OverlayValues[109] = d109
+						ps1503.OverlayValues[110] = d110
+						ps1503.OverlayValues[112] = d112
+						ps1503.OverlayValues[113] = d113
+						ps1503.OverlayValues[114] = d114
+						ps1503.OverlayValues[115] = d115
+						ps1503.OverlayValues[117] = d117
+						ps1503.OverlayValues[119] = d119
+						ps1503.OverlayValues[120] = d120
+						ps1503.OverlayValues[152] = d152
+						ps1503.OverlayValues[155] = d155
+						ps1503.OverlayValues[189] = d189
+						ps1503.OverlayValues[190] = d190
+						ps1503.OverlayValues[192] = d192
+						ps1503.OverlayValues[193] = d193
+						ps1503.OverlayValues[194] = d194
+						ps1503.OverlayValues[195] = d195
+						ps1503.OverlayValues[196] = d196
+						ps1503.OverlayValues[197] = d197
+						ps1503.OverlayValues[198] = d198
+						ps1503.OverlayValues[199] = d199
+						ps1503.OverlayValues[200] = d200
+						ps1503.OverlayValues[201] = d201
+						ps1503.OverlayValues[202] = d202
+						ps1503.OverlayValues[205] = d205
+						ps1503.OverlayValues[302] = d302
+						ps1503.OverlayValues[303] = d303
+						ps1503.OverlayValues[304] = d304
+						ps1503.OverlayValues[305] = d305
+						ps1503.OverlayValues[306] = d306
+						ps1503.OverlayValues[307] = d307
+						ps1503.OverlayValues[308] = d308
+						ps1503.OverlayValues[309] = d309
+						ps1503.OverlayValues[310] = d310
+						ps1503.OverlayValues[311] = d311
+						ps1503.OverlayValues[430] = d430
+						ps1503.OverlayValues[431] = d431
+						ps1503.OverlayValues[432] = d432
+						ps1503.OverlayValues[433] = d433
+						ps1503.OverlayValues[434] = d434
+						ps1503.OverlayValues[435] = d435
+						ps1503.OverlayValues[436] = d436
+						ps1503.OverlayValues[569] = d569
+						ps1503.OverlayValues[570] = d570
+						ps1503.OverlayValues[571] = d571
+						ps1503.OverlayValues[572] = d572
+						ps1503.OverlayValues[573] = d573
+						ps1503.OverlayValues[574] = d574
+						ps1503.OverlayValues[575] = d575
+						ps1503.OverlayValues[722] = d722
+						ps1503.OverlayValues[723] = d723
+						ps1503.OverlayValues[724] = d724
+						ps1503.OverlayValues[725] = d725
+						ps1503.OverlayValues[726] = d726
+						ps1503.OverlayValues[727] = d727
+						ps1503.OverlayValues[728] = d728
+						ps1503.OverlayValues[889] = d889
+						ps1503.OverlayValues[890] = d890
+						ps1503.OverlayValues[891] = d891
+						ps1503.OverlayValues[892] = d892
+						ps1503.OverlayValues[893] = d893
+						ps1503.OverlayValues[894] = d894
+						ps1503.OverlayValues[895] = d895
+						ps1503.OverlayValues[1070] = d1070
+						ps1503.OverlayValues[1071] = d1071
+						ps1503.OverlayValues[1072] = d1072
+						ps1503.OverlayValues[1073] = d1073
+						ps1503.OverlayValues[1074] = d1074
+						ps1503.OverlayValues[1075] = d1075
+						ps1503.OverlayValues[1076] = d1076
+						ps1503.OverlayValues[1077] = d1077
+						ps1503.OverlayValues[1078] = d1078
+						ps1503.OverlayValues[1079] = d1079
+						ps1503.OverlayValues[1275] = d1275
+						ps1503.OverlayValues[1276] = d1276
+						ps1503.OverlayValues[1277] = d1277
+						ps1503.OverlayValues[1278] = d1278
+						ps1503.OverlayValues[1279] = d1279
+						ps1503.OverlayValues[1280] = d1280
+						ps1503.OverlayValues[1281] = d1281
+						ps1503.OverlayValues[1282] = d1282
+						ps1503.OverlayValues[1493] = d1493
+						ps1503.OverlayValues[1494] = d1494
+						ps1503.OverlayValues[1496] = d1496
+						ps1503.OverlayValues[1497] = d1497
+						ps1503.OverlayValues[1498] = d1498
+						ps1503.OverlayValues[1499] = d1499
+						ps1503.OverlayValues[1500] = d1500
+						ps1503.OverlayValues[1501] = d1501
+						return bbs[27].RenderPS(ps1503)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[25].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d1500.Reg, 0)
+					ctx.EmitCmpRegImm32(d1501.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl25)
 					if bbs[27].Rendered {
 						ctx.EmitJmp(lbl28)
 					}
-					snap1503 := d1
-					snap1504 := d2
-					snap1505 := d3
-					snap1506 := d4
-					snap1507 := d5
-					snap1508 := d6
-					snap1509 := d25
-					snap1510 := d26
-					snap1511 := d28
-					snap1512 := d29
-					snap1513 := d30
-					snap1514 := d59
-					snap1515 := d60
-					snap1516 := d61
-					snap1517 := d62
-					snap1518 := d65
-					snap1519 := d85
-					snap1520 := d104
-					snap1521 := d105
-					snap1522 := d106
-					snap1523 := d107
-					snap1524 := d109
-					snap1525 := d110
-					snap1526 := d112
-					snap1527 := d113
-					snap1528 := d114
-					snap1529 := d115
-					snap1530 := d117
-					snap1531 := d119
-					snap1532 := d120
-					snap1533 := d152
-					snap1534 := d155
-					snap1535 := d189
-					snap1536 := d190
-					snap1537 := d192
-					snap1538 := d193
-					snap1539 := d194
-					snap1540 := d195
-					snap1541 := d196
-					snap1542 := d197
-					snap1543 := d198
-					snap1544 := d199
-					snap1545 := d200
-					snap1546 := d201
-					snap1547 := d202
-					snap1548 := d205
-					snap1549 := d302
-					snap1550 := d303
-					snap1551 := d304
-					snap1552 := d305
-					snap1553 := d306
-					snap1554 := d307
-					snap1555 := d308
-					snap1556 := d309
-					snap1557 := d310
-					snap1558 := d311
-					snap1559 := d430
-					snap1560 := d431
-					snap1561 := d432
-					snap1562 := d433
-					snap1563 := d434
-					snap1564 := d435
-					snap1565 := d436
-					snap1566 := d569
-					snap1567 := d570
-					snap1568 := d571
-					snap1569 := d572
-					snap1570 := d573
-					snap1571 := d574
-					snap1572 := d575
-					snap1573 := d722
-					snap1574 := d723
-					snap1575 := d724
-					snap1576 := d725
-					snap1577 := d726
-					snap1578 := d727
-					snap1579 := d728
-					snap1580 := d889
-					snap1581 := d890
-					snap1582 := d891
-					snap1583 := d892
-					snap1584 := d893
-					snap1585 := d894
-					snap1586 := d895
-					snap1587 := d1070
-					snap1588 := d1071
-					snap1589 := d1072
-					snap1590 := d1073
-					snap1591 := d1074
-					snap1592 := d1075
-					snap1593 := d1076
-					snap1594 := d1077
-					snap1595 := d1078
-					snap1596 := d1079
-					snap1597 := d1275
-					snap1598 := d1276
-					snap1599 := d1277
-					snap1600 := d1278
-					snap1601 := d1279
-					snap1602 := d1280
-					snap1603 := d1281
-					snap1604 := d1282
-					snap1605 := d1493
-					snap1606 := d1494
-					snap1607 := d1495
+					snap1504 := d1
+					snap1505 := d2
+					snap1506 := d3
+					snap1507 := d4
+					snap1508 := d5
+					snap1509 := d6
+					snap1510 := d25
+					snap1511 := d26
+					snap1512 := d28
+					snap1513 := d29
+					snap1514 := d30
+					snap1515 := d59
+					snap1516 := d60
+					snap1517 := d61
+					snap1518 := d62
+					snap1519 := d65
+					snap1520 := d85
+					snap1521 := d104
+					snap1522 := d105
+					snap1523 := d106
+					snap1524 := d107
+					snap1525 := d109
+					snap1526 := d110
+					snap1527 := d112
+					snap1528 := d113
+					snap1529 := d114
+					snap1530 := d115
+					snap1531 := d117
+					snap1532 := d119
+					snap1533 := d120
+					snap1534 := d152
+					snap1535 := d155
+					snap1536 := d189
+					snap1537 := d190
+					snap1538 := d192
+					snap1539 := d193
+					snap1540 := d194
+					snap1541 := d195
+					snap1542 := d196
+					snap1543 := d197
+					snap1544 := d198
+					snap1545 := d199
+					snap1546 := d200
+					snap1547 := d201
+					snap1548 := d202
+					snap1549 := d205
+					snap1550 := d302
+					snap1551 := d303
+					snap1552 := d304
+					snap1553 := d305
+					snap1554 := d306
+					snap1555 := d307
+					snap1556 := d308
+					snap1557 := d309
+					snap1558 := d310
+					snap1559 := d311
+					snap1560 := d430
+					snap1561 := d431
+					snap1562 := d432
+					snap1563 := d433
+					snap1564 := d434
+					snap1565 := d435
+					snap1566 := d436
+					snap1567 := d569
+					snap1568 := d570
+					snap1569 := d571
+					snap1570 := d572
+					snap1571 := d573
+					snap1572 := d574
+					snap1573 := d575
+					snap1574 := d722
+					snap1575 := d723
+					snap1576 := d724
+					snap1577 := d725
+					snap1578 := d726
+					snap1579 := d727
+					snap1580 := d728
+					snap1581 := d889
+					snap1582 := d890
+					snap1583 := d891
+					snap1584 := d892
+					snap1585 := d893
+					snap1586 := d894
+					snap1587 := d895
+					snap1588 := d1070
+					snap1589 := d1071
+					snap1590 := d1072
+					snap1591 := d1073
+					snap1592 := d1074
+					snap1593 := d1075
+					snap1594 := d1076
+					snap1595 := d1077
+					snap1596 := d1078
+					snap1597 := d1079
+					snap1598 := d1275
+					snap1599 := d1276
+					snap1600 := d1277
+					snap1601 := d1278
+					snap1602 := d1279
+					snap1603 := d1280
+					snap1604 := d1281
+					snap1605 := d1282
+					snap1606 := d1493
+					snap1607 := d1494
 					snap1608 := d1496
 					snap1609 := d1497
 					snap1610 := d1498
 					snap1611 := d1499
 					snap1612 := d1500
-					alloc1613 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc1613)
-					d1 = snap1503
-					d2 = snap1504
-					d3 = snap1505
-					d4 = snap1506
-					d5 = snap1507
-					d6 = snap1508
-					d25 = snap1509
-					d26 = snap1510
-					d28 = snap1511
-					d29 = snap1512
-					d30 = snap1513
-					d59 = snap1514
-					d60 = snap1515
-					d61 = snap1516
-					d62 = snap1517
-					d65 = snap1518
-					d85 = snap1519
-					d104 = snap1520
-					d105 = snap1521
-					d106 = snap1522
-					d107 = snap1523
-					d109 = snap1524
-					d110 = snap1525
-					d112 = snap1526
-					d113 = snap1527
-					d114 = snap1528
-					d115 = snap1529
-					d117 = snap1530
-					d119 = snap1531
-					d120 = snap1532
-					d152 = snap1533
-					d155 = snap1534
-					d189 = snap1535
-					d190 = snap1536
-					d192 = snap1537
-					d193 = snap1538
-					d194 = snap1539
-					d195 = snap1540
-					d196 = snap1541
-					d197 = snap1542
-					d198 = snap1543
-					d199 = snap1544
-					d200 = snap1545
-					d201 = snap1546
-					d202 = snap1547
-					d205 = snap1548
-					d302 = snap1549
-					d303 = snap1550
-					d304 = snap1551
-					d305 = snap1552
-					d306 = snap1553
-					d307 = snap1554
-					d308 = snap1555
-					d309 = snap1556
-					d310 = snap1557
-					d311 = snap1558
-					d430 = snap1559
-					d431 = snap1560
-					d432 = snap1561
-					d433 = snap1562
-					d434 = snap1563
-					d435 = snap1564
-					d436 = snap1565
-					d569 = snap1566
-					d570 = snap1567
-					d571 = snap1568
-					d572 = snap1569
-					d573 = snap1570
-					d574 = snap1571
-					d575 = snap1572
-					d722 = snap1573
-					d723 = snap1574
-					d724 = snap1575
-					d725 = snap1576
-					d726 = snap1577
-					d727 = snap1578
-					d728 = snap1579
-					d889 = snap1580
-					d890 = snap1581
-					d891 = snap1582
-					d892 = snap1583
-					d893 = snap1584
-					d894 = snap1585
-					d895 = snap1586
-					d1070 = snap1587
-					d1071 = snap1588
-					d1072 = snap1589
-					d1073 = snap1590
-					d1074 = snap1591
-					d1075 = snap1592
-					d1076 = snap1593
-					d1077 = snap1594
-					d1078 = snap1595
-					d1079 = snap1596
-					d1275 = snap1597
-					d1276 = snap1598
-					d1277 = snap1599
-					d1278 = snap1600
-					d1279 = snap1601
-					d1280 = snap1602
-					d1281 = snap1603
-					d1282 = snap1604
-					d1493 = snap1605
-					d1494 = snap1606
-					d1495 = snap1607
+					snap1613 := d1501
+					alloc1614 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc1614)
+					d1 = snap1504
+					d2 = snap1505
+					d3 = snap1506
+					d4 = snap1507
+					d5 = snap1508
+					d6 = snap1509
+					d25 = snap1510
+					d26 = snap1511
+					d28 = snap1512
+					d29 = snap1513
+					d30 = snap1514
+					d59 = snap1515
+					d60 = snap1516
+					d61 = snap1517
+					d62 = snap1518
+					d65 = snap1519
+					d85 = snap1520
+					d104 = snap1521
+					d105 = snap1522
+					d106 = snap1523
+					d107 = snap1524
+					d109 = snap1525
+					d110 = snap1526
+					d112 = snap1527
+					d113 = snap1528
+					d114 = snap1529
+					d115 = snap1530
+					d117 = snap1531
+					d119 = snap1532
+					d120 = snap1533
+					d152 = snap1534
+					d155 = snap1535
+					d189 = snap1536
+					d190 = snap1537
+					d192 = snap1538
+					d193 = snap1539
+					d194 = snap1540
+					d195 = snap1541
+					d196 = snap1542
+					d197 = snap1543
+					d198 = snap1544
+					d199 = snap1545
+					d200 = snap1546
+					d201 = snap1547
+					d202 = snap1548
+					d205 = snap1549
+					d302 = snap1550
+					d303 = snap1551
+					d304 = snap1552
+					d305 = snap1553
+					d306 = snap1554
+					d307 = snap1555
+					d308 = snap1556
+					d309 = snap1557
+					d310 = snap1558
+					d311 = snap1559
+					d430 = snap1560
+					d431 = snap1561
+					d432 = snap1562
+					d433 = snap1563
+					d434 = snap1564
+					d435 = snap1565
+					d436 = snap1566
+					d569 = snap1567
+					d570 = snap1568
+					d571 = snap1569
+					d572 = snap1570
+					d573 = snap1571
+					d574 = snap1572
+					d575 = snap1573
+					d722 = snap1574
+					d723 = snap1575
+					d724 = snap1576
+					d725 = snap1577
+					d726 = snap1578
+					d727 = snap1579
+					d728 = snap1580
+					d889 = snap1581
+					d890 = snap1582
+					d891 = snap1583
+					d892 = snap1584
+					d893 = snap1585
+					d894 = snap1586
+					d895 = snap1587
+					d1070 = snap1588
+					d1071 = snap1589
+					d1072 = snap1590
+					d1073 = snap1591
+					d1074 = snap1592
+					d1075 = snap1593
+					d1076 = snap1594
+					d1077 = snap1595
+					d1078 = snap1596
+					d1079 = snap1597
+					d1275 = snap1598
+					d1276 = snap1599
+					d1277 = snap1600
+					d1278 = snap1601
+					d1279 = snap1602
+					d1280 = snap1603
+					d1281 = snap1604
+					d1282 = snap1605
+					d1493 = snap1606
+					d1494 = snap1607
 					d1496 = snap1608
 					d1497 = snap1609
 					d1498 = snap1610
 					d1499 = snap1611
 					d1500 = snap1612
-					ctx.RestoreAllocState(alloc1613)
-					d1 = snap1503
-					d2 = snap1504
-					d3 = snap1505
-					d4 = snap1506
-					d5 = snap1507
-					d6 = snap1508
-					d25 = snap1509
-					d26 = snap1510
-					d28 = snap1511
-					d29 = snap1512
-					d30 = snap1513
-					d59 = snap1514
-					d60 = snap1515
-					d61 = snap1516
-					d62 = snap1517
-					d65 = snap1518
-					d85 = snap1519
-					d104 = snap1520
-					d105 = snap1521
-					d106 = snap1522
-					d107 = snap1523
-					d109 = snap1524
-					d110 = snap1525
-					d112 = snap1526
-					d113 = snap1527
-					d114 = snap1528
-					d115 = snap1529
-					d117 = snap1530
-					d119 = snap1531
-					d120 = snap1532
-					d152 = snap1533
-					d155 = snap1534
-					d189 = snap1535
-					d190 = snap1536
-					d192 = snap1537
-					d193 = snap1538
-					d194 = snap1539
-					d195 = snap1540
-					d196 = snap1541
-					d197 = snap1542
-					d198 = snap1543
-					d199 = snap1544
-					d200 = snap1545
-					d201 = snap1546
-					d202 = snap1547
-					d205 = snap1548
-					d302 = snap1549
-					d303 = snap1550
-					d304 = snap1551
-					d305 = snap1552
-					d306 = snap1553
-					d307 = snap1554
-					d308 = snap1555
-					d309 = snap1556
-					d310 = snap1557
-					d311 = snap1558
-					d430 = snap1559
-					d431 = snap1560
-					d432 = snap1561
-					d433 = snap1562
-					d434 = snap1563
-					d435 = snap1564
-					d436 = snap1565
-					d569 = snap1566
-					d570 = snap1567
-					d571 = snap1568
-					d572 = snap1569
-					d573 = snap1570
-					d574 = snap1571
-					d575 = snap1572
-					d722 = snap1573
-					d723 = snap1574
-					d724 = snap1575
-					d725 = snap1576
-					d726 = snap1577
-					d727 = snap1578
-					d728 = snap1579
-					d889 = snap1580
-					d890 = snap1581
-					d891 = snap1582
-					d892 = snap1583
-					d893 = snap1584
-					d894 = snap1585
-					d895 = snap1586
-					d1070 = snap1587
-					d1071 = snap1588
-					d1072 = snap1589
-					d1073 = snap1590
-					d1074 = snap1591
-					d1075 = snap1592
-					d1076 = snap1593
-					d1077 = snap1594
-					d1078 = snap1595
-					d1079 = snap1596
-					d1275 = snap1597
-					d1276 = snap1598
-					d1277 = snap1599
-					d1278 = snap1600
-					d1279 = snap1601
-					d1280 = snap1602
-					d1281 = snap1603
-					d1282 = snap1604
-					d1493 = snap1605
-					d1494 = snap1606
-					d1495 = snap1607
+					d1501 = snap1613
+					ctx.RestoreAllocState(alloc1614)
+					d1 = snap1504
+					d2 = snap1505
+					d3 = snap1506
+					d4 = snap1507
+					d5 = snap1508
+					d6 = snap1509
+					d25 = snap1510
+					d26 = snap1511
+					d28 = snap1512
+					d29 = snap1513
+					d30 = snap1514
+					d59 = snap1515
+					d60 = snap1516
+					d61 = snap1517
+					d62 = snap1518
+					d65 = snap1519
+					d85 = snap1520
+					d104 = snap1521
+					d105 = snap1522
+					d106 = snap1523
+					d107 = snap1524
+					d109 = snap1525
+					d110 = snap1526
+					d112 = snap1527
+					d113 = snap1528
+					d114 = snap1529
+					d115 = snap1530
+					d117 = snap1531
+					d119 = snap1532
+					d120 = snap1533
+					d152 = snap1534
+					d155 = snap1535
+					d189 = snap1536
+					d190 = snap1537
+					d192 = snap1538
+					d193 = snap1539
+					d194 = snap1540
+					d195 = snap1541
+					d196 = snap1542
+					d197 = snap1543
+					d198 = snap1544
+					d199 = snap1545
+					d200 = snap1546
+					d201 = snap1547
+					d202 = snap1548
+					d205 = snap1549
+					d302 = snap1550
+					d303 = snap1551
+					d304 = snap1552
+					d305 = snap1553
+					d306 = snap1554
+					d307 = snap1555
+					d308 = snap1556
+					d309 = snap1557
+					d310 = snap1558
+					d311 = snap1559
+					d430 = snap1560
+					d431 = snap1561
+					d432 = snap1562
+					d433 = snap1563
+					d434 = snap1564
+					d435 = snap1565
+					d436 = snap1566
+					d569 = snap1567
+					d570 = snap1568
+					d571 = snap1569
+					d572 = snap1570
+					d573 = snap1571
+					d574 = snap1572
+					d575 = snap1573
+					d722 = snap1574
+					d723 = snap1575
+					d724 = snap1576
+					d725 = snap1577
+					d726 = snap1578
+					d727 = snap1579
+					d728 = snap1580
+					d889 = snap1581
+					d890 = snap1582
+					d891 = snap1583
+					d892 = snap1584
+					d893 = snap1585
+					d894 = snap1586
+					d895 = snap1587
+					d1070 = snap1588
+					d1071 = snap1589
+					d1072 = snap1590
+					d1073 = snap1591
+					d1074 = snap1592
+					d1075 = snap1593
+					d1076 = snap1594
+					d1077 = snap1595
+					d1078 = snap1596
+					d1079 = snap1597
+					d1275 = snap1598
+					d1276 = snap1599
+					d1277 = snap1600
+					d1278 = snap1601
+					d1279 = snap1602
+					d1280 = snap1603
+					d1281 = snap1604
+					d1282 = snap1605
+					d1493 = snap1606
+					d1494 = snap1607
 					d1496 = snap1608
 					d1497 = snap1609
 					d1498 = snap1610
 					d1499 = snap1611
 					d1500 = snap1612
-					ps1614 := PhiState{General: true}
-					ps1614.OverlayValues = make([]JITValueDesc, 1501)
-					ps1614.OverlayValues[1] = d1
-					ps1614.OverlayValues[2] = d2
-					ps1614.OverlayValues[3] = d3
-					ps1614.OverlayValues[4] = d4
-					ps1614.OverlayValues[5] = d5
-					ps1614.OverlayValues[6] = d6
-					ps1614.OverlayValues[25] = d25
-					ps1614.OverlayValues[26] = d26
-					ps1614.OverlayValues[28] = d28
-					ps1614.OverlayValues[29] = d29
-					ps1614.OverlayValues[30] = d30
-					ps1614.OverlayValues[59] = d59
-					ps1614.OverlayValues[60] = d60
-					ps1614.OverlayValues[61] = d61
-					ps1614.OverlayValues[62] = d62
-					ps1614.OverlayValues[65] = d65
-					ps1614.OverlayValues[85] = d85
-					ps1614.OverlayValues[104] = d104
-					ps1614.OverlayValues[105] = d105
-					ps1614.OverlayValues[106] = d106
-					ps1614.OverlayValues[107] = d107
-					ps1614.OverlayValues[109] = d109
-					ps1614.OverlayValues[110] = d110
-					ps1614.OverlayValues[112] = d112
-					ps1614.OverlayValues[113] = d113
-					ps1614.OverlayValues[114] = d114
-					ps1614.OverlayValues[115] = d115
-					ps1614.OverlayValues[117] = d117
-					ps1614.OverlayValues[119] = d119
-					ps1614.OverlayValues[120] = d120
-					ps1614.OverlayValues[152] = d152
-					ps1614.OverlayValues[155] = d155
-					ps1614.OverlayValues[189] = d189
-					ps1614.OverlayValues[190] = d190
-					ps1614.OverlayValues[192] = d192
-					ps1614.OverlayValues[193] = d193
-					ps1614.OverlayValues[194] = d194
-					ps1614.OverlayValues[195] = d195
-					ps1614.OverlayValues[196] = d196
-					ps1614.OverlayValues[197] = d197
-					ps1614.OverlayValues[198] = d198
-					ps1614.OverlayValues[199] = d199
-					ps1614.OverlayValues[200] = d200
-					ps1614.OverlayValues[201] = d201
-					ps1614.OverlayValues[202] = d202
-					ps1614.OverlayValues[205] = d205
-					ps1614.OverlayValues[302] = d302
-					ps1614.OverlayValues[303] = d303
-					ps1614.OverlayValues[304] = d304
-					ps1614.OverlayValues[305] = d305
-					ps1614.OverlayValues[306] = d306
-					ps1614.OverlayValues[307] = d307
-					ps1614.OverlayValues[308] = d308
-					ps1614.OverlayValues[309] = d309
-					ps1614.OverlayValues[310] = d310
-					ps1614.OverlayValues[311] = d311
-					ps1614.OverlayValues[430] = d430
-					ps1614.OverlayValues[431] = d431
-					ps1614.OverlayValues[432] = d432
-					ps1614.OverlayValues[433] = d433
-					ps1614.OverlayValues[434] = d434
-					ps1614.OverlayValues[435] = d435
-					ps1614.OverlayValues[436] = d436
-					ps1614.OverlayValues[569] = d569
-					ps1614.OverlayValues[570] = d570
-					ps1614.OverlayValues[571] = d571
-					ps1614.OverlayValues[572] = d572
-					ps1614.OverlayValues[573] = d573
-					ps1614.OverlayValues[574] = d574
-					ps1614.OverlayValues[575] = d575
-					ps1614.OverlayValues[722] = d722
-					ps1614.OverlayValues[723] = d723
-					ps1614.OverlayValues[724] = d724
-					ps1614.OverlayValues[725] = d725
-					ps1614.OverlayValues[726] = d726
-					ps1614.OverlayValues[727] = d727
-					ps1614.OverlayValues[728] = d728
-					ps1614.OverlayValues[889] = d889
-					ps1614.OverlayValues[890] = d890
-					ps1614.OverlayValues[891] = d891
-					ps1614.OverlayValues[892] = d892
-					ps1614.OverlayValues[893] = d893
-					ps1614.OverlayValues[894] = d894
-					ps1614.OverlayValues[895] = d895
-					ps1614.OverlayValues[1070] = d1070
-					ps1614.OverlayValues[1071] = d1071
-					ps1614.OverlayValues[1072] = d1072
-					ps1614.OverlayValues[1073] = d1073
-					ps1614.OverlayValues[1074] = d1074
-					ps1614.OverlayValues[1075] = d1075
-					ps1614.OverlayValues[1076] = d1076
-					ps1614.OverlayValues[1077] = d1077
-					ps1614.OverlayValues[1078] = d1078
-					ps1614.OverlayValues[1079] = d1079
-					ps1614.OverlayValues[1275] = d1275
-					ps1614.OverlayValues[1276] = d1276
-					ps1614.OverlayValues[1277] = d1277
-					ps1614.OverlayValues[1278] = d1278
-					ps1614.OverlayValues[1279] = d1279
-					ps1614.OverlayValues[1280] = d1280
-					ps1614.OverlayValues[1281] = d1281
-					ps1614.OverlayValues[1282] = d1282
-					ps1614.OverlayValues[1493] = d1493
-					ps1614.OverlayValues[1494] = d1494
-					ps1614.OverlayValues[1495] = d1495
-					ps1614.OverlayValues[1496] = d1496
-					ps1614.OverlayValues[1497] = d1497
-					ps1614.OverlayValues[1498] = d1498
-					ps1614.OverlayValues[1499] = d1499
-					ps1614.OverlayValues[1500] = d1500
+					d1501 = snap1613
 					ps1615 := PhiState{General: true}
-					ps1615.OverlayValues = make([]JITValueDesc, 1501)
+					ps1615.OverlayValues = make([]JITValueDesc, 1502)
 					ps1615.OverlayValues[1] = d1
 					ps1615.OverlayValues[2] = d2
 					ps1615.OverlayValues[3] = d3
@@ -18960,242 +18920,354 @@ func init_date() {
 					ps1615.OverlayValues[1282] = d1282
 					ps1615.OverlayValues[1493] = d1493
 					ps1615.OverlayValues[1494] = d1494
-					ps1615.OverlayValues[1495] = d1495
 					ps1615.OverlayValues[1496] = d1496
 					ps1615.OverlayValues[1497] = d1497
 					ps1615.OverlayValues[1498] = d1498
 					ps1615.OverlayValues[1499] = d1499
 					ps1615.OverlayValues[1500] = d1500
-					snap1616 := d1
-					snap1617 := d2
-					snap1618 := d3
-					snap1619 := d4
-					snap1620 := d5
-					snap1621 := d6
-					snap1622 := d25
-					snap1623 := d26
-					snap1624 := d28
-					snap1625 := d29
-					snap1626 := d30
-					snap1627 := d59
-					snap1628 := d60
-					snap1629 := d61
-					snap1630 := d62
-					snap1631 := d65
-					snap1632 := d85
-					snap1633 := d104
-					snap1634 := d105
-					snap1635 := d106
-					snap1636 := d107
-					snap1637 := d109
-					snap1638 := d110
-					snap1639 := d112
-					snap1640 := d113
-					snap1641 := d114
-					snap1642 := d115
-					snap1643 := d117
-					snap1644 := d119
-					snap1645 := d120
-					snap1646 := d152
-					snap1647 := d155
-					snap1648 := d189
-					snap1649 := d190
-					snap1650 := d192
-					snap1651 := d193
-					snap1652 := d194
-					snap1653 := d195
-					snap1654 := d196
-					snap1655 := d197
-					snap1656 := d198
-					snap1657 := d199
-					snap1658 := d200
-					snap1659 := d201
-					snap1660 := d202
-					snap1661 := d205
-					snap1662 := d302
-					snap1663 := d303
-					snap1664 := d304
-					snap1665 := d305
-					snap1666 := d306
-					snap1667 := d307
-					snap1668 := d308
-					snap1669 := d309
-					snap1670 := d310
-					snap1671 := d311
-					snap1672 := d430
-					snap1673 := d431
-					snap1674 := d432
-					snap1675 := d433
-					snap1676 := d434
-					snap1677 := d435
-					snap1678 := d436
-					snap1679 := d569
-					snap1680 := d570
-					snap1681 := d571
-					snap1682 := d572
-					snap1683 := d573
-					snap1684 := d574
-					snap1685 := d575
-					snap1686 := d722
-					snap1687 := d723
-					snap1688 := d724
-					snap1689 := d725
-					snap1690 := d726
-					snap1691 := d727
-					snap1692 := d728
-					snap1693 := d889
-					snap1694 := d890
-					snap1695 := d891
-					snap1696 := d892
-					snap1697 := d893
-					snap1698 := d894
-					snap1699 := d895
-					snap1700 := d1070
-					snap1701 := d1071
-					snap1702 := d1072
-					snap1703 := d1073
-					snap1704 := d1074
-					snap1705 := d1075
-					snap1706 := d1076
-					snap1707 := d1077
-					snap1708 := d1078
-					snap1709 := d1079
-					snap1710 := d1275
-					snap1711 := d1276
-					snap1712 := d1277
-					snap1713 := d1278
-					snap1714 := d1279
-					snap1715 := d1280
-					snap1716 := d1281
-					snap1717 := d1282
-					snap1718 := d1493
-					snap1719 := d1494
-					snap1720 := d1495
+					ps1615.OverlayValues[1501] = d1501
+					ps1616 := PhiState{General: true}
+					ps1616.OverlayValues = make([]JITValueDesc, 1502)
+					ps1616.OverlayValues[1] = d1
+					ps1616.OverlayValues[2] = d2
+					ps1616.OverlayValues[3] = d3
+					ps1616.OverlayValues[4] = d4
+					ps1616.OverlayValues[5] = d5
+					ps1616.OverlayValues[6] = d6
+					ps1616.OverlayValues[25] = d25
+					ps1616.OverlayValues[26] = d26
+					ps1616.OverlayValues[28] = d28
+					ps1616.OverlayValues[29] = d29
+					ps1616.OverlayValues[30] = d30
+					ps1616.OverlayValues[59] = d59
+					ps1616.OverlayValues[60] = d60
+					ps1616.OverlayValues[61] = d61
+					ps1616.OverlayValues[62] = d62
+					ps1616.OverlayValues[65] = d65
+					ps1616.OverlayValues[85] = d85
+					ps1616.OverlayValues[104] = d104
+					ps1616.OverlayValues[105] = d105
+					ps1616.OverlayValues[106] = d106
+					ps1616.OverlayValues[107] = d107
+					ps1616.OverlayValues[109] = d109
+					ps1616.OverlayValues[110] = d110
+					ps1616.OverlayValues[112] = d112
+					ps1616.OverlayValues[113] = d113
+					ps1616.OverlayValues[114] = d114
+					ps1616.OverlayValues[115] = d115
+					ps1616.OverlayValues[117] = d117
+					ps1616.OverlayValues[119] = d119
+					ps1616.OverlayValues[120] = d120
+					ps1616.OverlayValues[152] = d152
+					ps1616.OverlayValues[155] = d155
+					ps1616.OverlayValues[189] = d189
+					ps1616.OverlayValues[190] = d190
+					ps1616.OverlayValues[192] = d192
+					ps1616.OverlayValues[193] = d193
+					ps1616.OverlayValues[194] = d194
+					ps1616.OverlayValues[195] = d195
+					ps1616.OverlayValues[196] = d196
+					ps1616.OverlayValues[197] = d197
+					ps1616.OverlayValues[198] = d198
+					ps1616.OverlayValues[199] = d199
+					ps1616.OverlayValues[200] = d200
+					ps1616.OverlayValues[201] = d201
+					ps1616.OverlayValues[202] = d202
+					ps1616.OverlayValues[205] = d205
+					ps1616.OverlayValues[302] = d302
+					ps1616.OverlayValues[303] = d303
+					ps1616.OverlayValues[304] = d304
+					ps1616.OverlayValues[305] = d305
+					ps1616.OverlayValues[306] = d306
+					ps1616.OverlayValues[307] = d307
+					ps1616.OverlayValues[308] = d308
+					ps1616.OverlayValues[309] = d309
+					ps1616.OverlayValues[310] = d310
+					ps1616.OverlayValues[311] = d311
+					ps1616.OverlayValues[430] = d430
+					ps1616.OverlayValues[431] = d431
+					ps1616.OverlayValues[432] = d432
+					ps1616.OverlayValues[433] = d433
+					ps1616.OverlayValues[434] = d434
+					ps1616.OverlayValues[435] = d435
+					ps1616.OverlayValues[436] = d436
+					ps1616.OverlayValues[569] = d569
+					ps1616.OverlayValues[570] = d570
+					ps1616.OverlayValues[571] = d571
+					ps1616.OverlayValues[572] = d572
+					ps1616.OverlayValues[573] = d573
+					ps1616.OverlayValues[574] = d574
+					ps1616.OverlayValues[575] = d575
+					ps1616.OverlayValues[722] = d722
+					ps1616.OverlayValues[723] = d723
+					ps1616.OverlayValues[724] = d724
+					ps1616.OverlayValues[725] = d725
+					ps1616.OverlayValues[726] = d726
+					ps1616.OverlayValues[727] = d727
+					ps1616.OverlayValues[728] = d728
+					ps1616.OverlayValues[889] = d889
+					ps1616.OverlayValues[890] = d890
+					ps1616.OverlayValues[891] = d891
+					ps1616.OverlayValues[892] = d892
+					ps1616.OverlayValues[893] = d893
+					ps1616.OverlayValues[894] = d894
+					ps1616.OverlayValues[895] = d895
+					ps1616.OverlayValues[1070] = d1070
+					ps1616.OverlayValues[1071] = d1071
+					ps1616.OverlayValues[1072] = d1072
+					ps1616.OverlayValues[1073] = d1073
+					ps1616.OverlayValues[1074] = d1074
+					ps1616.OverlayValues[1075] = d1075
+					ps1616.OverlayValues[1076] = d1076
+					ps1616.OverlayValues[1077] = d1077
+					ps1616.OverlayValues[1078] = d1078
+					ps1616.OverlayValues[1079] = d1079
+					ps1616.OverlayValues[1275] = d1275
+					ps1616.OverlayValues[1276] = d1276
+					ps1616.OverlayValues[1277] = d1277
+					ps1616.OverlayValues[1278] = d1278
+					ps1616.OverlayValues[1279] = d1279
+					ps1616.OverlayValues[1280] = d1280
+					ps1616.OverlayValues[1281] = d1281
+					ps1616.OverlayValues[1282] = d1282
+					ps1616.OverlayValues[1493] = d1493
+					ps1616.OverlayValues[1494] = d1494
+					ps1616.OverlayValues[1496] = d1496
+					ps1616.OverlayValues[1497] = d1497
+					ps1616.OverlayValues[1498] = d1498
+					ps1616.OverlayValues[1499] = d1499
+					ps1616.OverlayValues[1500] = d1500
+					ps1616.OverlayValues[1501] = d1501
+					snap1617 := d1
+					snap1618 := d2
+					snap1619 := d3
+					snap1620 := d4
+					snap1621 := d5
+					snap1622 := d6
+					snap1623 := d25
+					snap1624 := d26
+					snap1625 := d28
+					snap1626 := d29
+					snap1627 := d30
+					snap1628 := d59
+					snap1629 := d60
+					snap1630 := d61
+					snap1631 := d62
+					snap1632 := d65
+					snap1633 := d85
+					snap1634 := d104
+					snap1635 := d105
+					snap1636 := d106
+					snap1637 := d107
+					snap1638 := d109
+					snap1639 := d110
+					snap1640 := d112
+					snap1641 := d113
+					snap1642 := d114
+					snap1643 := d115
+					snap1644 := d117
+					snap1645 := d119
+					snap1646 := d120
+					snap1647 := d152
+					snap1648 := d155
+					snap1649 := d189
+					snap1650 := d190
+					snap1651 := d192
+					snap1652 := d193
+					snap1653 := d194
+					snap1654 := d195
+					snap1655 := d196
+					snap1656 := d197
+					snap1657 := d198
+					snap1658 := d199
+					snap1659 := d200
+					snap1660 := d201
+					snap1661 := d202
+					snap1662 := d205
+					snap1663 := d302
+					snap1664 := d303
+					snap1665 := d304
+					snap1666 := d305
+					snap1667 := d306
+					snap1668 := d307
+					snap1669 := d308
+					snap1670 := d309
+					snap1671 := d310
+					snap1672 := d311
+					snap1673 := d430
+					snap1674 := d431
+					snap1675 := d432
+					snap1676 := d433
+					snap1677 := d434
+					snap1678 := d435
+					snap1679 := d436
+					snap1680 := d569
+					snap1681 := d570
+					snap1682 := d571
+					snap1683 := d572
+					snap1684 := d573
+					snap1685 := d574
+					snap1686 := d575
+					snap1687 := d722
+					snap1688 := d723
+					snap1689 := d724
+					snap1690 := d725
+					snap1691 := d726
+					snap1692 := d727
+					snap1693 := d728
+					snap1694 := d889
+					snap1695 := d890
+					snap1696 := d891
+					snap1697 := d892
+					snap1698 := d893
+					snap1699 := d894
+					snap1700 := d895
+					snap1701 := d1070
+					snap1702 := d1071
+					snap1703 := d1072
+					snap1704 := d1073
+					snap1705 := d1074
+					snap1706 := d1075
+					snap1707 := d1076
+					snap1708 := d1077
+					snap1709 := d1078
+					snap1710 := d1079
+					snap1711 := d1275
+					snap1712 := d1276
+					snap1713 := d1277
+					snap1714 := d1278
+					snap1715 := d1279
+					snap1716 := d1280
+					snap1717 := d1281
+					snap1718 := d1282
+					snap1719 := d1493
+					snap1720 := d1494
 					snap1721 := d1496
 					snap1722 := d1497
 					snap1723 := d1498
 					snap1724 := d1499
 					snap1725 := d1500
-					alloc1726 := ctx.SnapshotAllocState()
+					snap1726 := d1501
+					alloc1727 := ctx.SnapshotAllocState()
 					if !bbs[27].Rendered {
-						bbs[27].RenderPS(ps1615)
+						bbs[27].RenderPS(ps1616)
 					}
-					ctx.RestoreAllocState(alloc1726)
-					d1 = snap1616
-					d2 = snap1617
-					d3 = snap1618
-					d4 = snap1619
-					d5 = snap1620
-					d6 = snap1621
-					d25 = snap1622
-					d26 = snap1623
-					d28 = snap1624
-					d29 = snap1625
-					d30 = snap1626
-					d59 = snap1627
-					d60 = snap1628
-					d61 = snap1629
-					d62 = snap1630
-					d65 = snap1631
-					d85 = snap1632
-					d104 = snap1633
-					d105 = snap1634
-					d106 = snap1635
-					d107 = snap1636
-					d109 = snap1637
-					d110 = snap1638
-					d112 = snap1639
-					d113 = snap1640
-					d114 = snap1641
-					d115 = snap1642
-					d117 = snap1643
-					d119 = snap1644
-					d120 = snap1645
-					d152 = snap1646
-					d155 = snap1647
-					d189 = snap1648
-					d190 = snap1649
-					d192 = snap1650
-					d193 = snap1651
-					d194 = snap1652
-					d195 = snap1653
-					d196 = snap1654
-					d197 = snap1655
-					d198 = snap1656
-					d199 = snap1657
-					d200 = snap1658
-					d201 = snap1659
-					d202 = snap1660
-					d205 = snap1661
-					d302 = snap1662
-					d303 = snap1663
-					d304 = snap1664
-					d305 = snap1665
-					d306 = snap1666
-					d307 = snap1667
-					d308 = snap1668
-					d309 = snap1669
-					d310 = snap1670
-					d311 = snap1671
-					d430 = snap1672
-					d431 = snap1673
-					d432 = snap1674
-					d433 = snap1675
-					d434 = snap1676
-					d435 = snap1677
-					d436 = snap1678
-					d569 = snap1679
-					d570 = snap1680
-					d571 = snap1681
-					d572 = snap1682
-					d573 = snap1683
-					d574 = snap1684
-					d575 = snap1685
-					d722 = snap1686
-					d723 = snap1687
-					d724 = snap1688
-					d725 = snap1689
-					d726 = snap1690
-					d727 = snap1691
-					d728 = snap1692
-					d889 = snap1693
-					d890 = snap1694
-					d891 = snap1695
-					d892 = snap1696
-					d893 = snap1697
-					d894 = snap1698
-					d895 = snap1699
-					d1070 = snap1700
-					d1071 = snap1701
-					d1072 = snap1702
-					d1073 = snap1703
-					d1074 = snap1704
-					d1075 = snap1705
-					d1076 = snap1706
-					d1077 = snap1707
-					d1078 = snap1708
-					d1079 = snap1709
-					d1275 = snap1710
-					d1276 = snap1711
-					d1277 = snap1712
-					d1278 = snap1713
-					d1279 = snap1714
-					d1280 = snap1715
-					d1281 = snap1716
-					d1282 = snap1717
-					d1493 = snap1718
-					d1494 = snap1719
-					d1495 = snap1720
+					ctx.RestoreAllocState(alloc1727)
+					d1 = snap1617
+					d2 = snap1618
+					d3 = snap1619
+					d4 = snap1620
+					d5 = snap1621
+					d6 = snap1622
+					d25 = snap1623
+					d26 = snap1624
+					d28 = snap1625
+					d29 = snap1626
+					d30 = snap1627
+					d59 = snap1628
+					d60 = snap1629
+					d61 = snap1630
+					d62 = snap1631
+					d65 = snap1632
+					d85 = snap1633
+					d104 = snap1634
+					d105 = snap1635
+					d106 = snap1636
+					d107 = snap1637
+					d109 = snap1638
+					d110 = snap1639
+					d112 = snap1640
+					d113 = snap1641
+					d114 = snap1642
+					d115 = snap1643
+					d117 = snap1644
+					d119 = snap1645
+					d120 = snap1646
+					d152 = snap1647
+					d155 = snap1648
+					d189 = snap1649
+					d190 = snap1650
+					d192 = snap1651
+					d193 = snap1652
+					d194 = snap1653
+					d195 = snap1654
+					d196 = snap1655
+					d197 = snap1656
+					d198 = snap1657
+					d199 = snap1658
+					d200 = snap1659
+					d201 = snap1660
+					d202 = snap1661
+					d205 = snap1662
+					d302 = snap1663
+					d303 = snap1664
+					d304 = snap1665
+					d305 = snap1666
+					d306 = snap1667
+					d307 = snap1668
+					d308 = snap1669
+					d309 = snap1670
+					d310 = snap1671
+					d311 = snap1672
+					d430 = snap1673
+					d431 = snap1674
+					d432 = snap1675
+					d433 = snap1676
+					d434 = snap1677
+					d435 = snap1678
+					d436 = snap1679
+					d569 = snap1680
+					d570 = snap1681
+					d571 = snap1682
+					d572 = snap1683
+					d573 = snap1684
+					d574 = snap1685
+					d575 = snap1686
+					d722 = snap1687
+					d723 = snap1688
+					d724 = snap1689
+					d725 = snap1690
+					d726 = snap1691
+					d727 = snap1692
+					d728 = snap1693
+					d889 = snap1694
+					d890 = snap1695
+					d891 = snap1696
+					d892 = snap1697
+					d893 = snap1698
+					d894 = snap1699
+					d895 = snap1700
+					d1070 = snap1701
+					d1071 = snap1702
+					d1072 = snap1703
+					d1073 = snap1704
+					d1074 = snap1705
+					d1075 = snap1706
+					d1076 = snap1707
+					d1077 = snap1708
+					d1078 = snap1709
+					d1079 = snap1710
+					d1275 = snap1711
+					d1276 = snap1712
+					d1277 = snap1713
+					d1278 = snap1714
+					d1279 = snap1715
+					d1280 = snap1716
+					d1281 = snap1717
+					d1282 = snap1718
+					d1493 = snap1719
+					d1494 = snap1720
 					d1496 = snap1721
 					d1497 = snap1722
 					d1498 = snap1723
 					d1499 = snap1724
 					d1500 = snap1725
+					d1501 = snap1726
 					if !bbs[24].Rendered {
-						return bbs[24].RenderPS(ps1614)
+						return bbs[24].RenderPS(ps1615)
 					}
 					return result
-					ctx.FreeDesc(&d1499)
+					ctx.FreeDesc(&d1500)
 					return result
 				}
 				bbs[26].RenderPS = func(ps PhiState) JITValueDesc {
@@ -19531,9 +19603,6 @@ func init_date() {
 					if len(ps.OverlayValues) > 1494 && ps.OverlayValues[1494].Loc != LocNone {
 						d1494 = ps.OverlayValues[1494]
 					}
-					if len(ps.OverlayValues) > 1495 && ps.OverlayValues[1495].Loc != LocNone {
-						d1495 = ps.OverlayValues[1495]
-					}
 					if len(ps.OverlayValues) > 1496 && ps.OverlayValues[1496].Loc != LocNone {
 						d1496 = ps.OverlayValues[1496]
 					}
@@ -19549,40 +19618,29 @@ func init_date() {
 					if len(ps.OverlayValues) > 1500 && ps.OverlayValues[1500].Loc != LocNone {
 						d1500 = ps.OverlayValues[1500]
 					}
+					if len(ps.OverlayValues) > 1501 && ps.OverlayValues[1501].Loc != LocNone {
+						d1501 = ps.OverlayValues[1501]
+					}
 					ctx.ReclaimUntrackedRegs()
 					d194 = JITPrepareGoSliceArg(ctx, d194)
 					if d194.Loc != LocRegTriple && d194.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Weekday arg0)")
 					}
 					ctx.SyncDesc(&d194)
-					d1727 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Weekday), []JITValueDesc{d194}, 1)
-					d1727.NoHeapPointer = true
-					ctx.BindReg(d1727.Reg, &d1727)
-					ctx.EnsureDesc(&d1727)
-					ctx.EnsureDesc(&d1727)
-					var d1728 JITValueDesc
-					if d1727.Loc == LocImm {
-						d1728 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d1727.Imm.Int() + 6)}
-					} else {
-						scratch := ctx.AllocRegExcept(d1727.Reg)
-						ctx.EmitMovRegReg(scratch, d1727.Reg)
-						ctx.EmitAddRegImm32(scratch, int32(6))
-						d1728 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-						ctx.BindReg(scratch, &d1728)
-					}
-					if d1728.Loc == LocReg && d1727.Loc == LocReg && d1728.Reg == d1727.Reg {
-						ctx.TransferReg(d1727.Reg)
-						d1727.Loc = LocNone
-					}
-					ctx.FreeDesc(&d1727)
+					d1728 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Weekday), []JITValueDesc{d194}, 1)
+					d1728.NoHeapPointer = true
+					ctx.BindReg(d1728.Reg, &d1728)
+					ctx.EnsureDesc(&d1728)
 					ctx.EnsureDesc(&d1728)
 					var d1729 JITValueDesc
 					if d1728.Loc == LocImm {
-						d1729 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d1728.Imm.Int() % 7)}
+						d1729 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d1728.Imm.Int() + 6)}
 					} else {
-						ctx.EmitIremRegImm(d1728.Reg, 7)
-						d1729 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d1728.Reg}
-						ctx.BindReg(d1728.Reg, &d1729)
+						scratch := ctx.AllocRegExcept(d1728.Reg)
+						ctx.EmitMovRegReg(scratch, d1728.Reg)
+						ctx.EmitAddRegImm32(scratch, int32(6))
+						d1729 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d1729)
 					}
 					if d1729.Loc == LocReg && d1728.Loc == LocReg && d1729.Reg == d1728.Reg {
 						ctx.TransferReg(d1728.Reg)
@@ -19590,16 +19648,30 @@ func init_date() {
 					}
 					ctx.FreeDesc(&d1728)
 					ctx.EnsureDesc(&d1729)
-					ctx.EnsureDesc(&d1729)
-					ctx.EnsureDesc(&d1729)
+					var d1730 JITValueDesc
 					if d1729.Loc == LocImm {
-						ctx.EmitMakeInt(result, d1729)
+						d1730 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d1729.Imm.Int() % 7)}
 					} else {
-						ctx.EmitMovToReg(result.Reg2, d1729)
-						d1731 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeInt(result, d1731)
-						if d1729.Loc == LocReg && d1729.Reg != result.Reg2 {
-							ctx.FreeReg(d1729.Reg)
+						ctx.EmitIremRegImm(d1729.Reg, 7)
+						d1730 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d1729.Reg}
+						ctx.BindReg(d1729.Reg, &d1730)
+					}
+					if d1730.Loc == LocReg && d1729.Loc == LocReg && d1730.Reg == d1729.Reg {
+						ctx.TransferReg(d1729.Reg)
+						d1729.Loc = LocNone
+					}
+					ctx.FreeDesc(&d1729)
+					ctx.EnsureDesc(&d1730)
+					ctx.EnsureDesc(&d1730)
+					ctx.EnsureDesc(&d1730)
+					if d1730.Loc == LocImm {
+						ctx.EmitMakeInt(result, d1730)
+					} else {
+						ctx.EmitMovToReg(result.Reg2, d1730)
+						d1732 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d1732)
+						if d1730.Loc == LocReg && d1730.Reg != result.Reg2 {
+							ctx.FreeReg(d1730.Reg)
 						}
 					}
 					result.Type = tagInt
@@ -19939,9 +20011,6 @@ func init_date() {
 					if len(ps.OverlayValues) > 1494 && ps.OverlayValues[1494].Loc != LocNone {
 						d1494 = ps.OverlayValues[1494]
 					}
-					if len(ps.OverlayValues) > 1495 && ps.OverlayValues[1495].Loc != LocNone {
-						d1495 = ps.OverlayValues[1495]
-					}
 					if len(ps.OverlayValues) > 1496 && ps.OverlayValues[1496].Loc != LocNone {
 						d1496 = ps.OverlayValues[1496]
 					}
@@ -19957,8 +20026,8 @@ func init_date() {
 					if len(ps.OverlayValues) > 1500 && ps.OverlayValues[1500].Loc != LocNone {
 						d1500 = ps.OverlayValues[1500]
 					}
-					if len(ps.OverlayValues) > 1727 && ps.OverlayValues[1727].Loc != LocNone {
-						d1727 = ps.OverlayValues[1727]
+					if len(ps.OverlayValues) > 1501 && ps.OverlayValues[1501].Loc != LocNone {
+						d1501 = ps.OverlayValues[1501]
 					}
 					if len(ps.OverlayValues) > 1728 && ps.OverlayValues[1728].Loc != LocNone {
 						d1728 = ps.OverlayValues[1728]
@@ -19972,402 +20041,404 @@ func init_date() {
 					if len(ps.OverlayValues) > 1731 && ps.OverlayValues[1731].Loc != LocNone {
 						d1731 = ps.OverlayValues[1731]
 					}
+					if len(ps.OverlayValues) > 1732 && ps.OverlayValues[1732].Loc != LocNone {
+						d1732 = ps.OverlayValues[1732]
+					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d198)
-					d1732 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("WEEKDAY")}
-					var d1733 JITValueDesc
-					if d1732.Loc == LocImm {
-						ctx.TrackImm(d1732.Imm)
-						ptrWord, _ := d1732.Imm.RawWords()
-						d1733 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.EmitMovRegImm64(d1733.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(d1733.Reg2, uint64(len(d1732.Imm.String())))
-						ctx.BindReg(d1733.Reg, &d1733)
-						ctx.BindReg(d1733.Reg2, &d1733)
+					d1733 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("WEEKDAY")}
+					var d1734 JITValueDesc
+					if d1733.Loc == LocImm {
+						ctx.TrackImm(d1733.Imm)
+						ptrWord, _ := d1733.Imm.RawWords()
+						d1734 = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.EmitMovRegImm64(d1734.Reg, uint64(ptrWord))
+						ctx.EmitMovRegImm64(d1734.Reg2, uint64(len(d1733.Imm.String())))
+						ctx.BindReg(d1734.Reg, &d1734)
+						ctx.BindReg(d1734.Reg2, &d1734)
 					} else {
-						d1733 = d1732
+						d1734 = d1733
 					}
-					d1734 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d198, d1733}, 1)
-					ctx.EmitAndRegImm32(d1734.Reg, 1)
-					d1734.Type = tagBool
-					ctx.BindReg(d1734.Reg, &d1734)
-					d1735 = d1734
-					ctx.EnsureDesc(&d1735)
-					if d1735.Loc != LocImm && d1735.Loc != LocReg {
+					d1735 = ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d198, d1734}, 1)
+					ctx.EmitAndRegImm32(d1735.Reg, 1)
+					d1735.Type = tagBool
+					ctx.BindReg(d1735.Reg, &d1735)
+					d1736 = d1735
+					ctx.EnsureDesc(&d1736)
+					if d1736.Loc != LocImm && d1736.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d1735.Loc == LocImm {
-						if d1735.Imm.Bool() {
+					if d1736.Loc == LocImm {
+						if d1736.Imm.Bool() {
 							if ps.General {
 							}
-							ps1736 := PhiState{General: ps.General}
-							ps1736.OverlayValues = make([]JITValueDesc, 1736)
-							ps1736.OverlayValues[1] = d1
-							ps1736.OverlayValues[2] = d2
-							ps1736.OverlayValues[3] = d3
-							ps1736.OverlayValues[4] = d4
-							ps1736.OverlayValues[5] = d5
-							ps1736.OverlayValues[6] = d6
-							ps1736.OverlayValues[25] = d25
-							ps1736.OverlayValues[26] = d26
-							ps1736.OverlayValues[28] = d28
-							ps1736.OverlayValues[29] = d29
-							ps1736.OverlayValues[30] = d30
-							ps1736.OverlayValues[59] = d59
-							ps1736.OverlayValues[60] = d60
-							ps1736.OverlayValues[61] = d61
-							ps1736.OverlayValues[62] = d62
-							ps1736.OverlayValues[65] = d65
-							ps1736.OverlayValues[85] = d85
-							ps1736.OverlayValues[104] = d104
-							ps1736.OverlayValues[105] = d105
-							ps1736.OverlayValues[106] = d106
-							ps1736.OverlayValues[107] = d107
-							ps1736.OverlayValues[109] = d109
-							ps1736.OverlayValues[110] = d110
-							ps1736.OverlayValues[112] = d112
-							ps1736.OverlayValues[113] = d113
-							ps1736.OverlayValues[114] = d114
-							ps1736.OverlayValues[115] = d115
-							ps1736.OverlayValues[117] = d117
-							ps1736.OverlayValues[119] = d119
-							ps1736.OverlayValues[120] = d120
-							ps1736.OverlayValues[152] = d152
-							ps1736.OverlayValues[155] = d155
-							ps1736.OverlayValues[189] = d189
-							ps1736.OverlayValues[190] = d190
-							ps1736.OverlayValues[192] = d192
-							ps1736.OverlayValues[193] = d193
-							ps1736.OverlayValues[194] = d194
-							ps1736.OverlayValues[195] = d195
-							ps1736.OverlayValues[196] = d196
-							ps1736.OverlayValues[197] = d197
-							ps1736.OverlayValues[198] = d198
-							ps1736.OverlayValues[199] = d199
-							ps1736.OverlayValues[200] = d200
-							ps1736.OverlayValues[201] = d201
-							ps1736.OverlayValues[202] = d202
-							ps1736.OverlayValues[205] = d205
-							ps1736.OverlayValues[302] = d302
-							ps1736.OverlayValues[303] = d303
-							ps1736.OverlayValues[304] = d304
-							ps1736.OverlayValues[305] = d305
-							ps1736.OverlayValues[306] = d306
-							ps1736.OverlayValues[307] = d307
-							ps1736.OverlayValues[308] = d308
-							ps1736.OverlayValues[309] = d309
-							ps1736.OverlayValues[310] = d310
-							ps1736.OverlayValues[311] = d311
-							ps1736.OverlayValues[430] = d430
-							ps1736.OverlayValues[431] = d431
-							ps1736.OverlayValues[432] = d432
-							ps1736.OverlayValues[433] = d433
-							ps1736.OverlayValues[434] = d434
-							ps1736.OverlayValues[435] = d435
-							ps1736.OverlayValues[436] = d436
-							ps1736.OverlayValues[569] = d569
-							ps1736.OverlayValues[570] = d570
-							ps1736.OverlayValues[571] = d571
-							ps1736.OverlayValues[572] = d572
-							ps1736.OverlayValues[573] = d573
-							ps1736.OverlayValues[574] = d574
-							ps1736.OverlayValues[575] = d575
-							ps1736.OverlayValues[722] = d722
-							ps1736.OverlayValues[723] = d723
-							ps1736.OverlayValues[724] = d724
-							ps1736.OverlayValues[725] = d725
-							ps1736.OverlayValues[726] = d726
-							ps1736.OverlayValues[727] = d727
-							ps1736.OverlayValues[728] = d728
-							ps1736.OverlayValues[889] = d889
-							ps1736.OverlayValues[890] = d890
-							ps1736.OverlayValues[891] = d891
-							ps1736.OverlayValues[892] = d892
-							ps1736.OverlayValues[893] = d893
-							ps1736.OverlayValues[894] = d894
-							ps1736.OverlayValues[895] = d895
-							ps1736.OverlayValues[1070] = d1070
-							ps1736.OverlayValues[1071] = d1071
-							ps1736.OverlayValues[1072] = d1072
-							ps1736.OverlayValues[1073] = d1073
-							ps1736.OverlayValues[1074] = d1074
-							ps1736.OverlayValues[1075] = d1075
-							ps1736.OverlayValues[1076] = d1076
-							ps1736.OverlayValues[1077] = d1077
-							ps1736.OverlayValues[1078] = d1078
-							ps1736.OverlayValues[1079] = d1079
-							ps1736.OverlayValues[1275] = d1275
-							ps1736.OverlayValues[1276] = d1276
-							ps1736.OverlayValues[1277] = d1277
-							ps1736.OverlayValues[1278] = d1278
-							ps1736.OverlayValues[1279] = d1279
-							ps1736.OverlayValues[1280] = d1280
-							ps1736.OverlayValues[1281] = d1281
-							ps1736.OverlayValues[1282] = d1282
-							ps1736.OverlayValues[1493] = d1493
-							ps1736.OverlayValues[1494] = d1494
-							ps1736.OverlayValues[1495] = d1495
-							ps1736.OverlayValues[1496] = d1496
-							ps1736.OverlayValues[1497] = d1497
-							ps1736.OverlayValues[1498] = d1498
-							ps1736.OverlayValues[1499] = d1499
-							ps1736.OverlayValues[1500] = d1500
-							ps1736.OverlayValues[1727] = d1727
-							ps1736.OverlayValues[1728] = d1728
-							ps1736.OverlayValues[1729] = d1729
-							ps1736.OverlayValues[1730] = d1730
-							ps1736.OverlayValues[1731] = d1731
-							ps1736.OverlayValues[1732] = d1732
-							ps1736.OverlayValues[1733] = d1733
-							ps1736.OverlayValues[1734] = d1734
-							ps1736.OverlayValues[1735] = d1735
-							return bbs[26].RenderPS(ps1736)
+							ps1737 := PhiState{General: ps.General}
+							ps1737.OverlayValues = make([]JITValueDesc, 1737)
+							ps1737.OverlayValues[1] = d1
+							ps1737.OverlayValues[2] = d2
+							ps1737.OverlayValues[3] = d3
+							ps1737.OverlayValues[4] = d4
+							ps1737.OverlayValues[5] = d5
+							ps1737.OverlayValues[6] = d6
+							ps1737.OverlayValues[25] = d25
+							ps1737.OverlayValues[26] = d26
+							ps1737.OverlayValues[28] = d28
+							ps1737.OverlayValues[29] = d29
+							ps1737.OverlayValues[30] = d30
+							ps1737.OverlayValues[59] = d59
+							ps1737.OverlayValues[60] = d60
+							ps1737.OverlayValues[61] = d61
+							ps1737.OverlayValues[62] = d62
+							ps1737.OverlayValues[65] = d65
+							ps1737.OverlayValues[85] = d85
+							ps1737.OverlayValues[104] = d104
+							ps1737.OverlayValues[105] = d105
+							ps1737.OverlayValues[106] = d106
+							ps1737.OverlayValues[107] = d107
+							ps1737.OverlayValues[109] = d109
+							ps1737.OverlayValues[110] = d110
+							ps1737.OverlayValues[112] = d112
+							ps1737.OverlayValues[113] = d113
+							ps1737.OverlayValues[114] = d114
+							ps1737.OverlayValues[115] = d115
+							ps1737.OverlayValues[117] = d117
+							ps1737.OverlayValues[119] = d119
+							ps1737.OverlayValues[120] = d120
+							ps1737.OverlayValues[152] = d152
+							ps1737.OverlayValues[155] = d155
+							ps1737.OverlayValues[189] = d189
+							ps1737.OverlayValues[190] = d190
+							ps1737.OverlayValues[192] = d192
+							ps1737.OverlayValues[193] = d193
+							ps1737.OverlayValues[194] = d194
+							ps1737.OverlayValues[195] = d195
+							ps1737.OverlayValues[196] = d196
+							ps1737.OverlayValues[197] = d197
+							ps1737.OverlayValues[198] = d198
+							ps1737.OverlayValues[199] = d199
+							ps1737.OverlayValues[200] = d200
+							ps1737.OverlayValues[201] = d201
+							ps1737.OverlayValues[202] = d202
+							ps1737.OverlayValues[205] = d205
+							ps1737.OverlayValues[302] = d302
+							ps1737.OverlayValues[303] = d303
+							ps1737.OverlayValues[304] = d304
+							ps1737.OverlayValues[305] = d305
+							ps1737.OverlayValues[306] = d306
+							ps1737.OverlayValues[307] = d307
+							ps1737.OverlayValues[308] = d308
+							ps1737.OverlayValues[309] = d309
+							ps1737.OverlayValues[310] = d310
+							ps1737.OverlayValues[311] = d311
+							ps1737.OverlayValues[430] = d430
+							ps1737.OverlayValues[431] = d431
+							ps1737.OverlayValues[432] = d432
+							ps1737.OverlayValues[433] = d433
+							ps1737.OverlayValues[434] = d434
+							ps1737.OverlayValues[435] = d435
+							ps1737.OverlayValues[436] = d436
+							ps1737.OverlayValues[569] = d569
+							ps1737.OverlayValues[570] = d570
+							ps1737.OverlayValues[571] = d571
+							ps1737.OverlayValues[572] = d572
+							ps1737.OverlayValues[573] = d573
+							ps1737.OverlayValues[574] = d574
+							ps1737.OverlayValues[575] = d575
+							ps1737.OverlayValues[722] = d722
+							ps1737.OverlayValues[723] = d723
+							ps1737.OverlayValues[724] = d724
+							ps1737.OverlayValues[725] = d725
+							ps1737.OverlayValues[726] = d726
+							ps1737.OverlayValues[727] = d727
+							ps1737.OverlayValues[728] = d728
+							ps1737.OverlayValues[889] = d889
+							ps1737.OverlayValues[890] = d890
+							ps1737.OverlayValues[891] = d891
+							ps1737.OverlayValues[892] = d892
+							ps1737.OverlayValues[893] = d893
+							ps1737.OverlayValues[894] = d894
+							ps1737.OverlayValues[895] = d895
+							ps1737.OverlayValues[1070] = d1070
+							ps1737.OverlayValues[1071] = d1071
+							ps1737.OverlayValues[1072] = d1072
+							ps1737.OverlayValues[1073] = d1073
+							ps1737.OverlayValues[1074] = d1074
+							ps1737.OverlayValues[1075] = d1075
+							ps1737.OverlayValues[1076] = d1076
+							ps1737.OverlayValues[1077] = d1077
+							ps1737.OverlayValues[1078] = d1078
+							ps1737.OverlayValues[1079] = d1079
+							ps1737.OverlayValues[1275] = d1275
+							ps1737.OverlayValues[1276] = d1276
+							ps1737.OverlayValues[1277] = d1277
+							ps1737.OverlayValues[1278] = d1278
+							ps1737.OverlayValues[1279] = d1279
+							ps1737.OverlayValues[1280] = d1280
+							ps1737.OverlayValues[1281] = d1281
+							ps1737.OverlayValues[1282] = d1282
+							ps1737.OverlayValues[1493] = d1493
+							ps1737.OverlayValues[1494] = d1494
+							ps1737.OverlayValues[1496] = d1496
+							ps1737.OverlayValues[1497] = d1497
+							ps1737.OverlayValues[1498] = d1498
+							ps1737.OverlayValues[1499] = d1499
+							ps1737.OverlayValues[1500] = d1500
+							ps1737.OverlayValues[1501] = d1501
+							ps1737.OverlayValues[1728] = d1728
+							ps1737.OverlayValues[1729] = d1729
+							ps1737.OverlayValues[1730] = d1730
+							ps1737.OverlayValues[1731] = d1731
+							ps1737.OverlayValues[1732] = d1732
+							ps1737.OverlayValues[1733] = d1733
+							ps1737.OverlayValues[1734] = d1734
+							ps1737.OverlayValues[1735] = d1735
+							ps1737.OverlayValues[1736] = d1736
+							return bbs[26].RenderPS(ps1737)
 						}
 						if ps.General {
 						}
-						ps1737 := PhiState{General: ps.General}
-						ps1737.OverlayValues = make([]JITValueDesc, 1736)
-						ps1737.OverlayValues[1] = d1
-						ps1737.OverlayValues[2] = d2
-						ps1737.OverlayValues[3] = d3
-						ps1737.OverlayValues[4] = d4
-						ps1737.OverlayValues[5] = d5
-						ps1737.OverlayValues[6] = d6
-						ps1737.OverlayValues[25] = d25
-						ps1737.OverlayValues[26] = d26
-						ps1737.OverlayValues[28] = d28
-						ps1737.OverlayValues[29] = d29
-						ps1737.OverlayValues[30] = d30
-						ps1737.OverlayValues[59] = d59
-						ps1737.OverlayValues[60] = d60
-						ps1737.OverlayValues[61] = d61
-						ps1737.OverlayValues[62] = d62
-						ps1737.OverlayValues[65] = d65
-						ps1737.OverlayValues[85] = d85
-						ps1737.OverlayValues[104] = d104
-						ps1737.OverlayValues[105] = d105
-						ps1737.OverlayValues[106] = d106
-						ps1737.OverlayValues[107] = d107
-						ps1737.OverlayValues[109] = d109
-						ps1737.OverlayValues[110] = d110
-						ps1737.OverlayValues[112] = d112
-						ps1737.OverlayValues[113] = d113
-						ps1737.OverlayValues[114] = d114
-						ps1737.OverlayValues[115] = d115
-						ps1737.OverlayValues[117] = d117
-						ps1737.OverlayValues[119] = d119
-						ps1737.OverlayValues[120] = d120
-						ps1737.OverlayValues[152] = d152
-						ps1737.OverlayValues[155] = d155
-						ps1737.OverlayValues[189] = d189
-						ps1737.OverlayValues[190] = d190
-						ps1737.OverlayValues[192] = d192
-						ps1737.OverlayValues[193] = d193
-						ps1737.OverlayValues[194] = d194
-						ps1737.OverlayValues[195] = d195
-						ps1737.OverlayValues[196] = d196
-						ps1737.OverlayValues[197] = d197
-						ps1737.OverlayValues[198] = d198
-						ps1737.OverlayValues[199] = d199
-						ps1737.OverlayValues[200] = d200
-						ps1737.OverlayValues[201] = d201
-						ps1737.OverlayValues[202] = d202
-						ps1737.OverlayValues[205] = d205
-						ps1737.OverlayValues[302] = d302
-						ps1737.OverlayValues[303] = d303
-						ps1737.OverlayValues[304] = d304
-						ps1737.OverlayValues[305] = d305
-						ps1737.OverlayValues[306] = d306
-						ps1737.OverlayValues[307] = d307
-						ps1737.OverlayValues[308] = d308
-						ps1737.OverlayValues[309] = d309
-						ps1737.OverlayValues[310] = d310
-						ps1737.OverlayValues[311] = d311
-						ps1737.OverlayValues[430] = d430
-						ps1737.OverlayValues[431] = d431
-						ps1737.OverlayValues[432] = d432
-						ps1737.OverlayValues[433] = d433
-						ps1737.OverlayValues[434] = d434
-						ps1737.OverlayValues[435] = d435
-						ps1737.OverlayValues[436] = d436
-						ps1737.OverlayValues[569] = d569
-						ps1737.OverlayValues[570] = d570
-						ps1737.OverlayValues[571] = d571
-						ps1737.OverlayValues[572] = d572
-						ps1737.OverlayValues[573] = d573
-						ps1737.OverlayValues[574] = d574
-						ps1737.OverlayValues[575] = d575
-						ps1737.OverlayValues[722] = d722
-						ps1737.OverlayValues[723] = d723
-						ps1737.OverlayValues[724] = d724
-						ps1737.OverlayValues[725] = d725
-						ps1737.OverlayValues[726] = d726
-						ps1737.OverlayValues[727] = d727
-						ps1737.OverlayValues[728] = d728
-						ps1737.OverlayValues[889] = d889
-						ps1737.OverlayValues[890] = d890
-						ps1737.OverlayValues[891] = d891
-						ps1737.OverlayValues[892] = d892
-						ps1737.OverlayValues[893] = d893
-						ps1737.OverlayValues[894] = d894
-						ps1737.OverlayValues[895] = d895
-						ps1737.OverlayValues[1070] = d1070
-						ps1737.OverlayValues[1071] = d1071
-						ps1737.OverlayValues[1072] = d1072
-						ps1737.OverlayValues[1073] = d1073
-						ps1737.OverlayValues[1074] = d1074
-						ps1737.OverlayValues[1075] = d1075
-						ps1737.OverlayValues[1076] = d1076
-						ps1737.OverlayValues[1077] = d1077
-						ps1737.OverlayValues[1078] = d1078
-						ps1737.OverlayValues[1079] = d1079
-						ps1737.OverlayValues[1275] = d1275
-						ps1737.OverlayValues[1276] = d1276
-						ps1737.OverlayValues[1277] = d1277
-						ps1737.OverlayValues[1278] = d1278
-						ps1737.OverlayValues[1279] = d1279
-						ps1737.OverlayValues[1280] = d1280
-						ps1737.OverlayValues[1281] = d1281
-						ps1737.OverlayValues[1282] = d1282
-						ps1737.OverlayValues[1493] = d1493
-						ps1737.OverlayValues[1494] = d1494
-						ps1737.OverlayValues[1495] = d1495
-						ps1737.OverlayValues[1496] = d1496
-						ps1737.OverlayValues[1497] = d1497
-						ps1737.OverlayValues[1498] = d1498
-						ps1737.OverlayValues[1499] = d1499
-						ps1737.OverlayValues[1500] = d1500
-						ps1737.OverlayValues[1727] = d1727
-						ps1737.OverlayValues[1728] = d1728
-						ps1737.OverlayValues[1729] = d1729
-						ps1737.OverlayValues[1730] = d1730
-						ps1737.OverlayValues[1731] = d1731
-						ps1737.OverlayValues[1732] = d1732
-						ps1737.OverlayValues[1733] = d1733
-						ps1737.OverlayValues[1734] = d1734
-						ps1737.OverlayValues[1735] = d1735
-						return bbs[28].RenderPS(ps1737)
+						ps1738 := PhiState{General: ps.General}
+						ps1738.OverlayValues = make([]JITValueDesc, 1737)
+						ps1738.OverlayValues[1] = d1
+						ps1738.OverlayValues[2] = d2
+						ps1738.OverlayValues[3] = d3
+						ps1738.OverlayValues[4] = d4
+						ps1738.OverlayValues[5] = d5
+						ps1738.OverlayValues[6] = d6
+						ps1738.OverlayValues[25] = d25
+						ps1738.OverlayValues[26] = d26
+						ps1738.OverlayValues[28] = d28
+						ps1738.OverlayValues[29] = d29
+						ps1738.OverlayValues[30] = d30
+						ps1738.OverlayValues[59] = d59
+						ps1738.OverlayValues[60] = d60
+						ps1738.OverlayValues[61] = d61
+						ps1738.OverlayValues[62] = d62
+						ps1738.OverlayValues[65] = d65
+						ps1738.OverlayValues[85] = d85
+						ps1738.OverlayValues[104] = d104
+						ps1738.OverlayValues[105] = d105
+						ps1738.OverlayValues[106] = d106
+						ps1738.OverlayValues[107] = d107
+						ps1738.OverlayValues[109] = d109
+						ps1738.OverlayValues[110] = d110
+						ps1738.OverlayValues[112] = d112
+						ps1738.OverlayValues[113] = d113
+						ps1738.OverlayValues[114] = d114
+						ps1738.OverlayValues[115] = d115
+						ps1738.OverlayValues[117] = d117
+						ps1738.OverlayValues[119] = d119
+						ps1738.OverlayValues[120] = d120
+						ps1738.OverlayValues[152] = d152
+						ps1738.OverlayValues[155] = d155
+						ps1738.OverlayValues[189] = d189
+						ps1738.OverlayValues[190] = d190
+						ps1738.OverlayValues[192] = d192
+						ps1738.OverlayValues[193] = d193
+						ps1738.OverlayValues[194] = d194
+						ps1738.OverlayValues[195] = d195
+						ps1738.OverlayValues[196] = d196
+						ps1738.OverlayValues[197] = d197
+						ps1738.OverlayValues[198] = d198
+						ps1738.OverlayValues[199] = d199
+						ps1738.OverlayValues[200] = d200
+						ps1738.OverlayValues[201] = d201
+						ps1738.OverlayValues[202] = d202
+						ps1738.OverlayValues[205] = d205
+						ps1738.OverlayValues[302] = d302
+						ps1738.OverlayValues[303] = d303
+						ps1738.OverlayValues[304] = d304
+						ps1738.OverlayValues[305] = d305
+						ps1738.OverlayValues[306] = d306
+						ps1738.OverlayValues[307] = d307
+						ps1738.OverlayValues[308] = d308
+						ps1738.OverlayValues[309] = d309
+						ps1738.OverlayValues[310] = d310
+						ps1738.OverlayValues[311] = d311
+						ps1738.OverlayValues[430] = d430
+						ps1738.OverlayValues[431] = d431
+						ps1738.OverlayValues[432] = d432
+						ps1738.OverlayValues[433] = d433
+						ps1738.OverlayValues[434] = d434
+						ps1738.OverlayValues[435] = d435
+						ps1738.OverlayValues[436] = d436
+						ps1738.OverlayValues[569] = d569
+						ps1738.OverlayValues[570] = d570
+						ps1738.OverlayValues[571] = d571
+						ps1738.OverlayValues[572] = d572
+						ps1738.OverlayValues[573] = d573
+						ps1738.OverlayValues[574] = d574
+						ps1738.OverlayValues[575] = d575
+						ps1738.OverlayValues[722] = d722
+						ps1738.OverlayValues[723] = d723
+						ps1738.OverlayValues[724] = d724
+						ps1738.OverlayValues[725] = d725
+						ps1738.OverlayValues[726] = d726
+						ps1738.OverlayValues[727] = d727
+						ps1738.OverlayValues[728] = d728
+						ps1738.OverlayValues[889] = d889
+						ps1738.OverlayValues[890] = d890
+						ps1738.OverlayValues[891] = d891
+						ps1738.OverlayValues[892] = d892
+						ps1738.OverlayValues[893] = d893
+						ps1738.OverlayValues[894] = d894
+						ps1738.OverlayValues[895] = d895
+						ps1738.OverlayValues[1070] = d1070
+						ps1738.OverlayValues[1071] = d1071
+						ps1738.OverlayValues[1072] = d1072
+						ps1738.OverlayValues[1073] = d1073
+						ps1738.OverlayValues[1074] = d1074
+						ps1738.OverlayValues[1075] = d1075
+						ps1738.OverlayValues[1076] = d1076
+						ps1738.OverlayValues[1077] = d1077
+						ps1738.OverlayValues[1078] = d1078
+						ps1738.OverlayValues[1079] = d1079
+						ps1738.OverlayValues[1275] = d1275
+						ps1738.OverlayValues[1276] = d1276
+						ps1738.OverlayValues[1277] = d1277
+						ps1738.OverlayValues[1278] = d1278
+						ps1738.OverlayValues[1279] = d1279
+						ps1738.OverlayValues[1280] = d1280
+						ps1738.OverlayValues[1281] = d1281
+						ps1738.OverlayValues[1282] = d1282
+						ps1738.OverlayValues[1493] = d1493
+						ps1738.OverlayValues[1494] = d1494
+						ps1738.OverlayValues[1496] = d1496
+						ps1738.OverlayValues[1497] = d1497
+						ps1738.OverlayValues[1498] = d1498
+						ps1738.OverlayValues[1499] = d1499
+						ps1738.OverlayValues[1500] = d1500
+						ps1738.OverlayValues[1501] = d1501
+						ps1738.OverlayValues[1728] = d1728
+						ps1738.OverlayValues[1729] = d1729
+						ps1738.OverlayValues[1730] = d1730
+						ps1738.OverlayValues[1731] = d1731
+						ps1738.OverlayValues[1732] = d1732
+						ps1738.OverlayValues[1733] = d1733
+						ps1738.OverlayValues[1734] = d1734
+						ps1738.OverlayValues[1735] = d1735
+						ps1738.OverlayValues[1736] = d1736
+						return bbs[28].RenderPS(ps1738)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[27].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d1735.Reg, 0)
+					ctx.EmitCmpRegImm32(d1736.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl27)
 					if bbs[28].Rendered {
 						ctx.EmitJmp(lbl29)
 					}
-					snap1738 := d1
-					snap1739 := d2
-					snap1740 := d3
-					snap1741 := d4
-					snap1742 := d5
-					snap1743 := d6
-					snap1744 := d25
-					snap1745 := d26
-					snap1746 := d28
-					snap1747 := d29
-					snap1748 := d30
-					snap1749 := d59
-					snap1750 := d60
-					snap1751 := d61
-					snap1752 := d62
-					snap1753 := d65
-					snap1754 := d85
-					snap1755 := d104
-					snap1756 := d105
-					snap1757 := d106
-					snap1758 := d107
-					snap1759 := d109
-					snap1760 := d110
-					snap1761 := d112
-					snap1762 := d113
-					snap1763 := d114
-					snap1764 := d115
-					snap1765 := d117
-					snap1766 := d119
-					snap1767 := d120
-					snap1768 := d152
-					snap1769 := d155
-					snap1770 := d189
-					snap1771 := d190
-					snap1772 := d192
-					snap1773 := d193
-					snap1774 := d194
-					snap1775 := d195
-					snap1776 := d196
-					snap1777 := d197
-					snap1778 := d198
-					snap1779 := d199
-					snap1780 := d200
-					snap1781 := d201
-					snap1782 := d202
-					snap1783 := d205
-					snap1784 := d302
-					snap1785 := d303
-					snap1786 := d304
-					snap1787 := d305
-					snap1788 := d306
-					snap1789 := d307
-					snap1790 := d308
-					snap1791 := d309
-					snap1792 := d310
-					snap1793 := d311
-					snap1794 := d430
-					snap1795 := d431
-					snap1796 := d432
-					snap1797 := d433
-					snap1798 := d434
-					snap1799 := d435
-					snap1800 := d436
-					snap1801 := d569
-					snap1802 := d570
-					snap1803 := d571
-					snap1804 := d572
-					snap1805 := d573
-					snap1806 := d574
-					snap1807 := d575
-					snap1808 := d722
-					snap1809 := d723
-					snap1810 := d724
-					snap1811 := d725
-					snap1812 := d726
-					snap1813 := d727
-					snap1814 := d728
-					snap1815 := d889
-					snap1816 := d890
-					snap1817 := d891
-					snap1818 := d892
-					snap1819 := d893
-					snap1820 := d894
-					snap1821 := d895
-					snap1822 := d1070
-					snap1823 := d1071
-					snap1824 := d1072
-					snap1825 := d1073
-					snap1826 := d1074
-					snap1827 := d1075
-					snap1828 := d1076
-					snap1829 := d1077
-					snap1830 := d1078
-					snap1831 := d1079
-					snap1832 := d1275
-					snap1833 := d1276
-					snap1834 := d1277
-					snap1835 := d1278
-					snap1836 := d1279
-					snap1837 := d1280
-					snap1838 := d1281
-					snap1839 := d1282
-					snap1840 := d1493
-					snap1841 := d1494
-					snap1842 := d1495
+					snap1739 := d1
+					snap1740 := d2
+					snap1741 := d3
+					snap1742 := d4
+					snap1743 := d5
+					snap1744 := d6
+					snap1745 := d25
+					snap1746 := d26
+					snap1747 := d28
+					snap1748 := d29
+					snap1749 := d30
+					snap1750 := d59
+					snap1751 := d60
+					snap1752 := d61
+					snap1753 := d62
+					snap1754 := d65
+					snap1755 := d85
+					snap1756 := d104
+					snap1757 := d105
+					snap1758 := d106
+					snap1759 := d107
+					snap1760 := d109
+					snap1761 := d110
+					snap1762 := d112
+					snap1763 := d113
+					snap1764 := d114
+					snap1765 := d115
+					snap1766 := d117
+					snap1767 := d119
+					snap1768 := d120
+					snap1769 := d152
+					snap1770 := d155
+					snap1771 := d189
+					snap1772 := d190
+					snap1773 := d192
+					snap1774 := d193
+					snap1775 := d194
+					snap1776 := d195
+					snap1777 := d196
+					snap1778 := d197
+					snap1779 := d198
+					snap1780 := d199
+					snap1781 := d200
+					snap1782 := d201
+					snap1783 := d202
+					snap1784 := d205
+					snap1785 := d302
+					snap1786 := d303
+					snap1787 := d304
+					snap1788 := d305
+					snap1789 := d306
+					snap1790 := d307
+					snap1791 := d308
+					snap1792 := d309
+					snap1793 := d310
+					snap1794 := d311
+					snap1795 := d430
+					snap1796 := d431
+					snap1797 := d432
+					snap1798 := d433
+					snap1799 := d434
+					snap1800 := d435
+					snap1801 := d436
+					snap1802 := d569
+					snap1803 := d570
+					snap1804 := d571
+					snap1805 := d572
+					snap1806 := d573
+					snap1807 := d574
+					snap1808 := d575
+					snap1809 := d722
+					snap1810 := d723
+					snap1811 := d724
+					snap1812 := d725
+					snap1813 := d726
+					snap1814 := d727
+					snap1815 := d728
+					snap1816 := d889
+					snap1817 := d890
+					snap1818 := d891
+					snap1819 := d892
+					snap1820 := d893
+					snap1821 := d894
+					snap1822 := d895
+					snap1823 := d1070
+					snap1824 := d1071
+					snap1825 := d1072
+					snap1826 := d1073
+					snap1827 := d1074
+					snap1828 := d1075
+					snap1829 := d1076
+					snap1830 := d1077
+					snap1831 := d1078
+					snap1832 := d1079
+					snap1833 := d1275
+					snap1834 := d1276
+					snap1835 := d1277
+					snap1836 := d1278
+					snap1837 := d1279
+					snap1838 := d1280
+					snap1839 := d1281
+					snap1840 := d1282
+					snap1841 := d1493
+					snap1842 := d1494
 					snap1843 := d1496
 					snap1844 := d1497
 					snap1845 := d1498
 					snap1846 := d1499
 					snap1847 := d1500
-					snap1848 := d1727
+					snap1848 := d1501
 					snap1849 := d1728
 					snap1850 := d1729
 					snap1851 := d1730
@@ -20376,119 +20447,119 @@ func init_date() {
 					snap1854 := d1733
 					snap1855 := d1734
 					snap1856 := d1735
-					alloc1857 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc1857)
-					d1 = snap1738
-					d2 = snap1739
-					d3 = snap1740
-					d4 = snap1741
-					d5 = snap1742
-					d6 = snap1743
-					d25 = snap1744
-					d26 = snap1745
-					d28 = snap1746
-					d29 = snap1747
-					d30 = snap1748
-					d59 = snap1749
-					d60 = snap1750
-					d61 = snap1751
-					d62 = snap1752
-					d65 = snap1753
-					d85 = snap1754
-					d104 = snap1755
-					d105 = snap1756
-					d106 = snap1757
-					d107 = snap1758
-					d109 = snap1759
-					d110 = snap1760
-					d112 = snap1761
-					d113 = snap1762
-					d114 = snap1763
-					d115 = snap1764
-					d117 = snap1765
-					d119 = snap1766
-					d120 = snap1767
-					d152 = snap1768
-					d155 = snap1769
-					d189 = snap1770
-					d190 = snap1771
-					d192 = snap1772
-					d193 = snap1773
-					d194 = snap1774
-					d195 = snap1775
-					d196 = snap1776
-					d197 = snap1777
-					d198 = snap1778
-					d199 = snap1779
-					d200 = snap1780
-					d201 = snap1781
-					d202 = snap1782
-					d205 = snap1783
-					d302 = snap1784
-					d303 = snap1785
-					d304 = snap1786
-					d305 = snap1787
-					d306 = snap1788
-					d307 = snap1789
-					d308 = snap1790
-					d309 = snap1791
-					d310 = snap1792
-					d311 = snap1793
-					d430 = snap1794
-					d431 = snap1795
-					d432 = snap1796
-					d433 = snap1797
-					d434 = snap1798
-					d435 = snap1799
-					d436 = snap1800
-					d569 = snap1801
-					d570 = snap1802
-					d571 = snap1803
-					d572 = snap1804
-					d573 = snap1805
-					d574 = snap1806
-					d575 = snap1807
-					d722 = snap1808
-					d723 = snap1809
-					d724 = snap1810
-					d725 = snap1811
-					d726 = snap1812
-					d727 = snap1813
-					d728 = snap1814
-					d889 = snap1815
-					d890 = snap1816
-					d891 = snap1817
-					d892 = snap1818
-					d893 = snap1819
-					d894 = snap1820
-					d895 = snap1821
-					d1070 = snap1822
-					d1071 = snap1823
-					d1072 = snap1824
-					d1073 = snap1825
-					d1074 = snap1826
-					d1075 = snap1827
-					d1076 = snap1828
-					d1077 = snap1829
-					d1078 = snap1830
-					d1079 = snap1831
-					d1275 = snap1832
-					d1276 = snap1833
-					d1277 = snap1834
-					d1278 = snap1835
-					d1279 = snap1836
-					d1280 = snap1837
-					d1281 = snap1838
-					d1282 = snap1839
-					d1493 = snap1840
-					d1494 = snap1841
-					d1495 = snap1842
+					snap1857 := d1736
+					alloc1858 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc1858)
+					d1 = snap1739
+					d2 = snap1740
+					d3 = snap1741
+					d4 = snap1742
+					d5 = snap1743
+					d6 = snap1744
+					d25 = snap1745
+					d26 = snap1746
+					d28 = snap1747
+					d29 = snap1748
+					d30 = snap1749
+					d59 = snap1750
+					d60 = snap1751
+					d61 = snap1752
+					d62 = snap1753
+					d65 = snap1754
+					d85 = snap1755
+					d104 = snap1756
+					d105 = snap1757
+					d106 = snap1758
+					d107 = snap1759
+					d109 = snap1760
+					d110 = snap1761
+					d112 = snap1762
+					d113 = snap1763
+					d114 = snap1764
+					d115 = snap1765
+					d117 = snap1766
+					d119 = snap1767
+					d120 = snap1768
+					d152 = snap1769
+					d155 = snap1770
+					d189 = snap1771
+					d190 = snap1772
+					d192 = snap1773
+					d193 = snap1774
+					d194 = snap1775
+					d195 = snap1776
+					d196 = snap1777
+					d197 = snap1778
+					d198 = snap1779
+					d199 = snap1780
+					d200 = snap1781
+					d201 = snap1782
+					d202 = snap1783
+					d205 = snap1784
+					d302 = snap1785
+					d303 = snap1786
+					d304 = snap1787
+					d305 = snap1788
+					d306 = snap1789
+					d307 = snap1790
+					d308 = snap1791
+					d309 = snap1792
+					d310 = snap1793
+					d311 = snap1794
+					d430 = snap1795
+					d431 = snap1796
+					d432 = snap1797
+					d433 = snap1798
+					d434 = snap1799
+					d435 = snap1800
+					d436 = snap1801
+					d569 = snap1802
+					d570 = snap1803
+					d571 = snap1804
+					d572 = snap1805
+					d573 = snap1806
+					d574 = snap1807
+					d575 = snap1808
+					d722 = snap1809
+					d723 = snap1810
+					d724 = snap1811
+					d725 = snap1812
+					d726 = snap1813
+					d727 = snap1814
+					d728 = snap1815
+					d889 = snap1816
+					d890 = snap1817
+					d891 = snap1818
+					d892 = snap1819
+					d893 = snap1820
+					d894 = snap1821
+					d895 = snap1822
+					d1070 = snap1823
+					d1071 = snap1824
+					d1072 = snap1825
+					d1073 = snap1826
+					d1074 = snap1827
+					d1075 = snap1828
+					d1076 = snap1829
+					d1077 = snap1830
+					d1078 = snap1831
+					d1079 = snap1832
+					d1275 = snap1833
+					d1276 = snap1834
+					d1277 = snap1835
+					d1278 = snap1836
+					d1279 = snap1837
+					d1280 = snap1838
+					d1281 = snap1839
+					d1282 = snap1840
+					d1493 = snap1841
+					d1494 = snap1842
 					d1496 = snap1843
 					d1497 = snap1844
 					d1498 = snap1845
 					d1499 = snap1846
 					d1500 = snap1847
-					d1727 = snap1848
+					d1501 = snap1848
 					d1728 = snap1849
 					d1729 = snap1850
 					d1730 = snap1851
@@ -20497,118 +20568,118 @@ func init_date() {
 					d1733 = snap1854
 					d1734 = snap1855
 					d1735 = snap1856
-					ctx.RestoreAllocState(alloc1857)
-					d1 = snap1738
-					d2 = snap1739
-					d3 = snap1740
-					d4 = snap1741
-					d5 = snap1742
-					d6 = snap1743
-					d25 = snap1744
-					d26 = snap1745
-					d28 = snap1746
-					d29 = snap1747
-					d30 = snap1748
-					d59 = snap1749
-					d60 = snap1750
-					d61 = snap1751
-					d62 = snap1752
-					d65 = snap1753
-					d85 = snap1754
-					d104 = snap1755
-					d105 = snap1756
-					d106 = snap1757
-					d107 = snap1758
-					d109 = snap1759
-					d110 = snap1760
-					d112 = snap1761
-					d113 = snap1762
-					d114 = snap1763
-					d115 = snap1764
-					d117 = snap1765
-					d119 = snap1766
-					d120 = snap1767
-					d152 = snap1768
-					d155 = snap1769
-					d189 = snap1770
-					d190 = snap1771
-					d192 = snap1772
-					d193 = snap1773
-					d194 = snap1774
-					d195 = snap1775
-					d196 = snap1776
-					d197 = snap1777
-					d198 = snap1778
-					d199 = snap1779
-					d200 = snap1780
-					d201 = snap1781
-					d202 = snap1782
-					d205 = snap1783
-					d302 = snap1784
-					d303 = snap1785
-					d304 = snap1786
-					d305 = snap1787
-					d306 = snap1788
-					d307 = snap1789
-					d308 = snap1790
-					d309 = snap1791
-					d310 = snap1792
-					d311 = snap1793
-					d430 = snap1794
-					d431 = snap1795
-					d432 = snap1796
-					d433 = snap1797
-					d434 = snap1798
-					d435 = snap1799
-					d436 = snap1800
-					d569 = snap1801
-					d570 = snap1802
-					d571 = snap1803
-					d572 = snap1804
-					d573 = snap1805
-					d574 = snap1806
-					d575 = snap1807
-					d722 = snap1808
-					d723 = snap1809
-					d724 = snap1810
-					d725 = snap1811
-					d726 = snap1812
-					d727 = snap1813
-					d728 = snap1814
-					d889 = snap1815
-					d890 = snap1816
-					d891 = snap1817
-					d892 = snap1818
-					d893 = snap1819
-					d894 = snap1820
-					d895 = snap1821
-					d1070 = snap1822
-					d1071 = snap1823
-					d1072 = snap1824
-					d1073 = snap1825
-					d1074 = snap1826
-					d1075 = snap1827
-					d1076 = snap1828
-					d1077 = snap1829
-					d1078 = snap1830
-					d1079 = snap1831
-					d1275 = snap1832
-					d1276 = snap1833
-					d1277 = snap1834
-					d1278 = snap1835
-					d1279 = snap1836
-					d1280 = snap1837
-					d1281 = snap1838
-					d1282 = snap1839
-					d1493 = snap1840
-					d1494 = snap1841
-					d1495 = snap1842
+					d1736 = snap1857
+					ctx.RestoreAllocState(alloc1858)
+					d1 = snap1739
+					d2 = snap1740
+					d3 = snap1741
+					d4 = snap1742
+					d5 = snap1743
+					d6 = snap1744
+					d25 = snap1745
+					d26 = snap1746
+					d28 = snap1747
+					d29 = snap1748
+					d30 = snap1749
+					d59 = snap1750
+					d60 = snap1751
+					d61 = snap1752
+					d62 = snap1753
+					d65 = snap1754
+					d85 = snap1755
+					d104 = snap1756
+					d105 = snap1757
+					d106 = snap1758
+					d107 = snap1759
+					d109 = snap1760
+					d110 = snap1761
+					d112 = snap1762
+					d113 = snap1763
+					d114 = snap1764
+					d115 = snap1765
+					d117 = snap1766
+					d119 = snap1767
+					d120 = snap1768
+					d152 = snap1769
+					d155 = snap1770
+					d189 = snap1771
+					d190 = snap1772
+					d192 = snap1773
+					d193 = snap1774
+					d194 = snap1775
+					d195 = snap1776
+					d196 = snap1777
+					d197 = snap1778
+					d198 = snap1779
+					d199 = snap1780
+					d200 = snap1781
+					d201 = snap1782
+					d202 = snap1783
+					d205 = snap1784
+					d302 = snap1785
+					d303 = snap1786
+					d304 = snap1787
+					d305 = snap1788
+					d306 = snap1789
+					d307 = snap1790
+					d308 = snap1791
+					d309 = snap1792
+					d310 = snap1793
+					d311 = snap1794
+					d430 = snap1795
+					d431 = snap1796
+					d432 = snap1797
+					d433 = snap1798
+					d434 = snap1799
+					d435 = snap1800
+					d436 = snap1801
+					d569 = snap1802
+					d570 = snap1803
+					d571 = snap1804
+					d572 = snap1805
+					d573 = snap1806
+					d574 = snap1807
+					d575 = snap1808
+					d722 = snap1809
+					d723 = snap1810
+					d724 = snap1811
+					d725 = snap1812
+					d726 = snap1813
+					d727 = snap1814
+					d728 = snap1815
+					d889 = snap1816
+					d890 = snap1817
+					d891 = snap1818
+					d892 = snap1819
+					d893 = snap1820
+					d894 = snap1821
+					d895 = snap1822
+					d1070 = snap1823
+					d1071 = snap1824
+					d1072 = snap1825
+					d1073 = snap1826
+					d1074 = snap1827
+					d1075 = snap1828
+					d1076 = snap1829
+					d1077 = snap1830
+					d1078 = snap1831
+					d1079 = snap1832
+					d1275 = snap1833
+					d1276 = snap1834
+					d1277 = snap1835
+					d1278 = snap1836
+					d1279 = snap1837
+					d1280 = snap1838
+					d1281 = snap1839
+					d1282 = snap1840
+					d1493 = snap1841
+					d1494 = snap1842
 					d1496 = snap1843
 					d1497 = snap1844
 					d1498 = snap1845
 					d1499 = snap1846
 					d1500 = snap1847
-					d1727 = snap1848
+					d1501 = snap1848
 					d1728 = snap1849
 					d1729 = snap1850
 					d1730 = snap1851
@@ -20617,129 +20688,9 @@ func init_date() {
 					d1733 = snap1854
 					d1734 = snap1855
 					d1735 = snap1856
-					ps1858 := PhiState{General: true}
-					ps1858.OverlayValues = make([]JITValueDesc, 1736)
-					ps1858.OverlayValues[1] = d1
-					ps1858.OverlayValues[2] = d2
-					ps1858.OverlayValues[3] = d3
-					ps1858.OverlayValues[4] = d4
-					ps1858.OverlayValues[5] = d5
-					ps1858.OverlayValues[6] = d6
-					ps1858.OverlayValues[25] = d25
-					ps1858.OverlayValues[26] = d26
-					ps1858.OverlayValues[28] = d28
-					ps1858.OverlayValues[29] = d29
-					ps1858.OverlayValues[30] = d30
-					ps1858.OverlayValues[59] = d59
-					ps1858.OverlayValues[60] = d60
-					ps1858.OverlayValues[61] = d61
-					ps1858.OverlayValues[62] = d62
-					ps1858.OverlayValues[65] = d65
-					ps1858.OverlayValues[85] = d85
-					ps1858.OverlayValues[104] = d104
-					ps1858.OverlayValues[105] = d105
-					ps1858.OverlayValues[106] = d106
-					ps1858.OverlayValues[107] = d107
-					ps1858.OverlayValues[109] = d109
-					ps1858.OverlayValues[110] = d110
-					ps1858.OverlayValues[112] = d112
-					ps1858.OverlayValues[113] = d113
-					ps1858.OverlayValues[114] = d114
-					ps1858.OverlayValues[115] = d115
-					ps1858.OverlayValues[117] = d117
-					ps1858.OverlayValues[119] = d119
-					ps1858.OverlayValues[120] = d120
-					ps1858.OverlayValues[152] = d152
-					ps1858.OverlayValues[155] = d155
-					ps1858.OverlayValues[189] = d189
-					ps1858.OverlayValues[190] = d190
-					ps1858.OverlayValues[192] = d192
-					ps1858.OverlayValues[193] = d193
-					ps1858.OverlayValues[194] = d194
-					ps1858.OverlayValues[195] = d195
-					ps1858.OverlayValues[196] = d196
-					ps1858.OverlayValues[197] = d197
-					ps1858.OverlayValues[198] = d198
-					ps1858.OverlayValues[199] = d199
-					ps1858.OverlayValues[200] = d200
-					ps1858.OverlayValues[201] = d201
-					ps1858.OverlayValues[202] = d202
-					ps1858.OverlayValues[205] = d205
-					ps1858.OverlayValues[302] = d302
-					ps1858.OverlayValues[303] = d303
-					ps1858.OverlayValues[304] = d304
-					ps1858.OverlayValues[305] = d305
-					ps1858.OverlayValues[306] = d306
-					ps1858.OverlayValues[307] = d307
-					ps1858.OverlayValues[308] = d308
-					ps1858.OverlayValues[309] = d309
-					ps1858.OverlayValues[310] = d310
-					ps1858.OverlayValues[311] = d311
-					ps1858.OverlayValues[430] = d430
-					ps1858.OverlayValues[431] = d431
-					ps1858.OverlayValues[432] = d432
-					ps1858.OverlayValues[433] = d433
-					ps1858.OverlayValues[434] = d434
-					ps1858.OverlayValues[435] = d435
-					ps1858.OverlayValues[436] = d436
-					ps1858.OverlayValues[569] = d569
-					ps1858.OverlayValues[570] = d570
-					ps1858.OverlayValues[571] = d571
-					ps1858.OverlayValues[572] = d572
-					ps1858.OverlayValues[573] = d573
-					ps1858.OverlayValues[574] = d574
-					ps1858.OverlayValues[575] = d575
-					ps1858.OverlayValues[722] = d722
-					ps1858.OverlayValues[723] = d723
-					ps1858.OverlayValues[724] = d724
-					ps1858.OverlayValues[725] = d725
-					ps1858.OverlayValues[726] = d726
-					ps1858.OverlayValues[727] = d727
-					ps1858.OverlayValues[728] = d728
-					ps1858.OverlayValues[889] = d889
-					ps1858.OverlayValues[890] = d890
-					ps1858.OverlayValues[891] = d891
-					ps1858.OverlayValues[892] = d892
-					ps1858.OverlayValues[893] = d893
-					ps1858.OverlayValues[894] = d894
-					ps1858.OverlayValues[895] = d895
-					ps1858.OverlayValues[1070] = d1070
-					ps1858.OverlayValues[1071] = d1071
-					ps1858.OverlayValues[1072] = d1072
-					ps1858.OverlayValues[1073] = d1073
-					ps1858.OverlayValues[1074] = d1074
-					ps1858.OverlayValues[1075] = d1075
-					ps1858.OverlayValues[1076] = d1076
-					ps1858.OverlayValues[1077] = d1077
-					ps1858.OverlayValues[1078] = d1078
-					ps1858.OverlayValues[1079] = d1079
-					ps1858.OverlayValues[1275] = d1275
-					ps1858.OverlayValues[1276] = d1276
-					ps1858.OverlayValues[1277] = d1277
-					ps1858.OverlayValues[1278] = d1278
-					ps1858.OverlayValues[1279] = d1279
-					ps1858.OverlayValues[1280] = d1280
-					ps1858.OverlayValues[1281] = d1281
-					ps1858.OverlayValues[1282] = d1282
-					ps1858.OverlayValues[1493] = d1493
-					ps1858.OverlayValues[1494] = d1494
-					ps1858.OverlayValues[1495] = d1495
-					ps1858.OverlayValues[1496] = d1496
-					ps1858.OverlayValues[1497] = d1497
-					ps1858.OverlayValues[1498] = d1498
-					ps1858.OverlayValues[1499] = d1499
-					ps1858.OverlayValues[1500] = d1500
-					ps1858.OverlayValues[1727] = d1727
-					ps1858.OverlayValues[1728] = d1728
-					ps1858.OverlayValues[1729] = d1729
-					ps1858.OverlayValues[1730] = d1730
-					ps1858.OverlayValues[1731] = d1731
-					ps1858.OverlayValues[1732] = d1732
-					ps1858.OverlayValues[1733] = d1733
-					ps1858.OverlayValues[1734] = d1734
-					ps1858.OverlayValues[1735] = d1735
+					d1736 = snap1857
 					ps1859 := PhiState{General: true}
-					ps1859.OverlayValues = make([]JITValueDesc, 1736)
+					ps1859.OverlayValues = make([]JITValueDesc, 1737)
 					ps1859.OverlayValues[1] = d1
 					ps1859.OverlayValues[2] = d2
 					ps1859.OverlayValues[3] = d3
@@ -20844,13 +20795,12 @@ func init_date() {
 					ps1859.OverlayValues[1282] = d1282
 					ps1859.OverlayValues[1493] = d1493
 					ps1859.OverlayValues[1494] = d1494
-					ps1859.OverlayValues[1495] = d1495
 					ps1859.OverlayValues[1496] = d1496
 					ps1859.OverlayValues[1497] = d1497
 					ps1859.OverlayValues[1498] = d1498
 					ps1859.OverlayValues[1499] = d1499
 					ps1859.OverlayValues[1500] = d1500
-					ps1859.OverlayValues[1727] = d1727
+					ps1859.OverlayValues[1501] = d1501
 					ps1859.OverlayValues[1728] = d1728
 					ps1859.OverlayValues[1729] = d1729
 					ps1859.OverlayValues[1730] = d1730
@@ -20859,117 +20809,238 @@ func init_date() {
 					ps1859.OverlayValues[1733] = d1733
 					ps1859.OverlayValues[1734] = d1734
 					ps1859.OverlayValues[1735] = d1735
-					snap1860 := d1
-					snap1861 := d2
-					snap1862 := d3
-					snap1863 := d4
-					snap1864 := d5
-					snap1865 := d6
-					snap1866 := d25
-					snap1867 := d26
-					snap1868 := d28
-					snap1869 := d29
-					snap1870 := d30
-					snap1871 := d59
-					snap1872 := d60
-					snap1873 := d61
-					snap1874 := d62
-					snap1875 := d65
-					snap1876 := d85
-					snap1877 := d104
-					snap1878 := d105
-					snap1879 := d106
-					snap1880 := d107
-					snap1881 := d109
-					snap1882 := d110
-					snap1883 := d112
-					snap1884 := d113
-					snap1885 := d114
-					snap1886 := d115
-					snap1887 := d117
-					snap1888 := d119
-					snap1889 := d120
-					snap1890 := d152
-					snap1891 := d155
-					snap1892 := d189
-					snap1893 := d190
-					snap1894 := d192
-					snap1895 := d193
-					snap1896 := d194
-					snap1897 := d195
-					snap1898 := d196
-					snap1899 := d197
-					snap1900 := d198
-					snap1901 := d199
-					snap1902 := d200
-					snap1903 := d201
-					snap1904 := d202
-					snap1905 := d205
-					snap1906 := d302
-					snap1907 := d303
-					snap1908 := d304
-					snap1909 := d305
-					snap1910 := d306
-					snap1911 := d307
-					snap1912 := d308
-					snap1913 := d309
-					snap1914 := d310
-					snap1915 := d311
-					snap1916 := d430
-					snap1917 := d431
-					snap1918 := d432
-					snap1919 := d433
-					snap1920 := d434
-					snap1921 := d435
-					snap1922 := d436
-					snap1923 := d569
-					snap1924 := d570
-					snap1925 := d571
-					snap1926 := d572
-					snap1927 := d573
-					snap1928 := d574
-					snap1929 := d575
-					snap1930 := d722
-					snap1931 := d723
-					snap1932 := d724
-					snap1933 := d725
-					snap1934 := d726
-					snap1935 := d727
-					snap1936 := d728
-					snap1937 := d889
-					snap1938 := d890
-					snap1939 := d891
-					snap1940 := d892
-					snap1941 := d893
-					snap1942 := d894
-					snap1943 := d895
-					snap1944 := d1070
-					snap1945 := d1071
-					snap1946 := d1072
-					snap1947 := d1073
-					snap1948 := d1074
-					snap1949 := d1075
-					snap1950 := d1076
-					snap1951 := d1077
-					snap1952 := d1078
-					snap1953 := d1079
-					snap1954 := d1275
-					snap1955 := d1276
-					snap1956 := d1277
-					snap1957 := d1278
-					snap1958 := d1279
-					snap1959 := d1280
-					snap1960 := d1281
-					snap1961 := d1282
-					snap1962 := d1493
-					snap1963 := d1494
-					snap1964 := d1495
+					ps1859.OverlayValues[1736] = d1736
+					ps1860 := PhiState{General: true}
+					ps1860.OverlayValues = make([]JITValueDesc, 1737)
+					ps1860.OverlayValues[1] = d1
+					ps1860.OverlayValues[2] = d2
+					ps1860.OverlayValues[3] = d3
+					ps1860.OverlayValues[4] = d4
+					ps1860.OverlayValues[5] = d5
+					ps1860.OverlayValues[6] = d6
+					ps1860.OverlayValues[25] = d25
+					ps1860.OverlayValues[26] = d26
+					ps1860.OverlayValues[28] = d28
+					ps1860.OverlayValues[29] = d29
+					ps1860.OverlayValues[30] = d30
+					ps1860.OverlayValues[59] = d59
+					ps1860.OverlayValues[60] = d60
+					ps1860.OverlayValues[61] = d61
+					ps1860.OverlayValues[62] = d62
+					ps1860.OverlayValues[65] = d65
+					ps1860.OverlayValues[85] = d85
+					ps1860.OverlayValues[104] = d104
+					ps1860.OverlayValues[105] = d105
+					ps1860.OverlayValues[106] = d106
+					ps1860.OverlayValues[107] = d107
+					ps1860.OverlayValues[109] = d109
+					ps1860.OverlayValues[110] = d110
+					ps1860.OverlayValues[112] = d112
+					ps1860.OverlayValues[113] = d113
+					ps1860.OverlayValues[114] = d114
+					ps1860.OverlayValues[115] = d115
+					ps1860.OverlayValues[117] = d117
+					ps1860.OverlayValues[119] = d119
+					ps1860.OverlayValues[120] = d120
+					ps1860.OverlayValues[152] = d152
+					ps1860.OverlayValues[155] = d155
+					ps1860.OverlayValues[189] = d189
+					ps1860.OverlayValues[190] = d190
+					ps1860.OverlayValues[192] = d192
+					ps1860.OverlayValues[193] = d193
+					ps1860.OverlayValues[194] = d194
+					ps1860.OverlayValues[195] = d195
+					ps1860.OverlayValues[196] = d196
+					ps1860.OverlayValues[197] = d197
+					ps1860.OverlayValues[198] = d198
+					ps1860.OverlayValues[199] = d199
+					ps1860.OverlayValues[200] = d200
+					ps1860.OverlayValues[201] = d201
+					ps1860.OverlayValues[202] = d202
+					ps1860.OverlayValues[205] = d205
+					ps1860.OverlayValues[302] = d302
+					ps1860.OverlayValues[303] = d303
+					ps1860.OverlayValues[304] = d304
+					ps1860.OverlayValues[305] = d305
+					ps1860.OverlayValues[306] = d306
+					ps1860.OverlayValues[307] = d307
+					ps1860.OverlayValues[308] = d308
+					ps1860.OverlayValues[309] = d309
+					ps1860.OverlayValues[310] = d310
+					ps1860.OverlayValues[311] = d311
+					ps1860.OverlayValues[430] = d430
+					ps1860.OverlayValues[431] = d431
+					ps1860.OverlayValues[432] = d432
+					ps1860.OverlayValues[433] = d433
+					ps1860.OverlayValues[434] = d434
+					ps1860.OverlayValues[435] = d435
+					ps1860.OverlayValues[436] = d436
+					ps1860.OverlayValues[569] = d569
+					ps1860.OverlayValues[570] = d570
+					ps1860.OverlayValues[571] = d571
+					ps1860.OverlayValues[572] = d572
+					ps1860.OverlayValues[573] = d573
+					ps1860.OverlayValues[574] = d574
+					ps1860.OverlayValues[575] = d575
+					ps1860.OverlayValues[722] = d722
+					ps1860.OverlayValues[723] = d723
+					ps1860.OverlayValues[724] = d724
+					ps1860.OverlayValues[725] = d725
+					ps1860.OverlayValues[726] = d726
+					ps1860.OverlayValues[727] = d727
+					ps1860.OverlayValues[728] = d728
+					ps1860.OverlayValues[889] = d889
+					ps1860.OverlayValues[890] = d890
+					ps1860.OverlayValues[891] = d891
+					ps1860.OverlayValues[892] = d892
+					ps1860.OverlayValues[893] = d893
+					ps1860.OverlayValues[894] = d894
+					ps1860.OverlayValues[895] = d895
+					ps1860.OverlayValues[1070] = d1070
+					ps1860.OverlayValues[1071] = d1071
+					ps1860.OverlayValues[1072] = d1072
+					ps1860.OverlayValues[1073] = d1073
+					ps1860.OverlayValues[1074] = d1074
+					ps1860.OverlayValues[1075] = d1075
+					ps1860.OverlayValues[1076] = d1076
+					ps1860.OverlayValues[1077] = d1077
+					ps1860.OverlayValues[1078] = d1078
+					ps1860.OverlayValues[1079] = d1079
+					ps1860.OverlayValues[1275] = d1275
+					ps1860.OverlayValues[1276] = d1276
+					ps1860.OverlayValues[1277] = d1277
+					ps1860.OverlayValues[1278] = d1278
+					ps1860.OverlayValues[1279] = d1279
+					ps1860.OverlayValues[1280] = d1280
+					ps1860.OverlayValues[1281] = d1281
+					ps1860.OverlayValues[1282] = d1282
+					ps1860.OverlayValues[1493] = d1493
+					ps1860.OverlayValues[1494] = d1494
+					ps1860.OverlayValues[1496] = d1496
+					ps1860.OverlayValues[1497] = d1497
+					ps1860.OverlayValues[1498] = d1498
+					ps1860.OverlayValues[1499] = d1499
+					ps1860.OverlayValues[1500] = d1500
+					ps1860.OverlayValues[1501] = d1501
+					ps1860.OverlayValues[1728] = d1728
+					ps1860.OverlayValues[1729] = d1729
+					ps1860.OverlayValues[1730] = d1730
+					ps1860.OverlayValues[1731] = d1731
+					ps1860.OverlayValues[1732] = d1732
+					ps1860.OverlayValues[1733] = d1733
+					ps1860.OverlayValues[1734] = d1734
+					ps1860.OverlayValues[1735] = d1735
+					ps1860.OverlayValues[1736] = d1736
+					snap1861 := d1
+					snap1862 := d2
+					snap1863 := d3
+					snap1864 := d4
+					snap1865 := d5
+					snap1866 := d6
+					snap1867 := d25
+					snap1868 := d26
+					snap1869 := d28
+					snap1870 := d29
+					snap1871 := d30
+					snap1872 := d59
+					snap1873 := d60
+					snap1874 := d61
+					snap1875 := d62
+					snap1876 := d65
+					snap1877 := d85
+					snap1878 := d104
+					snap1879 := d105
+					snap1880 := d106
+					snap1881 := d107
+					snap1882 := d109
+					snap1883 := d110
+					snap1884 := d112
+					snap1885 := d113
+					snap1886 := d114
+					snap1887 := d115
+					snap1888 := d117
+					snap1889 := d119
+					snap1890 := d120
+					snap1891 := d152
+					snap1892 := d155
+					snap1893 := d189
+					snap1894 := d190
+					snap1895 := d192
+					snap1896 := d193
+					snap1897 := d194
+					snap1898 := d195
+					snap1899 := d196
+					snap1900 := d197
+					snap1901 := d198
+					snap1902 := d199
+					snap1903 := d200
+					snap1904 := d201
+					snap1905 := d202
+					snap1906 := d205
+					snap1907 := d302
+					snap1908 := d303
+					snap1909 := d304
+					snap1910 := d305
+					snap1911 := d306
+					snap1912 := d307
+					snap1913 := d308
+					snap1914 := d309
+					snap1915 := d310
+					snap1916 := d311
+					snap1917 := d430
+					snap1918 := d431
+					snap1919 := d432
+					snap1920 := d433
+					snap1921 := d434
+					snap1922 := d435
+					snap1923 := d436
+					snap1924 := d569
+					snap1925 := d570
+					snap1926 := d571
+					snap1927 := d572
+					snap1928 := d573
+					snap1929 := d574
+					snap1930 := d575
+					snap1931 := d722
+					snap1932 := d723
+					snap1933 := d724
+					snap1934 := d725
+					snap1935 := d726
+					snap1936 := d727
+					snap1937 := d728
+					snap1938 := d889
+					snap1939 := d890
+					snap1940 := d891
+					snap1941 := d892
+					snap1942 := d893
+					snap1943 := d894
+					snap1944 := d895
+					snap1945 := d1070
+					snap1946 := d1071
+					snap1947 := d1072
+					snap1948 := d1073
+					snap1949 := d1074
+					snap1950 := d1075
+					snap1951 := d1076
+					snap1952 := d1077
+					snap1953 := d1078
+					snap1954 := d1079
+					snap1955 := d1275
+					snap1956 := d1276
+					snap1957 := d1277
+					snap1958 := d1278
+					snap1959 := d1279
+					snap1960 := d1280
+					snap1961 := d1281
+					snap1962 := d1282
+					snap1963 := d1493
+					snap1964 := d1494
 					snap1965 := d1496
 					snap1966 := d1497
 					snap1967 := d1498
 					snap1968 := d1499
 					snap1969 := d1500
-					snap1970 := d1727
+					snap1970 := d1501
 					snap1971 := d1728
 					snap1972 := d1729
 					snap1973 := d1730
@@ -20978,122 +21049,122 @@ func init_date() {
 					snap1976 := d1733
 					snap1977 := d1734
 					snap1978 := d1735
-					alloc1979 := ctx.SnapshotAllocState()
+					snap1979 := d1736
+					alloc1980 := ctx.SnapshotAllocState()
 					if !bbs[28].Rendered {
-						bbs[28].RenderPS(ps1859)
+						bbs[28].RenderPS(ps1860)
 					}
-					ctx.RestoreAllocState(alloc1979)
-					d1 = snap1860
-					d2 = snap1861
-					d3 = snap1862
-					d4 = snap1863
-					d5 = snap1864
-					d6 = snap1865
-					d25 = snap1866
-					d26 = snap1867
-					d28 = snap1868
-					d29 = snap1869
-					d30 = snap1870
-					d59 = snap1871
-					d60 = snap1872
-					d61 = snap1873
-					d62 = snap1874
-					d65 = snap1875
-					d85 = snap1876
-					d104 = snap1877
-					d105 = snap1878
-					d106 = snap1879
-					d107 = snap1880
-					d109 = snap1881
-					d110 = snap1882
-					d112 = snap1883
-					d113 = snap1884
-					d114 = snap1885
-					d115 = snap1886
-					d117 = snap1887
-					d119 = snap1888
-					d120 = snap1889
-					d152 = snap1890
-					d155 = snap1891
-					d189 = snap1892
-					d190 = snap1893
-					d192 = snap1894
-					d193 = snap1895
-					d194 = snap1896
-					d195 = snap1897
-					d196 = snap1898
-					d197 = snap1899
-					d198 = snap1900
-					d199 = snap1901
-					d200 = snap1902
-					d201 = snap1903
-					d202 = snap1904
-					d205 = snap1905
-					d302 = snap1906
-					d303 = snap1907
-					d304 = snap1908
-					d305 = snap1909
-					d306 = snap1910
-					d307 = snap1911
-					d308 = snap1912
-					d309 = snap1913
-					d310 = snap1914
-					d311 = snap1915
-					d430 = snap1916
-					d431 = snap1917
-					d432 = snap1918
-					d433 = snap1919
-					d434 = snap1920
-					d435 = snap1921
-					d436 = snap1922
-					d569 = snap1923
-					d570 = snap1924
-					d571 = snap1925
-					d572 = snap1926
-					d573 = snap1927
-					d574 = snap1928
-					d575 = snap1929
-					d722 = snap1930
-					d723 = snap1931
-					d724 = snap1932
-					d725 = snap1933
-					d726 = snap1934
-					d727 = snap1935
-					d728 = snap1936
-					d889 = snap1937
-					d890 = snap1938
-					d891 = snap1939
-					d892 = snap1940
-					d893 = snap1941
-					d894 = snap1942
-					d895 = snap1943
-					d1070 = snap1944
-					d1071 = snap1945
-					d1072 = snap1946
-					d1073 = snap1947
-					d1074 = snap1948
-					d1075 = snap1949
-					d1076 = snap1950
-					d1077 = snap1951
-					d1078 = snap1952
-					d1079 = snap1953
-					d1275 = snap1954
-					d1276 = snap1955
-					d1277 = snap1956
-					d1278 = snap1957
-					d1279 = snap1958
-					d1280 = snap1959
-					d1281 = snap1960
-					d1282 = snap1961
-					d1493 = snap1962
-					d1494 = snap1963
-					d1495 = snap1964
+					ctx.RestoreAllocState(alloc1980)
+					d1 = snap1861
+					d2 = snap1862
+					d3 = snap1863
+					d4 = snap1864
+					d5 = snap1865
+					d6 = snap1866
+					d25 = snap1867
+					d26 = snap1868
+					d28 = snap1869
+					d29 = snap1870
+					d30 = snap1871
+					d59 = snap1872
+					d60 = snap1873
+					d61 = snap1874
+					d62 = snap1875
+					d65 = snap1876
+					d85 = snap1877
+					d104 = snap1878
+					d105 = snap1879
+					d106 = snap1880
+					d107 = snap1881
+					d109 = snap1882
+					d110 = snap1883
+					d112 = snap1884
+					d113 = snap1885
+					d114 = snap1886
+					d115 = snap1887
+					d117 = snap1888
+					d119 = snap1889
+					d120 = snap1890
+					d152 = snap1891
+					d155 = snap1892
+					d189 = snap1893
+					d190 = snap1894
+					d192 = snap1895
+					d193 = snap1896
+					d194 = snap1897
+					d195 = snap1898
+					d196 = snap1899
+					d197 = snap1900
+					d198 = snap1901
+					d199 = snap1902
+					d200 = snap1903
+					d201 = snap1904
+					d202 = snap1905
+					d205 = snap1906
+					d302 = snap1907
+					d303 = snap1908
+					d304 = snap1909
+					d305 = snap1910
+					d306 = snap1911
+					d307 = snap1912
+					d308 = snap1913
+					d309 = snap1914
+					d310 = snap1915
+					d311 = snap1916
+					d430 = snap1917
+					d431 = snap1918
+					d432 = snap1919
+					d433 = snap1920
+					d434 = snap1921
+					d435 = snap1922
+					d436 = snap1923
+					d569 = snap1924
+					d570 = snap1925
+					d571 = snap1926
+					d572 = snap1927
+					d573 = snap1928
+					d574 = snap1929
+					d575 = snap1930
+					d722 = snap1931
+					d723 = snap1932
+					d724 = snap1933
+					d725 = snap1934
+					d726 = snap1935
+					d727 = snap1936
+					d728 = snap1937
+					d889 = snap1938
+					d890 = snap1939
+					d891 = snap1940
+					d892 = snap1941
+					d893 = snap1942
+					d894 = snap1943
+					d895 = snap1944
+					d1070 = snap1945
+					d1071 = snap1946
+					d1072 = snap1947
+					d1073 = snap1948
+					d1074 = snap1949
+					d1075 = snap1950
+					d1076 = snap1951
+					d1077 = snap1952
+					d1078 = snap1953
+					d1079 = snap1954
+					d1275 = snap1955
+					d1276 = snap1956
+					d1277 = snap1957
+					d1278 = snap1958
+					d1279 = snap1959
+					d1280 = snap1960
+					d1281 = snap1961
+					d1282 = snap1962
+					d1493 = snap1963
+					d1494 = snap1964
 					d1496 = snap1965
 					d1497 = snap1966
 					d1498 = snap1967
 					d1499 = snap1968
 					d1500 = snap1969
-					d1727 = snap1970
+					d1501 = snap1970
 					d1728 = snap1971
 					d1729 = snap1972
 					d1730 = snap1973
@@ -21102,11 +21173,12 @@ func init_date() {
 					d1733 = snap1976
 					d1734 = snap1977
 					d1735 = snap1978
+					d1736 = snap1979
 					if !bbs[26].Rendered {
-						return bbs[26].RenderPS(ps1858)
+						return bbs[26].RenderPS(ps1859)
 					}
 					return result
-					ctx.FreeDesc(&d1734)
+					ctx.FreeDesc(&d1735)
 					return result
 				}
 				bbs[28].RenderPS = func(ps PhiState) JITValueDesc {
@@ -21442,9 +21514,6 @@ func init_date() {
 					if len(ps.OverlayValues) > 1494 && ps.OverlayValues[1494].Loc != LocNone {
 						d1494 = ps.OverlayValues[1494]
 					}
-					if len(ps.OverlayValues) > 1495 && ps.OverlayValues[1495].Loc != LocNone {
-						d1495 = ps.OverlayValues[1495]
-					}
 					if len(ps.OverlayValues) > 1496 && ps.OverlayValues[1496].Loc != LocNone {
 						d1496 = ps.OverlayValues[1496]
 					}
@@ -21460,8 +21529,8 @@ func init_date() {
 					if len(ps.OverlayValues) > 1500 && ps.OverlayValues[1500].Loc != LocNone {
 						d1500 = ps.OverlayValues[1500]
 					}
-					if len(ps.OverlayValues) > 1727 && ps.OverlayValues[1727].Loc != LocNone {
-						d1727 = ps.OverlayValues[1727]
+					if len(ps.OverlayValues) > 1501 && ps.OverlayValues[1501].Loc != LocNone {
+						d1501 = ps.OverlayValues[1501]
 					}
 					if len(ps.OverlayValues) > 1728 && ps.OverlayValues[1728].Loc != LocNone {
 						d1728 = ps.OverlayValues[1728]
@@ -21487,13 +21556,16 @@ func init_date() {
 					if len(ps.OverlayValues) > 1735 && ps.OverlayValues[1735].Loc != LocNone {
 						d1735 = ps.OverlayValues[1735]
 					}
+					if len(ps.OverlayValues) > 1736 && ps.OverlayValues[1736].Loc != LocNone {
+						d1736 = ps.OverlayValues[1736]
+					}
 					ctx.ReclaimUntrackedRegs()
 					_ = jitEmitGoVariadicCallFromDescs(ctx, declarations["extract_date"].Fn, args, result)
 					ctx.EmitGoPanic("jit: builtin panic boundary unexpectedly returned")
 					return result
 				}
-				ps1980 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps1980)
+				ps1981 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps1981)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -22935,7 +23007,7 @@ func init_date() {
 					ctx.FreeDesc(&d120)
 					if ps.General {
 						ctx.SyncDesc(&d121)
-						if d121.Loc == LocReg {
+						if d121.Loc == LocReg || d121.Loc == LocFPReg {
 							ctx.ProtectReg(d121.Reg)
 						} else if d121.Loc == LocRegPair {
 							ctx.ProtectReg(d121.Reg)
@@ -22958,7 +23030,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d122, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d121.Loc == LocReg {
+						if d121.Loc == LocReg || d121.Loc == LocFPReg {
 							ctx.UnprotectReg(d121.Reg)
 						} else if d121.Loc == LocRegPair {
 							ctx.UnprotectReg(d121.Reg)
@@ -23154,7 +23226,7 @@ func init_date() {
 					ctx.FreeDesc(&d126)
 					if ps.General {
 						ctx.SyncDesc(&d127)
-						if d127.Loc == LocReg {
+						if d127.Loc == LocReg || d127.Loc == LocFPReg {
 							ctx.ProtectReg(d127.Reg)
 						} else if d127.Loc == LocRegPair {
 							ctx.ProtectReg(d127.Reg)
@@ -23177,7 +23249,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d128, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d127.Loc == LocReg {
+						if d127.Loc == LocReg || d127.Loc == LocFPReg {
 							ctx.UnprotectReg(d127.Reg)
 						} else if d127.Loc == LocRegPair {
 							ctx.UnprotectReg(d127.Reg)
@@ -23947,7 +24019,7 @@ func init_date() {
 					ctx.FreeDesc(&d220)
 					if ps.General {
 						ctx.SyncDesc(&d221)
-						if d221.Loc == LocReg {
+						if d221.Loc == LocReg || d221.Loc == LocFPReg {
 							ctx.ProtectReg(d221.Reg)
 						} else if d221.Loc == LocRegPair {
 							ctx.ProtectReg(d221.Reg)
@@ -23970,7 +24042,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d222, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d221.Loc == LocReg {
+						if d221.Loc == LocReg || d221.Loc == LocFPReg {
 							ctx.UnprotectReg(d221.Reg)
 						} else if d221.Loc == LocRegPair {
 							ctx.UnprotectReg(d221.Reg)
@@ -24876,7 +24948,7 @@ func init_date() {
 					ctx.StabilizeDescForControlFlow(&d333)
 					if ps.General {
 						ctx.SyncDesc(&d333)
-						if d333.Loc == LocReg {
+						if d333.Loc == LocReg || d333.Loc == LocFPReg {
 							ctx.ProtectReg(d333.Reg)
 						} else if d333.Loc == LocRegPair {
 							ctx.ProtectReg(d333.Reg)
@@ -24899,7 +24971,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d334, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d333.Loc == LocReg {
+						if d333.Loc == LocReg || d333.Loc == LocFPReg {
 							ctx.UnprotectReg(d333.Reg)
 						} else if d333.Loc == LocRegPair {
 							ctx.UnprotectReg(d333.Reg)
@@ -25966,7 +26038,7 @@ func init_date() {
 					ctx.FreeDesc(&d461)
 					if ps.General {
 						ctx.SyncDesc(&d464)
-						if d464.Loc == LocReg {
+						if d464.Loc == LocReg || d464.Loc == LocFPReg {
 							ctx.ProtectReg(d464.Reg)
 						} else if d464.Loc == LocRegPair {
 							ctx.ProtectReg(d464.Reg)
@@ -25989,7 +26061,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d465, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d464.Loc == LocReg {
+						if d464.Loc == LocReg || d464.Loc == LocFPReg {
 							ctx.UnprotectReg(d464.Reg)
 						} else if d464.Loc == LocRegPair {
 							ctx.UnprotectReg(d464.Reg)
@@ -27199,7 +27271,7 @@ func init_date() {
 					ctx.StabilizeDescForControlFlow(&d614)
 					if ps.General {
 						ctx.SyncDesc(&d614)
-						if d614.Loc == LocReg {
+						if d614.Loc == LocReg || d614.Loc == LocFPReg {
 							ctx.ProtectReg(d614.Reg)
 						} else if d614.Loc == LocRegPair {
 							ctx.ProtectReg(d614.Reg)
@@ -27222,7 +27294,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d615, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d614.Loc == LocReg {
+						if d614.Loc == LocReg || d614.Loc == LocFPReg {
 							ctx.UnprotectReg(d614.Reg)
 						} else if d614.Loc == LocRegPair {
 							ctx.UnprotectReg(d614.Reg)
@@ -28577,7 +28649,7 @@ func init_date() {
 					ctx.FreeDesc(&d56)
 					if ps.General {
 						ctx.SyncDesc(&d782)
-						if d782.Loc == LocReg {
+						if d782.Loc == LocReg || d782.Loc == LocFPReg {
 							ctx.ProtectReg(d782.Reg)
 						} else if d782.Loc == LocRegPair {
 							ctx.ProtectReg(d782.Reg)
@@ -28600,7 +28672,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d783, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d782.Loc == LocReg {
+						if d782.Loc == LocReg || d782.Loc == LocFPReg {
 							ctx.UnprotectReg(d782.Reg)
 						} else if d782.Loc == LocRegPair {
 							ctx.UnprotectReg(d782.Reg)
@@ -31554,7 +31626,7 @@ func init_date() {
 					ctx.FreeDesc(&d121)
 					if ps.General {
 						ctx.SyncDesc(&d122)
-						if d122.Loc == LocReg {
+						if d122.Loc == LocReg || d122.Loc == LocFPReg {
 							ctx.ProtectReg(d122.Reg)
 						} else if d122.Loc == LocRegPair {
 							ctx.ProtectReg(d122.Reg)
@@ -31577,7 +31649,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d123, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d122.Loc == LocReg {
+						if d122.Loc == LocReg || d122.Loc == LocFPReg {
 							ctx.UnprotectReg(d122.Reg)
 						} else if d122.Loc == LocRegPair {
 							ctx.UnprotectReg(d122.Reg)
@@ -31799,7 +31871,7 @@ func init_date() {
 					ctx.FreeDesc(&d128)
 					if ps.General {
 						ctx.SyncDesc(&d129)
-						if d129.Loc == LocReg {
+						if d129.Loc == LocReg || d129.Loc == LocFPReg {
 							ctx.ProtectReg(d129.Reg)
 						} else if d129.Loc == LocRegPair {
 							ctx.ProtectReg(d129.Reg)
@@ -31822,7 +31894,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d130, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d129.Loc == LocReg {
+						if d129.Loc == LocReg || d129.Loc == LocFPReg {
 							ctx.UnprotectReg(d129.Reg)
 						} else if d129.Loc == LocRegPair {
 							ctx.UnprotectReg(d129.Reg)
@@ -32646,7 +32718,7 @@ func init_date() {
 					ctx.FreeDesc(&d227)
 					if ps.General {
 						ctx.SyncDesc(&d228)
-						if d228.Loc == LocReg {
+						if d228.Loc == LocReg || d228.Loc == LocFPReg {
 							ctx.ProtectReg(d228.Reg)
 						} else if d228.Loc == LocRegPair {
 							ctx.ProtectReg(d228.Reg)
@@ -32669,7 +32741,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d229, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d228.Loc == LocReg {
+						if d228.Loc == LocReg || d228.Loc == LocFPReg {
 							ctx.UnprotectReg(d228.Reg)
 						} else if d228.Loc == LocRegPair {
 							ctx.UnprotectReg(d228.Reg)
@@ -33647,7 +33719,7 @@ func init_date() {
 					ctx.FreeDesc(&d344)
 					if ps.General {
 						ctx.SyncDesc(&d347)
-						if d347.Loc == LocReg {
+						if d347.Loc == LocReg || d347.Loc == LocFPReg {
 							ctx.ProtectReg(d347.Reg)
 						} else if d347.Loc == LocRegPair {
 							ctx.ProtectReg(d347.Reg)
@@ -33670,7 +33742,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d348, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d347.Loc == LocReg {
+						if d347.Loc == LocReg || d347.Loc == LocFPReg {
 							ctx.UnprotectReg(d347.Reg)
 						} else if d347.Loc == LocRegPair {
 							ctx.UnprotectReg(d347.Reg)
@@ -34823,7 +34895,7 @@ func init_date() {
 					ctx.FreeDesc(&d484)
 					if ps.General {
 						ctx.SyncDesc(&d487)
-						if d487.Loc == LocReg {
+						if d487.Loc == LocReg || d487.Loc == LocFPReg {
 							ctx.ProtectReg(d487.Reg)
 						} else if d487.Loc == LocRegPair {
 							ctx.ProtectReg(d487.Reg)
@@ -34846,7 +34918,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d488, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d487.Loc == LocReg {
+						if d487.Loc == LocReg || d487.Loc == LocFPReg {
 							ctx.UnprotectReg(d487.Reg)
 						} else if d487.Loc == LocRegPair {
 							ctx.UnprotectReg(d487.Reg)
@@ -36160,7 +36232,7 @@ func init_date() {
 					ctx.FreeDesc(&d645)
 					if ps.General {
 						ctx.SyncDesc(&d648)
-						if d648.Loc == LocReg {
+						if d648.Loc == LocReg || d648.Loc == LocFPReg {
 							ctx.ProtectReg(d648.Reg)
 						} else if d648.Loc == LocRegPair {
 							ctx.ProtectReg(d648.Reg)
@@ -36183,7 +36255,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d649, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d648.Loc == LocReg {
+						if d648.Loc == LocReg || d648.Loc == LocFPReg {
 							ctx.UnprotectReg(d648.Reg)
 						} else if d648.Loc == LocRegPair {
 							ctx.UnprotectReg(d648.Reg)
@@ -37658,7 +37730,7 @@ func init_date() {
 					ctx.FreeDesc(&d826)
 					if ps.General {
 						ctx.SyncDesc(&d829)
-						if d829.Loc == LocReg {
+						if d829.Loc == LocReg || d829.Loc == LocFPReg {
 							ctx.ProtectReg(d829.Reg)
 						} else if d829.Loc == LocRegPair {
 							ctx.ProtectReg(d829.Reg)
@@ -37681,7 +37753,7 @@ func init_date() {
 							ctx.EmitStoreToStack(d830, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d829.Loc == LocReg {
+						if d829.Loc == LocReg || d829.Loc == LocFPReg {
 							ctx.UnprotectReg(d829.Reg)
 						} else if d829.Loc == LocRegPair {
 							ctx.UnprotectReg(d829.Reg)
@@ -40446,14 +40518,12 @@ func init_date() {
 				_ = d3421
 				var d3423 JITValueDesc
 				_ = d3423
-				var d3424 JITValueDesc
-				_ = d3424
 				var d3425 JITValueDesc
 				_ = d3425
 				var d3426 JITValueDesc
 				_ = d3426
-				var d3428 JITValueDesc
-				_ = d3428
+				var d3427 JITValueDesc
+				_ = d3427
 				var d3429 JITValueDesc
 				_ = d3429
 				var d3430 JITValueDesc
@@ -40464,30 +40534,32 @@ func init_date() {
 				_ = d3432
 				var d3433 JITValueDesc
 				_ = d3433
-				var d3435 JITValueDesc
-				_ = d3435
-				var d3437 JITValueDesc
-				_ = d3437
-				var d3647 JITValueDesc
-				_ = d3647
-				var d3650 JITValueDesc
-				_ = d3650
-				var d3862 JITValueDesc
-				_ = d3862
+				var d3434 JITValueDesc
+				_ = d3434
+				var d3436 JITValueDesc
+				_ = d3436
+				var d3438 JITValueDesc
+				_ = d3438
+				var d3648 JITValueDesc
+				_ = d3648
+				var d3651 JITValueDesc
+				_ = d3651
 				var d3863 JITValueDesc
 				_ = d3863
 				var d3864 JITValueDesc
 				_ = d3864
 				var d3865 JITValueDesc
 				_ = d3865
-				var d3867 JITValueDesc
-				_ = d3867
-				var d3869 JITValueDesc
-				_ = d3869
-				var d4087 JITValueDesc
-				_ = d4087
-				var d4090 JITValueDesc
-				_ = d4090
+				var d3866 JITValueDesc
+				_ = d3866
+				var d3868 JITValueDesc
+				_ = d3868
+				var d3870 JITValueDesc
+				_ = d3870
+				var d4088 JITValueDesc
+				_ = d4088
+				var d4091 JITValueDesc
+				_ = d4091
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				phiBase0 := ctx.AllocStack(int32(48))
 				var bbs [33]BBDescriptor
@@ -42731,8 +42803,9 @@ func init_date() {
 					if d262.Loc == LocImm {
 						d264 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d262.Imm.Int()))}
 					} else {
-						r1 := ctx.AllocRegExcept(d262.Reg)
-						ctx.EmitMovRegReg(r1, d262.Reg)
+						var r1 Reg
+						r1 = d262.Reg
+						d262.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r1)
 						d264 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r1}
 						ctx.BindReg(r1, &d264)
@@ -42745,8 +42818,9 @@ func init_date() {
 					if d263.Loc == LocImm {
 						d265 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d263.Imm.Int()))}
 					} else {
-						r2 := ctx.AllocRegExcept(d263.Reg)
-						ctx.EmitMovRegReg(r2, d263.Reg)
+						var r2 Reg
+						r2 = d263.Reg
+						d263.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r2)
 						d265 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r2}
 						ctx.BindReg(r2, &d265)
@@ -43667,8 +43741,9 @@ func init_date() {
 					if d371.Loc == LocImm {
 						d373 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d371.Imm.Int()))}
 					} else {
-						r6 := ctx.AllocRegExcept(d371.Reg)
-						ctx.EmitMovRegReg(r6, d371.Reg)
+						var r6 Reg
+						r6 = d371.Reg
+						d371.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r6)
 						d373 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r6}
 						ctx.BindReg(r6, &d373)
@@ -43681,8 +43756,9 @@ func init_date() {
 					if d372.Loc == LocImm {
 						d374 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d372.Imm.Int()))}
 					} else {
-						r7 := ctx.AllocRegExcept(d372.Reg)
-						ctx.EmitMovRegReg(r7, d372.Reg)
+						var r7 Reg
+						r7 = d372.Reg
+						d372.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r7)
 						d374 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r7}
 						ctx.BindReg(r7, &d374)
@@ -44798,8 +44874,9 @@ func init_date() {
 					if d506.Loc == LocImm {
 						d508 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d506.Imm.Int()))}
 					} else {
-						r11 := ctx.AllocRegExcept(d506.Reg)
-						ctx.EmitMovRegReg(r11, d506.Reg)
+						var r11 Reg
+						r11 = d506.Reg
+						d506.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r11)
 						d508 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r11}
 						ctx.BindReg(r11, &d508)
@@ -44812,8 +44889,9 @@ func init_date() {
 					if d507.Loc == LocImm {
 						d509 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d507.Imm.Int()))}
 					} else {
-						r12 := ctx.AllocRegExcept(d507.Reg)
-						ctx.EmitMovRegReg(r12, d507.Reg)
+						var r12 Reg
+						r12 = d507.Reg
+						d507.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r12)
 						d509 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r12}
 						ctx.BindReg(r12, &d509)
@@ -46274,8 +46352,9 @@ func init_date() {
 					if d685.Loc == LocImm {
 						d687 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d685.Imm.Int()))}
 					} else {
-						r16 := ctx.AllocRegExcept(d685.Reg)
-						ctx.EmitMovRegReg(r16, d685.Reg)
+						var r16 Reg
+						r16 = d685.Reg
+						d685.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r16)
 						d687 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r16}
 						ctx.BindReg(r16, &d687)
@@ -46288,8 +46367,9 @@ func init_date() {
 					if d686.Loc == LocImm {
 						d688 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d686.Imm.Int()))}
 					} else {
-						r17 := ctx.AllocRegExcept(d686.Reg)
-						ctx.EmitMovRegReg(r17, d686.Reg)
+						var r17 Reg
+						r17 = d686.Reg
+						d686.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r17)
 						d688 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r17}
 						ctx.BindReg(r17, &d688)
@@ -48245,8 +48325,9 @@ func init_date() {
 					if d929.Loc == LocImm {
 						d931 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d929.Imm.Int()))}
 					} else {
-						r21 := ctx.AllocRegExcept(d929.Reg)
-						ctx.EmitMovRegReg(r21, d929.Reg)
+						var r21 Reg
+						r21 = d929.Reg
+						d929.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r21)
 						d931 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r21}
 						ctx.BindReg(r21, &d931)
@@ -48259,8 +48340,9 @@ func init_date() {
 					if d930.Loc == LocImm {
 						d932 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d930.Imm.Int()))}
 					} else {
-						r22 := ctx.AllocRegExcept(d930.Reg)
-						ctx.EmitMovRegReg(r22, d930.Reg)
+						var r22 Reg
+						r22 = d930.Reg
+						d930.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r22)
 						d932 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r22}
 						ctx.BindReg(r22, &d932)
@@ -50905,7 +50987,7 @@ func init_date() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d1230)
-							if d1230.Loc == LocReg {
+							if d1230.Loc == LocReg || d1230.Loc == LocFPReg {
 								ctx.ProtectReg(d1230.Reg)
 							} else if d1230.Loc == LocRegPair {
 								ctx.ProtectReg(d1230.Reg)
@@ -50917,7 +50999,7 @@ func init_date() {
 							}
 							ctx.EnsureDesc(&d1236)
 							ctx.EmitStoreToStack(d1236, int32(bbs[23].PhiBase)+int32(0))
-							if d1230.Loc == LocReg {
+							if d1230.Loc == LocReg || d1230.Loc == LocFPReg {
 								ctx.UnprotectReg(d1230.Reg)
 							} else if d1230.Loc == LocRegPair {
 								ctx.UnprotectReg(d1230.Reg)
@@ -51398,7 +51480,7 @@ func init_date() {
 					d1238 = snap1390
 					ctx.MarkLabel(lbl40)
 					ctx.SyncDesc(&d1230)
-					if d1230.Loc == LocReg {
+					if d1230.Loc == LocReg || d1230.Loc == LocFPReg {
 						ctx.ProtectReg(d1230.Reg)
 					} else if d1230.Loc == LocRegPair {
 						ctx.ProtectReg(d1230.Reg)
@@ -51410,7 +51492,7 @@ func init_date() {
 					}
 					ctx.EnsureDesc(&d1392)
 					ctx.EmitStoreToStack(d1392, int32(bbs[23].PhiBase)+int32(0))
-					if d1230.Loc == LocReg {
+					if d1230.Loc == LocReg || d1230.Loc == LocFPReg {
 						ctx.UnprotectReg(d1230.Reg)
 					} else if d1230.Loc == LocRegPair {
 						ctx.UnprotectReg(d1230.Reg)
@@ -55082,7 +55164,7 @@ func init_date() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d1886)
-							if d1886.Loc == LocReg {
+							if d1886.Loc == LocReg || d1886.Loc == LocFPReg {
 								ctx.ProtectReg(d1886.Reg)
 							} else if d1886.Loc == LocRegPair {
 								ctx.ProtectReg(d1886.Reg)
@@ -55094,7 +55176,7 @@ func init_date() {
 							}
 							ctx.EnsureDesc(&d1892)
 							ctx.EmitStoreToStack(d1892, int32(bbs[27].PhiBase)+int32(0))
-							if d1886.Loc == LocReg {
+							if d1886.Loc == LocReg || d1886.Loc == LocFPReg {
 								ctx.UnprotectReg(d1886.Reg)
 							} else if d1886.Loc == LocRegPair {
 								ctx.UnprotectReg(d1886.Reg)
@@ -55641,7 +55723,7 @@ func init_date() {
 					d1894 = snap2068
 					ctx.MarkLabel(lbl41)
 					ctx.SyncDesc(&d1886)
-					if d1886.Loc == LocReg {
+					if d1886.Loc == LocReg || d1886.Loc == LocFPReg {
 						ctx.ProtectReg(d1886.Reg)
 					} else if d1886.Loc == LocRegPair {
 						ctx.ProtectReg(d1886.Reg)
@@ -55653,7 +55735,7 @@ func init_date() {
 					}
 					ctx.EnsureDesc(&d2070)
 					ctx.EmitStoreToStack(d2070, int32(bbs[27].PhiBase)+int32(0))
-					if d1886.Loc == LocReg {
+					if d1886.Loc == LocReg || d1886.Loc == LocFPReg {
 						ctx.UnprotectReg(d1886.Reg)
 					} else if d1886.Loc == LocRegPair {
 						ctx.UnprotectReg(d1886.Reg)
@@ -66475,28 +66557,32 @@ func init_date() {
 					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d2)
-					var d3424 JITValueDesc
+					resultTarget3424 := false
+					_ = resultTarget3424
+					var d3425 JITValueDesc
 					if d2.Loc == LocImm {
-						d3424 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d2.Imm.Int() / 3)}
+						d3425 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d2.Imm.Int() / 3)}
 					} else {
-						ctx.EmitIdivRegImm(d2.Reg, 3)
-						d3424 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d2.Reg}
-						ctx.BindReg(d2.Reg, &d3424)
+						r48 := ctx.AllocRegExcept(d2.Reg)
+						ctx.EmitMovRegReg(r48, d2.Reg)
+						ctx.EmitIdivRegImm(r48, 3)
+						d3425 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r48}
+						ctx.BindReg(r48, &d3425)
 					}
-					if d3424.Loc == LocReg && d2.Loc == LocReg && d3424.Reg == d2.Reg {
+					if d3425.Loc == LocReg && d2.Loc == LocReg && d3425.Reg == d2.Reg {
 						ctx.TransferReg(d2.Reg)
 						d2.Loc = LocNone
 					}
 					ctx.FreeDesc(&d2)
-					ctx.EnsureDesc(&d3424)
-					if d3424.Loc == LocImm {
-						ctx.EmitMakeInt(result, d3424)
-					} else {
-						ctx.EmitMovToReg(result.Reg2, d3424)
-						d3425 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+					ctx.EnsureDesc(&d3425)
+					if d3425.Loc == LocImm {
 						ctx.EmitMakeInt(result, d3425)
-						if d3424.Loc == LocReg && d3424.Reg != result.Reg2 {
-							ctx.FreeReg(d3424.Reg)
+					} else {
+						ctx.EmitMovToReg(result.Reg2, d3425)
+						d3426 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d3426)
+						if d3425.Loc == LocReg && d3425.Reg != result.Reg2 {
+							ctx.FreeReg(d3425.Reg)
 						}
 					}
 					result.Type = tagInt
@@ -67116,11 +67202,11 @@ func init_date() {
 					if len(ps.OverlayValues) > 3423 && ps.OverlayValues[3423].Loc != LocNone {
 						d3423 = ps.OverlayValues[3423]
 					}
-					if len(ps.OverlayValues) > 3424 && ps.OverlayValues[3424].Loc != LocNone {
-						d3424 = ps.OverlayValues[3424]
-					}
 					if len(ps.OverlayValues) > 3425 && ps.OverlayValues[3425].Loc != LocNone {
 						d3425 = ps.OverlayValues[3425]
+					}
+					if len(ps.OverlayValues) > 3426 && ps.OverlayValues[3426].Loc != LocNone {
+						d3426 = ps.OverlayValues[3426]
 					}
 					ctx.ReclaimUntrackedRegs()
 					_ = jitEmitGoVariadicCallFromDescs(ctx, declarations["timestampdiff"].Fn, args, result)
@@ -67740,250 +67826,250 @@ func init_date() {
 					if len(ps.OverlayValues) > 3423 && ps.OverlayValues[3423].Loc != LocNone {
 						d3423 = ps.OverlayValues[3423]
 					}
-					if len(ps.OverlayValues) > 3424 && ps.OverlayValues[3424].Loc != LocNone {
-						d3424 = ps.OverlayValues[3424]
-					}
 					if len(ps.OverlayValues) > 3425 && ps.OverlayValues[3425].Loc != LocNone {
 						d3425 = ps.OverlayValues[3425]
+					}
+					if len(ps.OverlayValues) > 3426 && ps.OverlayValues[3426].Loc != LocNone {
+						d3426 = ps.OverlayValues[3426]
 					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d2627)
 					ctx.EnsureDesc(&d2627)
-					var d3426 JITValueDesc
+					var d3427 JITValueDesc
 					if d2627.Loc == LocImm {
-						d3426 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d2627.Imm.Int() - 1)}
+						d3427 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d2627.Imm.Int() - 1)}
 					} else {
 						scratch := ctx.AllocRegExcept(d2627.Reg)
 						ctx.EmitMovRegReg(scratch, d2627.Reg)
 						ctx.EmitSubRegImm32(scratch, int32(1))
-						d3426 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-						ctx.BindReg(scratch, &d3426)
+						d3427 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d3427)
 					}
-					if d3426.Loc == LocReg && d2627.Loc == LocReg && d3426.Reg == d2627.Reg {
+					if d3427.Loc == LocReg && d2627.Loc == LocReg && d3427.Reg == d2627.Reg {
 						ctx.TransferReg(d2627.Reg)
 						d2627.Loc = LocNone
 					}
-					ctx.EnsureDesc(&d3426)
-					ctx.EmitStoreToStack(d3426, int32(bbs[30].PhiBase)+int32(0))
-					ctx.StabilizeDescForControlFlow(&d3426)
+					ctx.EnsureDesc(&d3427)
+					ctx.EmitStoreToStack(d3427, int32(bbs[30].PhiBase)+int32(0))
+					ctx.StabilizeDescForControlFlow(&d3427)
 					if ps.General {
 					}
-					ps3427 := PhiState{General: ps.General}
-					ps3427.OverlayValues = make([]JITValueDesc, 3427)
-					ps3427.OverlayValues[1] = d1
-					ps3427.OverlayValues[2] = d2
-					ps3427.OverlayValues[3] = d3
-					ps3427.OverlayValues[4] = d4
-					ps3427.OverlayValues[5] = d5
-					ps3427.OverlayValues[6] = d6
-					ps3427.OverlayValues[7] = d7
-					ps3427.OverlayValues[28] = d28
-					ps3427.OverlayValues[29] = d29
-					ps3427.OverlayValues[31] = d31
-					ps3427.OverlayValues[32] = d32
-					ps3427.OverlayValues[33] = d33
-					ps3427.OverlayValues[35] = d35
-					ps3427.OverlayValues[36] = d36
-					ps3427.OverlayValues[37] = d37
-					ps3427.OverlayValues[74] = d74
-					ps3427.OverlayValues[75] = d75
-					ps3427.OverlayValues[76] = d76
-					ps3427.OverlayValues[77] = d77
-					ps3427.OverlayValues[122] = d122
-					ps3427.OverlayValues[123] = d123
-					ps3427.OverlayValues[124] = d124
-					ps3427.OverlayValues[125] = d125
-					ps3427.OverlayValues[126] = d126
-					ps3427.OverlayValues[127] = d127
-					ps3427.OverlayValues[128] = d128
-					ps3427.OverlayValues[129] = d129
-					ps3427.OverlayValues[130] = d130
-					ps3427.OverlayValues[193] = d193
-					ps3427.OverlayValues[258] = d258
-					ps3427.OverlayValues[259] = d259
-					ps3427.OverlayValues[260] = d260
-					ps3427.OverlayValues[261] = d261
-					ps3427.OverlayValues[262] = d262
-					ps3427.OverlayValues[263] = d263
-					ps3427.OverlayValues[264] = d264
-					ps3427.OverlayValues[265] = d265
-					ps3427.OverlayValues[266] = d266
-					ps3427.OverlayValues[267] = d267
-					ps3427.OverlayValues[268] = d268
-					ps3427.OverlayValues[269] = d269
-					ps3427.OverlayValues[270] = d270
-					ps3427.OverlayValues[271] = d271
-					ps3427.OverlayValues[272] = d272
-					ps3427.OverlayValues[273] = d273
-					ps3427.OverlayValues[370] = d370
-					ps3427.OverlayValues[371] = d371
-					ps3427.OverlayValues[372] = d372
-					ps3427.OverlayValues[373] = d373
-					ps3427.OverlayValues[374] = d374
-					ps3427.OverlayValues[375] = d375
-					ps3427.OverlayValues[376] = d376
-					ps3427.OverlayValues[377] = d377
-					ps3427.OverlayValues[378] = d378
-					ps3427.OverlayValues[379] = d379
-					ps3427.OverlayValues[380] = d380
-					ps3427.OverlayValues[381] = d381
-					ps3427.OverlayValues[382] = d382
-					ps3427.OverlayValues[505] = d505
-					ps3427.OverlayValues[506] = d506
-					ps3427.OverlayValues[507] = d507
-					ps3427.OverlayValues[508] = d508
-					ps3427.OverlayValues[509] = d509
-					ps3427.OverlayValues[510] = d510
-					ps3427.OverlayValues[511] = d511
-					ps3427.OverlayValues[512] = d512
-					ps3427.OverlayValues[513] = d513
-					ps3427.OverlayValues[514] = d514
-					ps3427.OverlayValues[515] = d515
-					ps3427.OverlayValues[516] = d516
-					ps3427.OverlayValues[517] = d517
-					ps3427.OverlayValues[666] = d666
-					ps3427.OverlayValues[667] = d667
-					ps3427.OverlayValues[668] = d668
-					ps3427.OverlayValues[669] = d669
-					ps3427.OverlayValues[670] = d670
-					ps3427.OverlayValues[671] = d671
-					ps3427.OverlayValues[672] = d672
-					ps3427.OverlayValues[673] = d673
-					ps3427.OverlayValues[674] = d674
-					ps3427.OverlayValues[675] = d675
-					ps3427.OverlayValues[676] = d676
-					ps3427.OverlayValues[677] = d677
-					ps3427.OverlayValues[678] = d678
-					ps3427.OverlayValues[679] = d679
-					ps3427.OverlayValues[680] = d680
-					ps3427.OverlayValues[681] = d681
-					ps3427.OverlayValues[682] = d682
-					ps3427.OverlayValues[683] = d683
-					ps3427.OverlayValues[684] = d684
-					ps3427.OverlayValues[685] = d685
-					ps3427.OverlayValues[686] = d686
-					ps3427.OverlayValues[687] = d687
-					ps3427.OverlayValues[688] = d688
-					ps3427.OverlayValues[689] = d689
-					ps3427.OverlayValues[690] = d690
-					ps3427.OverlayValues[691] = d691
-					ps3427.OverlayValues[692] = d692
-					ps3427.OverlayValues[693] = d693
-					ps3427.OverlayValues[694] = d694
-					ps3427.OverlayValues[695] = d695
-					ps3427.OverlayValues[696] = d696
-					ps3427.OverlayValues[697] = d697
-					ps3427.OverlayValues[910] = d910
-					ps3427.OverlayValues[911] = d911
-					ps3427.OverlayValues[912] = d912
-					ps3427.OverlayValues[913] = d913
-					ps3427.OverlayValues[914] = d914
-					ps3427.OverlayValues[915] = d915
-					ps3427.OverlayValues[916] = d916
-					ps3427.OverlayValues[917] = d917
-					ps3427.OverlayValues[918] = d918
-					ps3427.OverlayValues[919] = d919
-					ps3427.OverlayValues[920] = d920
-					ps3427.OverlayValues[921] = d921
-					ps3427.OverlayValues[922] = d922
-					ps3427.OverlayValues[923] = d923
-					ps3427.OverlayValues[924] = d924
-					ps3427.OverlayValues[925] = d925
-					ps3427.OverlayValues[926] = d926
-					ps3427.OverlayValues[927] = d927
-					ps3427.OverlayValues[928] = d928
-					ps3427.OverlayValues[929] = d929
-					ps3427.OverlayValues[930] = d930
-					ps3427.OverlayValues[931] = d931
-					ps3427.OverlayValues[932] = d932
-					ps3427.OverlayValues[933] = d933
-					ps3427.OverlayValues[934] = d934
-					ps3427.OverlayValues[935] = d935
-					ps3427.OverlayValues[936] = d936
-					ps3427.OverlayValues[937] = d937
-					ps3427.OverlayValues[938] = d938
-					ps3427.OverlayValues[939] = d939
-					ps3427.OverlayValues[940] = d940
-					ps3427.OverlayValues[941] = d941
-					ps3427.OverlayValues[942] = d942
-					ps3427.OverlayValues[1221] = d1221
-					ps3427.OverlayValues[1222] = d1222
-					ps3427.OverlayValues[1223] = d1223
-					ps3427.OverlayValues[1224] = d1224
-					ps3427.OverlayValues[1225] = d1225
-					ps3427.OverlayValues[1226] = d1226
-					ps3427.OverlayValues[1227] = d1227
-					ps3427.OverlayValues[1228] = d1228
-					ps3427.OverlayValues[1229] = d1229
-					ps3427.OverlayValues[1230] = d1230
-					ps3427.OverlayValues[1231] = d1231
-					ps3427.OverlayValues[1232] = d1232
-					ps3427.OverlayValues[1233] = d1233
-					ps3427.OverlayValues[1234] = d1234
-					ps3427.OverlayValues[1236] = d1236
-					ps3427.OverlayValues[1238] = d1238
-					ps3427.OverlayValues[1392] = d1392
-					ps3427.OverlayValues[1395] = d1395
-					ps3427.OverlayValues[1551] = d1551
-					ps3427.OverlayValues[1552] = d1552
-					ps3427.OverlayValues[1553] = d1553
-					ps3427.OverlayValues[1554] = d1554
-					ps3427.OverlayValues[1877] = d1877
-					ps3427.OverlayValues[1878] = d1878
-					ps3427.OverlayValues[1879] = d1879
-					ps3427.OverlayValues[1880] = d1880
-					ps3427.OverlayValues[1881] = d1881
-					ps3427.OverlayValues[1882] = d1882
-					ps3427.OverlayValues[1883] = d1883
-					ps3427.OverlayValues[1884] = d1884
-					ps3427.OverlayValues[1885] = d1885
-					ps3427.OverlayValues[1886] = d1886
-					ps3427.OverlayValues[1887] = d1887
-					ps3427.OverlayValues[1888] = d1888
-					ps3427.OverlayValues[1889] = d1889
-					ps3427.OverlayValues[1890] = d1890
-					ps3427.OverlayValues[1892] = d1892
-					ps3427.OverlayValues[1894] = d1894
-					ps3427.OverlayValues[2070] = d2070
-					ps3427.OverlayValues[2073] = d2073
-					ps3427.OverlayValues[2251] = d2251
-					ps3427.OverlayValues[2252] = d2252
-					ps3427.OverlayValues[2253] = d2253
-					ps3427.OverlayValues[2254] = d2254
-					ps3427.OverlayValues[2621] = d2621
-					ps3427.OverlayValues[2623] = d2623
-					ps3427.OverlayValues[2624] = d2624
-					ps3427.OverlayValues[2625] = d2625
-					ps3427.OverlayValues[2626] = d2626
-					ps3427.OverlayValues[2627] = d2627
-					ps3427.OverlayValues[2628] = d2628
-					ps3427.OverlayValues[2629] = d2629
-					ps3427.OverlayValues[2630] = d2630
-					ps3427.OverlayValues[2631] = d2631
-					ps3427.OverlayValues[2632] = d2632
-					ps3427.OverlayValues[3021] = d3021
-					ps3427.OverlayValues[3022] = d3022
-					ps3427.OverlayValues[3023] = d3023
-					ps3427.OverlayValues[3024] = d3024
-					ps3427.OverlayValues[3421] = d3421
-					ps3427.OverlayValues[3423] = d3423
-					ps3427.OverlayValues[3424] = d3424
-					ps3427.OverlayValues[3425] = d3425
-					ps3427.OverlayValues[3426] = d3426
-					ps3427.PhiValues = make([]JITValueDesc, 1)
-					if ps3427.General && bbs[30].Rendered {
+					ps3428 := PhiState{General: ps.General}
+					ps3428.OverlayValues = make([]JITValueDesc, 3428)
+					ps3428.OverlayValues[1] = d1
+					ps3428.OverlayValues[2] = d2
+					ps3428.OverlayValues[3] = d3
+					ps3428.OverlayValues[4] = d4
+					ps3428.OverlayValues[5] = d5
+					ps3428.OverlayValues[6] = d6
+					ps3428.OverlayValues[7] = d7
+					ps3428.OverlayValues[28] = d28
+					ps3428.OverlayValues[29] = d29
+					ps3428.OverlayValues[31] = d31
+					ps3428.OverlayValues[32] = d32
+					ps3428.OverlayValues[33] = d33
+					ps3428.OverlayValues[35] = d35
+					ps3428.OverlayValues[36] = d36
+					ps3428.OverlayValues[37] = d37
+					ps3428.OverlayValues[74] = d74
+					ps3428.OverlayValues[75] = d75
+					ps3428.OverlayValues[76] = d76
+					ps3428.OverlayValues[77] = d77
+					ps3428.OverlayValues[122] = d122
+					ps3428.OverlayValues[123] = d123
+					ps3428.OverlayValues[124] = d124
+					ps3428.OverlayValues[125] = d125
+					ps3428.OverlayValues[126] = d126
+					ps3428.OverlayValues[127] = d127
+					ps3428.OverlayValues[128] = d128
+					ps3428.OverlayValues[129] = d129
+					ps3428.OverlayValues[130] = d130
+					ps3428.OverlayValues[193] = d193
+					ps3428.OverlayValues[258] = d258
+					ps3428.OverlayValues[259] = d259
+					ps3428.OverlayValues[260] = d260
+					ps3428.OverlayValues[261] = d261
+					ps3428.OverlayValues[262] = d262
+					ps3428.OverlayValues[263] = d263
+					ps3428.OverlayValues[264] = d264
+					ps3428.OverlayValues[265] = d265
+					ps3428.OverlayValues[266] = d266
+					ps3428.OverlayValues[267] = d267
+					ps3428.OverlayValues[268] = d268
+					ps3428.OverlayValues[269] = d269
+					ps3428.OverlayValues[270] = d270
+					ps3428.OverlayValues[271] = d271
+					ps3428.OverlayValues[272] = d272
+					ps3428.OverlayValues[273] = d273
+					ps3428.OverlayValues[370] = d370
+					ps3428.OverlayValues[371] = d371
+					ps3428.OverlayValues[372] = d372
+					ps3428.OverlayValues[373] = d373
+					ps3428.OverlayValues[374] = d374
+					ps3428.OverlayValues[375] = d375
+					ps3428.OverlayValues[376] = d376
+					ps3428.OverlayValues[377] = d377
+					ps3428.OverlayValues[378] = d378
+					ps3428.OverlayValues[379] = d379
+					ps3428.OverlayValues[380] = d380
+					ps3428.OverlayValues[381] = d381
+					ps3428.OverlayValues[382] = d382
+					ps3428.OverlayValues[505] = d505
+					ps3428.OverlayValues[506] = d506
+					ps3428.OverlayValues[507] = d507
+					ps3428.OverlayValues[508] = d508
+					ps3428.OverlayValues[509] = d509
+					ps3428.OverlayValues[510] = d510
+					ps3428.OverlayValues[511] = d511
+					ps3428.OverlayValues[512] = d512
+					ps3428.OverlayValues[513] = d513
+					ps3428.OverlayValues[514] = d514
+					ps3428.OverlayValues[515] = d515
+					ps3428.OverlayValues[516] = d516
+					ps3428.OverlayValues[517] = d517
+					ps3428.OverlayValues[666] = d666
+					ps3428.OverlayValues[667] = d667
+					ps3428.OverlayValues[668] = d668
+					ps3428.OverlayValues[669] = d669
+					ps3428.OverlayValues[670] = d670
+					ps3428.OverlayValues[671] = d671
+					ps3428.OverlayValues[672] = d672
+					ps3428.OverlayValues[673] = d673
+					ps3428.OverlayValues[674] = d674
+					ps3428.OverlayValues[675] = d675
+					ps3428.OverlayValues[676] = d676
+					ps3428.OverlayValues[677] = d677
+					ps3428.OverlayValues[678] = d678
+					ps3428.OverlayValues[679] = d679
+					ps3428.OverlayValues[680] = d680
+					ps3428.OverlayValues[681] = d681
+					ps3428.OverlayValues[682] = d682
+					ps3428.OverlayValues[683] = d683
+					ps3428.OverlayValues[684] = d684
+					ps3428.OverlayValues[685] = d685
+					ps3428.OverlayValues[686] = d686
+					ps3428.OverlayValues[687] = d687
+					ps3428.OverlayValues[688] = d688
+					ps3428.OverlayValues[689] = d689
+					ps3428.OverlayValues[690] = d690
+					ps3428.OverlayValues[691] = d691
+					ps3428.OverlayValues[692] = d692
+					ps3428.OverlayValues[693] = d693
+					ps3428.OverlayValues[694] = d694
+					ps3428.OverlayValues[695] = d695
+					ps3428.OverlayValues[696] = d696
+					ps3428.OverlayValues[697] = d697
+					ps3428.OverlayValues[910] = d910
+					ps3428.OverlayValues[911] = d911
+					ps3428.OverlayValues[912] = d912
+					ps3428.OverlayValues[913] = d913
+					ps3428.OverlayValues[914] = d914
+					ps3428.OverlayValues[915] = d915
+					ps3428.OverlayValues[916] = d916
+					ps3428.OverlayValues[917] = d917
+					ps3428.OverlayValues[918] = d918
+					ps3428.OverlayValues[919] = d919
+					ps3428.OverlayValues[920] = d920
+					ps3428.OverlayValues[921] = d921
+					ps3428.OverlayValues[922] = d922
+					ps3428.OverlayValues[923] = d923
+					ps3428.OverlayValues[924] = d924
+					ps3428.OverlayValues[925] = d925
+					ps3428.OverlayValues[926] = d926
+					ps3428.OverlayValues[927] = d927
+					ps3428.OverlayValues[928] = d928
+					ps3428.OverlayValues[929] = d929
+					ps3428.OverlayValues[930] = d930
+					ps3428.OverlayValues[931] = d931
+					ps3428.OverlayValues[932] = d932
+					ps3428.OverlayValues[933] = d933
+					ps3428.OverlayValues[934] = d934
+					ps3428.OverlayValues[935] = d935
+					ps3428.OverlayValues[936] = d936
+					ps3428.OverlayValues[937] = d937
+					ps3428.OverlayValues[938] = d938
+					ps3428.OverlayValues[939] = d939
+					ps3428.OverlayValues[940] = d940
+					ps3428.OverlayValues[941] = d941
+					ps3428.OverlayValues[942] = d942
+					ps3428.OverlayValues[1221] = d1221
+					ps3428.OverlayValues[1222] = d1222
+					ps3428.OverlayValues[1223] = d1223
+					ps3428.OverlayValues[1224] = d1224
+					ps3428.OverlayValues[1225] = d1225
+					ps3428.OverlayValues[1226] = d1226
+					ps3428.OverlayValues[1227] = d1227
+					ps3428.OverlayValues[1228] = d1228
+					ps3428.OverlayValues[1229] = d1229
+					ps3428.OverlayValues[1230] = d1230
+					ps3428.OverlayValues[1231] = d1231
+					ps3428.OverlayValues[1232] = d1232
+					ps3428.OverlayValues[1233] = d1233
+					ps3428.OverlayValues[1234] = d1234
+					ps3428.OverlayValues[1236] = d1236
+					ps3428.OverlayValues[1238] = d1238
+					ps3428.OverlayValues[1392] = d1392
+					ps3428.OverlayValues[1395] = d1395
+					ps3428.OverlayValues[1551] = d1551
+					ps3428.OverlayValues[1552] = d1552
+					ps3428.OverlayValues[1553] = d1553
+					ps3428.OverlayValues[1554] = d1554
+					ps3428.OverlayValues[1877] = d1877
+					ps3428.OverlayValues[1878] = d1878
+					ps3428.OverlayValues[1879] = d1879
+					ps3428.OverlayValues[1880] = d1880
+					ps3428.OverlayValues[1881] = d1881
+					ps3428.OverlayValues[1882] = d1882
+					ps3428.OverlayValues[1883] = d1883
+					ps3428.OverlayValues[1884] = d1884
+					ps3428.OverlayValues[1885] = d1885
+					ps3428.OverlayValues[1886] = d1886
+					ps3428.OverlayValues[1887] = d1887
+					ps3428.OverlayValues[1888] = d1888
+					ps3428.OverlayValues[1889] = d1889
+					ps3428.OverlayValues[1890] = d1890
+					ps3428.OverlayValues[1892] = d1892
+					ps3428.OverlayValues[1894] = d1894
+					ps3428.OverlayValues[2070] = d2070
+					ps3428.OverlayValues[2073] = d2073
+					ps3428.OverlayValues[2251] = d2251
+					ps3428.OverlayValues[2252] = d2252
+					ps3428.OverlayValues[2253] = d2253
+					ps3428.OverlayValues[2254] = d2254
+					ps3428.OverlayValues[2621] = d2621
+					ps3428.OverlayValues[2623] = d2623
+					ps3428.OverlayValues[2624] = d2624
+					ps3428.OverlayValues[2625] = d2625
+					ps3428.OverlayValues[2626] = d2626
+					ps3428.OverlayValues[2627] = d2627
+					ps3428.OverlayValues[2628] = d2628
+					ps3428.OverlayValues[2629] = d2629
+					ps3428.OverlayValues[2630] = d2630
+					ps3428.OverlayValues[2631] = d2631
+					ps3428.OverlayValues[2632] = d2632
+					ps3428.OverlayValues[3021] = d3021
+					ps3428.OverlayValues[3022] = d3022
+					ps3428.OverlayValues[3023] = d3023
+					ps3428.OverlayValues[3024] = d3024
+					ps3428.OverlayValues[3421] = d3421
+					ps3428.OverlayValues[3423] = d3423
+					ps3428.OverlayValues[3425] = d3425
+					ps3428.OverlayValues[3426] = d3426
+					ps3428.OverlayValues[3427] = d3427
+					ps3428.PhiValues = make([]JITValueDesc, 1)
+					if ps3428.General && bbs[30].Rendered {
 						ctx.EmitJmp(lbl31)
 						return result
 					}
-					return bbs[30].RenderPS(ps3427)
+					return bbs[30].RenderPS(ps3428)
 					return result
 				}
 				bbs[30].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d3428 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d3428)
-							ctx.EmitStoreToStack(d3428, int32(bbs[30].PhiBase)+int32(0))
+							d3429 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d3429)
+							ctx.EmitStoreToStack(d3429, int32(bbs[30].PhiBase)+int32(0))
 						}
 						if bbs[30].VisitCount >= 0 {
 							ps.General = true
@@ -68596,17 +68682,17 @@ func init_date() {
 					if len(ps.OverlayValues) > 3423 && ps.OverlayValues[3423].Loc != LocNone {
 						d3423 = ps.OverlayValues[3423]
 					}
-					if len(ps.OverlayValues) > 3424 && ps.OverlayValues[3424].Loc != LocNone {
-						d3424 = ps.OverlayValues[3424]
-					}
 					if len(ps.OverlayValues) > 3425 && ps.OverlayValues[3425].Loc != LocNone {
 						d3425 = ps.OverlayValues[3425]
 					}
 					if len(ps.OverlayValues) > 3426 && ps.OverlayValues[3426].Loc != LocNone {
 						d3426 = ps.OverlayValues[3426]
 					}
-					if len(ps.OverlayValues) > 3428 && ps.OverlayValues[3428].Loc != LocNone {
-						d3428 = ps.OverlayValues[3428]
+					if len(ps.OverlayValues) > 3427 && ps.OverlayValues[3427].Loc != LocNone {
+						d3427 = ps.OverlayValues[3427]
+					}
+					if len(ps.OverlayValues) > 3429 && ps.OverlayValues[3429].Loc != LocNone {
+						d3429 = ps.OverlayValues[3429]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
 						d3 = ps.PhiValues[0]
@@ -68617,8 +68703,8 @@ func init_date() {
 						ctx.EmitMakeInt(result, d3)
 					} else {
 						ctx.EmitMovToReg(result.Reg2, d3)
-						d3429 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeInt(result, d3429)
+						d3430 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d3430)
 						if d3.Loc == LocReg && d3.Reg != result.Reg2 {
 							ctx.FreeReg(d3.Reg)
 						}
@@ -69240,20 +69326,20 @@ func init_date() {
 					if len(ps.OverlayValues) > 3423 && ps.OverlayValues[3423].Loc != LocNone {
 						d3423 = ps.OverlayValues[3423]
 					}
-					if len(ps.OverlayValues) > 3424 && ps.OverlayValues[3424].Loc != LocNone {
-						d3424 = ps.OverlayValues[3424]
-					}
 					if len(ps.OverlayValues) > 3425 && ps.OverlayValues[3425].Loc != LocNone {
 						d3425 = ps.OverlayValues[3425]
 					}
 					if len(ps.OverlayValues) > 3426 && ps.OverlayValues[3426].Loc != LocNone {
 						d3426 = ps.OverlayValues[3426]
 					}
-					if len(ps.OverlayValues) > 3428 && ps.OverlayValues[3428].Loc != LocNone {
-						d3428 = ps.OverlayValues[3428]
+					if len(ps.OverlayValues) > 3427 && ps.OverlayValues[3427].Loc != LocNone {
+						d3427 = ps.OverlayValues[3427]
 					}
 					if len(ps.OverlayValues) > 3429 && ps.OverlayValues[3429].Loc != LocNone {
 						d3429 = ps.OverlayValues[3429]
+					}
+					if len(ps.OverlayValues) > 3430 && ps.OverlayValues[3430].Loc != LocNone {
+						d3430 = ps.OverlayValues[3430]
 					}
 					ctx.ReclaimUntrackedRegs()
 					d35 = JITPrepareGoSliceArg(ctx, d35)
@@ -69261,1370 +69347,1159 @@ func init_date() {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
 					}
 					ctx.SyncDesc(&d35)
-					d3430 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d35}, 1)
-					d3430.NoHeapPointer = true
-					ctx.BindReg(d3430.Reg, &d3430)
+					d3431 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d35}, 1)
+					d3431.NoHeapPointer = true
+					ctx.BindReg(d3431.Reg, &d3431)
 					d31 = JITPrepareGoSliceArg(ctx, d31)
 					if d31.Loc != LocRegTriple && d31.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
 					}
 					ctx.SyncDesc(&d31)
-					d3431 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d31}, 1)
-					d3431.NoHeapPointer = true
-					ctx.BindReg(d3431.Reg, &d3431)
-					ctx.EnsureDesc(&d3430)
+					d3432 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d31}, 1)
+					d3432.NoHeapPointer = true
+					ctx.BindReg(d3432.Reg, &d3432)
 					ctx.EnsureDesc(&d3431)
-					ctx.EnsureDescsTogether(&d3430, &d3431)
-					var d3432 JITValueDesc
-					if d3430.Loc == LocImm && d3431.Loc == LocImm {
-						d3432 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d3430.Imm.Int() == d3431.Imm.Int())}
-					} else if d3431.Loc == LocImm {
-						r48 := ctx.AllocReg()
-						if d3431.Imm.Int() >= -2147483648 && d3431.Imm.Int() <= 2147483647 {
-							ctx.EmitCmpRegImm32(d3430.Reg, int32(d3431.Imm.Int()))
-						} else {
-							ctx.EmitMovRegImm64(RegR11, uint64(d3431.Imm.Int()))
-							ctx.EmitCmpInt64(d3430.Reg, RegR11)
-						}
-						d3432 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r48, Condition: CondEqual}
-						ctx.BindReg(r48, &d3432)
-					} else if d3430.Loc == LocImm {
+					ctx.EnsureDesc(&d3432)
+					ctx.EnsureDescsTogether(&d3431, &d3432)
+					var d3433 JITValueDesc
+					if d3431.Loc == LocImm && d3432.Loc == LocImm {
+						d3433 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d3431.Imm.Int() == d3432.Imm.Int())}
+					} else if d3432.Loc == LocImm {
 						r49 := ctx.AllocReg()
-						ctx.EmitMovRegImm64(RegR11, uint64(d3430.Imm.Int()))
-						ctx.EmitCmpInt64(RegR11, d3431.Reg)
-						d3432 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r49, Condition: CondEqual}
-						ctx.BindReg(r49, &d3432)
-					} else {
+						if d3432.Imm.Int() >= -2147483648 && d3432.Imm.Int() <= 2147483647 {
+							ctx.EmitCmpRegImm32(d3431.Reg, int32(d3432.Imm.Int()))
+						} else {
+							ctx.EmitMovRegImm64(RegR11, uint64(d3432.Imm.Int()))
+							ctx.EmitCmpInt64(d3431.Reg, RegR11)
+						}
+						d3433 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r49, Condition: CondEqual}
+						ctx.BindReg(r49, &d3433)
+					} else if d3431.Loc == LocImm {
 						r50 := ctx.AllocReg()
-						ctx.EmitCmpInt64(d3430.Reg, d3431.Reg)
-						d3432 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r50, Condition: CondEqual}
-						ctx.BindReg(r50, &d3432)
+						ctx.EmitMovRegImm64(RegR11, uint64(d3431.Imm.Int()))
+						ctx.EmitCmpInt64(RegR11, d3432.Reg)
+						d3433 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r50, Condition: CondEqual}
+						ctx.BindReg(r50, &d3433)
+					} else {
+						r51 := ctx.AllocReg()
+						ctx.EmitCmpInt64(d3431.Reg, d3432.Reg)
+						d3433 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r51, Condition: CondEqual}
+						ctx.BindReg(r51, &d3433)
 					}
-					ctx.FreeDesc(&d3430)
 					ctx.FreeDesc(&d3431)
-					d3433 = d3432
-					ctx.EnsureDesc(&d3433)
-					if d3433.Loc != LocImm && d3433.Loc != LocFlags {
+					ctx.FreeDesc(&d3432)
+					d3434 = d3433
+					ctx.EnsureDesc(&d3434)
+					if d3434.Loc != LocImm && d3434.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d3433.Loc == LocImm {
-						if d3433.Imm.Bool() {
+					if d3434.Loc == LocImm {
+						if d3434.Imm.Bool() {
 							if ps.General {
 							}
-							ps3434 := PhiState{General: ps.General}
-							ps3434.OverlayValues = make([]JITValueDesc, 3434)
-							ps3434.OverlayValues[1] = d1
-							ps3434.OverlayValues[2] = d2
-							ps3434.OverlayValues[3] = d3
-							ps3434.OverlayValues[4] = d4
-							ps3434.OverlayValues[5] = d5
-							ps3434.OverlayValues[6] = d6
-							ps3434.OverlayValues[7] = d7
-							ps3434.OverlayValues[28] = d28
-							ps3434.OverlayValues[29] = d29
-							ps3434.OverlayValues[31] = d31
-							ps3434.OverlayValues[32] = d32
-							ps3434.OverlayValues[33] = d33
-							ps3434.OverlayValues[35] = d35
-							ps3434.OverlayValues[36] = d36
-							ps3434.OverlayValues[37] = d37
-							ps3434.OverlayValues[74] = d74
-							ps3434.OverlayValues[75] = d75
-							ps3434.OverlayValues[76] = d76
-							ps3434.OverlayValues[77] = d77
-							ps3434.OverlayValues[122] = d122
-							ps3434.OverlayValues[123] = d123
-							ps3434.OverlayValues[124] = d124
-							ps3434.OverlayValues[125] = d125
-							ps3434.OverlayValues[126] = d126
-							ps3434.OverlayValues[127] = d127
-							ps3434.OverlayValues[128] = d128
-							ps3434.OverlayValues[129] = d129
-							ps3434.OverlayValues[130] = d130
-							ps3434.OverlayValues[193] = d193
-							ps3434.OverlayValues[258] = d258
-							ps3434.OverlayValues[259] = d259
-							ps3434.OverlayValues[260] = d260
-							ps3434.OverlayValues[261] = d261
-							ps3434.OverlayValues[262] = d262
-							ps3434.OverlayValues[263] = d263
-							ps3434.OverlayValues[264] = d264
-							ps3434.OverlayValues[265] = d265
-							ps3434.OverlayValues[266] = d266
-							ps3434.OverlayValues[267] = d267
-							ps3434.OverlayValues[268] = d268
-							ps3434.OverlayValues[269] = d269
-							ps3434.OverlayValues[270] = d270
-							ps3434.OverlayValues[271] = d271
-							ps3434.OverlayValues[272] = d272
-							ps3434.OverlayValues[273] = d273
-							ps3434.OverlayValues[370] = d370
-							ps3434.OverlayValues[371] = d371
-							ps3434.OverlayValues[372] = d372
-							ps3434.OverlayValues[373] = d373
-							ps3434.OverlayValues[374] = d374
-							ps3434.OverlayValues[375] = d375
-							ps3434.OverlayValues[376] = d376
-							ps3434.OverlayValues[377] = d377
-							ps3434.OverlayValues[378] = d378
-							ps3434.OverlayValues[379] = d379
-							ps3434.OverlayValues[380] = d380
-							ps3434.OverlayValues[381] = d381
-							ps3434.OverlayValues[382] = d382
-							ps3434.OverlayValues[505] = d505
-							ps3434.OverlayValues[506] = d506
-							ps3434.OverlayValues[507] = d507
-							ps3434.OverlayValues[508] = d508
-							ps3434.OverlayValues[509] = d509
-							ps3434.OverlayValues[510] = d510
-							ps3434.OverlayValues[511] = d511
-							ps3434.OverlayValues[512] = d512
-							ps3434.OverlayValues[513] = d513
-							ps3434.OverlayValues[514] = d514
-							ps3434.OverlayValues[515] = d515
-							ps3434.OverlayValues[516] = d516
-							ps3434.OverlayValues[517] = d517
-							ps3434.OverlayValues[666] = d666
-							ps3434.OverlayValues[667] = d667
-							ps3434.OverlayValues[668] = d668
-							ps3434.OverlayValues[669] = d669
-							ps3434.OverlayValues[670] = d670
-							ps3434.OverlayValues[671] = d671
-							ps3434.OverlayValues[672] = d672
-							ps3434.OverlayValues[673] = d673
-							ps3434.OverlayValues[674] = d674
-							ps3434.OverlayValues[675] = d675
-							ps3434.OverlayValues[676] = d676
-							ps3434.OverlayValues[677] = d677
-							ps3434.OverlayValues[678] = d678
-							ps3434.OverlayValues[679] = d679
-							ps3434.OverlayValues[680] = d680
-							ps3434.OverlayValues[681] = d681
-							ps3434.OverlayValues[682] = d682
-							ps3434.OverlayValues[683] = d683
-							ps3434.OverlayValues[684] = d684
-							ps3434.OverlayValues[685] = d685
-							ps3434.OverlayValues[686] = d686
-							ps3434.OverlayValues[687] = d687
-							ps3434.OverlayValues[688] = d688
-							ps3434.OverlayValues[689] = d689
-							ps3434.OverlayValues[690] = d690
-							ps3434.OverlayValues[691] = d691
-							ps3434.OverlayValues[692] = d692
-							ps3434.OverlayValues[693] = d693
-							ps3434.OverlayValues[694] = d694
-							ps3434.OverlayValues[695] = d695
-							ps3434.OverlayValues[696] = d696
-							ps3434.OverlayValues[697] = d697
-							ps3434.OverlayValues[910] = d910
-							ps3434.OverlayValues[911] = d911
-							ps3434.OverlayValues[912] = d912
-							ps3434.OverlayValues[913] = d913
-							ps3434.OverlayValues[914] = d914
-							ps3434.OverlayValues[915] = d915
-							ps3434.OverlayValues[916] = d916
-							ps3434.OverlayValues[917] = d917
-							ps3434.OverlayValues[918] = d918
-							ps3434.OverlayValues[919] = d919
-							ps3434.OverlayValues[920] = d920
-							ps3434.OverlayValues[921] = d921
-							ps3434.OverlayValues[922] = d922
-							ps3434.OverlayValues[923] = d923
-							ps3434.OverlayValues[924] = d924
-							ps3434.OverlayValues[925] = d925
-							ps3434.OverlayValues[926] = d926
-							ps3434.OverlayValues[927] = d927
-							ps3434.OverlayValues[928] = d928
-							ps3434.OverlayValues[929] = d929
-							ps3434.OverlayValues[930] = d930
-							ps3434.OverlayValues[931] = d931
-							ps3434.OverlayValues[932] = d932
-							ps3434.OverlayValues[933] = d933
-							ps3434.OverlayValues[934] = d934
-							ps3434.OverlayValues[935] = d935
-							ps3434.OverlayValues[936] = d936
-							ps3434.OverlayValues[937] = d937
-							ps3434.OverlayValues[938] = d938
-							ps3434.OverlayValues[939] = d939
-							ps3434.OverlayValues[940] = d940
-							ps3434.OverlayValues[941] = d941
-							ps3434.OverlayValues[942] = d942
-							ps3434.OverlayValues[1221] = d1221
-							ps3434.OverlayValues[1222] = d1222
-							ps3434.OverlayValues[1223] = d1223
-							ps3434.OverlayValues[1224] = d1224
-							ps3434.OverlayValues[1225] = d1225
-							ps3434.OverlayValues[1226] = d1226
-							ps3434.OverlayValues[1227] = d1227
-							ps3434.OverlayValues[1228] = d1228
-							ps3434.OverlayValues[1229] = d1229
-							ps3434.OverlayValues[1230] = d1230
-							ps3434.OverlayValues[1231] = d1231
-							ps3434.OverlayValues[1232] = d1232
-							ps3434.OverlayValues[1233] = d1233
-							ps3434.OverlayValues[1234] = d1234
-							ps3434.OverlayValues[1236] = d1236
-							ps3434.OverlayValues[1238] = d1238
-							ps3434.OverlayValues[1392] = d1392
-							ps3434.OverlayValues[1395] = d1395
-							ps3434.OverlayValues[1551] = d1551
-							ps3434.OverlayValues[1552] = d1552
-							ps3434.OverlayValues[1553] = d1553
-							ps3434.OverlayValues[1554] = d1554
-							ps3434.OverlayValues[1877] = d1877
-							ps3434.OverlayValues[1878] = d1878
-							ps3434.OverlayValues[1879] = d1879
-							ps3434.OverlayValues[1880] = d1880
-							ps3434.OverlayValues[1881] = d1881
-							ps3434.OverlayValues[1882] = d1882
-							ps3434.OverlayValues[1883] = d1883
-							ps3434.OverlayValues[1884] = d1884
-							ps3434.OverlayValues[1885] = d1885
-							ps3434.OverlayValues[1886] = d1886
-							ps3434.OverlayValues[1887] = d1887
-							ps3434.OverlayValues[1888] = d1888
-							ps3434.OverlayValues[1889] = d1889
-							ps3434.OverlayValues[1890] = d1890
-							ps3434.OverlayValues[1892] = d1892
-							ps3434.OverlayValues[1894] = d1894
-							ps3434.OverlayValues[2070] = d2070
-							ps3434.OverlayValues[2073] = d2073
-							ps3434.OverlayValues[2251] = d2251
-							ps3434.OverlayValues[2252] = d2252
-							ps3434.OverlayValues[2253] = d2253
-							ps3434.OverlayValues[2254] = d2254
-							ps3434.OverlayValues[2621] = d2621
-							ps3434.OverlayValues[2623] = d2623
-							ps3434.OverlayValues[2624] = d2624
-							ps3434.OverlayValues[2625] = d2625
-							ps3434.OverlayValues[2626] = d2626
-							ps3434.OverlayValues[2627] = d2627
-							ps3434.OverlayValues[2628] = d2628
-							ps3434.OverlayValues[2629] = d2629
-							ps3434.OverlayValues[2630] = d2630
-							ps3434.OverlayValues[2631] = d2631
-							ps3434.OverlayValues[2632] = d2632
-							ps3434.OverlayValues[3021] = d3021
-							ps3434.OverlayValues[3022] = d3022
-							ps3434.OverlayValues[3023] = d3023
-							ps3434.OverlayValues[3024] = d3024
-							ps3434.OverlayValues[3421] = d3421
-							ps3434.OverlayValues[3423] = d3423
-							ps3434.OverlayValues[3424] = d3424
-							ps3434.OverlayValues[3425] = d3425
-							ps3434.OverlayValues[3426] = d3426
-							ps3434.OverlayValues[3428] = d3428
-							ps3434.OverlayValues[3429] = d3429
-							ps3434.OverlayValues[3430] = d3430
-							ps3434.OverlayValues[3431] = d3431
-							ps3434.OverlayValues[3432] = d3432
-							ps3434.OverlayValues[3433] = d3433
-							return bbs[32].RenderPS(ps3434)
+							ps3435 := PhiState{General: ps.General}
+							ps3435.OverlayValues = make([]JITValueDesc, 3435)
+							ps3435.OverlayValues[1] = d1
+							ps3435.OverlayValues[2] = d2
+							ps3435.OverlayValues[3] = d3
+							ps3435.OverlayValues[4] = d4
+							ps3435.OverlayValues[5] = d5
+							ps3435.OverlayValues[6] = d6
+							ps3435.OverlayValues[7] = d7
+							ps3435.OverlayValues[28] = d28
+							ps3435.OverlayValues[29] = d29
+							ps3435.OverlayValues[31] = d31
+							ps3435.OverlayValues[32] = d32
+							ps3435.OverlayValues[33] = d33
+							ps3435.OverlayValues[35] = d35
+							ps3435.OverlayValues[36] = d36
+							ps3435.OverlayValues[37] = d37
+							ps3435.OverlayValues[74] = d74
+							ps3435.OverlayValues[75] = d75
+							ps3435.OverlayValues[76] = d76
+							ps3435.OverlayValues[77] = d77
+							ps3435.OverlayValues[122] = d122
+							ps3435.OverlayValues[123] = d123
+							ps3435.OverlayValues[124] = d124
+							ps3435.OverlayValues[125] = d125
+							ps3435.OverlayValues[126] = d126
+							ps3435.OverlayValues[127] = d127
+							ps3435.OverlayValues[128] = d128
+							ps3435.OverlayValues[129] = d129
+							ps3435.OverlayValues[130] = d130
+							ps3435.OverlayValues[193] = d193
+							ps3435.OverlayValues[258] = d258
+							ps3435.OverlayValues[259] = d259
+							ps3435.OverlayValues[260] = d260
+							ps3435.OverlayValues[261] = d261
+							ps3435.OverlayValues[262] = d262
+							ps3435.OverlayValues[263] = d263
+							ps3435.OverlayValues[264] = d264
+							ps3435.OverlayValues[265] = d265
+							ps3435.OverlayValues[266] = d266
+							ps3435.OverlayValues[267] = d267
+							ps3435.OverlayValues[268] = d268
+							ps3435.OverlayValues[269] = d269
+							ps3435.OverlayValues[270] = d270
+							ps3435.OverlayValues[271] = d271
+							ps3435.OverlayValues[272] = d272
+							ps3435.OverlayValues[273] = d273
+							ps3435.OverlayValues[370] = d370
+							ps3435.OverlayValues[371] = d371
+							ps3435.OverlayValues[372] = d372
+							ps3435.OverlayValues[373] = d373
+							ps3435.OverlayValues[374] = d374
+							ps3435.OverlayValues[375] = d375
+							ps3435.OverlayValues[376] = d376
+							ps3435.OverlayValues[377] = d377
+							ps3435.OverlayValues[378] = d378
+							ps3435.OverlayValues[379] = d379
+							ps3435.OverlayValues[380] = d380
+							ps3435.OverlayValues[381] = d381
+							ps3435.OverlayValues[382] = d382
+							ps3435.OverlayValues[505] = d505
+							ps3435.OverlayValues[506] = d506
+							ps3435.OverlayValues[507] = d507
+							ps3435.OverlayValues[508] = d508
+							ps3435.OverlayValues[509] = d509
+							ps3435.OverlayValues[510] = d510
+							ps3435.OverlayValues[511] = d511
+							ps3435.OverlayValues[512] = d512
+							ps3435.OverlayValues[513] = d513
+							ps3435.OverlayValues[514] = d514
+							ps3435.OverlayValues[515] = d515
+							ps3435.OverlayValues[516] = d516
+							ps3435.OverlayValues[517] = d517
+							ps3435.OverlayValues[666] = d666
+							ps3435.OverlayValues[667] = d667
+							ps3435.OverlayValues[668] = d668
+							ps3435.OverlayValues[669] = d669
+							ps3435.OverlayValues[670] = d670
+							ps3435.OverlayValues[671] = d671
+							ps3435.OverlayValues[672] = d672
+							ps3435.OverlayValues[673] = d673
+							ps3435.OverlayValues[674] = d674
+							ps3435.OverlayValues[675] = d675
+							ps3435.OverlayValues[676] = d676
+							ps3435.OverlayValues[677] = d677
+							ps3435.OverlayValues[678] = d678
+							ps3435.OverlayValues[679] = d679
+							ps3435.OverlayValues[680] = d680
+							ps3435.OverlayValues[681] = d681
+							ps3435.OverlayValues[682] = d682
+							ps3435.OverlayValues[683] = d683
+							ps3435.OverlayValues[684] = d684
+							ps3435.OverlayValues[685] = d685
+							ps3435.OverlayValues[686] = d686
+							ps3435.OverlayValues[687] = d687
+							ps3435.OverlayValues[688] = d688
+							ps3435.OverlayValues[689] = d689
+							ps3435.OverlayValues[690] = d690
+							ps3435.OverlayValues[691] = d691
+							ps3435.OverlayValues[692] = d692
+							ps3435.OverlayValues[693] = d693
+							ps3435.OverlayValues[694] = d694
+							ps3435.OverlayValues[695] = d695
+							ps3435.OverlayValues[696] = d696
+							ps3435.OverlayValues[697] = d697
+							ps3435.OverlayValues[910] = d910
+							ps3435.OverlayValues[911] = d911
+							ps3435.OverlayValues[912] = d912
+							ps3435.OverlayValues[913] = d913
+							ps3435.OverlayValues[914] = d914
+							ps3435.OverlayValues[915] = d915
+							ps3435.OverlayValues[916] = d916
+							ps3435.OverlayValues[917] = d917
+							ps3435.OverlayValues[918] = d918
+							ps3435.OverlayValues[919] = d919
+							ps3435.OverlayValues[920] = d920
+							ps3435.OverlayValues[921] = d921
+							ps3435.OverlayValues[922] = d922
+							ps3435.OverlayValues[923] = d923
+							ps3435.OverlayValues[924] = d924
+							ps3435.OverlayValues[925] = d925
+							ps3435.OverlayValues[926] = d926
+							ps3435.OverlayValues[927] = d927
+							ps3435.OverlayValues[928] = d928
+							ps3435.OverlayValues[929] = d929
+							ps3435.OverlayValues[930] = d930
+							ps3435.OverlayValues[931] = d931
+							ps3435.OverlayValues[932] = d932
+							ps3435.OverlayValues[933] = d933
+							ps3435.OverlayValues[934] = d934
+							ps3435.OverlayValues[935] = d935
+							ps3435.OverlayValues[936] = d936
+							ps3435.OverlayValues[937] = d937
+							ps3435.OverlayValues[938] = d938
+							ps3435.OverlayValues[939] = d939
+							ps3435.OverlayValues[940] = d940
+							ps3435.OverlayValues[941] = d941
+							ps3435.OverlayValues[942] = d942
+							ps3435.OverlayValues[1221] = d1221
+							ps3435.OverlayValues[1222] = d1222
+							ps3435.OverlayValues[1223] = d1223
+							ps3435.OverlayValues[1224] = d1224
+							ps3435.OverlayValues[1225] = d1225
+							ps3435.OverlayValues[1226] = d1226
+							ps3435.OverlayValues[1227] = d1227
+							ps3435.OverlayValues[1228] = d1228
+							ps3435.OverlayValues[1229] = d1229
+							ps3435.OverlayValues[1230] = d1230
+							ps3435.OverlayValues[1231] = d1231
+							ps3435.OverlayValues[1232] = d1232
+							ps3435.OverlayValues[1233] = d1233
+							ps3435.OverlayValues[1234] = d1234
+							ps3435.OverlayValues[1236] = d1236
+							ps3435.OverlayValues[1238] = d1238
+							ps3435.OverlayValues[1392] = d1392
+							ps3435.OverlayValues[1395] = d1395
+							ps3435.OverlayValues[1551] = d1551
+							ps3435.OverlayValues[1552] = d1552
+							ps3435.OverlayValues[1553] = d1553
+							ps3435.OverlayValues[1554] = d1554
+							ps3435.OverlayValues[1877] = d1877
+							ps3435.OverlayValues[1878] = d1878
+							ps3435.OverlayValues[1879] = d1879
+							ps3435.OverlayValues[1880] = d1880
+							ps3435.OverlayValues[1881] = d1881
+							ps3435.OverlayValues[1882] = d1882
+							ps3435.OverlayValues[1883] = d1883
+							ps3435.OverlayValues[1884] = d1884
+							ps3435.OverlayValues[1885] = d1885
+							ps3435.OverlayValues[1886] = d1886
+							ps3435.OverlayValues[1887] = d1887
+							ps3435.OverlayValues[1888] = d1888
+							ps3435.OverlayValues[1889] = d1889
+							ps3435.OverlayValues[1890] = d1890
+							ps3435.OverlayValues[1892] = d1892
+							ps3435.OverlayValues[1894] = d1894
+							ps3435.OverlayValues[2070] = d2070
+							ps3435.OverlayValues[2073] = d2073
+							ps3435.OverlayValues[2251] = d2251
+							ps3435.OverlayValues[2252] = d2252
+							ps3435.OverlayValues[2253] = d2253
+							ps3435.OverlayValues[2254] = d2254
+							ps3435.OverlayValues[2621] = d2621
+							ps3435.OverlayValues[2623] = d2623
+							ps3435.OverlayValues[2624] = d2624
+							ps3435.OverlayValues[2625] = d2625
+							ps3435.OverlayValues[2626] = d2626
+							ps3435.OverlayValues[2627] = d2627
+							ps3435.OverlayValues[2628] = d2628
+							ps3435.OverlayValues[2629] = d2629
+							ps3435.OverlayValues[2630] = d2630
+							ps3435.OverlayValues[2631] = d2631
+							ps3435.OverlayValues[2632] = d2632
+							ps3435.OverlayValues[3021] = d3021
+							ps3435.OverlayValues[3022] = d3022
+							ps3435.OverlayValues[3023] = d3023
+							ps3435.OverlayValues[3024] = d3024
+							ps3435.OverlayValues[3421] = d3421
+							ps3435.OverlayValues[3423] = d3423
+							ps3435.OverlayValues[3425] = d3425
+							ps3435.OverlayValues[3426] = d3426
+							ps3435.OverlayValues[3427] = d3427
+							ps3435.OverlayValues[3429] = d3429
+							ps3435.OverlayValues[3430] = d3430
+							ps3435.OverlayValues[3431] = d3431
+							ps3435.OverlayValues[3432] = d3432
+							ps3435.OverlayValues[3433] = d3433
+							ps3435.OverlayValues[3434] = d3434
+							return bbs[32].RenderPS(ps3435)
 						}
 						if ps.General {
 							ctx.SyncDesc(&d2627)
-							if d2627.Loc == LocReg {
+							if d2627.Loc == LocReg || d2627.Loc == LocFPReg {
 								ctx.ProtectReg(d2627.Reg)
 							} else if d2627.Loc == LocRegPair {
 								ctx.ProtectReg(d2627.Reg)
 								ctx.ProtectReg(d2627.Reg2)
 							}
-							d3435 = d2627
-							if d3435.Loc == LocNone {
+							d3436 = d2627
+							if d3436.Loc == LocNone {
 								panic("jit: phi source has no location")
 							}
-							ctx.EnsureDesc(&d3435)
-							ctx.EmitStoreToStack(d3435, int32(bbs[30].PhiBase)+int32(0))
-							if d2627.Loc == LocReg {
+							ctx.EnsureDesc(&d3436)
+							ctx.EmitStoreToStack(d3436, int32(bbs[30].PhiBase)+int32(0))
+							if d2627.Loc == LocReg || d2627.Loc == LocFPReg {
 								ctx.UnprotectReg(d2627.Reg)
 							} else if d2627.Loc == LocRegPair {
 								ctx.UnprotectReg(d2627.Reg)
 								ctx.UnprotectReg(d2627.Reg2)
 							}
 						}
-						ps3436 := PhiState{General: ps.General}
-						ps3436.OverlayValues = make([]JITValueDesc, 3436)
-						ps3436.OverlayValues[1] = d1
-						ps3436.OverlayValues[2] = d2
-						ps3436.OverlayValues[3] = d3
-						ps3436.OverlayValues[4] = d4
-						ps3436.OverlayValues[5] = d5
-						ps3436.OverlayValues[6] = d6
-						ps3436.OverlayValues[7] = d7
-						ps3436.OverlayValues[28] = d28
-						ps3436.OverlayValues[29] = d29
-						ps3436.OverlayValues[31] = d31
-						ps3436.OverlayValues[32] = d32
-						ps3436.OverlayValues[33] = d33
-						ps3436.OverlayValues[35] = d35
-						ps3436.OverlayValues[36] = d36
-						ps3436.OverlayValues[37] = d37
-						ps3436.OverlayValues[74] = d74
-						ps3436.OverlayValues[75] = d75
-						ps3436.OverlayValues[76] = d76
-						ps3436.OverlayValues[77] = d77
-						ps3436.OverlayValues[122] = d122
-						ps3436.OverlayValues[123] = d123
-						ps3436.OverlayValues[124] = d124
-						ps3436.OverlayValues[125] = d125
-						ps3436.OverlayValues[126] = d126
-						ps3436.OverlayValues[127] = d127
-						ps3436.OverlayValues[128] = d128
-						ps3436.OverlayValues[129] = d129
-						ps3436.OverlayValues[130] = d130
-						ps3436.OverlayValues[193] = d193
-						ps3436.OverlayValues[258] = d258
-						ps3436.OverlayValues[259] = d259
-						ps3436.OverlayValues[260] = d260
-						ps3436.OverlayValues[261] = d261
-						ps3436.OverlayValues[262] = d262
-						ps3436.OverlayValues[263] = d263
-						ps3436.OverlayValues[264] = d264
-						ps3436.OverlayValues[265] = d265
-						ps3436.OverlayValues[266] = d266
-						ps3436.OverlayValues[267] = d267
-						ps3436.OverlayValues[268] = d268
-						ps3436.OverlayValues[269] = d269
-						ps3436.OverlayValues[270] = d270
-						ps3436.OverlayValues[271] = d271
-						ps3436.OverlayValues[272] = d272
-						ps3436.OverlayValues[273] = d273
-						ps3436.OverlayValues[370] = d370
-						ps3436.OverlayValues[371] = d371
-						ps3436.OverlayValues[372] = d372
-						ps3436.OverlayValues[373] = d373
-						ps3436.OverlayValues[374] = d374
-						ps3436.OverlayValues[375] = d375
-						ps3436.OverlayValues[376] = d376
-						ps3436.OverlayValues[377] = d377
-						ps3436.OverlayValues[378] = d378
-						ps3436.OverlayValues[379] = d379
-						ps3436.OverlayValues[380] = d380
-						ps3436.OverlayValues[381] = d381
-						ps3436.OverlayValues[382] = d382
-						ps3436.OverlayValues[505] = d505
-						ps3436.OverlayValues[506] = d506
-						ps3436.OverlayValues[507] = d507
-						ps3436.OverlayValues[508] = d508
-						ps3436.OverlayValues[509] = d509
-						ps3436.OverlayValues[510] = d510
-						ps3436.OverlayValues[511] = d511
-						ps3436.OverlayValues[512] = d512
-						ps3436.OverlayValues[513] = d513
-						ps3436.OverlayValues[514] = d514
-						ps3436.OverlayValues[515] = d515
-						ps3436.OverlayValues[516] = d516
-						ps3436.OverlayValues[517] = d517
-						ps3436.OverlayValues[666] = d666
-						ps3436.OverlayValues[667] = d667
-						ps3436.OverlayValues[668] = d668
-						ps3436.OverlayValues[669] = d669
-						ps3436.OverlayValues[670] = d670
-						ps3436.OverlayValues[671] = d671
-						ps3436.OverlayValues[672] = d672
-						ps3436.OverlayValues[673] = d673
-						ps3436.OverlayValues[674] = d674
-						ps3436.OverlayValues[675] = d675
-						ps3436.OverlayValues[676] = d676
-						ps3436.OverlayValues[677] = d677
-						ps3436.OverlayValues[678] = d678
-						ps3436.OverlayValues[679] = d679
-						ps3436.OverlayValues[680] = d680
-						ps3436.OverlayValues[681] = d681
-						ps3436.OverlayValues[682] = d682
-						ps3436.OverlayValues[683] = d683
-						ps3436.OverlayValues[684] = d684
-						ps3436.OverlayValues[685] = d685
-						ps3436.OverlayValues[686] = d686
-						ps3436.OverlayValues[687] = d687
-						ps3436.OverlayValues[688] = d688
-						ps3436.OverlayValues[689] = d689
-						ps3436.OverlayValues[690] = d690
-						ps3436.OverlayValues[691] = d691
-						ps3436.OverlayValues[692] = d692
-						ps3436.OverlayValues[693] = d693
-						ps3436.OverlayValues[694] = d694
-						ps3436.OverlayValues[695] = d695
-						ps3436.OverlayValues[696] = d696
-						ps3436.OverlayValues[697] = d697
-						ps3436.OverlayValues[910] = d910
-						ps3436.OverlayValues[911] = d911
-						ps3436.OverlayValues[912] = d912
-						ps3436.OverlayValues[913] = d913
-						ps3436.OverlayValues[914] = d914
-						ps3436.OverlayValues[915] = d915
-						ps3436.OverlayValues[916] = d916
-						ps3436.OverlayValues[917] = d917
-						ps3436.OverlayValues[918] = d918
-						ps3436.OverlayValues[919] = d919
-						ps3436.OverlayValues[920] = d920
-						ps3436.OverlayValues[921] = d921
-						ps3436.OverlayValues[922] = d922
-						ps3436.OverlayValues[923] = d923
-						ps3436.OverlayValues[924] = d924
-						ps3436.OverlayValues[925] = d925
-						ps3436.OverlayValues[926] = d926
-						ps3436.OverlayValues[927] = d927
-						ps3436.OverlayValues[928] = d928
-						ps3436.OverlayValues[929] = d929
-						ps3436.OverlayValues[930] = d930
-						ps3436.OverlayValues[931] = d931
-						ps3436.OverlayValues[932] = d932
-						ps3436.OverlayValues[933] = d933
-						ps3436.OverlayValues[934] = d934
-						ps3436.OverlayValues[935] = d935
-						ps3436.OverlayValues[936] = d936
-						ps3436.OverlayValues[937] = d937
-						ps3436.OverlayValues[938] = d938
-						ps3436.OverlayValues[939] = d939
-						ps3436.OverlayValues[940] = d940
-						ps3436.OverlayValues[941] = d941
-						ps3436.OverlayValues[942] = d942
-						ps3436.OverlayValues[1221] = d1221
-						ps3436.OverlayValues[1222] = d1222
-						ps3436.OverlayValues[1223] = d1223
-						ps3436.OverlayValues[1224] = d1224
-						ps3436.OverlayValues[1225] = d1225
-						ps3436.OverlayValues[1226] = d1226
-						ps3436.OverlayValues[1227] = d1227
-						ps3436.OverlayValues[1228] = d1228
-						ps3436.OverlayValues[1229] = d1229
-						ps3436.OverlayValues[1230] = d1230
-						ps3436.OverlayValues[1231] = d1231
-						ps3436.OverlayValues[1232] = d1232
-						ps3436.OverlayValues[1233] = d1233
-						ps3436.OverlayValues[1234] = d1234
-						ps3436.OverlayValues[1236] = d1236
-						ps3436.OverlayValues[1238] = d1238
-						ps3436.OverlayValues[1392] = d1392
-						ps3436.OverlayValues[1395] = d1395
-						ps3436.OverlayValues[1551] = d1551
-						ps3436.OverlayValues[1552] = d1552
-						ps3436.OverlayValues[1553] = d1553
-						ps3436.OverlayValues[1554] = d1554
-						ps3436.OverlayValues[1877] = d1877
-						ps3436.OverlayValues[1878] = d1878
-						ps3436.OverlayValues[1879] = d1879
-						ps3436.OverlayValues[1880] = d1880
-						ps3436.OverlayValues[1881] = d1881
-						ps3436.OverlayValues[1882] = d1882
-						ps3436.OverlayValues[1883] = d1883
-						ps3436.OverlayValues[1884] = d1884
-						ps3436.OverlayValues[1885] = d1885
-						ps3436.OverlayValues[1886] = d1886
-						ps3436.OverlayValues[1887] = d1887
-						ps3436.OverlayValues[1888] = d1888
-						ps3436.OverlayValues[1889] = d1889
-						ps3436.OverlayValues[1890] = d1890
-						ps3436.OverlayValues[1892] = d1892
-						ps3436.OverlayValues[1894] = d1894
-						ps3436.OverlayValues[2070] = d2070
-						ps3436.OverlayValues[2073] = d2073
-						ps3436.OverlayValues[2251] = d2251
-						ps3436.OverlayValues[2252] = d2252
-						ps3436.OverlayValues[2253] = d2253
-						ps3436.OverlayValues[2254] = d2254
-						ps3436.OverlayValues[2621] = d2621
-						ps3436.OverlayValues[2623] = d2623
-						ps3436.OverlayValues[2624] = d2624
-						ps3436.OverlayValues[2625] = d2625
-						ps3436.OverlayValues[2626] = d2626
-						ps3436.OverlayValues[2627] = d2627
-						ps3436.OverlayValues[2628] = d2628
-						ps3436.OverlayValues[2629] = d2629
-						ps3436.OverlayValues[2630] = d2630
-						ps3436.OverlayValues[2631] = d2631
-						ps3436.OverlayValues[2632] = d2632
-						ps3436.OverlayValues[3021] = d3021
-						ps3436.OverlayValues[3022] = d3022
-						ps3436.OverlayValues[3023] = d3023
-						ps3436.OverlayValues[3024] = d3024
-						ps3436.OverlayValues[3421] = d3421
-						ps3436.OverlayValues[3423] = d3423
-						ps3436.OverlayValues[3424] = d3424
-						ps3436.OverlayValues[3425] = d3425
-						ps3436.OverlayValues[3426] = d3426
-						ps3436.OverlayValues[3428] = d3428
-						ps3436.OverlayValues[3429] = d3429
-						ps3436.OverlayValues[3430] = d3430
-						ps3436.OverlayValues[3431] = d3431
-						ps3436.OverlayValues[3432] = d3432
-						ps3436.OverlayValues[3433] = d3433
-						ps3436.OverlayValues[3435] = d3435
-						ps3436.PhiValues = make([]JITValueDesc, 1)
-						d3437 = d2627
-						ps3436.PhiValues[0] = d3437
-						return bbs[30].RenderPS(ps3436)
+						ps3437 := PhiState{General: ps.General}
+						ps3437.OverlayValues = make([]JITValueDesc, 3437)
+						ps3437.OverlayValues[1] = d1
+						ps3437.OverlayValues[2] = d2
+						ps3437.OverlayValues[3] = d3
+						ps3437.OverlayValues[4] = d4
+						ps3437.OverlayValues[5] = d5
+						ps3437.OverlayValues[6] = d6
+						ps3437.OverlayValues[7] = d7
+						ps3437.OverlayValues[28] = d28
+						ps3437.OverlayValues[29] = d29
+						ps3437.OverlayValues[31] = d31
+						ps3437.OverlayValues[32] = d32
+						ps3437.OverlayValues[33] = d33
+						ps3437.OverlayValues[35] = d35
+						ps3437.OverlayValues[36] = d36
+						ps3437.OverlayValues[37] = d37
+						ps3437.OverlayValues[74] = d74
+						ps3437.OverlayValues[75] = d75
+						ps3437.OverlayValues[76] = d76
+						ps3437.OverlayValues[77] = d77
+						ps3437.OverlayValues[122] = d122
+						ps3437.OverlayValues[123] = d123
+						ps3437.OverlayValues[124] = d124
+						ps3437.OverlayValues[125] = d125
+						ps3437.OverlayValues[126] = d126
+						ps3437.OverlayValues[127] = d127
+						ps3437.OverlayValues[128] = d128
+						ps3437.OverlayValues[129] = d129
+						ps3437.OverlayValues[130] = d130
+						ps3437.OverlayValues[193] = d193
+						ps3437.OverlayValues[258] = d258
+						ps3437.OverlayValues[259] = d259
+						ps3437.OverlayValues[260] = d260
+						ps3437.OverlayValues[261] = d261
+						ps3437.OverlayValues[262] = d262
+						ps3437.OverlayValues[263] = d263
+						ps3437.OverlayValues[264] = d264
+						ps3437.OverlayValues[265] = d265
+						ps3437.OverlayValues[266] = d266
+						ps3437.OverlayValues[267] = d267
+						ps3437.OverlayValues[268] = d268
+						ps3437.OverlayValues[269] = d269
+						ps3437.OverlayValues[270] = d270
+						ps3437.OverlayValues[271] = d271
+						ps3437.OverlayValues[272] = d272
+						ps3437.OverlayValues[273] = d273
+						ps3437.OverlayValues[370] = d370
+						ps3437.OverlayValues[371] = d371
+						ps3437.OverlayValues[372] = d372
+						ps3437.OverlayValues[373] = d373
+						ps3437.OverlayValues[374] = d374
+						ps3437.OverlayValues[375] = d375
+						ps3437.OverlayValues[376] = d376
+						ps3437.OverlayValues[377] = d377
+						ps3437.OverlayValues[378] = d378
+						ps3437.OverlayValues[379] = d379
+						ps3437.OverlayValues[380] = d380
+						ps3437.OverlayValues[381] = d381
+						ps3437.OverlayValues[382] = d382
+						ps3437.OverlayValues[505] = d505
+						ps3437.OverlayValues[506] = d506
+						ps3437.OverlayValues[507] = d507
+						ps3437.OverlayValues[508] = d508
+						ps3437.OverlayValues[509] = d509
+						ps3437.OverlayValues[510] = d510
+						ps3437.OverlayValues[511] = d511
+						ps3437.OverlayValues[512] = d512
+						ps3437.OverlayValues[513] = d513
+						ps3437.OverlayValues[514] = d514
+						ps3437.OverlayValues[515] = d515
+						ps3437.OverlayValues[516] = d516
+						ps3437.OverlayValues[517] = d517
+						ps3437.OverlayValues[666] = d666
+						ps3437.OverlayValues[667] = d667
+						ps3437.OverlayValues[668] = d668
+						ps3437.OverlayValues[669] = d669
+						ps3437.OverlayValues[670] = d670
+						ps3437.OverlayValues[671] = d671
+						ps3437.OverlayValues[672] = d672
+						ps3437.OverlayValues[673] = d673
+						ps3437.OverlayValues[674] = d674
+						ps3437.OverlayValues[675] = d675
+						ps3437.OverlayValues[676] = d676
+						ps3437.OverlayValues[677] = d677
+						ps3437.OverlayValues[678] = d678
+						ps3437.OverlayValues[679] = d679
+						ps3437.OverlayValues[680] = d680
+						ps3437.OverlayValues[681] = d681
+						ps3437.OverlayValues[682] = d682
+						ps3437.OverlayValues[683] = d683
+						ps3437.OverlayValues[684] = d684
+						ps3437.OverlayValues[685] = d685
+						ps3437.OverlayValues[686] = d686
+						ps3437.OverlayValues[687] = d687
+						ps3437.OverlayValues[688] = d688
+						ps3437.OverlayValues[689] = d689
+						ps3437.OverlayValues[690] = d690
+						ps3437.OverlayValues[691] = d691
+						ps3437.OverlayValues[692] = d692
+						ps3437.OverlayValues[693] = d693
+						ps3437.OverlayValues[694] = d694
+						ps3437.OverlayValues[695] = d695
+						ps3437.OverlayValues[696] = d696
+						ps3437.OverlayValues[697] = d697
+						ps3437.OverlayValues[910] = d910
+						ps3437.OverlayValues[911] = d911
+						ps3437.OverlayValues[912] = d912
+						ps3437.OverlayValues[913] = d913
+						ps3437.OverlayValues[914] = d914
+						ps3437.OverlayValues[915] = d915
+						ps3437.OverlayValues[916] = d916
+						ps3437.OverlayValues[917] = d917
+						ps3437.OverlayValues[918] = d918
+						ps3437.OverlayValues[919] = d919
+						ps3437.OverlayValues[920] = d920
+						ps3437.OverlayValues[921] = d921
+						ps3437.OverlayValues[922] = d922
+						ps3437.OverlayValues[923] = d923
+						ps3437.OverlayValues[924] = d924
+						ps3437.OverlayValues[925] = d925
+						ps3437.OverlayValues[926] = d926
+						ps3437.OverlayValues[927] = d927
+						ps3437.OverlayValues[928] = d928
+						ps3437.OverlayValues[929] = d929
+						ps3437.OverlayValues[930] = d930
+						ps3437.OverlayValues[931] = d931
+						ps3437.OverlayValues[932] = d932
+						ps3437.OverlayValues[933] = d933
+						ps3437.OverlayValues[934] = d934
+						ps3437.OverlayValues[935] = d935
+						ps3437.OverlayValues[936] = d936
+						ps3437.OverlayValues[937] = d937
+						ps3437.OverlayValues[938] = d938
+						ps3437.OverlayValues[939] = d939
+						ps3437.OverlayValues[940] = d940
+						ps3437.OverlayValues[941] = d941
+						ps3437.OverlayValues[942] = d942
+						ps3437.OverlayValues[1221] = d1221
+						ps3437.OverlayValues[1222] = d1222
+						ps3437.OverlayValues[1223] = d1223
+						ps3437.OverlayValues[1224] = d1224
+						ps3437.OverlayValues[1225] = d1225
+						ps3437.OverlayValues[1226] = d1226
+						ps3437.OverlayValues[1227] = d1227
+						ps3437.OverlayValues[1228] = d1228
+						ps3437.OverlayValues[1229] = d1229
+						ps3437.OverlayValues[1230] = d1230
+						ps3437.OverlayValues[1231] = d1231
+						ps3437.OverlayValues[1232] = d1232
+						ps3437.OverlayValues[1233] = d1233
+						ps3437.OverlayValues[1234] = d1234
+						ps3437.OverlayValues[1236] = d1236
+						ps3437.OverlayValues[1238] = d1238
+						ps3437.OverlayValues[1392] = d1392
+						ps3437.OverlayValues[1395] = d1395
+						ps3437.OverlayValues[1551] = d1551
+						ps3437.OverlayValues[1552] = d1552
+						ps3437.OverlayValues[1553] = d1553
+						ps3437.OverlayValues[1554] = d1554
+						ps3437.OverlayValues[1877] = d1877
+						ps3437.OverlayValues[1878] = d1878
+						ps3437.OverlayValues[1879] = d1879
+						ps3437.OverlayValues[1880] = d1880
+						ps3437.OverlayValues[1881] = d1881
+						ps3437.OverlayValues[1882] = d1882
+						ps3437.OverlayValues[1883] = d1883
+						ps3437.OverlayValues[1884] = d1884
+						ps3437.OverlayValues[1885] = d1885
+						ps3437.OverlayValues[1886] = d1886
+						ps3437.OverlayValues[1887] = d1887
+						ps3437.OverlayValues[1888] = d1888
+						ps3437.OverlayValues[1889] = d1889
+						ps3437.OverlayValues[1890] = d1890
+						ps3437.OverlayValues[1892] = d1892
+						ps3437.OverlayValues[1894] = d1894
+						ps3437.OverlayValues[2070] = d2070
+						ps3437.OverlayValues[2073] = d2073
+						ps3437.OverlayValues[2251] = d2251
+						ps3437.OverlayValues[2252] = d2252
+						ps3437.OverlayValues[2253] = d2253
+						ps3437.OverlayValues[2254] = d2254
+						ps3437.OverlayValues[2621] = d2621
+						ps3437.OverlayValues[2623] = d2623
+						ps3437.OverlayValues[2624] = d2624
+						ps3437.OverlayValues[2625] = d2625
+						ps3437.OverlayValues[2626] = d2626
+						ps3437.OverlayValues[2627] = d2627
+						ps3437.OverlayValues[2628] = d2628
+						ps3437.OverlayValues[2629] = d2629
+						ps3437.OverlayValues[2630] = d2630
+						ps3437.OverlayValues[2631] = d2631
+						ps3437.OverlayValues[2632] = d2632
+						ps3437.OverlayValues[3021] = d3021
+						ps3437.OverlayValues[3022] = d3022
+						ps3437.OverlayValues[3023] = d3023
+						ps3437.OverlayValues[3024] = d3024
+						ps3437.OverlayValues[3421] = d3421
+						ps3437.OverlayValues[3423] = d3423
+						ps3437.OverlayValues[3425] = d3425
+						ps3437.OverlayValues[3426] = d3426
+						ps3437.OverlayValues[3427] = d3427
+						ps3437.OverlayValues[3429] = d3429
+						ps3437.OverlayValues[3430] = d3430
+						ps3437.OverlayValues[3431] = d3431
+						ps3437.OverlayValues[3432] = d3432
+						ps3437.OverlayValues[3433] = d3433
+						ps3437.OverlayValues[3434] = d3434
+						ps3437.OverlayValues[3436] = d3436
+						ps3437.PhiValues = make([]JITValueDesc, 1)
+						d3438 = d2627
+						ps3437.PhiValues[0] = d3438
+						return bbs[30].RenderPS(ps3437)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[31].RenderPS(ps)
 					}
 					lbl42 := ctx.ReserveLabel()
-					ctx.EmitJump(d3433.Condition, lbl33)
+					ctx.EmitJump(d3434.Condition, lbl33)
 					ctx.EmitJmp(lbl42)
-					ctx.FreeDesc(&d3432)
-					snap3438 := d1
-					snap3439 := d2
-					snap3440 := d3
-					snap3441 := d4
-					snap3442 := d5
-					snap3443 := d6
-					snap3444 := d7
-					snap3445 := d28
-					snap3446 := d29
-					snap3447 := d31
-					snap3448 := d32
-					snap3449 := d33
-					snap3450 := d35
-					snap3451 := d36
-					snap3452 := d37
-					snap3453 := d74
-					snap3454 := d75
-					snap3455 := d76
-					snap3456 := d77
-					snap3457 := d122
-					snap3458 := d123
-					snap3459 := d124
-					snap3460 := d125
-					snap3461 := d126
-					snap3462 := d127
-					snap3463 := d128
-					snap3464 := d129
-					snap3465 := d130
-					snap3466 := d193
-					snap3467 := d258
-					snap3468 := d259
-					snap3469 := d260
-					snap3470 := d261
-					snap3471 := d262
-					snap3472 := d263
-					snap3473 := d264
-					snap3474 := d265
-					snap3475 := d266
-					snap3476 := d267
-					snap3477 := d268
-					snap3478 := d269
-					snap3479 := d270
-					snap3480 := d271
-					snap3481 := d272
-					snap3482 := d273
-					snap3483 := d370
-					snap3484 := d371
-					snap3485 := d372
-					snap3486 := d373
-					snap3487 := d374
-					snap3488 := d375
-					snap3489 := d376
-					snap3490 := d377
-					snap3491 := d378
-					snap3492 := d379
-					snap3493 := d380
-					snap3494 := d381
-					snap3495 := d382
-					snap3496 := d505
-					snap3497 := d506
-					snap3498 := d507
-					snap3499 := d508
-					snap3500 := d509
-					snap3501 := d510
-					snap3502 := d511
-					snap3503 := d512
-					snap3504 := d513
-					snap3505 := d514
-					snap3506 := d515
-					snap3507 := d516
-					snap3508 := d517
-					snap3509 := d666
-					snap3510 := d667
-					snap3511 := d668
-					snap3512 := d669
-					snap3513 := d670
-					snap3514 := d671
-					snap3515 := d672
-					snap3516 := d673
-					snap3517 := d674
-					snap3518 := d675
-					snap3519 := d676
-					snap3520 := d677
-					snap3521 := d678
-					snap3522 := d679
-					snap3523 := d680
-					snap3524 := d681
-					snap3525 := d682
-					snap3526 := d683
-					snap3527 := d684
-					snap3528 := d685
-					snap3529 := d686
-					snap3530 := d687
-					snap3531 := d688
-					snap3532 := d689
-					snap3533 := d690
-					snap3534 := d691
-					snap3535 := d692
-					snap3536 := d693
-					snap3537 := d694
-					snap3538 := d695
-					snap3539 := d696
-					snap3540 := d697
-					snap3541 := d910
-					snap3542 := d911
-					snap3543 := d912
-					snap3544 := d913
-					snap3545 := d914
-					snap3546 := d915
-					snap3547 := d916
-					snap3548 := d917
-					snap3549 := d918
-					snap3550 := d919
-					snap3551 := d920
-					snap3552 := d921
-					snap3553 := d922
-					snap3554 := d923
-					snap3555 := d924
-					snap3556 := d925
-					snap3557 := d926
-					snap3558 := d927
-					snap3559 := d928
-					snap3560 := d929
-					snap3561 := d930
-					snap3562 := d931
-					snap3563 := d932
-					snap3564 := d933
-					snap3565 := d934
-					snap3566 := d935
-					snap3567 := d936
-					snap3568 := d937
-					snap3569 := d938
-					snap3570 := d939
-					snap3571 := d940
-					snap3572 := d941
-					snap3573 := d942
-					snap3574 := d1221
-					snap3575 := d1222
-					snap3576 := d1223
-					snap3577 := d1224
-					snap3578 := d1225
-					snap3579 := d1226
-					snap3580 := d1227
-					snap3581 := d1228
-					snap3582 := d1229
-					snap3583 := d1230
-					snap3584 := d1231
-					snap3585 := d1232
-					snap3586 := d1233
-					snap3587 := d1234
-					snap3588 := d1236
-					snap3589 := d1238
-					snap3590 := d1392
-					snap3591 := d1395
-					snap3592 := d1551
-					snap3593 := d1552
-					snap3594 := d1553
-					snap3595 := d1554
-					snap3596 := d1877
-					snap3597 := d1878
-					snap3598 := d1879
-					snap3599 := d1880
-					snap3600 := d1881
-					snap3601 := d1882
-					snap3602 := d1883
-					snap3603 := d1884
-					snap3604 := d1885
-					snap3605 := d1886
-					snap3606 := d1887
-					snap3607 := d1888
-					snap3608 := d1889
-					snap3609 := d1890
-					snap3610 := d1892
-					snap3611 := d1894
-					snap3612 := d2070
-					snap3613 := d2073
-					snap3614 := d2251
-					snap3615 := d2252
-					snap3616 := d2253
-					snap3617 := d2254
-					snap3618 := d2621
-					snap3619 := d2623
-					snap3620 := d2624
-					snap3621 := d2625
-					snap3622 := d2626
-					snap3623 := d2627
-					snap3624 := d2628
-					snap3625 := d2629
-					snap3626 := d2630
-					snap3627 := d2631
-					snap3628 := d2632
-					snap3629 := d3021
-					snap3630 := d3022
-					snap3631 := d3023
-					snap3632 := d3024
-					snap3633 := d3421
-					snap3634 := d3423
-					snap3635 := d3424
+					ctx.FreeDesc(&d3433)
+					snap3439 := d1
+					snap3440 := d2
+					snap3441 := d3
+					snap3442 := d4
+					snap3443 := d5
+					snap3444 := d6
+					snap3445 := d7
+					snap3446 := d28
+					snap3447 := d29
+					snap3448 := d31
+					snap3449 := d32
+					snap3450 := d33
+					snap3451 := d35
+					snap3452 := d36
+					snap3453 := d37
+					snap3454 := d74
+					snap3455 := d75
+					snap3456 := d76
+					snap3457 := d77
+					snap3458 := d122
+					snap3459 := d123
+					snap3460 := d124
+					snap3461 := d125
+					snap3462 := d126
+					snap3463 := d127
+					snap3464 := d128
+					snap3465 := d129
+					snap3466 := d130
+					snap3467 := d193
+					snap3468 := d258
+					snap3469 := d259
+					snap3470 := d260
+					snap3471 := d261
+					snap3472 := d262
+					snap3473 := d263
+					snap3474 := d264
+					snap3475 := d265
+					snap3476 := d266
+					snap3477 := d267
+					snap3478 := d268
+					snap3479 := d269
+					snap3480 := d270
+					snap3481 := d271
+					snap3482 := d272
+					snap3483 := d273
+					snap3484 := d370
+					snap3485 := d371
+					snap3486 := d372
+					snap3487 := d373
+					snap3488 := d374
+					snap3489 := d375
+					snap3490 := d376
+					snap3491 := d377
+					snap3492 := d378
+					snap3493 := d379
+					snap3494 := d380
+					snap3495 := d381
+					snap3496 := d382
+					snap3497 := d505
+					snap3498 := d506
+					snap3499 := d507
+					snap3500 := d508
+					snap3501 := d509
+					snap3502 := d510
+					snap3503 := d511
+					snap3504 := d512
+					snap3505 := d513
+					snap3506 := d514
+					snap3507 := d515
+					snap3508 := d516
+					snap3509 := d517
+					snap3510 := d666
+					snap3511 := d667
+					snap3512 := d668
+					snap3513 := d669
+					snap3514 := d670
+					snap3515 := d671
+					snap3516 := d672
+					snap3517 := d673
+					snap3518 := d674
+					snap3519 := d675
+					snap3520 := d676
+					snap3521 := d677
+					snap3522 := d678
+					snap3523 := d679
+					snap3524 := d680
+					snap3525 := d681
+					snap3526 := d682
+					snap3527 := d683
+					snap3528 := d684
+					snap3529 := d685
+					snap3530 := d686
+					snap3531 := d687
+					snap3532 := d688
+					snap3533 := d689
+					snap3534 := d690
+					snap3535 := d691
+					snap3536 := d692
+					snap3537 := d693
+					snap3538 := d694
+					snap3539 := d695
+					snap3540 := d696
+					snap3541 := d697
+					snap3542 := d910
+					snap3543 := d911
+					snap3544 := d912
+					snap3545 := d913
+					snap3546 := d914
+					snap3547 := d915
+					snap3548 := d916
+					snap3549 := d917
+					snap3550 := d918
+					snap3551 := d919
+					snap3552 := d920
+					snap3553 := d921
+					snap3554 := d922
+					snap3555 := d923
+					snap3556 := d924
+					snap3557 := d925
+					snap3558 := d926
+					snap3559 := d927
+					snap3560 := d928
+					snap3561 := d929
+					snap3562 := d930
+					snap3563 := d931
+					snap3564 := d932
+					snap3565 := d933
+					snap3566 := d934
+					snap3567 := d935
+					snap3568 := d936
+					snap3569 := d937
+					snap3570 := d938
+					snap3571 := d939
+					snap3572 := d940
+					snap3573 := d941
+					snap3574 := d942
+					snap3575 := d1221
+					snap3576 := d1222
+					snap3577 := d1223
+					snap3578 := d1224
+					snap3579 := d1225
+					snap3580 := d1226
+					snap3581 := d1227
+					snap3582 := d1228
+					snap3583 := d1229
+					snap3584 := d1230
+					snap3585 := d1231
+					snap3586 := d1232
+					snap3587 := d1233
+					snap3588 := d1234
+					snap3589 := d1236
+					snap3590 := d1238
+					snap3591 := d1392
+					snap3592 := d1395
+					snap3593 := d1551
+					snap3594 := d1552
+					snap3595 := d1553
+					snap3596 := d1554
+					snap3597 := d1877
+					snap3598 := d1878
+					snap3599 := d1879
+					snap3600 := d1880
+					snap3601 := d1881
+					snap3602 := d1882
+					snap3603 := d1883
+					snap3604 := d1884
+					snap3605 := d1885
+					snap3606 := d1886
+					snap3607 := d1887
+					snap3608 := d1888
+					snap3609 := d1889
+					snap3610 := d1890
+					snap3611 := d1892
+					snap3612 := d1894
+					snap3613 := d2070
+					snap3614 := d2073
+					snap3615 := d2251
+					snap3616 := d2252
+					snap3617 := d2253
+					snap3618 := d2254
+					snap3619 := d2621
+					snap3620 := d2623
+					snap3621 := d2624
+					snap3622 := d2625
+					snap3623 := d2626
+					snap3624 := d2627
+					snap3625 := d2628
+					snap3626 := d2629
+					snap3627 := d2630
+					snap3628 := d2631
+					snap3629 := d2632
+					snap3630 := d3021
+					snap3631 := d3022
+					snap3632 := d3023
+					snap3633 := d3024
+					snap3634 := d3421
+					snap3635 := d3423
 					snap3636 := d3425
 					snap3637 := d3426
-					snap3638 := d3428
+					snap3638 := d3427
 					snap3639 := d3429
 					snap3640 := d3430
 					snap3641 := d3431
 					snap3642 := d3432
 					snap3643 := d3433
-					snap3644 := d3435
-					snap3645 := d3437
-					alloc3646 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc3646)
-					d1 = snap3438
-					d2 = snap3439
-					d3 = snap3440
-					d4 = snap3441
-					d5 = snap3442
-					d6 = snap3443
-					d7 = snap3444
-					d28 = snap3445
-					d29 = snap3446
-					d31 = snap3447
-					d32 = snap3448
-					d33 = snap3449
-					d35 = snap3450
-					d36 = snap3451
-					d37 = snap3452
-					d74 = snap3453
-					d75 = snap3454
-					d76 = snap3455
-					d77 = snap3456
-					d122 = snap3457
-					d123 = snap3458
-					d124 = snap3459
-					d125 = snap3460
-					d126 = snap3461
-					d127 = snap3462
-					d128 = snap3463
-					d129 = snap3464
-					d130 = snap3465
-					d193 = snap3466
-					d258 = snap3467
-					d259 = snap3468
-					d260 = snap3469
-					d261 = snap3470
-					d262 = snap3471
-					d263 = snap3472
-					d264 = snap3473
-					d265 = snap3474
-					d266 = snap3475
-					d267 = snap3476
-					d268 = snap3477
-					d269 = snap3478
-					d270 = snap3479
-					d271 = snap3480
-					d272 = snap3481
-					d273 = snap3482
-					d370 = snap3483
-					d371 = snap3484
-					d372 = snap3485
-					d373 = snap3486
-					d374 = snap3487
-					d375 = snap3488
-					d376 = snap3489
-					d377 = snap3490
-					d378 = snap3491
-					d379 = snap3492
-					d380 = snap3493
-					d381 = snap3494
-					d382 = snap3495
-					d505 = snap3496
-					d506 = snap3497
-					d507 = snap3498
-					d508 = snap3499
-					d509 = snap3500
-					d510 = snap3501
-					d511 = snap3502
-					d512 = snap3503
-					d513 = snap3504
-					d514 = snap3505
-					d515 = snap3506
-					d516 = snap3507
-					d517 = snap3508
-					d666 = snap3509
-					d667 = snap3510
-					d668 = snap3511
-					d669 = snap3512
-					d670 = snap3513
-					d671 = snap3514
-					d672 = snap3515
-					d673 = snap3516
-					d674 = snap3517
-					d675 = snap3518
-					d676 = snap3519
-					d677 = snap3520
-					d678 = snap3521
-					d679 = snap3522
-					d680 = snap3523
-					d681 = snap3524
-					d682 = snap3525
-					d683 = snap3526
-					d684 = snap3527
-					d685 = snap3528
-					d686 = snap3529
-					d687 = snap3530
-					d688 = snap3531
-					d689 = snap3532
-					d690 = snap3533
-					d691 = snap3534
-					d692 = snap3535
-					d693 = snap3536
-					d694 = snap3537
-					d695 = snap3538
-					d696 = snap3539
-					d697 = snap3540
-					d910 = snap3541
-					d911 = snap3542
-					d912 = snap3543
-					d913 = snap3544
-					d914 = snap3545
-					d915 = snap3546
-					d916 = snap3547
-					d917 = snap3548
-					d918 = snap3549
-					d919 = snap3550
-					d920 = snap3551
-					d921 = snap3552
-					d922 = snap3553
-					d923 = snap3554
-					d924 = snap3555
-					d925 = snap3556
-					d926 = snap3557
-					d927 = snap3558
-					d928 = snap3559
-					d929 = snap3560
-					d930 = snap3561
-					d931 = snap3562
-					d932 = snap3563
-					d933 = snap3564
-					d934 = snap3565
-					d935 = snap3566
-					d936 = snap3567
-					d937 = snap3568
-					d938 = snap3569
-					d939 = snap3570
-					d940 = snap3571
-					d941 = snap3572
-					d942 = snap3573
-					d1221 = snap3574
-					d1222 = snap3575
-					d1223 = snap3576
-					d1224 = snap3577
-					d1225 = snap3578
-					d1226 = snap3579
-					d1227 = snap3580
-					d1228 = snap3581
-					d1229 = snap3582
-					d1230 = snap3583
-					d1231 = snap3584
-					d1232 = snap3585
-					d1233 = snap3586
-					d1234 = snap3587
-					d1236 = snap3588
-					d1238 = snap3589
-					d1392 = snap3590
-					d1395 = snap3591
-					d1551 = snap3592
-					d1552 = snap3593
-					d1553 = snap3594
-					d1554 = snap3595
-					d1877 = snap3596
-					d1878 = snap3597
-					d1879 = snap3598
-					d1880 = snap3599
-					d1881 = snap3600
-					d1882 = snap3601
-					d1883 = snap3602
-					d1884 = snap3603
-					d1885 = snap3604
-					d1886 = snap3605
-					d1887 = snap3606
-					d1888 = snap3607
-					d1889 = snap3608
-					d1890 = snap3609
-					d1892 = snap3610
-					d1894 = snap3611
-					d2070 = snap3612
-					d2073 = snap3613
-					d2251 = snap3614
-					d2252 = snap3615
-					d2253 = snap3616
-					d2254 = snap3617
-					d2621 = snap3618
-					d2623 = snap3619
-					d2624 = snap3620
-					d2625 = snap3621
-					d2626 = snap3622
-					d2627 = snap3623
-					d2628 = snap3624
-					d2629 = snap3625
-					d2630 = snap3626
-					d2631 = snap3627
-					d2632 = snap3628
-					d3021 = snap3629
-					d3022 = snap3630
-					d3023 = snap3631
-					d3024 = snap3632
-					d3421 = snap3633
-					d3423 = snap3634
-					d3424 = snap3635
+					snap3644 := d3434
+					snap3645 := d3436
+					snap3646 := d3438
+					alloc3647 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc3647)
+					d1 = snap3439
+					d2 = snap3440
+					d3 = snap3441
+					d4 = snap3442
+					d5 = snap3443
+					d6 = snap3444
+					d7 = snap3445
+					d28 = snap3446
+					d29 = snap3447
+					d31 = snap3448
+					d32 = snap3449
+					d33 = snap3450
+					d35 = snap3451
+					d36 = snap3452
+					d37 = snap3453
+					d74 = snap3454
+					d75 = snap3455
+					d76 = snap3456
+					d77 = snap3457
+					d122 = snap3458
+					d123 = snap3459
+					d124 = snap3460
+					d125 = snap3461
+					d126 = snap3462
+					d127 = snap3463
+					d128 = snap3464
+					d129 = snap3465
+					d130 = snap3466
+					d193 = snap3467
+					d258 = snap3468
+					d259 = snap3469
+					d260 = snap3470
+					d261 = snap3471
+					d262 = snap3472
+					d263 = snap3473
+					d264 = snap3474
+					d265 = snap3475
+					d266 = snap3476
+					d267 = snap3477
+					d268 = snap3478
+					d269 = snap3479
+					d270 = snap3480
+					d271 = snap3481
+					d272 = snap3482
+					d273 = snap3483
+					d370 = snap3484
+					d371 = snap3485
+					d372 = snap3486
+					d373 = snap3487
+					d374 = snap3488
+					d375 = snap3489
+					d376 = snap3490
+					d377 = snap3491
+					d378 = snap3492
+					d379 = snap3493
+					d380 = snap3494
+					d381 = snap3495
+					d382 = snap3496
+					d505 = snap3497
+					d506 = snap3498
+					d507 = snap3499
+					d508 = snap3500
+					d509 = snap3501
+					d510 = snap3502
+					d511 = snap3503
+					d512 = snap3504
+					d513 = snap3505
+					d514 = snap3506
+					d515 = snap3507
+					d516 = snap3508
+					d517 = snap3509
+					d666 = snap3510
+					d667 = snap3511
+					d668 = snap3512
+					d669 = snap3513
+					d670 = snap3514
+					d671 = snap3515
+					d672 = snap3516
+					d673 = snap3517
+					d674 = snap3518
+					d675 = snap3519
+					d676 = snap3520
+					d677 = snap3521
+					d678 = snap3522
+					d679 = snap3523
+					d680 = snap3524
+					d681 = snap3525
+					d682 = snap3526
+					d683 = snap3527
+					d684 = snap3528
+					d685 = snap3529
+					d686 = snap3530
+					d687 = snap3531
+					d688 = snap3532
+					d689 = snap3533
+					d690 = snap3534
+					d691 = snap3535
+					d692 = snap3536
+					d693 = snap3537
+					d694 = snap3538
+					d695 = snap3539
+					d696 = snap3540
+					d697 = snap3541
+					d910 = snap3542
+					d911 = snap3543
+					d912 = snap3544
+					d913 = snap3545
+					d914 = snap3546
+					d915 = snap3547
+					d916 = snap3548
+					d917 = snap3549
+					d918 = snap3550
+					d919 = snap3551
+					d920 = snap3552
+					d921 = snap3553
+					d922 = snap3554
+					d923 = snap3555
+					d924 = snap3556
+					d925 = snap3557
+					d926 = snap3558
+					d927 = snap3559
+					d928 = snap3560
+					d929 = snap3561
+					d930 = snap3562
+					d931 = snap3563
+					d932 = snap3564
+					d933 = snap3565
+					d934 = snap3566
+					d935 = snap3567
+					d936 = snap3568
+					d937 = snap3569
+					d938 = snap3570
+					d939 = snap3571
+					d940 = snap3572
+					d941 = snap3573
+					d942 = snap3574
+					d1221 = snap3575
+					d1222 = snap3576
+					d1223 = snap3577
+					d1224 = snap3578
+					d1225 = snap3579
+					d1226 = snap3580
+					d1227 = snap3581
+					d1228 = snap3582
+					d1229 = snap3583
+					d1230 = snap3584
+					d1231 = snap3585
+					d1232 = snap3586
+					d1233 = snap3587
+					d1234 = snap3588
+					d1236 = snap3589
+					d1238 = snap3590
+					d1392 = snap3591
+					d1395 = snap3592
+					d1551 = snap3593
+					d1552 = snap3594
+					d1553 = snap3595
+					d1554 = snap3596
+					d1877 = snap3597
+					d1878 = snap3598
+					d1879 = snap3599
+					d1880 = snap3600
+					d1881 = snap3601
+					d1882 = snap3602
+					d1883 = snap3603
+					d1884 = snap3604
+					d1885 = snap3605
+					d1886 = snap3606
+					d1887 = snap3607
+					d1888 = snap3608
+					d1889 = snap3609
+					d1890 = snap3610
+					d1892 = snap3611
+					d1894 = snap3612
+					d2070 = snap3613
+					d2073 = snap3614
+					d2251 = snap3615
+					d2252 = snap3616
+					d2253 = snap3617
+					d2254 = snap3618
+					d2621 = snap3619
+					d2623 = snap3620
+					d2624 = snap3621
+					d2625 = snap3622
+					d2626 = snap3623
+					d2627 = snap3624
+					d2628 = snap3625
+					d2629 = snap3626
+					d2630 = snap3627
+					d2631 = snap3628
+					d2632 = snap3629
+					d3021 = snap3630
+					d3022 = snap3631
+					d3023 = snap3632
+					d3024 = snap3633
+					d3421 = snap3634
+					d3423 = snap3635
 					d3425 = snap3636
 					d3426 = snap3637
-					d3428 = snap3638
+					d3427 = snap3638
 					d3429 = snap3639
 					d3430 = snap3640
 					d3431 = snap3641
 					d3432 = snap3642
 					d3433 = snap3643
-					d3435 = snap3644
-					d3437 = snap3645
+					d3434 = snap3644
+					d3436 = snap3645
+					d3438 = snap3646
 					ctx.MarkLabel(lbl42)
 					ctx.SyncDesc(&d2627)
-					if d2627.Loc == LocReg {
+					if d2627.Loc == LocReg || d2627.Loc == LocFPReg {
 						ctx.ProtectReg(d2627.Reg)
 					} else if d2627.Loc == LocRegPair {
 						ctx.ProtectReg(d2627.Reg)
 						ctx.ProtectReg(d2627.Reg2)
 					}
-					d3647 = d2627
-					if d3647.Loc == LocNone {
+					d3648 = d2627
+					if d3648.Loc == LocNone {
 						panic("jit: phi source has no location")
 					}
-					ctx.EnsureDesc(&d3647)
-					ctx.EmitStoreToStack(d3647, int32(bbs[30].PhiBase)+int32(0))
-					if d2627.Loc == LocReg {
+					ctx.EnsureDesc(&d3648)
+					ctx.EmitStoreToStack(d3648, int32(bbs[30].PhiBase)+int32(0))
+					if d2627.Loc == LocReg || d2627.Loc == LocFPReg {
 						ctx.UnprotectReg(d2627.Reg)
 					} else if d2627.Loc == LocRegPair {
 						ctx.UnprotectReg(d2627.Reg)
 						ctx.UnprotectReg(d2627.Reg2)
 					}
 					ctx.EmitJmp(lbl31)
-					ctx.RestoreAllocState(alloc3646)
-					d1 = snap3438
-					d2 = snap3439
-					d3 = snap3440
-					d4 = snap3441
-					d5 = snap3442
-					d6 = snap3443
-					d7 = snap3444
-					d28 = snap3445
-					d29 = snap3446
-					d31 = snap3447
-					d32 = snap3448
-					d33 = snap3449
-					d35 = snap3450
-					d36 = snap3451
-					d37 = snap3452
-					d74 = snap3453
-					d75 = snap3454
-					d76 = snap3455
-					d77 = snap3456
-					d122 = snap3457
-					d123 = snap3458
-					d124 = snap3459
-					d125 = snap3460
-					d126 = snap3461
-					d127 = snap3462
-					d128 = snap3463
-					d129 = snap3464
-					d130 = snap3465
-					d193 = snap3466
-					d258 = snap3467
-					d259 = snap3468
-					d260 = snap3469
-					d261 = snap3470
-					d262 = snap3471
-					d263 = snap3472
-					d264 = snap3473
-					d265 = snap3474
-					d266 = snap3475
-					d267 = snap3476
-					d268 = snap3477
-					d269 = snap3478
-					d270 = snap3479
-					d271 = snap3480
-					d272 = snap3481
-					d273 = snap3482
-					d370 = snap3483
-					d371 = snap3484
-					d372 = snap3485
-					d373 = snap3486
-					d374 = snap3487
-					d375 = snap3488
-					d376 = snap3489
-					d377 = snap3490
-					d378 = snap3491
-					d379 = snap3492
-					d380 = snap3493
-					d381 = snap3494
-					d382 = snap3495
-					d505 = snap3496
-					d506 = snap3497
-					d507 = snap3498
-					d508 = snap3499
-					d509 = snap3500
-					d510 = snap3501
-					d511 = snap3502
-					d512 = snap3503
-					d513 = snap3504
-					d514 = snap3505
-					d515 = snap3506
-					d516 = snap3507
-					d517 = snap3508
-					d666 = snap3509
-					d667 = snap3510
-					d668 = snap3511
-					d669 = snap3512
-					d670 = snap3513
-					d671 = snap3514
-					d672 = snap3515
-					d673 = snap3516
-					d674 = snap3517
-					d675 = snap3518
-					d676 = snap3519
-					d677 = snap3520
-					d678 = snap3521
-					d679 = snap3522
-					d680 = snap3523
-					d681 = snap3524
-					d682 = snap3525
-					d683 = snap3526
-					d684 = snap3527
-					d685 = snap3528
-					d686 = snap3529
-					d687 = snap3530
-					d688 = snap3531
-					d689 = snap3532
-					d690 = snap3533
-					d691 = snap3534
-					d692 = snap3535
-					d693 = snap3536
-					d694 = snap3537
-					d695 = snap3538
-					d696 = snap3539
-					d697 = snap3540
-					d910 = snap3541
-					d911 = snap3542
-					d912 = snap3543
-					d913 = snap3544
-					d914 = snap3545
-					d915 = snap3546
-					d916 = snap3547
-					d917 = snap3548
-					d918 = snap3549
-					d919 = snap3550
-					d920 = snap3551
-					d921 = snap3552
-					d922 = snap3553
-					d923 = snap3554
-					d924 = snap3555
-					d925 = snap3556
-					d926 = snap3557
-					d927 = snap3558
-					d928 = snap3559
-					d929 = snap3560
-					d930 = snap3561
-					d931 = snap3562
-					d932 = snap3563
-					d933 = snap3564
-					d934 = snap3565
-					d935 = snap3566
-					d936 = snap3567
-					d937 = snap3568
-					d938 = snap3569
-					d939 = snap3570
-					d940 = snap3571
-					d941 = snap3572
-					d942 = snap3573
-					d1221 = snap3574
-					d1222 = snap3575
-					d1223 = snap3576
-					d1224 = snap3577
-					d1225 = snap3578
-					d1226 = snap3579
-					d1227 = snap3580
-					d1228 = snap3581
-					d1229 = snap3582
-					d1230 = snap3583
-					d1231 = snap3584
-					d1232 = snap3585
-					d1233 = snap3586
-					d1234 = snap3587
-					d1236 = snap3588
-					d1238 = snap3589
-					d1392 = snap3590
-					d1395 = snap3591
-					d1551 = snap3592
-					d1552 = snap3593
-					d1553 = snap3594
-					d1554 = snap3595
-					d1877 = snap3596
-					d1878 = snap3597
-					d1879 = snap3598
-					d1880 = snap3599
-					d1881 = snap3600
-					d1882 = snap3601
-					d1883 = snap3602
-					d1884 = snap3603
-					d1885 = snap3604
-					d1886 = snap3605
-					d1887 = snap3606
-					d1888 = snap3607
-					d1889 = snap3608
-					d1890 = snap3609
-					d1892 = snap3610
-					d1894 = snap3611
-					d2070 = snap3612
-					d2073 = snap3613
-					d2251 = snap3614
-					d2252 = snap3615
-					d2253 = snap3616
-					d2254 = snap3617
-					d2621 = snap3618
-					d2623 = snap3619
-					d2624 = snap3620
-					d2625 = snap3621
-					d2626 = snap3622
-					d2627 = snap3623
-					d2628 = snap3624
-					d2629 = snap3625
-					d2630 = snap3626
-					d2631 = snap3627
-					d2632 = snap3628
-					d3021 = snap3629
-					d3022 = snap3630
-					d3023 = snap3631
-					d3024 = snap3632
-					d3421 = snap3633
-					d3423 = snap3634
-					d3424 = snap3635
+					ctx.RestoreAllocState(alloc3647)
+					d1 = snap3439
+					d2 = snap3440
+					d3 = snap3441
+					d4 = snap3442
+					d5 = snap3443
+					d6 = snap3444
+					d7 = snap3445
+					d28 = snap3446
+					d29 = snap3447
+					d31 = snap3448
+					d32 = snap3449
+					d33 = snap3450
+					d35 = snap3451
+					d36 = snap3452
+					d37 = snap3453
+					d74 = snap3454
+					d75 = snap3455
+					d76 = snap3456
+					d77 = snap3457
+					d122 = snap3458
+					d123 = snap3459
+					d124 = snap3460
+					d125 = snap3461
+					d126 = snap3462
+					d127 = snap3463
+					d128 = snap3464
+					d129 = snap3465
+					d130 = snap3466
+					d193 = snap3467
+					d258 = snap3468
+					d259 = snap3469
+					d260 = snap3470
+					d261 = snap3471
+					d262 = snap3472
+					d263 = snap3473
+					d264 = snap3474
+					d265 = snap3475
+					d266 = snap3476
+					d267 = snap3477
+					d268 = snap3478
+					d269 = snap3479
+					d270 = snap3480
+					d271 = snap3481
+					d272 = snap3482
+					d273 = snap3483
+					d370 = snap3484
+					d371 = snap3485
+					d372 = snap3486
+					d373 = snap3487
+					d374 = snap3488
+					d375 = snap3489
+					d376 = snap3490
+					d377 = snap3491
+					d378 = snap3492
+					d379 = snap3493
+					d380 = snap3494
+					d381 = snap3495
+					d382 = snap3496
+					d505 = snap3497
+					d506 = snap3498
+					d507 = snap3499
+					d508 = snap3500
+					d509 = snap3501
+					d510 = snap3502
+					d511 = snap3503
+					d512 = snap3504
+					d513 = snap3505
+					d514 = snap3506
+					d515 = snap3507
+					d516 = snap3508
+					d517 = snap3509
+					d666 = snap3510
+					d667 = snap3511
+					d668 = snap3512
+					d669 = snap3513
+					d670 = snap3514
+					d671 = snap3515
+					d672 = snap3516
+					d673 = snap3517
+					d674 = snap3518
+					d675 = snap3519
+					d676 = snap3520
+					d677 = snap3521
+					d678 = snap3522
+					d679 = snap3523
+					d680 = snap3524
+					d681 = snap3525
+					d682 = snap3526
+					d683 = snap3527
+					d684 = snap3528
+					d685 = snap3529
+					d686 = snap3530
+					d687 = snap3531
+					d688 = snap3532
+					d689 = snap3533
+					d690 = snap3534
+					d691 = snap3535
+					d692 = snap3536
+					d693 = snap3537
+					d694 = snap3538
+					d695 = snap3539
+					d696 = snap3540
+					d697 = snap3541
+					d910 = snap3542
+					d911 = snap3543
+					d912 = snap3544
+					d913 = snap3545
+					d914 = snap3546
+					d915 = snap3547
+					d916 = snap3548
+					d917 = snap3549
+					d918 = snap3550
+					d919 = snap3551
+					d920 = snap3552
+					d921 = snap3553
+					d922 = snap3554
+					d923 = snap3555
+					d924 = snap3556
+					d925 = snap3557
+					d926 = snap3558
+					d927 = snap3559
+					d928 = snap3560
+					d929 = snap3561
+					d930 = snap3562
+					d931 = snap3563
+					d932 = snap3564
+					d933 = snap3565
+					d934 = snap3566
+					d935 = snap3567
+					d936 = snap3568
+					d937 = snap3569
+					d938 = snap3570
+					d939 = snap3571
+					d940 = snap3572
+					d941 = snap3573
+					d942 = snap3574
+					d1221 = snap3575
+					d1222 = snap3576
+					d1223 = snap3577
+					d1224 = snap3578
+					d1225 = snap3579
+					d1226 = snap3580
+					d1227 = snap3581
+					d1228 = snap3582
+					d1229 = snap3583
+					d1230 = snap3584
+					d1231 = snap3585
+					d1232 = snap3586
+					d1233 = snap3587
+					d1234 = snap3588
+					d1236 = snap3589
+					d1238 = snap3590
+					d1392 = snap3591
+					d1395 = snap3592
+					d1551 = snap3593
+					d1552 = snap3594
+					d1553 = snap3595
+					d1554 = snap3596
+					d1877 = snap3597
+					d1878 = snap3598
+					d1879 = snap3599
+					d1880 = snap3600
+					d1881 = snap3601
+					d1882 = snap3602
+					d1883 = snap3603
+					d1884 = snap3604
+					d1885 = snap3605
+					d1886 = snap3606
+					d1887 = snap3607
+					d1888 = snap3608
+					d1889 = snap3609
+					d1890 = snap3610
+					d1892 = snap3611
+					d1894 = snap3612
+					d2070 = snap3613
+					d2073 = snap3614
+					d2251 = snap3615
+					d2252 = snap3616
+					d2253 = snap3617
+					d2254 = snap3618
+					d2621 = snap3619
+					d2623 = snap3620
+					d2624 = snap3621
+					d2625 = snap3622
+					d2626 = snap3623
+					d2627 = snap3624
+					d2628 = snap3625
+					d2629 = snap3626
+					d2630 = snap3627
+					d2631 = snap3628
+					d2632 = snap3629
+					d3021 = snap3630
+					d3022 = snap3631
+					d3023 = snap3632
+					d3024 = snap3633
+					d3421 = snap3634
+					d3423 = snap3635
 					d3425 = snap3636
 					d3426 = snap3637
-					d3428 = snap3638
+					d3427 = snap3638
 					d3429 = snap3639
 					d3430 = snap3640
 					d3431 = snap3641
 					d3432 = snap3642
 					d3433 = snap3643
-					d3435 = snap3644
-					d3437 = snap3645
-					ps3648 := PhiState{General: true}
-					ps3648.OverlayValues = make([]JITValueDesc, 3648)
-					ps3648.OverlayValues[1] = d1
-					ps3648.OverlayValues[2] = d2
-					ps3648.OverlayValues[3] = d3
-					ps3648.OverlayValues[4] = d4
-					ps3648.OverlayValues[5] = d5
-					ps3648.OverlayValues[6] = d6
-					ps3648.OverlayValues[7] = d7
-					ps3648.OverlayValues[28] = d28
-					ps3648.OverlayValues[29] = d29
-					ps3648.OverlayValues[31] = d31
-					ps3648.OverlayValues[32] = d32
-					ps3648.OverlayValues[33] = d33
-					ps3648.OverlayValues[35] = d35
-					ps3648.OverlayValues[36] = d36
-					ps3648.OverlayValues[37] = d37
-					ps3648.OverlayValues[74] = d74
-					ps3648.OverlayValues[75] = d75
-					ps3648.OverlayValues[76] = d76
-					ps3648.OverlayValues[77] = d77
-					ps3648.OverlayValues[122] = d122
-					ps3648.OverlayValues[123] = d123
-					ps3648.OverlayValues[124] = d124
-					ps3648.OverlayValues[125] = d125
-					ps3648.OverlayValues[126] = d126
-					ps3648.OverlayValues[127] = d127
-					ps3648.OverlayValues[128] = d128
-					ps3648.OverlayValues[129] = d129
-					ps3648.OverlayValues[130] = d130
-					ps3648.OverlayValues[193] = d193
-					ps3648.OverlayValues[258] = d258
-					ps3648.OverlayValues[259] = d259
-					ps3648.OverlayValues[260] = d260
-					ps3648.OverlayValues[261] = d261
-					ps3648.OverlayValues[262] = d262
-					ps3648.OverlayValues[263] = d263
-					ps3648.OverlayValues[264] = d264
-					ps3648.OverlayValues[265] = d265
-					ps3648.OverlayValues[266] = d266
-					ps3648.OverlayValues[267] = d267
-					ps3648.OverlayValues[268] = d268
-					ps3648.OverlayValues[269] = d269
-					ps3648.OverlayValues[270] = d270
-					ps3648.OverlayValues[271] = d271
-					ps3648.OverlayValues[272] = d272
-					ps3648.OverlayValues[273] = d273
-					ps3648.OverlayValues[370] = d370
-					ps3648.OverlayValues[371] = d371
-					ps3648.OverlayValues[372] = d372
-					ps3648.OverlayValues[373] = d373
-					ps3648.OverlayValues[374] = d374
-					ps3648.OverlayValues[375] = d375
-					ps3648.OverlayValues[376] = d376
-					ps3648.OverlayValues[377] = d377
-					ps3648.OverlayValues[378] = d378
-					ps3648.OverlayValues[379] = d379
-					ps3648.OverlayValues[380] = d380
-					ps3648.OverlayValues[381] = d381
-					ps3648.OverlayValues[382] = d382
-					ps3648.OverlayValues[505] = d505
-					ps3648.OverlayValues[506] = d506
-					ps3648.OverlayValues[507] = d507
-					ps3648.OverlayValues[508] = d508
-					ps3648.OverlayValues[509] = d509
-					ps3648.OverlayValues[510] = d510
-					ps3648.OverlayValues[511] = d511
-					ps3648.OverlayValues[512] = d512
-					ps3648.OverlayValues[513] = d513
-					ps3648.OverlayValues[514] = d514
-					ps3648.OverlayValues[515] = d515
-					ps3648.OverlayValues[516] = d516
-					ps3648.OverlayValues[517] = d517
-					ps3648.OverlayValues[666] = d666
-					ps3648.OverlayValues[667] = d667
-					ps3648.OverlayValues[668] = d668
-					ps3648.OverlayValues[669] = d669
-					ps3648.OverlayValues[670] = d670
-					ps3648.OverlayValues[671] = d671
-					ps3648.OverlayValues[672] = d672
-					ps3648.OverlayValues[673] = d673
-					ps3648.OverlayValues[674] = d674
-					ps3648.OverlayValues[675] = d675
-					ps3648.OverlayValues[676] = d676
-					ps3648.OverlayValues[677] = d677
-					ps3648.OverlayValues[678] = d678
-					ps3648.OverlayValues[679] = d679
-					ps3648.OverlayValues[680] = d680
-					ps3648.OverlayValues[681] = d681
-					ps3648.OverlayValues[682] = d682
-					ps3648.OverlayValues[683] = d683
-					ps3648.OverlayValues[684] = d684
-					ps3648.OverlayValues[685] = d685
-					ps3648.OverlayValues[686] = d686
-					ps3648.OverlayValues[687] = d687
-					ps3648.OverlayValues[688] = d688
-					ps3648.OverlayValues[689] = d689
-					ps3648.OverlayValues[690] = d690
-					ps3648.OverlayValues[691] = d691
-					ps3648.OverlayValues[692] = d692
-					ps3648.OverlayValues[693] = d693
-					ps3648.OverlayValues[694] = d694
-					ps3648.OverlayValues[695] = d695
-					ps3648.OverlayValues[696] = d696
-					ps3648.OverlayValues[697] = d697
-					ps3648.OverlayValues[910] = d910
-					ps3648.OverlayValues[911] = d911
-					ps3648.OverlayValues[912] = d912
-					ps3648.OverlayValues[913] = d913
-					ps3648.OverlayValues[914] = d914
-					ps3648.OverlayValues[915] = d915
-					ps3648.OverlayValues[916] = d916
-					ps3648.OverlayValues[917] = d917
-					ps3648.OverlayValues[918] = d918
-					ps3648.OverlayValues[919] = d919
-					ps3648.OverlayValues[920] = d920
-					ps3648.OverlayValues[921] = d921
-					ps3648.OverlayValues[922] = d922
-					ps3648.OverlayValues[923] = d923
-					ps3648.OverlayValues[924] = d924
-					ps3648.OverlayValues[925] = d925
-					ps3648.OverlayValues[926] = d926
-					ps3648.OverlayValues[927] = d927
-					ps3648.OverlayValues[928] = d928
-					ps3648.OverlayValues[929] = d929
-					ps3648.OverlayValues[930] = d930
-					ps3648.OverlayValues[931] = d931
-					ps3648.OverlayValues[932] = d932
-					ps3648.OverlayValues[933] = d933
-					ps3648.OverlayValues[934] = d934
-					ps3648.OverlayValues[935] = d935
-					ps3648.OverlayValues[936] = d936
-					ps3648.OverlayValues[937] = d937
-					ps3648.OverlayValues[938] = d938
-					ps3648.OverlayValues[939] = d939
-					ps3648.OverlayValues[940] = d940
-					ps3648.OverlayValues[941] = d941
-					ps3648.OverlayValues[942] = d942
-					ps3648.OverlayValues[1221] = d1221
-					ps3648.OverlayValues[1222] = d1222
-					ps3648.OverlayValues[1223] = d1223
-					ps3648.OverlayValues[1224] = d1224
-					ps3648.OverlayValues[1225] = d1225
-					ps3648.OverlayValues[1226] = d1226
-					ps3648.OverlayValues[1227] = d1227
-					ps3648.OverlayValues[1228] = d1228
-					ps3648.OverlayValues[1229] = d1229
-					ps3648.OverlayValues[1230] = d1230
-					ps3648.OverlayValues[1231] = d1231
-					ps3648.OverlayValues[1232] = d1232
-					ps3648.OverlayValues[1233] = d1233
-					ps3648.OverlayValues[1234] = d1234
-					ps3648.OverlayValues[1236] = d1236
-					ps3648.OverlayValues[1238] = d1238
-					ps3648.OverlayValues[1392] = d1392
-					ps3648.OverlayValues[1395] = d1395
-					ps3648.OverlayValues[1551] = d1551
-					ps3648.OverlayValues[1552] = d1552
-					ps3648.OverlayValues[1553] = d1553
-					ps3648.OverlayValues[1554] = d1554
-					ps3648.OverlayValues[1877] = d1877
-					ps3648.OverlayValues[1878] = d1878
-					ps3648.OverlayValues[1879] = d1879
-					ps3648.OverlayValues[1880] = d1880
-					ps3648.OverlayValues[1881] = d1881
-					ps3648.OverlayValues[1882] = d1882
-					ps3648.OverlayValues[1883] = d1883
-					ps3648.OverlayValues[1884] = d1884
-					ps3648.OverlayValues[1885] = d1885
-					ps3648.OverlayValues[1886] = d1886
-					ps3648.OverlayValues[1887] = d1887
-					ps3648.OverlayValues[1888] = d1888
-					ps3648.OverlayValues[1889] = d1889
-					ps3648.OverlayValues[1890] = d1890
-					ps3648.OverlayValues[1892] = d1892
-					ps3648.OverlayValues[1894] = d1894
-					ps3648.OverlayValues[2070] = d2070
-					ps3648.OverlayValues[2073] = d2073
-					ps3648.OverlayValues[2251] = d2251
-					ps3648.OverlayValues[2252] = d2252
-					ps3648.OverlayValues[2253] = d2253
-					ps3648.OverlayValues[2254] = d2254
-					ps3648.OverlayValues[2621] = d2621
-					ps3648.OverlayValues[2623] = d2623
-					ps3648.OverlayValues[2624] = d2624
-					ps3648.OverlayValues[2625] = d2625
-					ps3648.OverlayValues[2626] = d2626
-					ps3648.OverlayValues[2627] = d2627
-					ps3648.OverlayValues[2628] = d2628
-					ps3648.OverlayValues[2629] = d2629
-					ps3648.OverlayValues[2630] = d2630
-					ps3648.OverlayValues[2631] = d2631
-					ps3648.OverlayValues[2632] = d2632
-					ps3648.OverlayValues[3021] = d3021
-					ps3648.OverlayValues[3022] = d3022
-					ps3648.OverlayValues[3023] = d3023
-					ps3648.OverlayValues[3024] = d3024
-					ps3648.OverlayValues[3421] = d3421
-					ps3648.OverlayValues[3423] = d3423
-					ps3648.OverlayValues[3424] = d3424
-					ps3648.OverlayValues[3425] = d3425
-					ps3648.OverlayValues[3426] = d3426
-					ps3648.OverlayValues[3428] = d3428
-					ps3648.OverlayValues[3429] = d3429
-					ps3648.OverlayValues[3430] = d3430
-					ps3648.OverlayValues[3431] = d3431
-					ps3648.OverlayValues[3432] = d3432
-					ps3648.OverlayValues[3433] = d3433
-					ps3648.OverlayValues[3435] = d3435
-					ps3648.OverlayValues[3437] = d3437
-					ps3648.OverlayValues[3647] = d3647
+					d3434 = snap3644
+					d3436 = snap3645
+					d3438 = snap3646
 					ps3649 := PhiState{General: true}
-					ps3649.OverlayValues = make([]JITValueDesc, 3648)
+					ps3649.OverlayValues = make([]JITValueDesc, 3649)
 					ps3649.OverlayValues[1] = d1
 					ps3649.OverlayValues[2] = d2
 					ps3649.OverlayValues[3] = d3
@@ -70822,448 +70697,659 @@ func init_date() {
 					ps3649.OverlayValues[3024] = d3024
 					ps3649.OverlayValues[3421] = d3421
 					ps3649.OverlayValues[3423] = d3423
-					ps3649.OverlayValues[3424] = d3424
 					ps3649.OverlayValues[3425] = d3425
 					ps3649.OverlayValues[3426] = d3426
-					ps3649.OverlayValues[3428] = d3428
+					ps3649.OverlayValues[3427] = d3427
 					ps3649.OverlayValues[3429] = d3429
 					ps3649.OverlayValues[3430] = d3430
 					ps3649.OverlayValues[3431] = d3431
 					ps3649.OverlayValues[3432] = d3432
 					ps3649.OverlayValues[3433] = d3433
-					ps3649.OverlayValues[3435] = d3435
-					ps3649.OverlayValues[3437] = d3437
-					ps3649.OverlayValues[3647] = d3647
-					ps3649.PhiValues = make([]JITValueDesc, 1)
-					d3650 = d2627
-					ps3649.PhiValues[0] = d3650
-					snap3651 := d1
-					snap3652 := d2
-					snap3653 := d3
-					snap3654 := d4
-					snap3655 := d5
-					snap3656 := d6
-					snap3657 := d7
-					snap3658 := d28
-					snap3659 := d29
-					snap3660 := d31
-					snap3661 := d32
-					snap3662 := d33
-					snap3663 := d35
-					snap3664 := d36
-					snap3665 := d37
-					snap3666 := d74
-					snap3667 := d75
-					snap3668 := d76
-					snap3669 := d77
-					snap3670 := d122
-					snap3671 := d123
-					snap3672 := d124
-					snap3673 := d125
-					snap3674 := d126
-					snap3675 := d127
-					snap3676 := d128
-					snap3677 := d129
-					snap3678 := d130
-					snap3679 := d193
-					snap3680 := d258
-					snap3681 := d259
-					snap3682 := d260
-					snap3683 := d261
-					snap3684 := d262
-					snap3685 := d263
-					snap3686 := d264
-					snap3687 := d265
-					snap3688 := d266
-					snap3689 := d267
-					snap3690 := d268
-					snap3691 := d269
-					snap3692 := d270
-					snap3693 := d271
-					snap3694 := d272
-					snap3695 := d273
-					snap3696 := d370
-					snap3697 := d371
-					snap3698 := d372
-					snap3699 := d373
-					snap3700 := d374
-					snap3701 := d375
-					snap3702 := d376
-					snap3703 := d377
-					snap3704 := d378
-					snap3705 := d379
-					snap3706 := d380
-					snap3707 := d381
-					snap3708 := d382
-					snap3709 := d505
-					snap3710 := d506
-					snap3711 := d507
-					snap3712 := d508
-					snap3713 := d509
-					snap3714 := d510
-					snap3715 := d511
-					snap3716 := d512
-					snap3717 := d513
-					snap3718 := d514
-					snap3719 := d515
-					snap3720 := d516
-					snap3721 := d517
-					snap3722 := d666
-					snap3723 := d667
-					snap3724 := d668
-					snap3725 := d669
-					snap3726 := d670
-					snap3727 := d671
-					snap3728 := d672
-					snap3729 := d673
-					snap3730 := d674
-					snap3731 := d675
-					snap3732 := d676
-					snap3733 := d677
-					snap3734 := d678
-					snap3735 := d679
-					snap3736 := d680
-					snap3737 := d681
-					snap3738 := d682
-					snap3739 := d683
-					snap3740 := d684
-					snap3741 := d685
-					snap3742 := d686
-					snap3743 := d687
-					snap3744 := d688
-					snap3745 := d689
-					snap3746 := d690
-					snap3747 := d691
-					snap3748 := d692
-					snap3749 := d693
-					snap3750 := d694
-					snap3751 := d695
-					snap3752 := d696
-					snap3753 := d697
-					snap3754 := d910
-					snap3755 := d911
-					snap3756 := d912
-					snap3757 := d913
-					snap3758 := d914
-					snap3759 := d915
-					snap3760 := d916
-					snap3761 := d917
-					snap3762 := d918
-					snap3763 := d919
-					snap3764 := d920
-					snap3765 := d921
-					snap3766 := d922
-					snap3767 := d923
-					snap3768 := d924
-					snap3769 := d925
-					snap3770 := d926
-					snap3771 := d927
-					snap3772 := d928
-					snap3773 := d929
-					snap3774 := d930
-					snap3775 := d931
-					snap3776 := d932
-					snap3777 := d933
-					snap3778 := d934
-					snap3779 := d935
-					snap3780 := d936
-					snap3781 := d937
-					snap3782 := d938
-					snap3783 := d939
-					snap3784 := d940
-					snap3785 := d941
-					snap3786 := d942
-					snap3787 := d1221
-					snap3788 := d1222
-					snap3789 := d1223
-					snap3790 := d1224
-					snap3791 := d1225
-					snap3792 := d1226
-					snap3793 := d1227
-					snap3794 := d1228
-					snap3795 := d1229
-					snap3796 := d1230
-					snap3797 := d1231
-					snap3798 := d1232
-					snap3799 := d1233
-					snap3800 := d1234
-					snap3801 := d1236
-					snap3802 := d1238
-					snap3803 := d1392
-					snap3804 := d1395
-					snap3805 := d1551
-					snap3806 := d1552
-					snap3807 := d1553
-					snap3808 := d1554
-					snap3809 := d1877
-					snap3810 := d1878
-					snap3811 := d1879
-					snap3812 := d1880
-					snap3813 := d1881
-					snap3814 := d1882
-					snap3815 := d1883
-					snap3816 := d1884
-					snap3817 := d1885
-					snap3818 := d1886
-					snap3819 := d1887
-					snap3820 := d1888
-					snap3821 := d1889
-					snap3822 := d1890
-					snap3823 := d1892
-					snap3824 := d1894
-					snap3825 := d2070
-					snap3826 := d2073
-					snap3827 := d2251
-					snap3828 := d2252
-					snap3829 := d2253
-					snap3830 := d2254
-					snap3831 := d2621
-					snap3832 := d2623
-					snap3833 := d2624
-					snap3834 := d2625
-					snap3835 := d2626
-					snap3836 := d2627
-					snap3837 := d2628
-					snap3838 := d2629
-					snap3839 := d2630
-					snap3840 := d2631
-					snap3841 := d2632
-					snap3842 := d3021
-					snap3843 := d3022
-					snap3844 := d3023
-					snap3845 := d3024
-					snap3846 := d3421
-					snap3847 := d3423
-					snap3848 := d3424
+					ps3649.OverlayValues[3434] = d3434
+					ps3649.OverlayValues[3436] = d3436
+					ps3649.OverlayValues[3438] = d3438
+					ps3649.OverlayValues[3648] = d3648
+					ps3650 := PhiState{General: true}
+					ps3650.OverlayValues = make([]JITValueDesc, 3649)
+					ps3650.OverlayValues[1] = d1
+					ps3650.OverlayValues[2] = d2
+					ps3650.OverlayValues[3] = d3
+					ps3650.OverlayValues[4] = d4
+					ps3650.OverlayValues[5] = d5
+					ps3650.OverlayValues[6] = d6
+					ps3650.OverlayValues[7] = d7
+					ps3650.OverlayValues[28] = d28
+					ps3650.OverlayValues[29] = d29
+					ps3650.OverlayValues[31] = d31
+					ps3650.OverlayValues[32] = d32
+					ps3650.OverlayValues[33] = d33
+					ps3650.OverlayValues[35] = d35
+					ps3650.OverlayValues[36] = d36
+					ps3650.OverlayValues[37] = d37
+					ps3650.OverlayValues[74] = d74
+					ps3650.OverlayValues[75] = d75
+					ps3650.OverlayValues[76] = d76
+					ps3650.OverlayValues[77] = d77
+					ps3650.OverlayValues[122] = d122
+					ps3650.OverlayValues[123] = d123
+					ps3650.OverlayValues[124] = d124
+					ps3650.OverlayValues[125] = d125
+					ps3650.OverlayValues[126] = d126
+					ps3650.OverlayValues[127] = d127
+					ps3650.OverlayValues[128] = d128
+					ps3650.OverlayValues[129] = d129
+					ps3650.OverlayValues[130] = d130
+					ps3650.OverlayValues[193] = d193
+					ps3650.OverlayValues[258] = d258
+					ps3650.OverlayValues[259] = d259
+					ps3650.OverlayValues[260] = d260
+					ps3650.OverlayValues[261] = d261
+					ps3650.OverlayValues[262] = d262
+					ps3650.OverlayValues[263] = d263
+					ps3650.OverlayValues[264] = d264
+					ps3650.OverlayValues[265] = d265
+					ps3650.OverlayValues[266] = d266
+					ps3650.OverlayValues[267] = d267
+					ps3650.OverlayValues[268] = d268
+					ps3650.OverlayValues[269] = d269
+					ps3650.OverlayValues[270] = d270
+					ps3650.OverlayValues[271] = d271
+					ps3650.OverlayValues[272] = d272
+					ps3650.OverlayValues[273] = d273
+					ps3650.OverlayValues[370] = d370
+					ps3650.OverlayValues[371] = d371
+					ps3650.OverlayValues[372] = d372
+					ps3650.OverlayValues[373] = d373
+					ps3650.OverlayValues[374] = d374
+					ps3650.OverlayValues[375] = d375
+					ps3650.OverlayValues[376] = d376
+					ps3650.OverlayValues[377] = d377
+					ps3650.OverlayValues[378] = d378
+					ps3650.OverlayValues[379] = d379
+					ps3650.OverlayValues[380] = d380
+					ps3650.OverlayValues[381] = d381
+					ps3650.OverlayValues[382] = d382
+					ps3650.OverlayValues[505] = d505
+					ps3650.OverlayValues[506] = d506
+					ps3650.OverlayValues[507] = d507
+					ps3650.OverlayValues[508] = d508
+					ps3650.OverlayValues[509] = d509
+					ps3650.OverlayValues[510] = d510
+					ps3650.OverlayValues[511] = d511
+					ps3650.OverlayValues[512] = d512
+					ps3650.OverlayValues[513] = d513
+					ps3650.OverlayValues[514] = d514
+					ps3650.OverlayValues[515] = d515
+					ps3650.OverlayValues[516] = d516
+					ps3650.OverlayValues[517] = d517
+					ps3650.OverlayValues[666] = d666
+					ps3650.OverlayValues[667] = d667
+					ps3650.OverlayValues[668] = d668
+					ps3650.OverlayValues[669] = d669
+					ps3650.OverlayValues[670] = d670
+					ps3650.OverlayValues[671] = d671
+					ps3650.OverlayValues[672] = d672
+					ps3650.OverlayValues[673] = d673
+					ps3650.OverlayValues[674] = d674
+					ps3650.OverlayValues[675] = d675
+					ps3650.OverlayValues[676] = d676
+					ps3650.OverlayValues[677] = d677
+					ps3650.OverlayValues[678] = d678
+					ps3650.OverlayValues[679] = d679
+					ps3650.OverlayValues[680] = d680
+					ps3650.OverlayValues[681] = d681
+					ps3650.OverlayValues[682] = d682
+					ps3650.OverlayValues[683] = d683
+					ps3650.OverlayValues[684] = d684
+					ps3650.OverlayValues[685] = d685
+					ps3650.OverlayValues[686] = d686
+					ps3650.OverlayValues[687] = d687
+					ps3650.OverlayValues[688] = d688
+					ps3650.OverlayValues[689] = d689
+					ps3650.OverlayValues[690] = d690
+					ps3650.OverlayValues[691] = d691
+					ps3650.OverlayValues[692] = d692
+					ps3650.OverlayValues[693] = d693
+					ps3650.OverlayValues[694] = d694
+					ps3650.OverlayValues[695] = d695
+					ps3650.OverlayValues[696] = d696
+					ps3650.OverlayValues[697] = d697
+					ps3650.OverlayValues[910] = d910
+					ps3650.OverlayValues[911] = d911
+					ps3650.OverlayValues[912] = d912
+					ps3650.OverlayValues[913] = d913
+					ps3650.OverlayValues[914] = d914
+					ps3650.OverlayValues[915] = d915
+					ps3650.OverlayValues[916] = d916
+					ps3650.OverlayValues[917] = d917
+					ps3650.OverlayValues[918] = d918
+					ps3650.OverlayValues[919] = d919
+					ps3650.OverlayValues[920] = d920
+					ps3650.OverlayValues[921] = d921
+					ps3650.OverlayValues[922] = d922
+					ps3650.OverlayValues[923] = d923
+					ps3650.OverlayValues[924] = d924
+					ps3650.OverlayValues[925] = d925
+					ps3650.OverlayValues[926] = d926
+					ps3650.OverlayValues[927] = d927
+					ps3650.OverlayValues[928] = d928
+					ps3650.OverlayValues[929] = d929
+					ps3650.OverlayValues[930] = d930
+					ps3650.OverlayValues[931] = d931
+					ps3650.OverlayValues[932] = d932
+					ps3650.OverlayValues[933] = d933
+					ps3650.OverlayValues[934] = d934
+					ps3650.OverlayValues[935] = d935
+					ps3650.OverlayValues[936] = d936
+					ps3650.OverlayValues[937] = d937
+					ps3650.OverlayValues[938] = d938
+					ps3650.OverlayValues[939] = d939
+					ps3650.OverlayValues[940] = d940
+					ps3650.OverlayValues[941] = d941
+					ps3650.OverlayValues[942] = d942
+					ps3650.OverlayValues[1221] = d1221
+					ps3650.OverlayValues[1222] = d1222
+					ps3650.OverlayValues[1223] = d1223
+					ps3650.OverlayValues[1224] = d1224
+					ps3650.OverlayValues[1225] = d1225
+					ps3650.OverlayValues[1226] = d1226
+					ps3650.OverlayValues[1227] = d1227
+					ps3650.OverlayValues[1228] = d1228
+					ps3650.OverlayValues[1229] = d1229
+					ps3650.OverlayValues[1230] = d1230
+					ps3650.OverlayValues[1231] = d1231
+					ps3650.OverlayValues[1232] = d1232
+					ps3650.OverlayValues[1233] = d1233
+					ps3650.OverlayValues[1234] = d1234
+					ps3650.OverlayValues[1236] = d1236
+					ps3650.OverlayValues[1238] = d1238
+					ps3650.OverlayValues[1392] = d1392
+					ps3650.OverlayValues[1395] = d1395
+					ps3650.OverlayValues[1551] = d1551
+					ps3650.OverlayValues[1552] = d1552
+					ps3650.OverlayValues[1553] = d1553
+					ps3650.OverlayValues[1554] = d1554
+					ps3650.OverlayValues[1877] = d1877
+					ps3650.OverlayValues[1878] = d1878
+					ps3650.OverlayValues[1879] = d1879
+					ps3650.OverlayValues[1880] = d1880
+					ps3650.OverlayValues[1881] = d1881
+					ps3650.OverlayValues[1882] = d1882
+					ps3650.OverlayValues[1883] = d1883
+					ps3650.OverlayValues[1884] = d1884
+					ps3650.OverlayValues[1885] = d1885
+					ps3650.OverlayValues[1886] = d1886
+					ps3650.OverlayValues[1887] = d1887
+					ps3650.OverlayValues[1888] = d1888
+					ps3650.OverlayValues[1889] = d1889
+					ps3650.OverlayValues[1890] = d1890
+					ps3650.OverlayValues[1892] = d1892
+					ps3650.OverlayValues[1894] = d1894
+					ps3650.OverlayValues[2070] = d2070
+					ps3650.OverlayValues[2073] = d2073
+					ps3650.OverlayValues[2251] = d2251
+					ps3650.OverlayValues[2252] = d2252
+					ps3650.OverlayValues[2253] = d2253
+					ps3650.OverlayValues[2254] = d2254
+					ps3650.OverlayValues[2621] = d2621
+					ps3650.OverlayValues[2623] = d2623
+					ps3650.OverlayValues[2624] = d2624
+					ps3650.OverlayValues[2625] = d2625
+					ps3650.OverlayValues[2626] = d2626
+					ps3650.OverlayValues[2627] = d2627
+					ps3650.OverlayValues[2628] = d2628
+					ps3650.OverlayValues[2629] = d2629
+					ps3650.OverlayValues[2630] = d2630
+					ps3650.OverlayValues[2631] = d2631
+					ps3650.OverlayValues[2632] = d2632
+					ps3650.OverlayValues[3021] = d3021
+					ps3650.OverlayValues[3022] = d3022
+					ps3650.OverlayValues[3023] = d3023
+					ps3650.OverlayValues[3024] = d3024
+					ps3650.OverlayValues[3421] = d3421
+					ps3650.OverlayValues[3423] = d3423
+					ps3650.OverlayValues[3425] = d3425
+					ps3650.OverlayValues[3426] = d3426
+					ps3650.OverlayValues[3427] = d3427
+					ps3650.OverlayValues[3429] = d3429
+					ps3650.OverlayValues[3430] = d3430
+					ps3650.OverlayValues[3431] = d3431
+					ps3650.OverlayValues[3432] = d3432
+					ps3650.OverlayValues[3433] = d3433
+					ps3650.OverlayValues[3434] = d3434
+					ps3650.OverlayValues[3436] = d3436
+					ps3650.OverlayValues[3438] = d3438
+					ps3650.OverlayValues[3648] = d3648
+					ps3650.PhiValues = make([]JITValueDesc, 1)
+					d3651 = d2627
+					ps3650.PhiValues[0] = d3651
+					snap3652 := d1
+					snap3653 := d2
+					snap3654 := d3
+					snap3655 := d4
+					snap3656 := d5
+					snap3657 := d6
+					snap3658 := d7
+					snap3659 := d28
+					snap3660 := d29
+					snap3661 := d31
+					snap3662 := d32
+					snap3663 := d33
+					snap3664 := d35
+					snap3665 := d36
+					snap3666 := d37
+					snap3667 := d74
+					snap3668 := d75
+					snap3669 := d76
+					snap3670 := d77
+					snap3671 := d122
+					snap3672 := d123
+					snap3673 := d124
+					snap3674 := d125
+					snap3675 := d126
+					snap3676 := d127
+					snap3677 := d128
+					snap3678 := d129
+					snap3679 := d130
+					snap3680 := d193
+					snap3681 := d258
+					snap3682 := d259
+					snap3683 := d260
+					snap3684 := d261
+					snap3685 := d262
+					snap3686 := d263
+					snap3687 := d264
+					snap3688 := d265
+					snap3689 := d266
+					snap3690 := d267
+					snap3691 := d268
+					snap3692 := d269
+					snap3693 := d270
+					snap3694 := d271
+					snap3695 := d272
+					snap3696 := d273
+					snap3697 := d370
+					snap3698 := d371
+					snap3699 := d372
+					snap3700 := d373
+					snap3701 := d374
+					snap3702 := d375
+					snap3703 := d376
+					snap3704 := d377
+					snap3705 := d378
+					snap3706 := d379
+					snap3707 := d380
+					snap3708 := d381
+					snap3709 := d382
+					snap3710 := d505
+					snap3711 := d506
+					snap3712 := d507
+					snap3713 := d508
+					snap3714 := d509
+					snap3715 := d510
+					snap3716 := d511
+					snap3717 := d512
+					snap3718 := d513
+					snap3719 := d514
+					snap3720 := d515
+					snap3721 := d516
+					snap3722 := d517
+					snap3723 := d666
+					snap3724 := d667
+					snap3725 := d668
+					snap3726 := d669
+					snap3727 := d670
+					snap3728 := d671
+					snap3729 := d672
+					snap3730 := d673
+					snap3731 := d674
+					snap3732 := d675
+					snap3733 := d676
+					snap3734 := d677
+					snap3735 := d678
+					snap3736 := d679
+					snap3737 := d680
+					snap3738 := d681
+					snap3739 := d682
+					snap3740 := d683
+					snap3741 := d684
+					snap3742 := d685
+					snap3743 := d686
+					snap3744 := d687
+					snap3745 := d688
+					snap3746 := d689
+					snap3747 := d690
+					snap3748 := d691
+					snap3749 := d692
+					snap3750 := d693
+					snap3751 := d694
+					snap3752 := d695
+					snap3753 := d696
+					snap3754 := d697
+					snap3755 := d910
+					snap3756 := d911
+					snap3757 := d912
+					snap3758 := d913
+					snap3759 := d914
+					snap3760 := d915
+					snap3761 := d916
+					snap3762 := d917
+					snap3763 := d918
+					snap3764 := d919
+					snap3765 := d920
+					snap3766 := d921
+					snap3767 := d922
+					snap3768 := d923
+					snap3769 := d924
+					snap3770 := d925
+					snap3771 := d926
+					snap3772 := d927
+					snap3773 := d928
+					snap3774 := d929
+					snap3775 := d930
+					snap3776 := d931
+					snap3777 := d932
+					snap3778 := d933
+					snap3779 := d934
+					snap3780 := d935
+					snap3781 := d936
+					snap3782 := d937
+					snap3783 := d938
+					snap3784 := d939
+					snap3785 := d940
+					snap3786 := d941
+					snap3787 := d942
+					snap3788 := d1221
+					snap3789 := d1222
+					snap3790 := d1223
+					snap3791 := d1224
+					snap3792 := d1225
+					snap3793 := d1226
+					snap3794 := d1227
+					snap3795 := d1228
+					snap3796 := d1229
+					snap3797 := d1230
+					snap3798 := d1231
+					snap3799 := d1232
+					snap3800 := d1233
+					snap3801 := d1234
+					snap3802 := d1236
+					snap3803 := d1238
+					snap3804 := d1392
+					snap3805 := d1395
+					snap3806 := d1551
+					snap3807 := d1552
+					snap3808 := d1553
+					snap3809 := d1554
+					snap3810 := d1877
+					snap3811 := d1878
+					snap3812 := d1879
+					snap3813 := d1880
+					snap3814 := d1881
+					snap3815 := d1882
+					snap3816 := d1883
+					snap3817 := d1884
+					snap3818 := d1885
+					snap3819 := d1886
+					snap3820 := d1887
+					snap3821 := d1888
+					snap3822 := d1889
+					snap3823 := d1890
+					snap3824 := d1892
+					snap3825 := d1894
+					snap3826 := d2070
+					snap3827 := d2073
+					snap3828 := d2251
+					snap3829 := d2252
+					snap3830 := d2253
+					snap3831 := d2254
+					snap3832 := d2621
+					snap3833 := d2623
+					snap3834 := d2624
+					snap3835 := d2625
+					snap3836 := d2626
+					snap3837 := d2627
+					snap3838 := d2628
+					snap3839 := d2629
+					snap3840 := d2630
+					snap3841 := d2631
+					snap3842 := d2632
+					snap3843 := d3021
+					snap3844 := d3022
+					snap3845 := d3023
+					snap3846 := d3024
+					snap3847 := d3421
+					snap3848 := d3423
 					snap3849 := d3425
 					snap3850 := d3426
-					snap3851 := d3428
+					snap3851 := d3427
 					snap3852 := d3429
 					snap3853 := d3430
 					snap3854 := d3431
 					snap3855 := d3432
 					snap3856 := d3433
-					snap3857 := d3435
-					snap3858 := d3437
-					snap3859 := d3647
-					snap3860 := d3650
-					alloc3861 := ctx.SnapshotAllocState()
+					snap3857 := d3434
+					snap3858 := d3436
+					snap3859 := d3438
+					snap3860 := d3648
+					snap3861 := d3651
+					alloc3862 := ctx.SnapshotAllocState()
 					if !bbs[30].Rendered {
-						bbs[30].RenderPS(ps3649)
+						bbs[30].RenderPS(ps3650)
 					}
-					ctx.RestoreAllocState(alloc3861)
-					d1 = snap3651
-					d2 = snap3652
-					d3 = snap3653
-					d4 = snap3654
-					d5 = snap3655
-					d6 = snap3656
-					d7 = snap3657
-					d28 = snap3658
-					d29 = snap3659
-					d31 = snap3660
-					d32 = snap3661
-					d33 = snap3662
-					d35 = snap3663
-					d36 = snap3664
-					d37 = snap3665
-					d74 = snap3666
-					d75 = snap3667
-					d76 = snap3668
-					d77 = snap3669
-					d122 = snap3670
-					d123 = snap3671
-					d124 = snap3672
-					d125 = snap3673
-					d126 = snap3674
-					d127 = snap3675
-					d128 = snap3676
-					d129 = snap3677
-					d130 = snap3678
-					d193 = snap3679
-					d258 = snap3680
-					d259 = snap3681
-					d260 = snap3682
-					d261 = snap3683
-					d262 = snap3684
-					d263 = snap3685
-					d264 = snap3686
-					d265 = snap3687
-					d266 = snap3688
-					d267 = snap3689
-					d268 = snap3690
-					d269 = snap3691
-					d270 = snap3692
-					d271 = snap3693
-					d272 = snap3694
-					d273 = snap3695
-					d370 = snap3696
-					d371 = snap3697
-					d372 = snap3698
-					d373 = snap3699
-					d374 = snap3700
-					d375 = snap3701
-					d376 = snap3702
-					d377 = snap3703
-					d378 = snap3704
-					d379 = snap3705
-					d380 = snap3706
-					d381 = snap3707
-					d382 = snap3708
-					d505 = snap3709
-					d506 = snap3710
-					d507 = snap3711
-					d508 = snap3712
-					d509 = snap3713
-					d510 = snap3714
-					d511 = snap3715
-					d512 = snap3716
-					d513 = snap3717
-					d514 = snap3718
-					d515 = snap3719
-					d516 = snap3720
-					d517 = snap3721
-					d666 = snap3722
-					d667 = snap3723
-					d668 = snap3724
-					d669 = snap3725
-					d670 = snap3726
-					d671 = snap3727
-					d672 = snap3728
-					d673 = snap3729
-					d674 = snap3730
-					d675 = snap3731
-					d676 = snap3732
-					d677 = snap3733
-					d678 = snap3734
-					d679 = snap3735
-					d680 = snap3736
-					d681 = snap3737
-					d682 = snap3738
-					d683 = snap3739
-					d684 = snap3740
-					d685 = snap3741
-					d686 = snap3742
-					d687 = snap3743
-					d688 = snap3744
-					d689 = snap3745
-					d690 = snap3746
-					d691 = snap3747
-					d692 = snap3748
-					d693 = snap3749
-					d694 = snap3750
-					d695 = snap3751
-					d696 = snap3752
-					d697 = snap3753
-					d910 = snap3754
-					d911 = snap3755
-					d912 = snap3756
-					d913 = snap3757
-					d914 = snap3758
-					d915 = snap3759
-					d916 = snap3760
-					d917 = snap3761
-					d918 = snap3762
-					d919 = snap3763
-					d920 = snap3764
-					d921 = snap3765
-					d922 = snap3766
-					d923 = snap3767
-					d924 = snap3768
-					d925 = snap3769
-					d926 = snap3770
-					d927 = snap3771
-					d928 = snap3772
-					d929 = snap3773
-					d930 = snap3774
-					d931 = snap3775
-					d932 = snap3776
-					d933 = snap3777
-					d934 = snap3778
-					d935 = snap3779
-					d936 = snap3780
-					d937 = snap3781
-					d938 = snap3782
-					d939 = snap3783
-					d940 = snap3784
-					d941 = snap3785
-					d942 = snap3786
-					d1221 = snap3787
-					d1222 = snap3788
-					d1223 = snap3789
-					d1224 = snap3790
-					d1225 = snap3791
-					d1226 = snap3792
-					d1227 = snap3793
-					d1228 = snap3794
-					d1229 = snap3795
-					d1230 = snap3796
-					d1231 = snap3797
-					d1232 = snap3798
-					d1233 = snap3799
-					d1234 = snap3800
-					d1236 = snap3801
-					d1238 = snap3802
-					d1392 = snap3803
-					d1395 = snap3804
-					d1551 = snap3805
-					d1552 = snap3806
-					d1553 = snap3807
-					d1554 = snap3808
-					d1877 = snap3809
-					d1878 = snap3810
-					d1879 = snap3811
-					d1880 = snap3812
-					d1881 = snap3813
-					d1882 = snap3814
-					d1883 = snap3815
-					d1884 = snap3816
-					d1885 = snap3817
-					d1886 = snap3818
-					d1887 = snap3819
-					d1888 = snap3820
-					d1889 = snap3821
-					d1890 = snap3822
-					d1892 = snap3823
-					d1894 = snap3824
-					d2070 = snap3825
-					d2073 = snap3826
-					d2251 = snap3827
-					d2252 = snap3828
-					d2253 = snap3829
-					d2254 = snap3830
-					d2621 = snap3831
-					d2623 = snap3832
-					d2624 = snap3833
-					d2625 = snap3834
-					d2626 = snap3835
-					d2627 = snap3836
-					d2628 = snap3837
-					d2629 = snap3838
-					d2630 = snap3839
-					d2631 = snap3840
-					d2632 = snap3841
-					d3021 = snap3842
-					d3022 = snap3843
-					d3023 = snap3844
-					d3024 = snap3845
-					d3421 = snap3846
-					d3423 = snap3847
-					d3424 = snap3848
+					ctx.RestoreAllocState(alloc3862)
+					d1 = snap3652
+					d2 = snap3653
+					d3 = snap3654
+					d4 = snap3655
+					d5 = snap3656
+					d6 = snap3657
+					d7 = snap3658
+					d28 = snap3659
+					d29 = snap3660
+					d31 = snap3661
+					d32 = snap3662
+					d33 = snap3663
+					d35 = snap3664
+					d36 = snap3665
+					d37 = snap3666
+					d74 = snap3667
+					d75 = snap3668
+					d76 = snap3669
+					d77 = snap3670
+					d122 = snap3671
+					d123 = snap3672
+					d124 = snap3673
+					d125 = snap3674
+					d126 = snap3675
+					d127 = snap3676
+					d128 = snap3677
+					d129 = snap3678
+					d130 = snap3679
+					d193 = snap3680
+					d258 = snap3681
+					d259 = snap3682
+					d260 = snap3683
+					d261 = snap3684
+					d262 = snap3685
+					d263 = snap3686
+					d264 = snap3687
+					d265 = snap3688
+					d266 = snap3689
+					d267 = snap3690
+					d268 = snap3691
+					d269 = snap3692
+					d270 = snap3693
+					d271 = snap3694
+					d272 = snap3695
+					d273 = snap3696
+					d370 = snap3697
+					d371 = snap3698
+					d372 = snap3699
+					d373 = snap3700
+					d374 = snap3701
+					d375 = snap3702
+					d376 = snap3703
+					d377 = snap3704
+					d378 = snap3705
+					d379 = snap3706
+					d380 = snap3707
+					d381 = snap3708
+					d382 = snap3709
+					d505 = snap3710
+					d506 = snap3711
+					d507 = snap3712
+					d508 = snap3713
+					d509 = snap3714
+					d510 = snap3715
+					d511 = snap3716
+					d512 = snap3717
+					d513 = snap3718
+					d514 = snap3719
+					d515 = snap3720
+					d516 = snap3721
+					d517 = snap3722
+					d666 = snap3723
+					d667 = snap3724
+					d668 = snap3725
+					d669 = snap3726
+					d670 = snap3727
+					d671 = snap3728
+					d672 = snap3729
+					d673 = snap3730
+					d674 = snap3731
+					d675 = snap3732
+					d676 = snap3733
+					d677 = snap3734
+					d678 = snap3735
+					d679 = snap3736
+					d680 = snap3737
+					d681 = snap3738
+					d682 = snap3739
+					d683 = snap3740
+					d684 = snap3741
+					d685 = snap3742
+					d686 = snap3743
+					d687 = snap3744
+					d688 = snap3745
+					d689 = snap3746
+					d690 = snap3747
+					d691 = snap3748
+					d692 = snap3749
+					d693 = snap3750
+					d694 = snap3751
+					d695 = snap3752
+					d696 = snap3753
+					d697 = snap3754
+					d910 = snap3755
+					d911 = snap3756
+					d912 = snap3757
+					d913 = snap3758
+					d914 = snap3759
+					d915 = snap3760
+					d916 = snap3761
+					d917 = snap3762
+					d918 = snap3763
+					d919 = snap3764
+					d920 = snap3765
+					d921 = snap3766
+					d922 = snap3767
+					d923 = snap3768
+					d924 = snap3769
+					d925 = snap3770
+					d926 = snap3771
+					d927 = snap3772
+					d928 = snap3773
+					d929 = snap3774
+					d930 = snap3775
+					d931 = snap3776
+					d932 = snap3777
+					d933 = snap3778
+					d934 = snap3779
+					d935 = snap3780
+					d936 = snap3781
+					d937 = snap3782
+					d938 = snap3783
+					d939 = snap3784
+					d940 = snap3785
+					d941 = snap3786
+					d942 = snap3787
+					d1221 = snap3788
+					d1222 = snap3789
+					d1223 = snap3790
+					d1224 = snap3791
+					d1225 = snap3792
+					d1226 = snap3793
+					d1227 = snap3794
+					d1228 = snap3795
+					d1229 = snap3796
+					d1230 = snap3797
+					d1231 = snap3798
+					d1232 = snap3799
+					d1233 = snap3800
+					d1234 = snap3801
+					d1236 = snap3802
+					d1238 = snap3803
+					d1392 = snap3804
+					d1395 = snap3805
+					d1551 = snap3806
+					d1552 = snap3807
+					d1553 = snap3808
+					d1554 = snap3809
+					d1877 = snap3810
+					d1878 = snap3811
+					d1879 = snap3812
+					d1880 = snap3813
+					d1881 = snap3814
+					d1882 = snap3815
+					d1883 = snap3816
+					d1884 = snap3817
+					d1885 = snap3818
+					d1886 = snap3819
+					d1887 = snap3820
+					d1888 = snap3821
+					d1889 = snap3822
+					d1890 = snap3823
+					d1892 = snap3824
+					d1894 = snap3825
+					d2070 = snap3826
+					d2073 = snap3827
+					d2251 = snap3828
+					d2252 = snap3829
+					d2253 = snap3830
+					d2254 = snap3831
+					d2621 = snap3832
+					d2623 = snap3833
+					d2624 = snap3834
+					d2625 = snap3835
+					d2626 = snap3836
+					d2627 = snap3837
+					d2628 = snap3838
+					d2629 = snap3839
+					d2630 = snap3840
+					d2631 = snap3841
+					d2632 = snap3842
+					d3021 = snap3843
+					d3022 = snap3844
+					d3023 = snap3845
+					d3024 = snap3846
+					d3421 = snap3847
+					d3423 = snap3848
 					d3425 = snap3849
 					d3426 = snap3850
-					d3428 = snap3851
+					d3427 = snap3851
 					d3429 = snap3852
 					d3430 = snap3853
 					d3431 = snap3854
 					d3432 = snap3855
 					d3433 = snap3856
-					d3435 = snap3857
-					d3437 = snap3858
-					d3647 = snap3859
-					d3650 = snap3860
+					d3434 = snap3857
+					d3436 = snap3858
+					d3438 = snap3859
+					d3648 = snap3860
+					d3651 = snap3861
 					if !bbs[32].Rendered {
-						return bbs[32].RenderPS(ps3648)
+						return bbs[32].RenderPS(ps3649)
 					}
 					return result
 					return result
@@ -71881,17 +71967,14 @@ func init_date() {
 					if len(ps.OverlayValues) > 3423 && ps.OverlayValues[3423].Loc != LocNone {
 						d3423 = ps.OverlayValues[3423]
 					}
-					if len(ps.OverlayValues) > 3424 && ps.OverlayValues[3424].Loc != LocNone {
-						d3424 = ps.OverlayValues[3424]
-					}
 					if len(ps.OverlayValues) > 3425 && ps.OverlayValues[3425].Loc != LocNone {
 						d3425 = ps.OverlayValues[3425]
 					}
 					if len(ps.OverlayValues) > 3426 && ps.OverlayValues[3426].Loc != LocNone {
 						d3426 = ps.OverlayValues[3426]
 					}
-					if len(ps.OverlayValues) > 3428 && ps.OverlayValues[3428].Loc != LocNone {
-						d3428 = ps.OverlayValues[3428]
+					if len(ps.OverlayValues) > 3427 && ps.OverlayValues[3427].Loc != LocNone {
+						d3427 = ps.OverlayValues[3427]
 					}
 					if len(ps.OverlayValues) > 3429 && ps.OverlayValues[3429].Loc != LocNone {
 						d3429 = ps.OverlayValues[3429]
@@ -71908,17 +71991,20 @@ func init_date() {
 					if len(ps.OverlayValues) > 3433 && ps.OverlayValues[3433].Loc != LocNone {
 						d3433 = ps.OverlayValues[3433]
 					}
-					if len(ps.OverlayValues) > 3435 && ps.OverlayValues[3435].Loc != LocNone {
-						d3435 = ps.OverlayValues[3435]
+					if len(ps.OverlayValues) > 3434 && ps.OverlayValues[3434].Loc != LocNone {
+						d3434 = ps.OverlayValues[3434]
 					}
-					if len(ps.OverlayValues) > 3437 && ps.OverlayValues[3437].Loc != LocNone {
-						d3437 = ps.OverlayValues[3437]
+					if len(ps.OverlayValues) > 3436 && ps.OverlayValues[3436].Loc != LocNone {
+						d3436 = ps.OverlayValues[3436]
 					}
-					if len(ps.OverlayValues) > 3647 && ps.OverlayValues[3647].Loc != LocNone {
-						d3647 = ps.OverlayValues[3647]
+					if len(ps.OverlayValues) > 3438 && ps.OverlayValues[3438].Loc != LocNone {
+						d3438 = ps.OverlayValues[3438]
 					}
-					if len(ps.OverlayValues) > 3650 && ps.OverlayValues[3650].Loc != LocNone {
-						d3650 = ps.OverlayValues[3650]
+					if len(ps.OverlayValues) > 3648 && ps.OverlayValues[3648].Loc != LocNone {
+						d3648 = ps.OverlayValues[3648]
+					}
+					if len(ps.OverlayValues) > 3651 && ps.OverlayValues[3651].Loc != LocNone {
+						d3651 = ps.OverlayValues[3651]
 					}
 					ctx.ReclaimUntrackedRegs()
 					d35 = JITPrepareGoSliceArg(ctx, d35)
@@ -71926,1418 +72012,1199 @@ func init_date() {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
 					}
 					ctx.SyncDesc(&d35)
-					d3862 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d35}, 1)
-					d3862.NoHeapPointer = true
-					ctx.BindReg(d3862.Reg, &d3862)
+					d3863 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d35}, 1)
+					d3863.NoHeapPointer = true
+					ctx.BindReg(d3863.Reg, &d3863)
 					d31 = JITPrepareGoSliceArg(ctx, d31)
 					if d31.Loc != LocRegTriple && d31.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
 					}
 					ctx.SyncDesc(&d31)
-					d3863 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d31}, 1)
-					d3863.NoHeapPointer = true
-					ctx.BindReg(d3863.Reg, &d3863)
-					ctx.EnsureDesc(&d3862)
+					d3864 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d31}, 1)
+					d3864.NoHeapPointer = true
+					ctx.BindReg(d3864.Reg, &d3864)
 					ctx.EnsureDesc(&d3863)
-					ctx.EnsureDescsTogether(&d3862, &d3863)
-					var d3864 JITValueDesc
-					if d3862.Loc == LocImm && d3863.Loc == LocImm {
-						d3864 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d3862.Imm.Int() < d3863.Imm.Int())}
-					} else if d3863.Loc == LocImm {
-						r51 := ctx.AllocReg()
-						if d3863.Imm.Int() >= -2147483648 && d3863.Imm.Int() <= 2147483647 {
-							ctx.EmitCmpRegImm32(d3862.Reg, int32(d3863.Imm.Int()))
-						} else {
-							ctx.EmitMovRegImm64(RegR11, uint64(d3863.Imm.Int()))
-							ctx.EmitCmpInt64(d3862.Reg, RegR11)
-						}
-						d3864 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r51, Condition: CondSignedLess}
-						ctx.BindReg(r51, &d3864)
-					} else if d3862.Loc == LocImm {
+					ctx.EnsureDesc(&d3864)
+					ctx.EnsureDescsTogether(&d3863, &d3864)
+					var d3865 JITValueDesc
+					if d3863.Loc == LocImm && d3864.Loc == LocImm {
+						d3865 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d3863.Imm.Int() < d3864.Imm.Int())}
+					} else if d3864.Loc == LocImm {
 						r52 := ctx.AllocReg()
-						ctx.EmitMovRegImm64(RegR11, uint64(d3862.Imm.Int()))
-						ctx.EmitCmpInt64(RegR11, d3863.Reg)
-						d3864 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r52, Condition: CondSignedLess}
-						ctx.BindReg(r52, &d3864)
-					} else {
+						if d3864.Imm.Int() >= -2147483648 && d3864.Imm.Int() <= 2147483647 {
+							ctx.EmitCmpRegImm32(d3863.Reg, int32(d3864.Imm.Int()))
+						} else {
+							ctx.EmitMovRegImm64(RegR11, uint64(d3864.Imm.Int()))
+							ctx.EmitCmpInt64(d3863.Reg, RegR11)
+						}
+						d3865 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r52, Condition: CondSignedLess}
+						ctx.BindReg(r52, &d3865)
+					} else if d3863.Loc == LocImm {
 						r53 := ctx.AllocReg()
-						ctx.EmitCmpInt64(d3862.Reg, d3863.Reg)
-						d3864 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r53, Condition: CondSignedLess}
-						ctx.BindReg(r53, &d3864)
+						ctx.EmitMovRegImm64(RegR11, uint64(d3863.Imm.Int()))
+						ctx.EmitCmpInt64(RegR11, d3864.Reg)
+						d3865 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r53, Condition: CondSignedLess}
+						ctx.BindReg(r53, &d3865)
+					} else {
+						r54 := ctx.AllocReg()
+						ctx.EmitCmpInt64(d3863.Reg, d3864.Reg)
+						d3865 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r54, Condition: CondSignedLess}
+						ctx.BindReg(r54, &d3865)
 					}
-					ctx.FreeDesc(&d3862)
 					ctx.FreeDesc(&d3863)
-					d3865 = d3864
-					ctx.EnsureDesc(&d3865)
-					if d3865.Loc != LocImm && d3865.Loc != LocFlags {
+					ctx.FreeDesc(&d3864)
+					d3866 = d3865
+					ctx.EnsureDesc(&d3866)
+					if d3866.Loc != LocImm && d3866.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d3865.Loc == LocImm {
-						if d3865.Imm.Bool() {
+					if d3866.Loc == LocImm {
+						if d3866.Imm.Bool() {
 							if ps.General {
 							}
-							ps3866 := PhiState{General: ps.General}
-							ps3866.OverlayValues = make([]JITValueDesc, 3866)
-							ps3866.OverlayValues[1] = d1
-							ps3866.OverlayValues[2] = d2
-							ps3866.OverlayValues[3] = d3
-							ps3866.OverlayValues[4] = d4
-							ps3866.OverlayValues[5] = d5
-							ps3866.OverlayValues[6] = d6
-							ps3866.OverlayValues[7] = d7
-							ps3866.OverlayValues[28] = d28
-							ps3866.OverlayValues[29] = d29
-							ps3866.OverlayValues[31] = d31
-							ps3866.OverlayValues[32] = d32
-							ps3866.OverlayValues[33] = d33
-							ps3866.OverlayValues[35] = d35
-							ps3866.OverlayValues[36] = d36
-							ps3866.OverlayValues[37] = d37
-							ps3866.OverlayValues[74] = d74
-							ps3866.OverlayValues[75] = d75
-							ps3866.OverlayValues[76] = d76
-							ps3866.OverlayValues[77] = d77
-							ps3866.OverlayValues[122] = d122
-							ps3866.OverlayValues[123] = d123
-							ps3866.OverlayValues[124] = d124
-							ps3866.OverlayValues[125] = d125
-							ps3866.OverlayValues[126] = d126
-							ps3866.OverlayValues[127] = d127
-							ps3866.OverlayValues[128] = d128
-							ps3866.OverlayValues[129] = d129
-							ps3866.OverlayValues[130] = d130
-							ps3866.OverlayValues[193] = d193
-							ps3866.OverlayValues[258] = d258
-							ps3866.OverlayValues[259] = d259
-							ps3866.OverlayValues[260] = d260
-							ps3866.OverlayValues[261] = d261
-							ps3866.OverlayValues[262] = d262
-							ps3866.OverlayValues[263] = d263
-							ps3866.OverlayValues[264] = d264
-							ps3866.OverlayValues[265] = d265
-							ps3866.OverlayValues[266] = d266
-							ps3866.OverlayValues[267] = d267
-							ps3866.OverlayValues[268] = d268
-							ps3866.OverlayValues[269] = d269
-							ps3866.OverlayValues[270] = d270
-							ps3866.OverlayValues[271] = d271
-							ps3866.OverlayValues[272] = d272
-							ps3866.OverlayValues[273] = d273
-							ps3866.OverlayValues[370] = d370
-							ps3866.OverlayValues[371] = d371
-							ps3866.OverlayValues[372] = d372
-							ps3866.OverlayValues[373] = d373
-							ps3866.OverlayValues[374] = d374
-							ps3866.OverlayValues[375] = d375
-							ps3866.OverlayValues[376] = d376
-							ps3866.OverlayValues[377] = d377
-							ps3866.OverlayValues[378] = d378
-							ps3866.OverlayValues[379] = d379
-							ps3866.OverlayValues[380] = d380
-							ps3866.OverlayValues[381] = d381
-							ps3866.OverlayValues[382] = d382
-							ps3866.OverlayValues[505] = d505
-							ps3866.OverlayValues[506] = d506
-							ps3866.OverlayValues[507] = d507
-							ps3866.OverlayValues[508] = d508
-							ps3866.OverlayValues[509] = d509
-							ps3866.OverlayValues[510] = d510
-							ps3866.OverlayValues[511] = d511
-							ps3866.OverlayValues[512] = d512
-							ps3866.OverlayValues[513] = d513
-							ps3866.OverlayValues[514] = d514
-							ps3866.OverlayValues[515] = d515
-							ps3866.OverlayValues[516] = d516
-							ps3866.OverlayValues[517] = d517
-							ps3866.OverlayValues[666] = d666
-							ps3866.OverlayValues[667] = d667
-							ps3866.OverlayValues[668] = d668
-							ps3866.OverlayValues[669] = d669
-							ps3866.OverlayValues[670] = d670
-							ps3866.OverlayValues[671] = d671
-							ps3866.OverlayValues[672] = d672
-							ps3866.OverlayValues[673] = d673
-							ps3866.OverlayValues[674] = d674
-							ps3866.OverlayValues[675] = d675
-							ps3866.OverlayValues[676] = d676
-							ps3866.OverlayValues[677] = d677
-							ps3866.OverlayValues[678] = d678
-							ps3866.OverlayValues[679] = d679
-							ps3866.OverlayValues[680] = d680
-							ps3866.OverlayValues[681] = d681
-							ps3866.OverlayValues[682] = d682
-							ps3866.OverlayValues[683] = d683
-							ps3866.OverlayValues[684] = d684
-							ps3866.OverlayValues[685] = d685
-							ps3866.OverlayValues[686] = d686
-							ps3866.OverlayValues[687] = d687
-							ps3866.OverlayValues[688] = d688
-							ps3866.OverlayValues[689] = d689
-							ps3866.OverlayValues[690] = d690
-							ps3866.OverlayValues[691] = d691
-							ps3866.OverlayValues[692] = d692
-							ps3866.OverlayValues[693] = d693
-							ps3866.OverlayValues[694] = d694
-							ps3866.OverlayValues[695] = d695
-							ps3866.OverlayValues[696] = d696
-							ps3866.OverlayValues[697] = d697
-							ps3866.OverlayValues[910] = d910
-							ps3866.OverlayValues[911] = d911
-							ps3866.OverlayValues[912] = d912
-							ps3866.OverlayValues[913] = d913
-							ps3866.OverlayValues[914] = d914
-							ps3866.OverlayValues[915] = d915
-							ps3866.OverlayValues[916] = d916
-							ps3866.OverlayValues[917] = d917
-							ps3866.OverlayValues[918] = d918
-							ps3866.OverlayValues[919] = d919
-							ps3866.OverlayValues[920] = d920
-							ps3866.OverlayValues[921] = d921
-							ps3866.OverlayValues[922] = d922
-							ps3866.OverlayValues[923] = d923
-							ps3866.OverlayValues[924] = d924
-							ps3866.OverlayValues[925] = d925
-							ps3866.OverlayValues[926] = d926
-							ps3866.OverlayValues[927] = d927
-							ps3866.OverlayValues[928] = d928
-							ps3866.OverlayValues[929] = d929
-							ps3866.OverlayValues[930] = d930
-							ps3866.OverlayValues[931] = d931
-							ps3866.OverlayValues[932] = d932
-							ps3866.OverlayValues[933] = d933
-							ps3866.OverlayValues[934] = d934
-							ps3866.OverlayValues[935] = d935
-							ps3866.OverlayValues[936] = d936
-							ps3866.OverlayValues[937] = d937
-							ps3866.OverlayValues[938] = d938
-							ps3866.OverlayValues[939] = d939
-							ps3866.OverlayValues[940] = d940
-							ps3866.OverlayValues[941] = d941
-							ps3866.OverlayValues[942] = d942
-							ps3866.OverlayValues[1221] = d1221
-							ps3866.OverlayValues[1222] = d1222
-							ps3866.OverlayValues[1223] = d1223
-							ps3866.OverlayValues[1224] = d1224
-							ps3866.OverlayValues[1225] = d1225
-							ps3866.OverlayValues[1226] = d1226
-							ps3866.OverlayValues[1227] = d1227
-							ps3866.OverlayValues[1228] = d1228
-							ps3866.OverlayValues[1229] = d1229
-							ps3866.OverlayValues[1230] = d1230
-							ps3866.OverlayValues[1231] = d1231
-							ps3866.OverlayValues[1232] = d1232
-							ps3866.OverlayValues[1233] = d1233
-							ps3866.OverlayValues[1234] = d1234
-							ps3866.OverlayValues[1236] = d1236
-							ps3866.OverlayValues[1238] = d1238
-							ps3866.OverlayValues[1392] = d1392
-							ps3866.OverlayValues[1395] = d1395
-							ps3866.OverlayValues[1551] = d1551
-							ps3866.OverlayValues[1552] = d1552
-							ps3866.OverlayValues[1553] = d1553
-							ps3866.OverlayValues[1554] = d1554
-							ps3866.OverlayValues[1877] = d1877
-							ps3866.OverlayValues[1878] = d1878
-							ps3866.OverlayValues[1879] = d1879
-							ps3866.OverlayValues[1880] = d1880
-							ps3866.OverlayValues[1881] = d1881
-							ps3866.OverlayValues[1882] = d1882
-							ps3866.OverlayValues[1883] = d1883
-							ps3866.OverlayValues[1884] = d1884
-							ps3866.OverlayValues[1885] = d1885
-							ps3866.OverlayValues[1886] = d1886
-							ps3866.OverlayValues[1887] = d1887
-							ps3866.OverlayValues[1888] = d1888
-							ps3866.OverlayValues[1889] = d1889
-							ps3866.OverlayValues[1890] = d1890
-							ps3866.OverlayValues[1892] = d1892
-							ps3866.OverlayValues[1894] = d1894
-							ps3866.OverlayValues[2070] = d2070
-							ps3866.OverlayValues[2073] = d2073
-							ps3866.OverlayValues[2251] = d2251
-							ps3866.OverlayValues[2252] = d2252
-							ps3866.OverlayValues[2253] = d2253
-							ps3866.OverlayValues[2254] = d2254
-							ps3866.OverlayValues[2621] = d2621
-							ps3866.OverlayValues[2623] = d2623
-							ps3866.OverlayValues[2624] = d2624
-							ps3866.OverlayValues[2625] = d2625
-							ps3866.OverlayValues[2626] = d2626
-							ps3866.OverlayValues[2627] = d2627
-							ps3866.OverlayValues[2628] = d2628
-							ps3866.OverlayValues[2629] = d2629
-							ps3866.OverlayValues[2630] = d2630
-							ps3866.OverlayValues[2631] = d2631
-							ps3866.OverlayValues[2632] = d2632
-							ps3866.OverlayValues[3021] = d3021
-							ps3866.OverlayValues[3022] = d3022
-							ps3866.OverlayValues[3023] = d3023
-							ps3866.OverlayValues[3024] = d3024
-							ps3866.OverlayValues[3421] = d3421
-							ps3866.OverlayValues[3423] = d3423
-							ps3866.OverlayValues[3424] = d3424
-							ps3866.OverlayValues[3425] = d3425
-							ps3866.OverlayValues[3426] = d3426
-							ps3866.OverlayValues[3428] = d3428
-							ps3866.OverlayValues[3429] = d3429
-							ps3866.OverlayValues[3430] = d3430
-							ps3866.OverlayValues[3431] = d3431
-							ps3866.OverlayValues[3432] = d3432
-							ps3866.OverlayValues[3433] = d3433
-							ps3866.OverlayValues[3435] = d3435
-							ps3866.OverlayValues[3437] = d3437
-							ps3866.OverlayValues[3647] = d3647
-							ps3866.OverlayValues[3650] = d3650
-							ps3866.OverlayValues[3862] = d3862
-							ps3866.OverlayValues[3863] = d3863
-							ps3866.OverlayValues[3864] = d3864
-							ps3866.OverlayValues[3865] = d3865
-							return bbs[29].RenderPS(ps3866)
+							ps3867 := PhiState{General: ps.General}
+							ps3867.OverlayValues = make([]JITValueDesc, 3867)
+							ps3867.OverlayValues[1] = d1
+							ps3867.OverlayValues[2] = d2
+							ps3867.OverlayValues[3] = d3
+							ps3867.OverlayValues[4] = d4
+							ps3867.OverlayValues[5] = d5
+							ps3867.OverlayValues[6] = d6
+							ps3867.OverlayValues[7] = d7
+							ps3867.OverlayValues[28] = d28
+							ps3867.OverlayValues[29] = d29
+							ps3867.OverlayValues[31] = d31
+							ps3867.OverlayValues[32] = d32
+							ps3867.OverlayValues[33] = d33
+							ps3867.OverlayValues[35] = d35
+							ps3867.OverlayValues[36] = d36
+							ps3867.OverlayValues[37] = d37
+							ps3867.OverlayValues[74] = d74
+							ps3867.OverlayValues[75] = d75
+							ps3867.OverlayValues[76] = d76
+							ps3867.OverlayValues[77] = d77
+							ps3867.OverlayValues[122] = d122
+							ps3867.OverlayValues[123] = d123
+							ps3867.OverlayValues[124] = d124
+							ps3867.OverlayValues[125] = d125
+							ps3867.OverlayValues[126] = d126
+							ps3867.OverlayValues[127] = d127
+							ps3867.OverlayValues[128] = d128
+							ps3867.OverlayValues[129] = d129
+							ps3867.OverlayValues[130] = d130
+							ps3867.OverlayValues[193] = d193
+							ps3867.OverlayValues[258] = d258
+							ps3867.OverlayValues[259] = d259
+							ps3867.OverlayValues[260] = d260
+							ps3867.OverlayValues[261] = d261
+							ps3867.OverlayValues[262] = d262
+							ps3867.OverlayValues[263] = d263
+							ps3867.OverlayValues[264] = d264
+							ps3867.OverlayValues[265] = d265
+							ps3867.OverlayValues[266] = d266
+							ps3867.OverlayValues[267] = d267
+							ps3867.OverlayValues[268] = d268
+							ps3867.OverlayValues[269] = d269
+							ps3867.OverlayValues[270] = d270
+							ps3867.OverlayValues[271] = d271
+							ps3867.OverlayValues[272] = d272
+							ps3867.OverlayValues[273] = d273
+							ps3867.OverlayValues[370] = d370
+							ps3867.OverlayValues[371] = d371
+							ps3867.OverlayValues[372] = d372
+							ps3867.OverlayValues[373] = d373
+							ps3867.OverlayValues[374] = d374
+							ps3867.OverlayValues[375] = d375
+							ps3867.OverlayValues[376] = d376
+							ps3867.OverlayValues[377] = d377
+							ps3867.OverlayValues[378] = d378
+							ps3867.OverlayValues[379] = d379
+							ps3867.OverlayValues[380] = d380
+							ps3867.OverlayValues[381] = d381
+							ps3867.OverlayValues[382] = d382
+							ps3867.OverlayValues[505] = d505
+							ps3867.OverlayValues[506] = d506
+							ps3867.OverlayValues[507] = d507
+							ps3867.OverlayValues[508] = d508
+							ps3867.OverlayValues[509] = d509
+							ps3867.OverlayValues[510] = d510
+							ps3867.OverlayValues[511] = d511
+							ps3867.OverlayValues[512] = d512
+							ps3867.OverlayValues[513] = d513
+							ps3867.OverlayValues[514] = d514
+							ps3867.OverlayValues[515] = d515
+							ps3867.OverlayValues[516] = d516
+							ps3867.OverlayValues[517] = d517
+							ps3867.OverlayValues[666] = d666
+							ps3867.OverlayValues[667] = d667
+							ps3867.OverlayValues[668] = d668
+							ps3867.OverlayValues[669] = d669
+							ps3867.OverlayValues[670] = d670
+							ps3867.OverlayValues[671] = d671
+							ps3867.OverlayValues[672] = d672
+							ps3867.OverlayValues[673] = d673
+							ps3867.OverlayValues[674] = d674
+							ps3867.OverlayValues[675] = d675
+							ps3867.OverlayValues[676] = d676
+							ps3867.OverlayValues[677] = d677
+							ps3867.OverlayValues[678] = d678
+							ps3867.OverlayValues[679] = d679
+							ps3867.OverlayValues[680] = d680
+							ps3867.OverlayValues[681] = d681
+							ps3867.OverlayValues[682] = d682
+							ps3867.OverlayValues[683] = d683
+							ps3867.OverlayValues[684] = d684
+							ps3867.OverlayValues[685] = d685
+							ps3867.OverlayValues[686] = d686
+							ps3867.OverlayValues[687] = d687
+							ps3867.OverlayValues[688] = d688
+							ps3867.OverlayValues[689] = d689
+							ps3867.OverlayValues[690] = d690
+							ps3867.OverlayValues[691] = d691
+							ps3867.OverlayValues[692] = d692
+							ps3867.OverlayValues[693] = d693
+							ps3867.OverlayValues[694] = d694
+							ps3867.OverlayValues[695] = d695
+							ps3867.OverlayValues[696] = d696
+							ps3867.OverlayValues[697] = d697
+							ps3867.OverlayValues[910] = d910
+							ps3867.OverlayValues[911] = d911
+							ps3867.OverlayValues[912] = d912
+							ps3867.OverlayValues[913] = d913
+							ps3867.OverlayValues[914] = d914
+							ps3867.OverlayValues[915] = d915
+							ps3867.OverlayValues[916] = d916
+							ps3867.OverlayValues[917] = d917
+							ps3867.OverlayValues[918] = d918
+							ps3867.OverlayValues[919] = d919
+							ps3867.OverlayValues[920] = d920
+							ps3867.OverlayValues[921] = d921
+							ps3867.OverlayValues[922] = d922
+							ps3867.OverlayValues[923] = d923
+							ps3867.OverlayValues[924] = d924
+							ps3867.OverlayValues[925] = d925
+							ps3867.OverlayValues[926] = d926
+							ps3867.OverlayValues[927] = d927
+							ps3867.OverlayValues[928] = d928
+							ps3867.OverlayValues[929] = d929
+							ps3867.OverlayValues[930] = d930
+							ps3867.OverlayValues[931] = d931
+							ps3867.OverlayValues[932] = d932
+							ps3867.OverlayValues[933] = d933
+							ps3867.OverlayValues[934] = d934
+							ps3867.OverlayValues[935] = d935
+							ps3867.OverlayValues[936] = d936
+							ps3867.OverlayValues[937] = d937
+							ps3867.OverlayValues[938] = d938
+							ps3867.OverlayValues[939] = d939
+							ps3867.OverlayValues[940] = d940
+							ps3867.OverlayValues[941] = d941
+							ps3867.OverlayValues[942] = d942
+							ps3867.OverlayValues[1221] = d1221
+							ps3867.OverlayValues[1222] = d1222
+							ps3867.OverlayValues[1223] = d1223
+							ps3867.OverlayValues[1224] = d1224
+							ps3867.OverlayValues[1225] = d1225
+							ps3867.OverlayValues[1226] = d1226
+							ps3867.OverlayValues[1227] = d1227
+							ps3867.OverlayValues[1228] = d1228
+							ps3867.OverlayValues[1229] = d1229
+							ps3867.OverlayValues[1230] = d1230
+							ps3867.OverlayValues[1231] = d1231
+							ps3867.OverlayValues[1232] = d1232
+							ps3867.OverlayValues[1233] = d1233
+							ps3867.OverlayValues[1234] = d1234
+							ps3867.OverlayValues[1236] = d1236
+							ps3867.OverlayValues[1238] = d1238
+							ps3867.OverlayValues[1392] = d1392
+							ps3867.OverlayValues[1395] = d1395
+							ps3867.OverlayValues[1551] = d1551
+							ps3867.OverlayValues[1552] = d1552
+							ps3867.OverlayValues[1553] = d1553
+							ps3867.OverlayValues[1554] = d1554
+							ps3867.OverlayValues[1877] = d1877
+							ps3867.OverlayValues[1878] = d1878
+							ps3867.OverlayValues[1879] = d1879
+							ps3867.OverlayValues[1880] = d1880
+							ps3867.OverlayValues[1881] = d1881
+							ps3867.OverlayValues[1882] = d1882
+							ps3867.OverlayValues[1883] = d1883
+							ps3867.OverlayValues[1884] = d1884
+							ps3867.OverlayValues[1885] = d1885
+							ps3867.OverlayValues[1886] = d1886
+							ps3867.OverlayValues[1887] = d1887
+							ps3867.OverlayValues[1888] = d1888
+							ps3867.OverlayValues[1889] = d1889
+							ps3867.OverlayValues[1890] = d1890
+							ps3867.OverlayValues[1892] = d1892
+							ps3867.OverlayValues[1894] = d1894
+							ps3867.OverlayValues[2070] = d2070
+							ps3867.OverlayValues[2073] = d2073
+							ps3867.OverlayValues[2251] = d2251
+							ps3867.OverlayValues[2252] = d2252
+							ps3867.OverlayValues[2253] = d2253
+							ps3867.OverlayValues[2254] = d2254
+							ps3867.OverlayValues[2621] = d2621
+							ps3867.OverlayValues[2623] = d2623
+							ps3867.OverlayValues[2624] = d2624
+							ps3867.OverlayValues[2625] = d2625
+							ps3867.OverlayValues[2626] = d2626
+							ps3867.OverlayValues[2627] = d2627
+							ps3867.OverlayValues[2628] = d2628
+							ps3867.OverlayValues[2629] = d2629
+							ps3867.OverlayValues[2630] = d2630
+							ps3867.OverlayValues[2631] = d2631
+							ps3867.OverlayValues[2632] = d2632
+							ps3867.OverlayValues[3021] = d3021
+							ps3867.OverlayValues[3022] = d3022
+							ps3867.OverlayValues[3023] = d3023
+							ps3867.OverlayValues[3024] = d3024
+							ps3867.OverlayValues[3421] = d3421
+							ps3867.OverlayValues[3423] = d3423
+							ps3867.OverlayValues[3425] = d3425
+							ps3867.OverlayValues[3426] = d3426
+							ps3867.OverlayValues[3427] = d3427
+							ps3867.OverlayValues[3429] = d3429
+							ps3867.OverlayValues[3430] = d3430
+							ps3867.OverlayValues[3431] = d3431
+							ps3867.OverlayValues[3432] = d3432
+							ps3867.OverlayValues[3433] = d3433
+							ps3867.OverlayValues[3434] = d3434
+							ps3867.OverlayValues[3436] = d3436
+							ps3867.OverlayValues[3438] = d3438
+							ps3867.OverlayValues[3648] = d3648
+							ps3867.OverlayValues[3651] = d3651
+							ps3867.OverlayValues[3863] = d3863
+							ps3867.OverlayValues[3864] = d3864
+							ps3867.OverlayValues[3865] = d3865
+							ps3867.OverlayValues[3866] = d3866
+							return bbs[29].RenderPS(ps3867)
 						}
 						if ps.General {
 							ctx.SyncDesc(&d2627)
-							if d2627.Loc == LocReg {
+							if d2627.Loc == LocReg || d2627.Loc == LocFPReg {
 								ctx.ProtectReg(d2627.Reg)
 							} else if d2627.Loc == LocRegPair {
 								ctx.ProtectReg(d2627.Reg)
 								ctx.ProtectReg(d2627.Reg2)
 							}
-							d3867 = d2627
-							if d3867.Loc == LocNone {
+							d3868 = d2627
+							if d3868.Loc == LocNone {
 								panic("jit: phi source has no location")
 							}
-							ctx.EnsureDesc(&d3867)
-							ctx.EmitStoreToStack(d3867, int32(bbs[30].PhiBase)+int32(0))
-							if d2627.Loc == LocReg {
+							ctx.EnsureDesc(&d3868)
+							ctx.EmitStoreToStack(d3868, int32(bbs[30].PhiBase)+int32(0))
+							if d2627.Loc == LocReg || d2627.Loc == LocFPReg {
 								ctx.UnprotectReg(d2627.Reg)
 							} else if d2627.Loc == LocRegPair {
 								ctx.UnprotectReg(d2627.Reg)
 								ctx.UnprotectReg(d2627.Reg2)
 							}
 						}
-						ps3868 := PhiState{General: ps.General}
-						ps3868.OverlayValues = make([]JITValueDesc, 3868)
-						ps3868.OverlayValues[1] = d1
-						ps3868.OverlayValues[2] = d2
-						ps3868.OverlayValues[3] = d3
-						ps3868.OverlayValues[4] = d4
-						ps3868.OverlayValues[5] = d5
-						ps3868.OverlayValues[6] = d6
-						ps3868.OverlayValues[7] = d7
-						ps3868.OverlayValues[28] = d28
-						ps3868.OverlayValues[29] = d29
-						ps3868.OverlayValues[31] = d31
-						ps3868.OverlayValues[32] = d32
-						ps3868.OverlayValues[33] = d33
-						ps3868.OverlayValues[35] = d35
-						ps3868.OverlayValues[36] = d36
-						ps3868.OverlayValues[37] = d37
-						ps3868.OverlayValues[74] = d74
-						ps3868.OverlayValues[75] = d75
-						ps3868.OverlayValues[76] = d76
-						ps3868.OverlayValues[77] = d77
-						ps3868.OverlayValues[122] = d122
-						ps3868.OverlayValues[123] = d123
-						ps3868.OverlayValues[124] = d124
-						ps3868.OverlayValues[125] = d125
-						ps3868.OverlayValues[126] = d126
-						ps3868.OverlayValues[127] = d127
-						ps3868.OverlayValues[128] = d128
-						ps3868.OverlayValues[129] = d129
-						ps3868.OverlayValues[130] = d130
-						ps3868.OverlayValues[193] = d193
-						ps3868.OverlayValues[258] = d258
-						ps3868.OverlayValues[259] = d259
-						ps3868.OverlayValues[260] = d260
-						ps3868.OverlayValues[261] = d261
-						ps3868.OverlayValues[262] = d262
-						ps3868.OverlayValues[263] = d263
-						ps3868.OverlayValues[264] = d264
-						ps3868.OverlayValues[265] = d265
-						ps3868.OverlayValues[266] = d266
-						ps3868.OverlayValues[267] = d267
-						ps3868.OverlayValues[268] = d268
-						ps3868.OverlayValues[269] = d269
-						ps3868.OverlayValues[270] = d270
-						ps3868.OverlayValues[271] = d271
-						ps3868.OverlayValues[272] = d272
-						ps3868.OverlayValues[273] = d273
-						ps3868.OverlayValues[370] = d370
-						ps3868.OverlayValues[371] = d371
-						ps3868.OverlayValues[372] = d372
-						ps3868.OverlayValues[373] = d373
-						ps3868.OverlayValues[374] = d374
-						ps3868.OverlayValues[375] = d375
-						ps3868.OverlayValues[376] = d376
-						ps3868.OverlayValues[377] = d377
-						ps3868.OverlayValues[378] = d378
-						ps3868.OverlayValues[379] = d379
-						ps3868.OverlayValues[380] = d380
-						ps3868.OverlayValues[381] = d381
-						ps3868.OverlayValues[382] = d382
-						ps3868.OverlayValues[505] = d505
-						ps3868.OverlayValues[506] = d506
-						ps3868.OverlayValues[507] = d507
-						ps3868.OverlayValues[508] = d508
-						ps3868.OverlayValues[509] = d509
-						ps3868.OverlayValues[510] = d510
-						ps3868.OverlayValues[511] = d511
-						ps3868.OverlayValues[512] = d512
-						ps3868.OverlayValues[513] = d513
-						ps3868.OverlayValues[514] = d514
-						ps3868.OverlayValues[515] = d515
-						ps3868.OverlayValues[516] = d516
-						ps3868.OverlayValues[517] = d517
-						ps3868.OverlayValues[666] = d666
-						ps3868.OverlayValues[667] = d667
-						ps3868.OverlayValues[668] = d668
-						ps3868.OverlayValues[669] = d669
-						ps3868.OverlayValues[670] = d670
-						ps3868.OverlayValues[671] = d671
-						ps3868.OverlayValues[672] = d672
-						ps3868.OverlayValues[673] = d673
-						ps3868.OverlayValues[674] = d674
-						ps3868.OverlayValues[675] = d675
-						ps3868.OverlayValues[676] = d676
-						ps3868.OverlayValues[677] = d677
-						ps3868.OverlayValues[678] = d678
-						ps3868.OverlayValues[679] = d679
-						ps3868.OverlayValues[680] = d680
-						ps3868.OverlayValues[681] = d681
-						ps3868.OverlayValues[682] = d682
-						ps3868.OverlayValues[683] = d683
-						ps3868.OverlayValues[684] = d684
-						ps3868.OverlayValues[685] = d685
-						ps3868.OverlayValues[686] = d686
-						ps3868.OverlayValues[687] = d687
-						ps3868.OverlayValues[688] = d688
-						ps3868.OverlayValues[689] = d689
-						ps3868.OverlayValues[690] = d690
-						ps3868.OverlayValues[691] = d691
-						ps3868.OverlayValues[692] = d692
-						ps3868.OverlayValues[693] = d693
-						ps3868.OverlayValues[694] = d694
-						ps3868.OverlayValues[695] = d695
-						ps3868.OverlayValues[696] = d696
-						ps3868.OverlayValues[697] = d697
-						ps3868.OverlayValues[910] = d910
-						ps3868.OverlayValues[911] = d911
-						ps3868.OverlayValues[912] = d912
-						ps3868.OverlayValues[913] = d913
-						ps3868.OverlayValues[914] = d914
-						ps3868.OverlayValues[915] = d915
-						ps3868.OverlayValues[916] = d916
-						ps3868.OverlayValues[917] = d917
-						ps3868.OverlayValues[918] = d918
-						ps3868.OverlayValues[919] = d919
-						ps3868.OverlayValues[920] = d920
-						ps3868.OverlayValues[921] = d921
-						ps3868.OverlayValues[922] = d922
-						ps3868.OverlayValues[923] = d923
-						ps3868.OverlayValues[924] = d924
-						ps3868.OverlayValues[925] = d925
-						ps3868.OverlayValues[926] = d926
-						ps3868.OverlayValues[927] = d927
-						ps3868.OverlayValues[928] = d928
-						ps3868.OverlayValues[929] = d929
-						ps3868.OverlayValues[930] = d930
-						ps3868.OverlayValues[931] = d931
-						ps3868.OverlayValues[932] = d932
-						ps3868.OverlayValues[933] = d933
-						ps3868.OverlayValues[934] = d934
-						ps3868.OverlayValues[935] = d935
-						ps3868.OverlayValues[936] = d936
-						ps3868.OverlayValues[937] = d937
-						ps3868.OverlayValues[938] = d938
-						ps3868.OverlayValues[939] = d939
-						ps3868.OverlayValues[940] = d940
-						ps3868.OverlayValues[941] = d941
-						ps3868.OverlayValues[942] = d942
-						ps3868.OverlayValues[1221] = d1221
-						ps3868.OverlayValues[1222] = d1222
-						ps3868.OverlayValues[1223] = d1223
-						ps3868.OverlayValues[1224] = d1224
-						ps3868.OverlayValues[1225] = d1225
-						ps3868.OverlayValues[1226] = d1226
-						ps3868.OverlayValues[1227] = d1227
-						ps3868.OverlayValues[1228] = d1228
-						ps3868.OverlayValues[1229] = d1229
-						ps3868.OverlayValues[1230] = d1230
-						ps3868.OverlayValues[1231] = d1231
-						ps3868.OverlayValues[1232] = d1232
-						ps3868.OverlayValues[1233] = d1233
-						ps3868.OverlayValues[1234] = d1234
-						ps3868.OverlayValues[1236] = d1236
-						ps3868.OverlayValues[1238] = d1238
-						ps3868.OverlayValues[1392] = d1392
-						ps3868.OverlayValues[1395] = d1395
-						ps3868.OverlayValues[1551] = d1551
-						ps3868.OverlayValues[1552] = d1552
-						ps3868.OverlayValues[1553] = d1553
-						ps3868.OverlayValues[1554] = d1554
-						ps3868.OverlayValues[1877] = d1877
-						ps3868.OverlayValues[1878] = d1878
-						ps3868.OverlayValues[1879] = d1879
-						ps3868.OverlayValues[1880] = d1880
-						ps3868.OverlayValues[1881] = d1881
-						ps3868.OverlayValues[1882] = d1882
-						ps3868.OverlayValues[1883] = d1883
-						ps3868.OverlayValues[1884] = d1884
-						ps3868.OverlayValues[1885] = d1885
-						ps3868.OverlayValues[1886] = d1886
-						ps3868.OverlayValues[1887] = d1887
-						ps3868.OverlayValues[1888] = d1888
-						ps3868.OverlayValues[1889] = d1889
-						ps3868.OverlayValues[1890] = d1890
-						ps3868.OverlayValues[1892] = d1892
-						ps3868.OverlayValues[1894] = d1894
-						ps3868.OverlayValues[2070] = d2070
-						ps3868.OverlayValues[2073] = d2073
-						ps3868.OverlayValues[2251] = d2251
-						ps3868.OverlayValues[2252] = d2252
-						ps3868.OverlayValues[2253] = d2253
-						ps3868.OverlayValues[2254] = d2254
-						ps3868.OverlayValues[2621] = d2621
-						ps3868.OverlayValues[2623] = d2623
-						ps3868.OverlayValues[2624] = d2624
-						ps3868.OverlayValues[2625] = d2625
-						ps3868.OverlayValues[2626] = d2626
-						ps3868.OverlayValues[2627] = d2627
-						ps3868.OverlayValues[2628] = d2628
-						ps3868.OverlayValues[2629] = d2629
-						ps3868.OverlayValues[2630] = d2630
-						ps3868.OverlayValues[2631] = d2631
-						ps3868.OverlayValues[2632] = d2632
-						ps3868.OverlayValues[3021] = d3021
-						ps3868.OverlayValues[3022] = d3022
-						ps3868.OverlayValues[3023] = d3023
-						ps3868.OverlayValues[3024] = d3024
-						ps3868.OverlayValues[3421] = d3421
-						ps3868.OverlayValues[3423] = d3423
-						ps3868.OverlayValues[3424] = d3424
-						ps3868.OverlayValues[3425] = d3425
-						ps3868.OverlayValues[3426] = d3426
-						ps3868.OverlayValues[3428] = d3428
-						ps3868.OverlayValues[3429] = d3429
-						ps3868.OverlayValues[3430] = d3430
-						ps3868.OverlayValues[3431] = d3431
-						ps3868.OverlayValues[3432] = d3432
-						ps3868.OverlayValues[3433] = d3433
-						ps3868.OverlayValues[3435] = d3435
-						ps3868.OverlayValues[3437] = d3437
-						ps3868.OverlayValues[3647] = d3647
-						ps3868.OverlayValues[3650] = d3650
-						ps3868.OverlayValues[3862] = d3862
-						ps3868.OverlayValues[3863] = d3863
-						ps3868.OverlayValues[3864] = d3864
-						ps3868.OverlayValues[3865] = d3865
-						ps3868.OverlayValues[3867] = d3867
-						ps3868.PhiValues = make([]JITValueDesc, 1)
-						d3869 = d2627
-						ps3868.PhiValues[0] = d3869
-						return bbs[30].RenderPS(ps3868)
+						ps3869 := PhiState{General: ps.General}
+						ps3869.OverlayValues = make([]JITValueDesc, 3869)
+						ps3869.OverlayValues[1] = d1
+						ps3869.OverlayValues[2] = d2
+						ps3869.OverlayValues[3] = d3
+						ps3869.OverlayValues[4] = d4
+						ps3869.OverlayValues[5] = d5
+						ps3869.OverlayValues[6] = d6
+						ps3869.OverlayValues[7] = d7
+						ps3869.OverlayValues[28] = d28
+						ps3869.OverlayValues[29] = d29
+						ps3869.OverlayValues[31] = d31
+						ps3869.OverlayValues[32] = d32
+						ps3869.OverlayValues[33] = d33
+						ps3869.OverlayValues[35] = d35
+						ps3869.OverlayValues[36] = d36
+						ps3869.OverlayValues[37] = d37
+						ps3869.OverlayValues[74] = d74
+						ps3869.OverlayValues[75] = d75
+						ps3869.OverlayValues[76] = d76
+						ps3869.OverlayValues[77] = d77
+						ps3869.OverlayValues[122] = d122
+						ps3869.OverlayValues[123] = d123
+						ps3869.OverlayValues[124] = d124
+						ps3869.OverlayValues[125] = d125
+						ps3869.OverlayValues[126] = d126
+						ps3869.OverlayValues[127] = d127
+						ps3869.OverlayValues[128] = d128
+						ps3869.OverlayValues[129] = d129
+						ps3869.OverlayValues[130] = d130
+						ps3869.OverlayValues[193] = d193
+						ps3869.OverlayValues[258] = d258
+						ps3869.OverlayValues[259] = d259
+						ps3869.OverlayValues[260] = d260
+						ps3869.OverlayValues[261] = d261
+						ps3869.OverlayValues[262] = d262
+						ps3869.OverlayValues[263] = d263
+						ps3869.OverlayValues[264] = d264
+						ps3869.OverlayValues[265] = d265
+						ps3869.OverlayValues[266] = d266
+						ps3869.OverlayValues[267] = d267
+						ps3869.OverlayValues[268] = d268
+						ps3869.OverlayValues[269] = d269
+						ps3869.OverlayValues[270] = d270
+						ps3869.OverlayValues[271] = d271
+						ps3869.OverlayValues[272] = d272
+						ps3869.OverlayValues[273] = d273
+						ps3869.OverlayValues[370] = d370
+						ps3869.OverlayValues[371] = d371
+						ps3869.OverlayValues[372] = d372
+						ps3869.OverlayValues[373] = d373
+						ps3869.OverlayValues[374] = d374
+						ps3869.OverlayValues[375] = d375
+						ps3869.OverlayValues[376] = d376
+						ps3869.OverlayValues[377] = d377
+						ps3869.OverlayValues[378] = d378
+						ps3869.OverlayValues[379] = d379
+						ps3869.OverlayValues[380] = d380
+						ps3869.OverlayValues[381] = d381
+						ps3869.OverlayValues[382] = d382
+						ps3869.OverlayValues[505] = d505
+						ps3869.OverlayValues[506] = d506
+						ps3869.OverlayValues[507] = d507
+						ps3869.OverlayValues[508] = d508
+						ps3869.OverlayValues[509] = d509
+						ps3869.OverlayValues[510] = d510
+						ps3869.OverlayValues[511] = d511
+						ps3869.OverlayValues[512] = d512
+						ps3869.OverlayValues[513] = d513
+						ps3869.OverlayValues[514] = d514
+						ps3869.OverlayValues[515] = d515
+						ps3869.OverlayValues[516] = d516
+						ps3869.OverlayValues[517] = d517
+						ps3869.OverlayValues[666] = d666
+						ps3869.OverlayValues[667] = d667
+						ps3869.OverlayValues[668] = d668
+						ps3869.OverlayValues[669] = d669
+						ps3869.OverlayValues[670] = d670
+						ps3869.OverlayValues[671] = d671
+						ps3869.OverlayValues[672] = d672
+						ps3869.OverlayValues[673] = d673
+						ps3869.OverlayValues[674] = d674
+						ps3869.OverlayValues[675] = d675
+						ps3869.OverlayValues[676] = d676
+						ps3869.OverlayValues[677] = d677
+						ps3869.OverlayValues[678] = d678
+						ps3869.OverlayValues[679] = d679
+						ps3869.OverlayValues[680] = d680
+						ps3869.OverlayValues[681] = d681
+						ps3869.OverlayValues[682] = d682
+						ps3869.OverlayValues[683] = d683
+						ps3869.OverlayValues[684] = d684
+						ps3869.OverlayValues[685] = d685
+						ps3869.OverlayValues[686] = d686
+						ps3869.OverlayValues[687] = d687
+						ps3869.OverlayValues[688] = d688
+						ps3869.OverlayValues[689] = d689
+						ps3869.OverlayValues[690] = d690
+						ps3869.OverlayValues[691] = d691
+						ps3869.OverlayValues[692] = d692
+						ps3869.OverlayValues[693] = d693
+						ps3869.OverlayValues[694] = d694
+						ps3869.OverlayValues[695] = d695
+						ps3869.OverlayValues[696] = d696
+						ps3869.OverlayValues[697] = d697
+						ps3869.OverlayValues[910] = d910
+						ps3869.OverlayValues[911] = d911
+						ps3869.OverlayValues[912] = d912
+						ps3869.OverlayValues[913] = d913
+						ps3869.OverlayValues[914] = d914
+						ps3869.OverlayValues[915] = d915
+						ps3869.OverlayValues[916] = d916
+						ps3869.OverlayValues[917] = d917
+						ps3869.OverlayValues[918] = d918
+						ps3869.OverlayValues[919] = d919
+						ps3869.OverlayValues[920] = d920
+						ps3869.OverlayValues[921] = d921
+						ps3869.OverlayValues[922] = d922
+						ps3869.OverlayValues[923] = d923
+						ps3869.OverlayValues[924] = d924
+						ps3869.OverlayValues[925] = d925
+						ps3869.OverlayValues[926] = d926
+						ps3869.OverlayValues[927] = d927
+						ps3869.OverlayValues[928] = d928
+						ps3869.OverlayValues[929] = d929
+						ps3869.OverlayValues[930] = d930
+						ps3869.OverlayValues[931] = d931
+						ps3869.OverlayValues[932] = d932
+						ps3869.OverlayValues[933] = d933
+						ps3869.OverlayValues[934] = d934
+						ps3869.OverlayValues[935] = d935
+						ps3869.OverlayValues[936] = d936
+						ps3869.OverlayValues[937] = d937
+						ps3869.OverlayValues[938] = d938
+						ps3869.OverlayValues[939] = d939
+						ps3869.OverlayValues[940] = d940
+						ps3869.OverlayValues[941] = d941
+						ps3869.OverlayValues[942] = d942
+						ps3869.OverlayValues[1221] = d1221
+						ps3869.OverlayValues[1222] = d1222
+						ps3869.OverlayValues[1223] = d1223
+						ps3869.OverlayValues[1224] = d1224
+						ps3869.OverlayValues[1225] = d1225
+						ps3869.OverlayValues[1226] = d1226
+						ps3869.OverlayValues[1227] = d1227
+						ps3869.OverlayValues[1228] = d1228
+						ps3869.OverlayValues[1229] = d1229
+						ps3869.OverlayValues[1230] = d1230
+						ps3869.OverlayValues[1231] = d1231
+						ps3869.OverlayValues[1232] = d1232
+						ps3869.OverlayValues[1233] = d1233
+						ps3869.OverlayValues[1234] = d1234
+						ps3869.OverlayValues[1236] = d1236
+						ps3869.OverlayValues[1238] = d1238
+						ps3869.OverlayValues[1392] = d1392
+						ps3869.OverlayValues[1395] = d1395
+						ps3869.OverlayValues[1551] = d1551
+						ps3869.OverlayValues[1552] = d1552
+						ps3869.OverlayValues[1553] = d1553
+						ps3869.OverlayValues[1554] = d1554
+						ps3869.OverlayValues[1877] = d1877
+						ps3869.OverlayValues[1878] = d1878
+						ps3869.OverlayValues[1879] = d1879
+						ps3869.OverlayValues[1880] = d1880
+						ps3869.OverlayValues[1881] = d1881
+						ps3869.OverlayValues[1882] = d1882
+						ps3869.OverlayValues[1883] = d1883
+						ps3869.OverlayValues[1884] = d1884
+						ps3869.OverlayValues[1885] = d1885
+						ps3869.OverlayValues[1886] = d1886
+						ps3869.OverlayValues[1887] = d1887
+						ps3869.OverlayValues[1888] = d1888
+						ps3869.OverlayValues[1889] = d1889
+						ps3869.OverlayValues[1890] = d1890
+						ps3869.OverlayValues[1892] = d1892
+						ps3869.OverlayValues[1894] = d1894
+						ps3869.OverlayValues[2070] = d2070
+						ps3869.OverlayValues[2073] = d2073
+						ps3869.OverlayValues[2251] = d2251
+						ps3869.OverlayValues[2252] = d2252
+						ps3869.OverlayValues[2253] = d2253
+						ps3869.OverlayValues[2254] = d2254
+						ps3869.OverlayValues[2621] = d2621
+						ps3869.OverlayValues[2623] = d2623
+						ps3869.OverlayValues[2624] = d2624
+						ps3869.OverlayValues[2625] = d2625
+						ps3869.OverlayValues[2626] = d2626
+						ps3869.OverlayValues[2627] = d2627
+						ps3869.OverlayValues[2628] = d2628
+						ps3869.OverlayValues[2629] = d2629
+						ps3869.OverlayValues[2630] = d2630
+						ps3869.OverlayValues[2631] = d2631
+						ps3869.OverlayValues[2632] = d2632
+						ps3869.OverlayValues[3021] = d3021
+						ps3869.OverlayValues[3022] = d3022
+						ps3869.OverlayValues[3023] = d3023
+						ps3869.OverlayValues[3024] = d3024
+						ps3869.OverlayValues[3421] = d3421
+						ps3869.OverlayValues[3423] = d3423
+						ps3869.OverlayValues[3425] = d3425
+						ps3869.OverlayValues[3426] = d3426
+						ps3869.OverlayValues[3427] = d3427
+						ps3869.OverlayValues[3429] = d3429
+						ps3869.OverlayValues[3430] = d3430
+						ps3869.OverlayValues[3431] = d3431
+						ps3869.OverlayValues[3432] = d3432
+						ps3869.OverlayValues[3433] = d3433
+						ps3869.OverlayValues[3434] = d3434
+						ps3869.OverlayValues[3436] = d3436
+						ps3869.OverlayValues[3438] = d3438
+						ps3869.OverlayValues[3648] = d3648
+						ps3869.OverlayValues[3651] = d3651
+						ps3869.OverlayValues[3863] = d3863
+						ps3869.OverlayValues[3864] = d3864
+						ps3869.OverlayValues[3865] = d3865
+						ps3869.OverlayValues[3866] = d3866
+						ps3869.OverlayValues[3868] = d3868
+						ps3869.PhiValues = make([]JITValueDesc, 1)
+						d3870 = d2627
+						ps3869.PhiValues[0] = d3870
+						return bbs[30].RenderPS(ps3869)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[32].RenderPS(ps)
 					}
 					lbl43 := ctx.ReserveLabel()
-					ctx.EmitJump(d3865.Condition, lbl30)
+					ctx.EmitJump(d3866.Condition, lbl30)
 					ctx.EmitJmp(lbl43)
-					ctx.FreeDesc(&d3864)
-					snap3870 := d1
-					snap3871 := d2
-					snap3872 := d3
-					snap3873 := d4
-					snap3874 := d5
-					snap3875 := d6
-					snap3876 := d7
-					snap3877 := d28
-					snap3878 := d29
-					snap3879 := d31
-					snap3880 := d32
-					snap3881 := d33
-					snap3882 := d35
-					snap3883 := d36
-					snap3884 := d37
-					snap3885 := d74
-					snap3886 := d75
-					snap3887 := d76
-					snap3888 := d77
-					snap3889 := d122
-					snap3890 := d123
-					snap3891 := d124
-					snap3892 := d125
-					snap3893 := d126
-					snap3894 := d127
-					snap3895 := d128
-					snap3896 := d129
-					snap3897 := d130
-					snap3898 := d193
-					snap3899 := d258
-					snap3900 := d259
-					snap3901 := d260
-					snap3902 := d261
-					snap3903 := d262
-					snap3904 := d263
-					snap3905 := d264
-					snap3906 := d265
-					snap3907 := d266
-					snap3908 := d267
-					snap3909 := d268
-					snap3910 := d269
-					snap3911 := d270
-					snap3912 := d271
-					snap3913 := d272
-					snap3914 := d273
-					snap3915 := d370
-					snap3916 := d371
-					snap3917 := d372
-					snap3918 := d373
-					snap3919 := d374
-					snap3920 := d375
-					snap3921 := d376
-					snap3922 := d377
-					snap3923 := d378
-					snap3924 := d379
-					snap3925 := d380
-					snap3926 := d381
-					snap3927 := d382
-					snap3928 := d505
-					snap3929 := d506
-					snap3930 := d507
-					snap3931 := d508
-					snap3932 := d509
-					snap3933 := d510
-					snap3934 := d511
-					snap3935 := d512
-					snap3936 := d513
-					snap3937 := d514
-					snap3938 := d515
-					snap3939 := d516
-					snap3940 := d517
-					snap3941 := d666
-					snap3942 := d667
-					snap3943 := d668
-					snap3944 := d669
-					snap3945 := d670
-					snap3946 := d671
-					snap3947 := d672
-					snap3948 := d673
-					snap3949 := d674
-					snap3950 := d675
-					snap3951 := d676
-					snap3952 := d677
-					snap3953 := d678
-					snap3954 := d679
-					snap3955 := d680
-					snap3956 := d681
-					snap3957 := d682
-					snap3958 := d683
-					snap3959 := d684
-					snap3960 := d685
-					snap3961 := d686
-					snap3962 := d687
-					snap3963 := d688
-					snap3964 := d689
-					snap3965 := d690
-					snap3966 := d691
-					snap3967 := d692
-					snap3968 := d693
-					snap3969 := d694
-					snap3970 := d695
-					snap3971 := d696
-					snap3972 := d697
-					snap3973 := d910
-					snap3974 := d911
-					snap3975 := d912
-					snap3976 := d913
-					snap3977 := d914
-					snap3978 := d915
-					snap3979 := d916
-					snap3980 := d917
-					snap3981 := d918
-					snap3982 := d919
-					snap3983 := d920
-					snap3984 := d921
-					snap3985 := d922
-					snap3986 := d923
-					snap3987 := d924
-					snap3988 := d925
-					snap3989 := d926
-					snap3990 := d927
-					snap3991 := d928
-					snap3992 := d929
-					snap3993 := d930
-					snap3994 := d931
-					snap3995 := d932
-					snap3996 := d933
-					snap3997 := d934
-					snap3998 := d935
-					snap3999 := d936
-					snap4000 := d937
-					snap4001 := d938
-					snap4002 := d939
-					snap4003 := d940
-					snap4004 := d941
-					snap4005 := d942
-					snap4006 := d1221
-					snap4007 := d1222
-					snap4008 := d1223
-					snap4009 := d1224
-					snap4010 := d1225
-					snap4011 := d1226
-					snap4012 := d1227
-					snap4013 := d1228
-					snap4014 := d1229
-					snap4015 := d1230
-					snap4016 := d1231
-					snap4017 := d1232
-					snap4018 := d1233
-					snap4019 := d1234
-					snap4020 := d1236
-					snap4021 := d1238
-					snap4022 := d1392
-					snap4023 := d1395
-					snap4024 := d1551
-					snap4025 := d1552
-					snap4026 := d1553
-					snap4027 := d1554
-					snap4028 := d1877
-					snap4029 := d1878
-					snap4030 := d1879
-					snap4031 := d1880
-					snap4032 := d1881
-					snap4033 := d1882
-					snap4034 := d1883
-					snap4035 := d1884
-					snap4036 := d1885
-					snap4037 := d1886
-					snap4038 := d1887
-					snap4039 := d1888
-					snap4040 := d1889
-					snap4041 := d1890
-					snap4042 := d1892
-					snap4043 := d1894
-					snap4044 := d2070
-					snap4045 := d2073
-					snap4046 := d2251
-					snap4047 := d2252
-					snap4048 := d2253
-					snap4049 := d2254
-					snap4050 := d2621
-					snap4051 := d2623
-					snap4052 := d2624
-					snap4053 := d2625
-					snap4054 := d2626
-					snap4055 := d2627
-					snap4056 := d2628
-					snap4057 := d2629
-					snap4058 := d2630
-					snap4059 := d2631
-					snap4060 := d2632
-					snap4061 := d3021
-					snap4062 := d3022
-					snap4063 := d3023
-					snap4064 := d3024
-					snap4065 := d3421
-					snap4066 := d3423
-					snap4067 := d3424
+					ctx.FreeDesc(&d3865)
+					snap3871 := d1
+					snap3872 := d2
+					snap3873 := d3
+					snap3874 := d4
+					snap3875 := d5
+					snap3876 := d6
+					snap3877 := d7
+					snap3878 := d28
+					snap3879 := d29
+					snap3880 := d31
+					snap3881 := d32
+					snap3882 := d33
+					snap3883 := d35
+					snap3884 := d36
+					snap3885 := d37
+					snap3886 := d74
+					snap3887 := d75
+					snap3888 := d76
+					snap3889 := d77
+					snap3890 := d122
+					snap3891 := d123
+					snap3892 := d124
+					snap3893 := d125
+					snap3894 := d126
+					snap3895 := d127
+					snap3896 := d128
+					snap3897 := d129
+					snap3898 := d130
+					snap3899 := d193
+					snap3900 := d258
+					snap3901 := d259
+					snap3902 := d260
+					snap3903 := d261
+					snap3904 := d262
+					snap3905 := d263
+					snap3906 := d264
+					snap3907 := d265
+					snap3908 := d266
+					snap3909 := d267
+					snap3910 := d268
+					snap3911 := d269
+					snap3912 := d270
+					snap3913 := d271
+					snap3914 := d272
+					snap3915 := d273
+					snap3916 := d370
+					snap3917 := d371
+					snap3918 := d372
+					snap3919 := d373
+					snap3920 := d374
+					snap3921 := d375
+					snap3922 := d376
+					snap3923 := d377
+					snap3924 := d378
+					snap3925 := d379
+					snap3926 := d380
+					snap3927 := d381
+					snap3928 := d382
+					snap3929 := d505
+					snap3930 := d506
+					snap3931 := d507
+					snap3932 := d508
+					snap3933 := d509
+					snap3934 := d510
+					snap3935 := d511
+					snap3936 := d512
+					snap3937 := d513
+					snap3938 := d514
+					snap3939 := d515
+					snap3940 := d516
+					snap3941 := d517
+					snap3942 := d666
+					snap3943 := d667
+					snap3944 := d668
+					snap3945 := d669
+					snap3946 := d670
+					snap3947 := d671
+					snap3948 := d672
+					snap3949 := d673
+					snap3950 := d674
+					snap3951 := d675
+					snap3952 := d676
+					snap3953 := d677
+					snap3954 := d678
+					snap3955 := d679
+					snap3956 := d680
+					snap3957 := d681
+					snap3958 := d682
+					snap3959 := d683
+					snap3960 := d684
+					snap3961 := d685
+					snap3962 := d686
+					snap3963 := d687
+					snap3964 := d688
+					snap3965 := d689
+					snap3966 := d690
+					snap3967 := d691
+					snap3968 := d692
+					snap3969 := d693
+					snap3970 := d694
+					snap3971 := d695
+					snap3972 := d696
+					snap3973 := d697
+					snap3974 := d910
+					snap3975 := d911
+					snap3976 := d912
+					snap3977 := d913
+					snap3978 := d914
+					snap3979 := d915
+					snap3980 := d916
+					snap3981 := d917
+					snap3982 := d918
+					snap3983 := d919
+					snap3984 := d920
+					snap3985 := d921
+					snap3986 := d922
+					snap3987 := d923
+					snap3988 := d924
+					snap3989 := d925
+					snap3990 := d926
+					snap3991 := d927
+					snap3992 := d928
+					snap3993 := d929
+					snap3994 := d930
+					snap3995 := d931
+					snap3996 := d932
+					snap3997 := d933
+					snap3998 := d934
+					snap3999 := d935
+					snap4000 := d936
+					snap4001 := d937
+					snap4002 := d938
+					snap4003 := d939
+					snap4004 := d940
+					snap4005 := d941
+					snap4006 := d942
+					snap4007 := d1221
+					snap4008 := d1222
+					snap4009 := d1223
+					snap4010 := d1224
+					snap4011 := d1225
+					snap4012 := d1226
+					snap4013 := d1227
+					snap4014 := d1228
+					snap4015 := d1229
+					snap4016 := d1230
+					snap4017 := d1231
+					snap4018 := d1232
+					snap4019 := d1233
+					snap4020 := d1234
+					snap4021 := d1236
+					snap4022 := d1238
+					snap4023 := d1392
+					snap4024 := d1395
+					snap4025 := d1551
+					snap4026 := d1552
+					snap4027 := d1553
+					snap4028 := d1554
+					snap4029 := d1877
+					snap4030 := d1878
+					snap4031 := d1879
+					snap4032 := d1880
+					snap4033 := d1881
+					snap4034 := d1882
+					snap4035 := d1883
+					snap4036 := d1884
+					snap4037 := d1885
+					snap4038 := d1886
+					snap4039 := d1887
+					snap4040 := d1888
+					snap4041 := d1889
+					snap4042 := d1890
+					snap4043 := d1892
+					snap4044 := d1894
+					snap4045 := d2070
+					snap4046 := d2073
+					snap4047 := d2251
+					snap4048 := d2252
+					snap4049 := d2253
+					snap4050 := d2254
+					snap4051 := d2621
+					snap4052 := d2623
+					snap4053 := d2624
+					snap4054 := d2625
+					snap4055 := d2626
+					snap4056 := d2627
+					snap4057 := d2628
+					snap4058 := d2629
+					snap4059 := d2630
+					snap4060 := d2631
+					snap4061 := d2632
+					snap4062 := d3021
+					snap4063 := d3022
+					snap4064 := d3023
+					snap4065 := d3024
+					snap4066 := d3421
+					snap4067 := d3423
 					snap4068 := d3425
 					snap4069 := d3426
-					snap4070 := d3428
+					snap4070 := d3427
 					snap4071 := d3429
 					snap4072 := d3430
 					snap4073 := d3431
 					snap4074 := d3432
 					snap4075 := d3433
-					snap4076 := d3435
-					snap4077 := d3437
-					snap4078 := d3647
-					snap4079 := d3650
-					snap4080 := d3862
+					snap4076 := d3434
+					snap4077 := d3436
+					snap4078 := d3438
+					snap4079 := d3648
+					snap4080 := d3651
 					snap4081 := d3863
 					snap4082 := d3864
 					snap4083 := d3865
-					snap4084 := d3867
-					snap4085 := d3869
-					alloc4086 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc4086)
-					d1 = snap3870
-					d2 = snap3871
-					d3 = snap3872
-					d4 = snap3873
-					d5 = snap3874
-					d6 = snap3875
-					d7 = snap3876
-					d28 = snap3877
-					d29 = snap3878
-					d31 = snap3879
-					d32 = snap3880
-					d33 = snap3881
-					d35 = snap3882
-					d36 = snap3883
-					d37 = snap3884
-					d74 = snap3885
-					d75 = snap3886
-					d76 = snap3887
-					d77 = snap3888
-					d122 = snap3889
-					d123 = snap3890
-					d124 = snap3891
-					d125 = snap3892
-					d126 = snap3893
-					d127 = snap3894
-					d128 = snap3895
-					d129 = snap3896
-					d130 = snap3897
-					d193 = snap3898
-					d258 = snap3899
-					d259 = snap3900
-					d260 = snap3901
-					d261 = snap3902
-					d262 = snap3903
-					d263 = snap3904
-					d264 = snap3905
-					d265 = snap3906
-					d266 = snap3907
-					d267 = snap3908
-					d268 = snap3909
-					d269 = snap3910
-					d270 = snap3911
-					d271 = snap3912
-					d272 = snap3913
-					d273 = snap3914
-					d370 = snap3915
-					d371 = snap3916
-					d372 = snap3917
-					d373 = snap3918
-					d374 = snap3919
-					d375 = snap3920
-					d376 = snap3921
-					d377 = snap3922
-					d378 = snap3923
-					d379 = snap3924
-					d380 = snap3925
-					d381 = snap3926
-					d382 = snap3927
-					d505 = snap3928
-					d506 = snap3929
-					d507 = snap3930
-					d508 = snap3931
-					d509 = snap3932
-					d510 = snap3933
-					d511 = snap3934
-					d512 = snap3935
-					d513 = snap3936
-					d514 = snap3937
-					d515 = snap3938
-					d516 = snap3939
-					d517 = snap3940
-					d666 = snap3941
-					d667 = snap3942
-					d668 = snap3943
-					d669 = snap3944
-					d670 = snap3945
-					d671 = snap3946
-					d672 = snap3947
-					d673 = snap3948
-					d674 = snap3949
-					d675 = snap3950
-					d676 = snap3951
-					d677 = snap3952
-					d678 = snap3953
-					d679 = snap3954
-					d680 = snap3955
-					d681 = snap3956
-					d682 = snap3957
-					d683 = snap3958
-					d684 = snap3959
-					d685 = snap3960
-					d686 = snap3961
-					d687 = snap3962
-					d688 = snap3963
-					d689 = snap3964
-					d690 = snap3965
-					d691 = snap3966
-					d692 = snap3967
-					d693 = snap3968
-					d694 = snap3969
-					d695 = snap3970
-					d696 = snap3971
-					d697 = snap3972
-					d910 = snap3973
-					d911 = snap3974
-					d912 = snap3975
-					d913 = snap3976
-					d914 = snap3977
-					d915 = snap3978
-					d916 = snap3979
-					d917 = snap3980
-					d918 = snap3981
-					d919 = snap3982
-					d920 = snap3983
-					d921 = snap3984
-					d922 = snap3985
-					d923 = snap3986
-					d924 = snap3987
-					d925 = snap3988
-					d926 = snap3989
-					d927 = snap3990
-					d928 = snap3991
-					d929 = snap3992
-					d930 = snap3993
-					d931 = snap3994
-					d932 = snap3995
-					d933 = snap3996
-					d934 = snap3997
-					d935 = snap3998
-					d936 = snap3999
-					d937 = snap4000
-					d938 = snap4001
-					d939 = snap4002
-					d940 = snap4003
-					d941 = snap4004
-					d942 = snap4005
-					d1221 = snap4006
-					d1222 = snap4007
-					d1223 = snap4008
-					d1224 = snap4009
-					d1225 = snap4010
-					d1226 = snap4011
-					d1227 = snap4012
-					d1228 = snap4013
-					d1229 = snap4014
-					d1230 = snap4015
-					d1231 = snap4016
-					d1232 = snap4017
-					d1233 = snap4018
-					d1234 = snap4019
-					d1236 = snap4020
-					d1238 = snap4021
-					d1392 = snap4022
-					d1395 = snap4023
-					d1551 = snap4024
-					d1552 = snap4025
-					d1553 = snap4026
-					d1554 = snap4027
-					d1877 = snap4028
-					d1878 = snap4029
-					d1879 = snap4030
-					d1880 = snap4031
-					d1881 = snap4032
-					d1882 = snap4033
-					d1883 = snap4034
-					d1884 = snap4035
-					d1885 = snap4036
-					d1886 = snap4037
-					d1887 = snap4038
-					d1888 = snap4039
-					d1889 = snap4040
-					d1890 = snap4041
-					d1892 = snap4042
-					d1894 = snap4043
-					d2070 = snap4044
-					d2073 = snap4045
-					d2251 = snap4046
-					d2252 = snap4047
-					d2253 = snap4048
-					d2254 = snap4049
-					d2621 = snap4050
-					d2623 = snap4051
-					d2624 = snap4052
-					d2625 = snap4053
-					d2626 = snap4054
-					d2627 = snap4055
-					d2628 = snap4056
-					d2629 = snap4057
-					d2630 = snap4058
-					d2631 = snap4059
-					d2632 = snap4060
-					d3021 = snap4061
-					d3022 = snap4062
-					d3023 = snap4063
-					d3024 = snap4064
-					d3421 = snap4065
-					d3423 = snap4066
-					d3424 = snap4067
+					snap4084 := d3866
+					snap4085 := d3868
+					snap4086 := d3870
+					alloc4087 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc4087)
+					d1 = snap3871
+					d2 = snap3872
+					d3 = snap3873
+					d4 = snap3874
+					d5 = snap3875
+					d6 = snap3876
+					d7 = snap3877
+					d28 = snap3878
+					d29 = snap3879
+					d31 = snap3880
+					d32 = snap3881
+					d33 = snap3882
+					d35 = snap3883
+					d36 = snap3884
+					d37 = snap3885
+					d74 = snap3886
+					d75 = snap3887
+					d76 = snap3888
+					d77 = snap3889
+					d122 = snap3890
+					d123 = snap3891
+					d124 = snap3892
+					d125 = snap3893
+					d126 = snap3894
+					d127 = snap3895
+					d128 = snap3896
+					d129 = snap3897
+					d130 = snap3898
+					d193 = snap3899
+					d258 = snap3900
+					d259 = snap3901
+					d260 = snap3902
+					d261 = snap3903
+					d262 = snap3904
+					d263 = snap3905
+					d264 = snap3906
+					d265 = snap3907
+					d266 = snap3908
+					d267 = snap3909
+					d268 = snap3910
+					d269 = snap3911
+					d270 = snap3912
+					d271 = snap3913
+					d272 = snap3914
+					d273 = snap3915
+					d370 = snap3916
+					d371 = snap3917
+					d372 = snap3918
+					d373 = snap3919
+					d374 = snap3920
+					d375 = snap3921
+					d376 = snap3922
+					d377 = snap3923
+					d378 = snap3924
+					d379 = snap3925
+					d380 = snap3926
+					d381 = snap3927
+					d382 = snap3928
+					d505 = snap3929
+					d506 = snap3930
+					d507 = snap3931
+					d508 = snap3932
+					d509 = snap3933
+					d510 = snap3934
+					d511 = snap3935
+					d512 = snap3936
+					d513 = snap3937
+					d514 = snap3938
+					d515 = snap3939
+					d516 = snap3940
+					d517 = snap3941
+					d666 = snap3942
+					d667 = snap3943
+					d668 = snap3944
+					d669 = snap3945
+					d670 = snap3946
+					d671 = snap3947
+					d672 = snap3948
+					d673 = snap3949
+					d674 = snap3950
+					d675 = snap3951
+					d676 = snap3952
+					d677 = snap3953
+					d678 = snap3954
+					d679 = snap3955
+					d680 = snap3956
+					d681 = snap3957
+					d682 = snap3958
+					d683 = snap3959
+					d684 = snap3960
+					d685 = snap3961
+					d686 = snap3962
+					d687 = snap3963
+					d688 = snap3964
+					d689 = snap3965
+					d690 = snap3966
+					d691 = snap3967
+					d692 = snap3968
+					d693 = snap3969
+					d694 = snap3970
+					d695 = snap3971
+					d696 = snap3972
+					d697 = snap3973
+					d910 = snap3974
+					d911 = snap3975
+					d912 = snap3976
+					d913 = snap3977
+					d914 = snap3978
+					d915 = snap3979
+					d916 = snap3980
+					d917 = snap3981
+					d918 = snap3982
+					d919 = snap3983
+					d920 = snap3984
+					d921 = snap3985
+					d922 = snap3986
+					d923 = snap3987
+					d924 = snap3988
+					d925 = snap3989
+					d926 = snap3990
+					d927 = snap3991
+					d928 = snap3992
+					d929 = snap3993
+					d930 = snap3994
+					d931 = snap3995
+					d932 = snap3996
+					d933 = snap3997
+					d934 = snap3998
+					d935 = snap3999
+					d936 = snap4000
+					d937 = snap4001
+					d938 = snap4002
+					d939 = snap4003
+					d940 = snap4004
+					d941 = snap4005
+					d942 = snap4006
+					d1221 = snap4007
+					d1222 = snap4008
+					d1223 = snap4009
+					d1224 = snap4010
+					d1225 = snap4011
+					d1226 = snap4012
+					d1227 = snap4013
+					d1228 = snap4014
+					d1229 = snap4015
+					d1230 = snap4016
+					d1231 = snap4017
+					d1232 = snap4018
+					d1233 = snap4019
+					d1234 = snap4020
+					d1236 = snap4021
+					d1238 = snap4022
+					d1392 = snap4023
+					d1395 = snap4024
+					d1551 = snap4025
+					d1552 = snap4026
+					d1553 = snap4027
+					d1554 = snap4028
+					d1877 = snap4029
+					d1878 = snap4030
+					d1879 = snap4031
+					d1880 = snap4032
+					d1881 = snap4033
+					d1882 = snap4034
+					d1883 = snap4035
+					d1884 = snap4036
+					d1885 = snap4037
+					d1886 = snap4038
+					d1887 = snap4039
+					d1888 = snap4040
+					d1889 = snap4041
+					d1890 = snap4042
+					d1892 = snap4043
+					d1894 = snap4044
+					d2070 = snap4045
+					d2073 = snap4046
+					d2251 = snap4047
+					d2252 = snap4048
+					d2253 = snap4049
+					d2254 = snap4050
+					d2621 = snap4051
+					d2623 = snap4052
+					d2624 = snap4053
+					d2625 = snap4054
+					d2626 = snap4055
+					d2627 = snap4056
+					d2628 = snap4057
+					d2629 = snap4058
+					d2630 = snap4059
+					d2631 = snap4060
+					d2632 = snap4061
+					d3021 = snap4062
+					d3022 = snap4063
+					d3023 = snap4064
+					d3024 = snap4065
+					d3421 = snap4066
+					d3423 = snap4067
 					d3425 = snap4068
 					d3426 = snap4069
-					d3428 = snap4070
+					d3427 = snap4070
 					d3429 = snap4071
 					d3430 = snap4072
 					d3431 = snap4073
 					d3432 = snap4074
 					d3433 = snap4075
-					d3435 = snap4076
-					d3437 = snap4077
-					d3647 = snap4078
-					d3650 = snap4079
-					d3862 = snap4080
+					d3434 = snap4076
+					d3436 = snap4077
+					d3438 = snap4078
+					d3648 = snap4079
+					d3651 = snap4080
 					d3863 = snap4081
 					d3864 = snap4082
 					d3865 = snap4083
-					d3867 = snap4084
-					d3869 = snap4085
+					d3866 = snap4084
+					d3868 = snap4085
+					d3870 = snap4086
 					ctx.MarkLabel(lbl43)
 					ctx.SyncDesc(&d2627)
-					if d2627.Loc == LocReg {
+					if d2627.Loc == LocReg || d2627.Loc == LocFPReg {
 						ctx.ProtectReg(d2627.Reg)
 					} else if d2627.Loc == LocRegPair {
 						ctx.ProtectReg(d2627.Reg)
 						ctx.ProtectReg(d2627.Reg2)
 					}
-					d4087 = d2627
-					if d4087.Loc == LocNone {
+					d4088 = d2627
+					if d4088.Loc == LocNone {
 						panic("jit: phi source has no location")
 					}
-					ctx.EnsureDesc(&d4087)
-					ctx.EmitStoreToStack(d4087, int32(bbs[30].PhiBase)+int32(0))
-					if d2627.Loc == LocReg {
+					ctx.EnsureDesc(&d4088)
+					ctx.EmitStoreToStack(d4088, int32(bbs[30].PhiBase)+int32(0))
+					if d2627.Loc == LocReg || d2627.Loc == LocFPReg {
 						ctx.UnprotectReg(d2627.Reg)
 					} else if d2627.Loc == LocRegPair {
 						ctx.UnprotectReg(d2627.Reg)
 						ctx.UnprotectReg(d2627.Reg2)
 					}
 					ctx.EmitJmp(lbl31)
-					ctx.RestoreAllocState(alloc4086)
-					d1 = snap3870
-					d2 = snap3871
-					d3 = snap3872
-					d4 = snap3873
-					d5 = snap3874
-					d6 = snap3875
-					d7 = snap3876
-					d28 = snap3877
-					d29 = snap3878
-					d31 = snap3879
-					d32 = snap3880
-					d33 = snap3881
-					d35 = snap3882
-					d36 = snap3883
-					d37 = snap3884
-					d74 = snap3885
-					d75 = snap3886
-					d76 = snap3887
-					d77 = snap3888
-					d122 = snap3889
-					d123 = snap3890
-					d124 = snap3891
-					d125 = snap3892
-					d126 = snap3893
-					d127 = snap3894
-					d128 = snap3895
-					d129 = snap3896
-					d130 = snap3897
-					d193 = snap3898
-					d258 = snap3899
-					d259 = snap3900
-					d260 = snap3901
-					d261 = snap3902
-					d262 = snap3903
-					d263 = snap3904
-					d264 = snap3905
-					d265 = snap3906
-					d266 = snap3907
-					d267 = snap3908
-					d268 = snap3909
-					d269 = snap3910
-					d270 = snap3911
-					d271 = snap3912
-					d272 = snap3913
-					d273 = snap3914
-					d370 = snap3915
-					d371 = snap3916
-					d372 = snap3917
-					d373 = snap3918
-					d374 = snap3919
-					d375 = snap3920
-					d376 = snap3921
-					d377 = snap3922
-					d378 = snap3923
-					d379 = snap3924
-					d380 = snap3925
-					d381 = snap3926
-					d382 = snap3927
-					d505 = snap3928
-					d506 = snap3929
-					d507 = snap3930
-					d508 = snap3931
-					d509 = snap3932
-					d510 = snap3933
-					d511 = snap3934
-					d512 = snap3935
-					d513 = snap3936
-					d514 = snap3937
-					d515 = snap3938
-					d516 = snap3939
-					d517 = snap3940
-					d666 = snap3941
-					d667 = snap3942
-					d668 = snap3943
-					d669 = snap3944
-					d670 = snap3945
-					d671 = snap3946
-					d672 = snap3947
-					d673 = snap3948
-					d674 = snap3949
-					d675 = snap3950
-					d676 = snap3951
-					d677 = snap3952
-					d678 = snap3953
-					d679 = snap3954
-					d680 = snap3955
-					d681 = snap3956
-					d682 = snap3957
-					d683 = snap3958
-					d684 = snap3959
-					d685 = snap3960
-					d686 = snap3961
-					d687 = snap3962
-					d688 = snap3963
-					d689 = snap3964
-					d690 = snap3965
-					d691 = snap3966
-					d692 = snap3967
-					d693 = snap3968
-					d694 = snap3969
-					d695 = snap3970
-					d696 = snap3971
-					d697 = snap3972
-					d910 = snap3973
-					d911 = snap3974
-					d912 = snap3975
-					d913 = snap3976
-					d914 = snap3977
-					d915 = snap3978
-					d916 = snap3979
-					d917 = snap3980
-					d918 = snap3981
-					d919 = snap3982
-					d920 = snap3983
-					d921 = snap3984
-					d922 = snap3985
-					d923 = snap3986
-					d924 = snap3987
-					d925 = snap3988
-					d926 = snap3989
-					d927 = snap3990
-					d928 = snap3991
-					d929 = snap3992
-					d930 = snap3993
-					d931 = snap3994
-					d932 = snap3995
-					d933 = snap3996
-					d934 = snap3997
-					d935 = snap3998
-					d936 = snap3999
-					d937 = snap4000
-					d938 = snap4001
-					d939 = snap4002
-					d940 = snap4003
-					d941 = snap4004
-					d942 = snap4005
-					d1221 = snap4006
-					d1222 = snap4007
-					d1223 = snap4008
-					d1224 = snap4009
-					d1225 = snap4010
-					d1226 = snap4011
-					d1227 = snap4012
-					d1228 = snap4013
-					d1229 = snap4014
-					d1230 = snap4015
-					d1231 = snap4016
-					d1232 = snap4017
-					d1233 = snap4018
-					d1234 = snap4019
-					d1236 = snap4020
-					d1238 = snap4021
-					d1392 = snap4022
-					d1395 = snap4023
-					d1551 = snap4024
-					d1552 = snap4025
-					d1553 = snap4026
-					d1554 = snap4027
-					d1877 = snap4028
-					d1878 = snap4029
-					d1879 = snap4030
-					d1880 = snap4031
-					d1881 = snap4032
-					d1882 = snap4033
-					d1883 = snap4034
-					d1884 = snap4035
-					d1885 = snap4036
-					d1886 = snap4037
-					d1887 = snap4038
-					d1888 = snap4039
-					d1889 = snap4040
-					d1890 = snap4041
-					d1892 = snap4042
-					d1894 = snap4043
-					d2070 = snap4044
-					d2073 = snap4045
-					d2251 = snap4046
-					d2252 = snap4047
-					d2253 = snap4048
-					d2254 = snap4049
-					d2621 = snap4050
-					d2623 = snap4051
-					d2624 = snap4052
-					d2625 = snap4053
-					d2626 = snap4054
-					d2627 = snap4055
-					d2628 = snap4056
-					d2629 = snap4057
-					d2630 = snap4058
-					d2631 = snap4059
-					d2632 = snap4060
-					d3021 = snap4061
-					d3022 = snap4062
-					d3023 = snap4063
-					d3024 = snap4064
-					d3421 = snap4065
-					d3423 = snap4066
-					d3424 = snap4067
+					ctx.RestoreAllocState(alloc4087)
+					d1 = snap3871
+					d2 = snap3872
+					d3 = snap3873
+					d4 = snap3874
+					d5 = snap3875
+					d6 = snap3876
+					d7 = snap3877
+					d28 = snap3878
+					d29 = snap3879
+					d31 = snap3880
+					d32 = snap3881
+					d33 = snap3882
+					d35 = snap3883
+					d36 = snap3884
+					d37 = snap3885
+					d74 = snap3886
+					d75 = snap3887
+					d76 = snap3888
+					d77 = snap3889
+					d122 = snap3890
+					d123 = snap3891
+					d124 = snap3892
+					d125 = snap3893
+					d126 = snap3894
+					d127 = snap3895
+					d128 = snap3896
+					d129 = snap3897
+					d130 = snap3898
+					d193 = snap3899
+					d258 = snap3900
+					d259 = snap3901
+					d260 = snap3902
+					d261 = snap3903
+					d262 = snap3904
+					d263 = snap3905
+					d264 = snap3906
+					d265 = snap3907
+					d266 = snap3908
+					d267 = snap3909
+					d268 = snap3910
+					d269 = snap3911
+					d270 = snap3912
+					d271 = snap3913
+					d272 = snap3914
+					d273 = snap3915
+					d370 = snap3916
+					d371 = snap3917
+					d372 = snap3918
+					d373 = snap3919
+					d374 = snap3920
+					d375 = snap3921
+					d376 = snap3922
+					d377 = snap3923
+					d378 = snap3924
+					d379 = snap3925
+					d380 = snap3926
+					d381 = snap3927
+					d382 = snap3928
+					d505 = snap3929
+					d506 = snap3930
+					d507 = snap3931
+					d508 = snap3932
+					d509 = snap3933
+					d510 = snap3934
+					d511 = snap3935
+					d512 = snap3936
+					d513 = snap3937
+					d514 = snap3938
+					d515 = snap3939
+					d516 = snap3940
+					d517 = snap3941
+					d666 = snap3942
+					d667 = snap3943
+					d668 = snap3944
+					d669 = snap3945
+					d670 = snap3946
+					d671 = snap3947
+					d672 = snap3948
+					d673 = snap3949
+					d674 = snap3950
+					d675 = snap3951
+					d676 = snap3952
+					d677 = snap3953
+					d678 = snap3954
+					d679 = snap3955
+					d680 = snap3956
+					d681 = snap3957
+					d682 = snap3958
+					d683 = snap3959
+					d684 = snap3960
+					d685 = snap3961
+					d686 = snap3962
+					d687 = snap3963
+					d688 = snap3964
+					d689 = snap3965
+					d690 = snap3966
+					d691 = snap3967
+					d692 = snap3968
+					d693 = snap3969
+					d694 = snap3970
+					d695 = snap3971
+					d696 = snap3972
+					d697 = snap3973
+					d910 = snap3974
+					d911 = snap3975
+					d912 = snap3976
+					d913 = snap3977
+					d914 = snap3978
+					d915 = snap3979
+					d916 = snap3980
+					d917 = snap3981
+					d918 = snap3982
+					d919 = snap3983
+					d920 = snap3984
+					d921 = snap3985
+					d922 = snap3986
+					d923 = snap3987
+					d924 = snap3988
+					d925 = snap3989
+					d926 = snap3990
+					d927 = snap3991
+					d928 = snap3992
+					d929 = snap3993
+					d930 = snap3994
+					d931 = snap3995
+					d932 = snap3996
+					d933 = snap3997
+					d934 = snap3998
+					d935 = snap3999
+					d936 = snap4000
+					d937 = snap4001
+					d938 = snap4002
+					d939 = snap4003
+					d940 = snap4004
+					d941 = snap4005
+					d942 = snap4006
+					d1221 = snap4007
+					d1222 = snap4008
+					d1223 = snap4009
+					d1224 = snap4010
+					d1225 = snap4011
+					d1226 = snap4012
+					d1227 = snap4013
+					d1228 = snap4014
+					d1229 = snap4015
+					d1230 = snap4016
+					d1231 = snap4017
+					d1232 = snap4018
+					d1233 = snap4019
+					d1234 = snap4020
+					d1236 = snap4021
+					d1238 = snap4022
+					d1392 = snap4023
+					d1395 = snap4024
+					d1551 = snap4025
+					d1552 = snap4026
+					d1553 = snap4027
+					d1554 = snap4028
+					d1877 = snap4029
+					d1878 = snap4030
+					d1879 = snap4031
+					d1880 = snap4032
+					d1881 = snap4033
+					d1882 = snap4034
+					d1883 = snap4035
+					d1884 = snap4036
+					d1885 = snap4037
+					d1886 = snap4038
+					d1887 = snap4039
+					d1888 = snap4040
+					d1889 = snap4041
+					d1890 = snap4042
+					d1892 = snap4043
+					d1894 = snap4044
+					d2070 = snap4045
+					d2073 = snap4046
+					d2251 = snap4047
+					d2252 = snap4048
+					d2253 = snap4049
+					d2254 = snap4050
+					d2621 = snap4051
+					d2623 = snap4052
+					d2624 = snap4053
+					d2625 = snap4054
+					d2626 = snap4055
+					d2627 = snap4056
+					d2628 = snap4057
+					d2629 = snap4058
+					d2630 = snap4059
+					d2631 = snap4060
+					d2632 = snap4061
+					d3021 = snap4062
+					d3022 = snap4063
+					d3023 = snap4064
+					d3024 = snap4065
+					d3421 = snap4066
+					d3423 = snap4067
 					d3425 = snap4068
 					d3426 = snap4069
-					d3428 = snap4070
+					d3427 = snap4070
 					d3429 = snap4071
 					d3430 = snap4072
 					d3431 = snap4073
 					d3432 = snap4074
 					d3433 = snap4075
-					d3435 = snap4076
-					d3437 = snap4077
-					d3647 = snap4078
-					d3650 = snap4079
-					d3862 = snap4080
+					d3434 = snap4076
+					d3436 = snap4077
+					d3438 = snap4078
+					d3648 = snap4079
+					d3651 = snap4080
 					d3863 = snap4081
 					d3864 = snap4082
 					d3865 = snap4083
-					d3867 = snap4084
-					d3869 = snap4085
-					ps4088 := PhiState{General: true}
-					ps4088.OverlayValues = make([]JITValueDesc, 4088)
-					ps4088.OverlayValues[1] = d1
-					ps4088.OverlayValues[2] = d2
-					ps4088.OverlayValues[3] = d3
-					ps4088.OverlayValues[4] = d4
-					ps4088.OverlayValues[5] = d5
-					ps4088.OverlayValues[6] = d6
-					ps4088.OverlayValues[7] = d7
-					ps4088.OverlayValues[28] = d28
-					ps4088.OverlayValues[29] = d29
-					ps4088.OverlayValues[31] = d31
-					ps4088.OverlayValues[32] = d32
-					ps4088.OverlayValues[33] = d33
-					ps4088.OverlayValues[35] = d35
-					ps4088.OverlayValues[36] = d36
-					ps4088.OverlayValues[37] = d37
-					ps4088.OverlayValues[74] = d74
-					ps4088.OverlayValues[75] = d75
-					ps4088.OverlayValues[76] = d76
-					ps4088.OverlayValues[77] = d77
-					ps4088.OverlayValues[122] = d122
-					ps4088.OverlayValues[123] = d123
-					ps4088.OverlayValues[124] = d124
-					ps4088.OverlayValues[125] = d125
-					ps4088.OverlayValues[126] = d126
-					ps4088.OverlayValues[127] = d127
-					ps4088.OverlayValues[128] = d128
-					ps4088.OverlayValues[129] = d129
-					ps4088.OverlayValues[130] = d130
-					ps4088.OverlayValues[193] = d193
-					ps4088.OverlayValues[258] = d258
-					ps4088.OverlayValues[259] = d259
-					ps4088.OverlayValues[260] = d260
-					ps4088.OverlayValues[261] = d261
-					ps4088.OverlayValues[262] = d262
-					ps4088.OverlayValues[263] = d263
-					ps4088.OverlayValues[264] = d264
-					ps4088.OverlayValues[265] = d265
-					ps4088.OverlayValues[266] = d266
-					ps4088.OverlayValues[267] = d267
-					ps4088.OverlayValues[268] = d268
-					ps4088.OverlayValues[269] = d269
-					ps4088.OverlayValues[270] = d270
-					ps4088.OverlayValues[271] = d271
-					ps4088.OverlayValues[272] = d272
-					ps4088.OverlayValues[273] = d273
-					ps4088.OverlayValues[370] = d370
-					ps4088.OverlayValues[371] = d371
-					ps4088.OverlayValues[372] = d372
-					ps4088.OverlayValues[373] = d373
-					ps4088.OverlayValues[374] = d374
-					ps4088.OverlayValues[375] = d375
-					ps4088.OverlayValues[376] = d376
-					ps4088.OverlayValues[377] = d377
-					ps4088.OverlayValues[378] = d378
-					ps4088.OverlayValues[379] = d379
-					ps4088.OverlayValues[380] = d380
-					ps4088.OverlayValues[381] = d381
-					ps4088.OverlayValues[382] = d382
-					ps4088.OverlayValues[505] = d505
-					ps4088.OverlayValues[506] = d506
-					ps4088.OverlayValues[507] = d507
-					ps4088.OverlayValues[508] = d508
-					ps4088.OverlayValues[509] = d509
-					ps4088.OverlayValues[510] = d510
-					ps4088.OverlayValues[511] = d511
-					ps4088.OverlayValues[512] = d512
-					ps4088.OverlayValues[513] = d513
-					ps4088.OverlayValues[514] = d514
-					ps4088.OverlayValues[515] = d515
-					ps4088.OverlayValues[516] = d516
-					ps4088.OverlayValues[517] = d517
-					ps4088.OverlayValues[666] = d666
-					ps4088.OverlayValues[667] = d667
-					ps4088.OverlayValues[668] = d668
-					ps4088.OverlayValues[669] = d669
-					ps4088.OverlayValues[670] = d670
-					ps4088.OverlayValues[671] = d671
-					ps4088.OverlayValues[672] = d672
-					ps4088.OverlayValues[673] = d673
-					ps4088.OverlayValues[674] = d674
-					ps4088.OverlayValues[675] = d675
-					ps4088.OverlayValues[676] = d676
-					ps4088.OverlayValues[677] = d677
-					ps4088.OverlayValues[678] = d678
-					ps4088.OverlayValues[679] = d679
-					ps4088.OverlayValues[680] = d680
-					ps4088.OverlayValues[681] = d681
-					ps4088.OverlayValues[682] = d682
-					ps4088.OverlayValues[683] = d683
-					ps4088.OverlayValues[684] = d684
-					ps4088.OverlayValues[685] = d685
-					ps4088.OverlayValues[686] = d686
-					ps4088.OverlayValues[687] = d687
-					ps4088.OverlayValues[688] = d688
-					ps4088.OverlayValues[689] = d689
-					ps4088.OverlayValues[690] = d690
-					ps4088.OverlayValues[691] = d691
-					ps4088.OverlayValues[692] = d692
-					ps4088.OverlayValues[693] = d693
-					ps4088.OverlayValues[694] = d694
-					ps4088.OverlayValues[695] = d695
-					ps4088.OverlayValues[696] = d696
-					ps4088.OverlayValues[697] = d697
-					ps4088.OverlayValues[910] = d910
-					ps4088.OverlayValues[911] = d911
-					ps4088.OverlayValues[912] = d912
-					ps4088.OverlayValues[913] = d913
-					ps4088.OverlayValues[914] = d914
-					ps4088.OverlayValues[915] = d915
-					ps4088.OverlayValues[916] = d916
-					ps4088.OverlayValues[917] = d917
-					ps4088.OverlayValues[918] = d918
-					ps4088.OverlayValues[919] = d919
-					ps4088.OverlayValues[920] = d920
-					ps4088.OverlayValues[921] = d921
-					ps4088.OverlayValues[922] = d922
-					ps4088.OverlayValues[923] = d923
-					ps4088.OverlayValues[924] = d924
-					ps4088.OverlayValues[925] = d925
-					ps4088.OverlayValues[926] = d926
-					ps4088.OverlayValues[927] = d927
-					ps4088.OverlayValues[928] = d928
-					ps4088.OverlayValues[929] = d929
-					ps4088.OverlayValues[930] = d930
-					ps4088.OverlayValues[931] = d931
-					ps4088.OverlayValues[932] = d932
-					ps4088.OverlayValues[933] = d933
-					ps4088.OverlayValues[934] = d934
-					ps4088.OverlayValues[935] = d935
-					ps4088.OverlayValues[936] = d936
-					ps4088.OverlayValues[937] = d937
-					ps4088.OverlayValues[938] = d938
-					ps4088.OverlayValues[939] = d939
-					ps4088.OverlayValues[940] = d940
-					ps4088.OverlayValues[941] = d941
-					ps4088.OverlayValues[942] = d942
-					ps4088.OverlayValues[1221] = d1221
-					ps4088.OverlayValues[1222] = d1222
-					ps4088.OverlayValues[1223] = d1223
-					ps4088.OverlayValues[1224] = d1224
-					ps4088.OverlayValues[1225] = d1225
-					ps4088.OverlayValues[1226] = d1226
-					ps4088.OverlayValues[1227] = d1227
-					ps4088.OverlayValues[1228] = d1228
-					ps4088.OverlayValues[1229] = d1229
-					ps4088.OverlayValues[1230] = d1230
-					ps4088.OverlayValues[1231] = d1231
-					ps4088.OverlayValues[1232] = d1232
-					ps4088.OverlayValues[1233] = d1233
-					ps4088.OverlayValues[1234] = d1234
-					ps4088.OverlayValues[1236] = d1236
-					ps4088.OverlayValues[1238] = d1238
-					ps4088.OverlayValues[1392] = d1392
-					ps4088.OverlayValues[1395] = d1395
-					ps4088.OverlayValues[1551] = d1551
-					ps4088.OverlayValues[1552] = d1552
-					ps4088.OverlayValues[1553] = d1553
-					ps4088.OverlayValues[1554] = d1554
-					ps4088.OverlayValues[1877] = d1877
-					ps4088.OverlayValues[1878] = d1878
-					ps4088.OverlayValues[1879] = d1879
-					ps4088.OverlayValues[1880] = d1880
-					ps4088.OverlayValues[1881] = d1881
-					ps4088.OverlayValues[1882] = d1882
-					ps4088.OverlayValues[1883] = d1883
-					ps4088.OverlayValues[1884] = d1884
-					ps4088.OverlayValues[1885] = d1885
-					ps4088.OverlayValues[1886] = d1886
-					ps4088.OverlayValues[1887] = d1887
-					ps4088.OverlayValues[1888] = d1888
-					ps4088.OverlayValues[1889] = d1889
-					ps4088.OverlayValues[1890] = d1890
-					ps4088.OverlayValues[1892] = d1892
-					ps4088.OverlayValues[1894] = d1894
-					ps4088.OverlayValues[2070] = d2070
-					ps4088.OverlayValues[2073] = d2073
-					ps4088.OverlayValues[2251] = d2251
-					ps4088.OverlayValues[2252] = d2252
-					ps4088.OverlayValues[2253] = d2253
-					ps4088.OverlayValues[2254] = d2254
-					ps4088.OverlayValues[2621] = d2621
-					ps4088.OverlayValues[2623] = d2623
-					ps4088.OverlayValues[2624] = d2624
-					ps4088.OverlayValues[2625] = d2625
-					ps4088.OverlayValues[2626] = d2626
-					ps4088.OverlayValues[2627] = d2627
-					ps4088.OverlayValues[2628] = d2628
-					ps4088.OverlayValues[2629] = d2629
-					ps4088.OverlayValues[2630] = d2630
-					ps4088.OverlayValues[2631] = d2631
-					ps4088.OverlayValues[2632] = d2632
-					ps4088.OverlayValues[3021] = d3021
-					ps4088.OverlayValues[3022] = d3022
-					ps4088.OverlayValues[3023] = d3023
-					ps4088.OverlayValues[3024] = d3024
-					ps4088.OverlayValues[3421] = d3421
-					ps4088.OverlayValues[3423] = d3423
-					ps4088.OverlayValues[3424] = d3424
-					ps4088.OverlayValues[3425] = d3425
-					ps4088.OverlayValues[3426] = d3426
-					ps4088.OverlayValues[3428] = d3428
-					ps4088.OverlayValues[3429] = d3429
-					ps4088.OverlayValues[3430] = d3430
-					ps4088.OverlayValues[3431] = d3431
-					ps4088.OverlayValues[3432] = d3432
-					ps4088.OverlayValues[3433] = d3433
-					ps4088.OverlayValues[3435] = d3435
-					ps4088.OverlayValues[3437] = d3437
-					ps4088.OverlayValues[3647] = d3647
-					ps4088.OverlayValues[3650] = d3650
-					ps4088.OverlayValues[3862] = d3862
-					ps4088.OverlayValues[3863] = d3863
-					ps4088.OverlayValues[3864] = d3864
-					ps4088.OverlayValues[3865] = d3865
-					ps4088.OverlayValues[3867] = d3867
-					ps4088.OverlayValues[3869] = d3869
-					ps4088.OverlayValues[4087] = d4087
+					d3866 = snap4084
+					d3868 = snap4085
+					d3870 = snap4086
 					ps4089 := PhiState{General: true}
-					ps4089.OverlayValues = make([]JITValueDesc, 4088)
+					ps4089.OverlayValues = make([]JITValueDesc, 4089)
 					ps4089.OverlayValues[1] = d1
 					ps4089.OverlayValues[2] = d2
 					ps4089.OverlayValues[3] = d3
@@ -73535,478 +73402,697 @@ func init_date() {
 					ps4089.OverlayValues[3024] = d3024
 					ps4089.OverlayValues[3421] = d3421
 					ps4089.OverlayValues[3423] = d3423
-					ps4089.OverlayValues[3424] = d3424
 					ps4089.OverlayValues[3425] = d3425
 					ps4089.OverlayValues[3426] = d3426
-					ps4089.OverlayValues[3428] = d3428
+					ps4089.OverlayValues[3427] = d3427
 					ps4089.OverlayValues[3429] = d3429
 					ps4089.OverlayValues[3430] = d3430
 					ps4089.OverlayValues[3431] = d3431
 					ps4089.OverlayValues[3432] = d3432
 					ps4089.OverlayValues[3433] = d3433
-					ps4089.OverlayValues[3435] = d3435
-					ps4089.OverlayValues[3437] = d3437
-					ps4089.OverlayValues[3647] = d3647
-					ps4089.OverlayValues[3650] = d3650
-					ps4089.OverlayValues[3862] = d3862
+					ps4089.OverlayValues[3434] = d3434
+					ps4089.OverlayValues[3436] = d3436
+					ps4089.OverlayValues[3438] = d3438
+					ps4089.OverlayValues[3648] = d3648
+					ps4089.OverlayValues[3651] = d3651
 					ps4089.OverlayValues[3863] = d3863
 					ps4089.OverlayValues[3864] = d3864
 					ps4089.OverlayValues[3865] = d3865
-					ps4089.OverlayValues[3867] = d3867
-					ps4089.OverlayValues[3869] = d3869
-					ps4089.OverlayValues[4087] = d4087
-					ps4089.PhiValues = make([]JITValueDesc, 1)
-					d4090 = d2627
-					ps4089.PhiValues[0] = d4090
-					snap4091 := d1
-					snap4092 := d2
-					snap4093 := d3
-					snap4094 := d4
-					snap4095 := d5
-					snap4096 := d6
-					snap4097 := d7
-					snap4098 := d28
-					snap4099 := d29
-					snap4100 := d31
-					snap4101 := d32
-					snap4102 := d33
-					snap4103 := d35
-					snap4104 := d36
-					snap4105 := d37
-					snap4106 := d74
-					snap4107 := d75
-					snap4108 := d76
-					snap4109 := d77
-					snap4110 := d122
-					snap4111 := d123
-					snap4112 := d124
-					snap4113 := d125
-					snap4114 := d126
-					snap4115 := d127
-					snap4116 := d128
-					snap4117 := d129
-					snap4118 := d130
-					snap4119 := d193
-					snap4120 := d258
-					snap4121 := d259
-					snap4122 := d260
-					snap4123 := d261
-					snap4124 := d262
-					snap4125 := d263
-					snap4126 := d264
-					snap4127 := d265
-					snap4128 := d266
-					snap4129 := d267
-					snap4130 := d268
-					snap4131 := d269
-					snap4132 := d270
-					snap4133 := d271
-					snap4134 := d272
-					snap4135 := d273
-					snap4136 := d370
-					snap4137 := d371
-					snap4138 := d372
-					snap4139 := d373
-					snap4140 := d374
-					snap4141 := d375
-					snap4142 := d376
-					snap4143 := d377
-					snap4144 := d378
-					snap4145 := d379
-					snap4146 := d380
-					snap4147 := d381
-					snap4148 := d382
-					snap4149 := d505
-					snap4150 := d506
-					snap4151 := d507
-					snap4152 := d508
-					snap4153 := d509
-					snap4154 := d510
-					snap4155 := d511
-					snap4156 := d512
-					snap4157 := d513
-					snap4158 := d514
-					snap4159 := d515
-					snap4160 := d516
-					snap4161 := d517
-					snap4162 := d666
-					snap4163 := d667
-					snap4164 := d668
-					snap4165 := d669
-					snap4166 := d670
-					snap4167 := d671
-					snap4168 := d672
-					snap4169 := d673
-					snap4170 := d674
-					snap4171 := d675
-					snap4172 := d676
-					snap4173 := d677
-					snap4174 := d678
-					snap4175 := d679
-					snap4176 := d680
-					snap4177 := d681
-					snap4178 := d682
-					snap4179 := d683
-					snap4180 := d684
-					snap4181 := d685
-					snap4182 := d686
-					snap4183 := d687
-					snap4184 := d688
-					snap4185 := d689
-					snap4186 := d690
-					snap4187 := d691
-					snap4188 := d692
-					snap4189 := d693
-					snap4190 := d694
-					snap4191 := d695
-					snap4192 := d696
-					snap4193 := d697
-					snap4194 := d910
-					snap4195 := d911
-					snap4196 := d912
-					snap4197 := d913
-					snap4198 := d914
-					snap4199 := d915
-					snap4200 := d916
-					snap4201 := d917
-					snap4202 := d918
-					snap4203 := d919
-					snap4204 := d920
-					snap4205 := d921
-					snap4206 := d922
-					snap4207 := d923
-					snap4208 := d924
-					snap4209 := d925
-					snap4210 := d926
-					snap4211 := d927
-					snap4212 := d928
-					snap4213 := d929
-					snap4214 := d930
-					snap4215 := d931
-					snap4216 := d932
-					snap4217 := d933
-					snap4218 := d934
-					snap4219 := d935
-					snap4220 := d936
-					snap4221 := d937
-					snap4222 := d938
-					snap4223 := d939
-					snap4224 := d940
-					snap4225 := d941
-					snap4226 := d942
-					snap4227 := d1221
-					snap4228 := d1222
-					snap4229 := d1223
-					snap4230 := d1224
-					snap4231 := d1225
-					snap4232 := d1226
-					snap4233 := d1227
-					snap4234 := d1228
-					snap4235 := d1229
-					snap4236 := d1230
-					snap4237 := d1231
-					snap4238 := d1232
-					snap4239 := d1233
-					snap4240 := d1234
-					snap4241 := d1236
-					snap4242 := d1238
-					snap4243 := d1392
-					snap4244 := d1395
-					snap4245 := d1551
-					snap4246 := d1552
-					snap4247 := d1553
-					snap4248 := d1554
-					snap4249 := d1877
-					snap4250 := d1878
-					snap4251 := d1879
-					snap4252 := d1880
-					snap4253 := d1881
-					snap4254 := d1882
-					snap4255 := d1883
-					snap4256 := d1884
-					snap4257 := d1885
-					snap4258 := d1886
-					snap4259 := d1887
-					snap4260 := d1888
-					snap4261 := d1889
-					snap4262 := d1890
-					snap4263 := d1892
-					snap4264 := d1894
-					snap4265 := d2070
-					snap4266 := d2073
-					snap4267 := d2251
-					snap4268 := d2252
-					snap4269 := d2253
-					snap4270 := d2254
-					snap4271 := d2621
-					snap4272 := d2623
-					snap4273 := d2624
-					snap4274 := d2625
-					snap4275 := d2626
-					snap4276 := d2627
-					snap4277 := d2628
-					snap4278 := d2629
-					snap4279 := d2630
-					snap4280 := d2631
-					snap4281 := d2632
-					snap4282 := d3021
-					snap4283 := d3022
-					snap4284 := d3023
-					snap4285 := d3024
-					snap4286 := d3421
-					snap4287 := d3423
-					snap4288 := d3424
+					ps4089.OverlayValues[3866] = d3866
+					ps4089.OverlayValues[3868] = d3868
+					ps4089.OverlayValues[3870] = d3870
+					ps4089.OverlayValues[4088] = d4088
+					ps4090 := PhiState{General: true}
+					ps4090.OverlayValues = make([]JITValueDesc, 4089)
+					ps4090.OverlayValues[1] = d1
+					ps4090.OverlayValues[2] = d2
+					ps4090.OverlayValues[3] = d3
+					ps4090.OverlayValues[4] = d4
+					ps4090.OverlayValues[5] = d5
+					ps4090.OverlayValues[6] = d6
+					ps4090.OverlayValues[7] = d7
+					ps4090.OverlayValues[28] = d28
+					ps4090.OverlayValues[29] = d29
+					ps4090.OverlayValues[31] = d31
+					ps4090.OverlayValues[32] = d32
+					ps4090.OverlayValues[33] = d33
+					ps4090.OverlayValues[35] = d35
+					ps4090.OverlayValues[36] = d36
+					ps4090.OverlayValues[37] = d37
+					ps4090.OverlayValues[74] = d74
+					ps4090.OverlayValues[75] = d75
+					ps4090.OverlayValues[76] = d76
+					ps4090.OverlayValues[77] = d77
+					ps4090.OverlayValues[122] = d122
+					ps4090.OverlayValues[123] = d123
+					ps4090.OverlayValues[124] = d124
+					ps4090.OverlayValues[125] = d125
+					ps4090.OverlayValues[126] = d126
+					ps4090.OverlayValues[127] = d127
+					ps4090.OverlayValues[128] = d128
+					ps4090.OverlayValues[129] = d129
+					ps4090.OverlayValues[130] = d130
+					ps4090.OverlayValues[193] = d193
+					ps4090.OverlayValues[258] = d258
+					ps4090.OverlayValues[259] = d259
+					ps4090.OverlayValues[260] = d260
+					ps4090.OverlayValues[261] = d261
+					ps4090.OverlayValues[262] = d262
+					ps4090.OverlayValues[263] = d263
+					ps4090.OverlayValues[264] = d264
+					ps4090.OverlayValues[265] = d265
+					ps4090.OverlayValues[266] = d266
+					ps4090.OverlayValues[267] = d267
+					ps4090.OverlayValues[268] = d268
+					ps4090.OverlayValues[269] = d269
+					ps4090.OverlayValues[270] = d270
+					ps4090.OverlayValues[271] = d271
+					ps4090.OverlayValues[272] = d272
+					ps4090.OverlayValues[273] = d273
+					ps4090.OverlayValues[370] = d370
+					ps4090.OverlayValues[371] = d371
+					ps4090.OverlayValues[372] = d372
+					ps4090.OverlayValues[373] = d373
+					ps4090.OverlayValues[374] = d374
+					ps4090.OverlayValues[375] = d375
+					ps4090.OverlayValues[376] = d376
+					ps4090.OverlayValues[377] = d377
+					ps4090.OverlayValues[378] = d378
+					ps4090.OverlayValues[379] = d379
+					ps4090.OverlayValues[380] = d380
+					ps4090.OverlayValues[381] = d381
+					ps4090.OverlayValues[382] = d382
+					ps4090.OverlayValues[505] = d505
+					ps4090.OverlayValues[506] = d506
+					ps4090.OverlayValues[507] = d507
+					ps4090.OverlayValues[508] = d508
+					ps4090.OverlayValues[509] = d509
+					ps4090.OverlayValues[510] = d510
+					ps4090.OverlayValues[511] = d511
+					ps4090.OverlayValues[512] = d512
+					ps4090.OverlayValues[513] = d513
+					ps4090.OverlayValues[514] = d514
+					ps4090.OverlayValues[515] = d515
+					ps4090.OverlayValues[516] = d516
+					ps4090.OverlayValues[517] = d517
+					ps4090.OverlayValues[666] = d666
+					ps4090.OverlayValues[667] = d667
+					ps4090.OverlayValues[668] = d668
+					ps4090.OverlayValues[669] = d669
+					ps4090.OverlayValues[670] = d670
+					ps4090.OverlayValues[671] = d671
+					ps4090.OverlayValues[672] = d672
+					ps4090.OverlayValues[673] = d673
+					ps4090.OverlayValues[674] = d674
+					ps4090.OverlayValues[675] = d675
+					ps4090.OverlayValues[676] = d676
+					ps4090.OverlayValues[677] = d677
+					ps4090.OverlayValues[678] = d678
+					ps4090.OverlayValues[679] = d679
+					ps4090.OverlayValues[680] = d680
+					ps4090.OverlayValues[681] = d681
+					ps4090.OverlayValues[682] = d682
+					ps4090.OverlayValues[683] = d683
+					ps4090.OverlayValues[684] = d684
+					ps4090.OverlayValues[685] = d685
+					ps4090.OverlayValues[686] = d686
+					ps4090.OverlayValues[687] = d687
+					ps4090.OverlayValues[688] = d688
+					ps4090.OverlayValues[689] = d689
+					ps4090.OverlayValues[690] = d690
+					ps4090.OverlayValues[691] = d691
+					ps4090.OverlayValues[692] = d692
+					ps4090.OverlayValues[693] = d693
+					ps4090.OverlayValues[694] = d694
+					ps4090.OverlayValues[695] = d695
+					ps4090.OverlayValues[696] = d696
+					ps4090.OverlayValues[697] = d697
+					ps4090.OverlayValues[910] = d910
+					ps4090.OverlayValues[911] = d911
+					ps4090.OverlayValues[912] = d912
+					ps4090.OverlayValues[913] = d913
+					ps4090.OverlayValues[914] = d914
+					ps4090.OverlayValues[915] = d915
+					ps4090.OverlayValues[916] = d916
+					ps4090.OverlayValues[917] = d917
+					ps4090.OverlayValues[918] = d918
+					ps4090.OverlayValues[919] = d919
+					ps4090.OverlayValues[920] = d920
+					ps4090.OverlayValues[921] = d921
+					ps4090.OverlayValues[922] = d922
+					ps4090.OverlayValues[923] = d923
+					ps4090.OverlayValues[924] = d924
+					ps4090.OverlayValues[925] = d925
+					ps4090.OverlayValues[926] = d926
+					ps4090.OverlayValues[927] = d927
+					ps4090.OverlayValues[928] = d928
+					ps4090.OverlayValues[929] = d929
+					ps4090.OverlayValues[930] = d930
+					ps4090.OverlayValues[931] = d931
+					ps4090.OverlayValues[932] = d932
+					ps4090.OverlayValues[933] = d933
+					ps4090.OverlayValues[934] = d934
+					ps4090.OverlayValues[935] = d935
+					ps4090.OverlayValues[936] = d936
+					ps4090.OverlayValues[937] = d937
+					ps4090.OverlayValues[938] = d938
+					ps4090.OverlayValues[939] = d939
+					ps4090.OverlayValues[940] = d940
+					ps4090.OverlayValues[941] = d941
+					ps4090.OverlayValues[942] = d942
+					ps4090.OverlayValues[1221] = d1221
+					ps4090.OverlayValues[1222] = d1222
+					ps4090.OverlayValues[1223] = d1223
+					ps4090.OverlayValues[1224] = d1224
+					ps4090.OverlayValues[1225] = d1225
+					ps4090.OverlayValues[1226] = d1226
+					ps4090.OverlayValues[1227] = d1227
+					ps4090.OverlayValues[1228] = d1228
+					ps4090.OverlayValues[1229] = d1229
+					ps4090.OverlayValues[1230] = d1230
+					ps4090.OverlayValues[1231] = d1231
+					ps4090.OverlayValues[1232] = d1232
+					ps4090.OverlayValues[1233] = d1233
+					ps4090.OverlayValues[1234] = d1234
+					ps4090.OverlayValues[1236] = d1236
+					ps4090.OverlayValues[1238] = d1238
+					ps4090.OverlayValues[1392] = d1392
+					ps4090.OverlayValues[1395] = d1395
+					ps4090.OverlayValues[1551] = d1551
+					ps4090.OverlayValues[1552] = d1552
+					ps4090.OverlayValues[1553] = d1553
+					ps4090.OverlayValues[1554] = d1554
+					ps4090.OverlayValues[1877] = d1877
+					ps4090.OverlayValues[1878] = d1878
+					ps4090.OverlayValues[1879] = d1879
+					ps4090.OverlayValues[1880] = d1880
+					ps4090.OverlayValues[1881] = d1881
+					ps4090.OverlayValues[1882] = d1882
+					ps4090.OverlayValues[1883] = d1883
+					ps4090.OverlayValues[1884] = d1884
+					ps4090.OverlayValues[1885] = d1885
+					ps4090.OverlayValues[1886] = d1886
+					ps4090.OverlayValues[1887] = d1887
+					ps4090.OverlayValues[1888] = d1888
+					ps4090.OverlayValues[1889] = d1889
+					ps4090.OverlayValues[1890] = d1890
+					ps4090.OverlayValues[1892] = d1892
+					ps4090.OverlayValues[1894] = d1894
+					ps4090.OverlayValues[2070] = d2070
+					ps4090.OverlayValues[2073] = d2073
+					ps4090.OverlayValues[2251] = d2251
+					ps4090.OverlayValues[2252] = d2252
+					ps4090.OverlayValues[2253] = d2253
+					ps4090.OverlayValues[2254] = d2254
+					ps4090.OverlayValues[2621] = d2621
+					ps4090.OverlayValues[2623] = d2623
+					ps4090.OverlayValues[2624] = d2624
+					ps4090.OverlayValues[2625] = d2625
+					ps4090.OverlayValues[2626] = d2626
+					ps4090.OverlayValues[2627] = d2627
+					ps4090.OverlayValues[2628] = d2628
+					ps4090.OverlayValues[2629] = d2629
+					ps4090.OverlayValues[2630] = d2630
+					ps4090.OverlayValues[2631] = d2631
+					ps4090.OverlayValues[2632] = d2632
+					ps4090.OverlayValues[3021] = d3021
+					ps4090.OverlayValues[3022] = d3022
+					ps4090.OverlayValues[3023] = d3023
+					ps4090.OverlayValues[3024] = d3024
+					ps4090.OverlayValues[3421] = d3421
+					ps4090.OverlayValues[3423] = d3423
+					ps4090.OverlayValues[3425] = d3425
+					ps4090.OverlayValues[3426] = d3426
+					ps4090.OverlayValues[3427] = d3427
+					ps4090.OverlayValues[3429] = d3429
+					ps4090.OverlayValues[3430] = d3430
+					ps4090.OverlayValues[3431] = d3431
+					ps4090.OverlayValues[3432] = d3432
+					ps4090.OverlayValues[3433] = d3433
+					ps4090.OverlayValues[3434] = d3434
+					ps4090.OverlayValues[3436] = d3436
+					ps4090.OverlayValues[3438] = d3438
+					ps4090.OverlayValues[3648] = d3648
+					ps4090.OverlayValues[3651] = d3651
+					ps4090.OverlayValues[3863] = d3863
+					ps4090.OverlayValues[3864] = d3864
+					ps4090.OverlayValues[3865] = d3865
+					ps4090.OverlayValues[3866] = d3866
+					ps4090.OverlayValues[3868] = d3868
+					ps4090.OverlayValues[3870] = d3870
+					ps4090.OverlayValues[4088] = d4088
+					ps4090.PhiValues = make([]JITValueDesc, 1)
+					d4091 = d2627
+					ps4090.PhiValues[0] = d4091
+					snap4092 := d1
+					snap4093 := d2
+					snap4094 := d3
+					snap4095 := d4
+					snap4096 := d5
+					snap4097 := d6
+					snap4098 := d7
+					snap4099 := d28
+					snap4100 := d29
+					snap4101 := d31
+					snap4102 := d32
+					snap4103 := d33
+					snap4104 := d35
+					snap4105 := d36
+					snap4106 := d37
+					snap4107 := d74
+					snap4108 := d75
+					snap4109 := d76
+					snap4110 := d77
+					snap4111 := d122
+					snap4112 := d123
+					snap4113 := d124
+					snap4114 := d125
+					snap4115 := d126
+					snap4116 := d127
+					snap4117 := d128
+					snap4118 := d129
+					snap4119 := d130
+					snap4120 := d193
+					snap4121 := d258
+					snap4122 := d259
+					snap4123 := d260
+					snap4124 := d261
+					snap4125 := d262
+					snap4126 := d263
+					snap4127 := d264
+					snap4128 := d265
+					snap4129 := d266
+					snap4130 := d267
+					snap4131 := d268
+					snap4132 := d269
+					snap4133 := d270
+					snap4134 := d271
+					snap4135 := d272
+					snap4136 := d273
+					snap4137 := d370
+					snap4138 := d371
+					snap4139 := d372
+					snap4140 := d373
+					snap4141 := d374
+					snap4142 := d375
+					snap4143 := d376
+					snap4144 := d377
+					snap4145 := d378
+					snap4146 := d379
+					snap4147 := d380
+					snap4148 := d381
+					snap4149 := d382
+					snap4150 := d505
+					snap4151 := d506
+					snap4152 := d507
+					snap4153 := d508
+					snap4154 := d509
+					snap4155 := d510
+					snap4156 := d511
+					snap4157 := d512
+					snap4158 := d513
+					snap4159 := d514
+					snap4160 := d515
+					snap4161 := d516
+					snap4162 := d517
+					snap4163 := d666
+					snap4164 := d667
+					snap4165 := d668
+					snap4166 := d669
+					snap4167 := d670
+					snap4168 := d671
+					snap4169 := d672
+					snap4170 := d673
+					snap4171 := d674
+					snap4172 := d675
+					snap4173 := d676
+					snap4174 := d677
+					snap4175 := d678
+					snap4176 := d679
+					snap4177 := d680
+					snap4178 := d681
+					snap4179 := d682
+					snap4180 := d683
+					snap4181 := d684
+					snap4182 := d685
+					snap4183 := d686
+					snap4184 := d687
+					snap4185 := d688
+					snap4186 := d689
+					snap4187 := d690
+					snap4188 := d691
+					snap4189 := d692
+					snap4190 := d693
+					snap4191 := d694
+					snap4192 := d695
+					snap4193 := d696
+					snap4194 := d697
+					snap4195 := d910
+					snap4196 := d911
+					snap4197 := d912
+					snap4198 := d913
+					snap4199 := d914
+					snap4200 := d915
+					snap4201 := d916
+					snap4202 := d917
+					snap4203 := d918
+					snap4204 := d919
+					snap4205 := d920
+					snap4206 := d921
+					snap4207 := d922
+					snap4208 := d923
+					snap4209 := d924
+					snap4210 := d925
+					snap4211 := d926
+					snap4212 := d927
+					snap4213 := d928
+					snap4214 := d929
+					snap4215 := d930
+					snap4216 := d931
+					snap4217 := d932
+					snap4218 := d933
+					snap4219 := d934
+					snap4220 := d935
+					snap4221 := d936
+					snap4222 := d937
+					snap4223 := d938
+					snap4224 := d939
+					snap4225 := d940
+					snap4226 := d941
+					snap4227 := d942
+					snap4228 := d1221
+					snap4229 := d1222
+					snap4230 := d1223
+					snap4231 := d1224
+					snap4232 := d1225
+					snap4233 := d1226
+					snap4234 := d1227
+					snap4235 := d1228
+					snap4236 := d1229
+					snap4237 := d1230
+					snap4238 := d1231
+					snap4239 := d1232
+					snap4240 := d1233
+					snap4241 := d1234
+					snap4242 := d1236
+					snap4243 := d1238
+					snap4244 := d1392
+					snap4245 := d1395
+					snap4246 := d1551
+					snap4247 := d1552
+					snap4248 := d1553
+					snap4249 := d1554
+					snap4250 := d1877
+					snap4251 := d1878
+					snap4252 := d1879
+					snap4253 := d1880
+					snap4254 := d1881
+					snap4255 := d1882
+					snap4256 := d1883
+					snap4257 := d1884
+					snap4258 := d1885
+					snap4259 := d1886
+					snap4260 := d1887
+					snap4261 := d1888
+					snap4262 := d1889
+					snap4263 := d1890
+					snap4264 := d1892
+					snap4265 := d1894
+					snap4266 := d2070
+					snap4267 := d2073
+					snap4268 := d2251
+					snap4269 := d2252
+					snap4270 := d2253
+					snap4271 := d2254
+					snap4272 := d2621
+					snap4273 := d2623
+					snap4274 := d2624
+					snap4275 := d2625
+					snap4276 := d2626
+					snap4277 := d2627
+					snap4278 := d2628
+					snap4279 := d2629
+					snap4280 := d2630
+					snap4281 := d2631
+					snap4282 := d2632
+					snap4283 := d3021
+					snap4284 := d3022
+					snap4285 := d3023
+					snap4286 := d3024
+					snap4287 := d3421
+					snap4288 := d3423
 					snap4289 := d3425
 					snap4290 := d3426
-					snap4291 := d3428
+					snap4291 := d3427
 					snap4292 := d3429
 					snap4293 := d3430
 					snap4294 := d3431
 					snap4295 := d3432
 					snap4296 := d3433
-					snap4297 := d3435
-					snap4298 := d3437
-					snap4299 := d3647
-					snap4300 := d3650
-					snap4301 := d3862
+					snap4297 := d3434
+					snap4298 := d3436
+					snap4299 := d3438
+					snap4300 := d3648
+					snap4301 := d3651
 					snap4302 := d3863
 					snap4303 := d3864
 					snap4304 := d3865
-					snap4305 := d3867
-					snap4306 := d3869
-					snap4307 := d4087
-					snap4308 := d4090
-					alloc4309 := ctx.SnapshotAllocState()
+					snap4305 := d3866
+					snap4306 := d3868
+					snap4307 := d3870
+					snap4308 := d4088
+					snap4309 := d4091
+					alloc4310 := ctx.SnapshotAllocState()
 					if !bbs[30].Rendered {
-						bbs[30].RenderPS(ps4089)
+						bbs[30].RenderPS(ps4090)
 					}
-					ctx.RestoreAllocState(alloc4309)
-					d1 = snap4091
-					d2 = snap4092
-					d3 = snap4093
-					d4 = snap4094
-					d5 = snap4095
-					d6 = snap4096
-					d7 = snap4097
-					d28 = snap4098
-					d29 = snap4099
-					d31 = snap4100
-					d32 = snap4101
-					d33 = snap4102
-					d35 = snap4103
-					d36 = snap4104
-					d37 = snap4105
-					d74 = snap4106
-					d75 = snap4107
-					d76 = snap4108
-					d77 = snap4109
-					d122 = snap4110
-					d123 = snap4111
-					d124 = snap4112
-					d125 = snap4113
-					d126 = snap4114
-					d127 = snap4115
-					d128 = snap4116
-					d129 = snap4117
-					d130 = snap4118
-					d193 = snap4119
-					d258 = snap4120
-					d259 = snap4121
-					d260 = snap4122
-					d261 = snap4123
-					d262 = snap4124
-					d263 = snap4125
-					d264 = snap4126
-					d265 = snap4127
-					d266 = snap4128
-					d267 = snap4129
-					d268 = snap4130
-					d269 = snap4131
-					d270 = snap4132
-					d271 = snap4133
-					d272 = snap4134
-					d273 = snap4135
-					d370 = snap4136
-					d371 = snap4137
-					d372 = snap4138
-					d373 = snap4139
-					d374 = snap4140
-					d375 = snap4141
-					d376 = snap4142
-					d377 = snap4143
-					d378 = snap4144
-					d379 = snap4145
-					d380 = snap4146
-					d381 = snap4147
-					d382 = snap4148
-					d505 = snap4149
-					d506 = snap4150
-					d507 = snap4151
-					d508 = snap4152
-					d509 = snap4153
-					d510 = snap4154
-					d511 = snap4155
-					d512 = snap4156
-					d513 = snap4157
-					d514 = snap4158
-					d515 = snap4159
-					d516 = snap4160
-					d517 = snap4161
-					d666 = snap4162
-					d667 = snap4163
-					d668 = snap4164
-					d669 = snap4165
-					d670 = snap4166
-					d671 = snap4167
-					d672 = snap4168
-					d673 = snap4169
-					d674 = snap4170
-					d675 = snap4171
-					d676 = snap4172
-					d677 = snap4173
-					d678 = snap4174
-					d679 = snap4175
-					d680 = snap4176
-					d681 = snap4177
-					d682 = snap4178
-					d683 = snap4179
-					d684 = snap4180
-					d685 = snap4181
-					d686 = snap4182
-					d687 = snap4183
-					d688 = snap4184
-					d689 = snap4185
-					d690 = snap4186
-					d691 = snap4187
-					d692 = snap4188
-					d693 = snap4189
-					d694 = snap4190
-					d695 = snap4191
-					d696 = snap4192
-					d697 = snap4193
-					d910 = snap4194
-					d911 = snap4195
-					d912 = snap4196
-					d913 = snap4197
-					d914 = snap4198
-					d915 = snap4199
-					d916 = snap4200
-					d917 = snap4201
-					d918 = snap4202
-					d919 = snap4203
-					d920 = snap4204
-					d921 = snap4205
-					d922 = snap4206
-					d923 = snap4207
-					d924 = snap4208
-					d925 = snap4209
-					d926 = snap4210
-					d927 = snap4211
-					d928 = snap4212
-					d929 = snap4213
-					d930 = snap4214
-					d931 = snap4215
-					d932 = snap4216
-					d933 = snap4217
-					d934 = snap4218
-					d935 = snap4219
-					d936 = snap4220
-					d937 = snap4221
-					d938 = snap4222
-					d939 = snap4223
-					d940 = snap4224
-					d941 = snap4225
-					d942 = snap4226
-					d1221 = snap4227
-					d1222 = snap4228
-					d1223 = snap4229
-					d1224 = snap4230
-					d1225 = snap4231
-					d1226 = snap4232
-					d1227 = snap4233
-					d1228 = snap4234
-					d1229 = snap4235
-					d1230 = snap4236
-					d1231 = snap4237
-					d1232 = snap4238
-					d1233 = snap4239
-					d1234 = snap4240
-					d1236 = snap4241
-					d1238 = snap4242
-					d1392 = snap4243
-					d1395 = snap4244
-					d1551 = snap4245
-					d1552 = snap4246
-					d1553 = snap4247
-					d1554 = snap4248
-					d1877 = snap4249
-					d1878 = snap4250
-					d1879 = snap4251
-					d1880 = snap4252
-					d1881 = snap4253
-					d1882 = snap4254
-					d1883 = snap4255
-					d1884 = snap4256
-					d1885 = snap4257
-					d1886 = snap4258
-					d1887 = snap4259
-					d1888 = snap4260
-					d1889 = snap4261
-					d1890 = snap4262
-					d1892 = snap4263
-					d1894 = snap4264
-					d2070 = snap4265
-					d2073 = snap4266
-					d2251 = snap4267
-					d2252 = snap4268
-					d2253 = snap4269
-					d2254 = snap4270
-					d2621 = snap4271
-					d2623 = snap4272
-					d2624 = snap4273
-					d2625 = snap4274
-					d2626 = snap4275
-					d2627 = snap4276
-					d2628 = snap4277
-					d2629 = snap4278
-					d2630 = snap4279
-					d2631 = snap4280
-					d2632 = snap4281
-					d3021 = snap4282
-					d3022 = snap4283
-					d3023 = snap4284
-					d3024 = snap4285
-					d3421 = snap4286
-					d3423 = snap4287
-					d3424 = snap4288
+					ctx.RestoreAllocState(alloc4310)
+					d1 = snap4092
+					d2 = snap4093
+					d3 = snap4094
+					d4 = snap4095
+					d5 = snap4096
+					d6 = snap4097
+					d7 = snap4098
+					d28 = snap4099
+					d29 = snap4100
+					d31 = snap4101
+					d32 = snap4102
+					d33 = snap4103
+					d35 = snap4104
+					d36 = snap4105
+					d37 = snap4106
+					d74 = snap4107
+					d75 = snap4108
+					d76 = snap4109
+					d77 = snap4110
+					d122 = snap4111
+					d123 = snap4112
+					d124 = snap4113
+					d125 = snap4114
+					d126 = snap4115
+					d127 = snap4116
+					d128 = snap4117
+					d129 = snap4118
+					d130 = snap4119
+					d193 = snap4120
+					d258 = snap4121
+					d259 = snap4122
+					d260 = snap4123
+					d261 = snap4124
+					d262 = snap4125
+					d263 = snap4126
+					d264 = snap4127
+					d265 = snap4128
+					d266 = snap4129
+					d267 = snap4130
+					d268 = snap4131
+					d269 = snap4132
+					d270 = snap4133
+					d271 = snap4134
+					d272 = snap4135
+					d273 = snap4136
+					d370 = snap4137
+					d371 = snap4138
+					d372 = snap4139
+					d373 = snap4140
+					d374 = snap4141
+					d375 = snap4142
+					d376 = snap4143
+					d377 = snap4144
+					d378 = snap4145
+					d379 = snap4146
+					d380 = snap4147
+					d381 = snap4148
+					d382 = snap4149
+					d505 = snap4150
+					d506 = snap4151
+					d507 = snap4152
+					d508 = snap4153
+					d509 = snap4154
+					d510 = snap4155
+					d511 = snap4156
+					d512 = snap4157
+					d513 = snap4158
+					d514 = snap4159
+					d515 = snap4160
+					d516 = snap4161
+					d517 = snap4162
+					d666 = snap4163
+					d667 = snap4164
+					d668 = snap4165
+					d669 = snap4166
+					d670 = snap4167
+					d671 = snap4168
+					d672 = snap4169
+					d673 = snap4170
+					d674 = snap4171
+					d675 = snap4172
+					d676 = snap4173
+					d677 = snap4174
+					d678 = snap4175
+					d679 = snap4176
+					d680 = snap4177
+					d681 = snap4178
+					d682 = snap4179
+					d683 = snap4180
+					d684 = snap4181
+					d685 = snap4182
+					d686 = snap4183
+					d687 = snap4184
+					d688 = snap4185
+					d689 = snap4186
+					d690 = snap4187
+					d691 = snap4188
+					d692 = snap4189
+					d693 = snap4190
+					d694 = snap4191
+					d695 = snap4192
+					d696 = snap4193
+					d697 = snap4194
+					d910 = snap4195
+					d911 = snap4196
+					d912 = snap4197
+					d913 = snap4198
+					d914 = snap4199
+					d915 = snap4200
+					d916 = snap4201
+					d917 = snap4202
+					d918 = snap4203
+					d919 = snap4204
+					d920 = snap4205
+					d921 = snap4206
+					d922 = snap4207
+					d923 = snap4208
+					d924 = snap4209
+					d925 = snap4210
+					d926 = snap4211
+					d927 = snap4212
+					d928 = snap4213
+					d929 = snap4214
+					d930 = snap4215
+					d931 = snap4216
+					d932 = snap4217
+					d933 = snap4218
+					d934 = snap4219
+					d935 = snap4220
+					d936 = snap4221
+					d937 = snap4222
+					d938 = snap4223
+					d939 = snap4224
+					d940 = snap4225
+					d941 = snap4226
+					d942 = snap4227
+					d1221 = snap4228
+					d1222 = snap4229
+					d1223 = snap4230
+					d1224 = snap4231
+					d1225 = snap4232
+					d1226 = snap4233
+					d1227 = snap4234
+					d1228 = snap4235
+					d1229 = snap4236
+					d1230 = snap4237
+					d1231 = snap4238
+					d1232 = snap4239
+					d1233 = snap4240
+					d1234 = snap4241
+					d1236 = snap4242
+					d1238 = snap4243
+					d1392 = snap4244
+					d1395 = snap4245
+					d1551 = snap4246
+					d1552 = snap4247
+					d1553 = snap4248
+					d1554 = snap4249
+					d1877 = snap4250
+					d1878 = snap4251
+					d1879 = snap4252
+					d1880 = snap4253
+					d1881 = snap4254
+					d1882 = snap4255
+					d1883 = snap4256
+					d1884 = snap4257
+					d1885 = snap4258
+					d1886 = snap4259
+					d1887 = snap4260
+					d1888 = snap4261
+					d1889 = snap4262
+					d1890 = snap4263
+					d1892 = snap4264
+					d1894 = snap4265
+					d2070 = snap4266
+					d2073 = snap4267
+					d2251 = snap4268
+					d2252 = snap4269
+					d2253 = snap4270
+					d2254 = snap4271
+					d2621 = snap4272
+					d2623 = snap4273
+					d2624 = snap4274
+					d2625 = snap4275
+					d2626 = snap4276
+					d2627 = snap4277
+					d2628 = snap4278
+					d2629 = snap4279
+					d2630 = snap4280
+					d2631 = snap4281
+					d2632 = snap4282
+					d3021 = snap4283
+					d3022 = snap4284
+					d3023 = snap4285
+					d3024 = snap4286
+					d3421 = snap4287
+					d3423 = snap4288
 					d3425 = snap4289
 					d3426 = snap4290
-					d3428 = snap4291
+					d3427 = snap4291
 					d3429 = snap4292
 					d3430 = snap4293
 					d3431 = snap4294
 					d3432 = snap4295
 					d3433 = snap4296
-					d3435 = snap4297
-					d3437 = snap4298
-					d3647 = snap4299
-					d3650 = snap4300
-					d3862 = snap4301
+					d3434 = snap4297
+					d3436 = snap4298
+					d3438 = snap4299
+					d3648 = snap4300
+					d3651 = snap4301
 					d3863 = snap4302
 					d3864 = snap4303
 					d3865 = snap4304
-					d3867 = snap4305
-					d3869 = snap4306
-					d4087 = snap4307
-					d4090 = snap4308
+					d3866 = snap4305
+					d3868 = snap4306
+					d3870 = snap4307
+					d4088 = snap4308
+					d4091 = snap4309
 					if !bbs[29].Rendered {
-						return bbs[29].RenderPS(ps4088)
+						return bbs[29].RenderPS(ps4089)
 					}
 					return result
 					return result
 				}
-				ps4310 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps4310)
+				ps4311 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps4311)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -75195,8 +75281,9 @@ func init_date() {
 					if d120.Loc == LocImm {
 						d122 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d120.Imm.Int()))}
 					} else {
-						r1 := ctx.AllocRegExcept(d120.Reg)
-						ctx.EmitMovRegReg(r1, d120.Reg)
+						var r1 Reg
+						r1 = d120.Reg
+						d120.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r1)
 						d122 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r1}
 						ctx.BindReg(r1, &d122)
@@ -75209,8 +75296,9 @@ func init_date() {
 					if d121.Loc == LocImm {
 						d123 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d121.Imm.Int()))}
 					} else {
-						r2 := ctx.AllocRegExcept(d121.Reg)
-						ctx.EmitMovRegReg(r2, d121.Reg)
+						var r2 Reg
+						r2 = d121.Reg
+						d121.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r2)
 						d123 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r2}
 						ctx.BindReg(r2, &d123)
@@ -76384,7 +76472,7 @@ func init_date() {
 						if d28.Loc != LocReg && d28.Loc != LocRegPair && d28.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r0 := ctx.AllocReg()
+						r0 := ctx.AllocRegExcept(d28.Reg)
 						ctx.EmitCmpRegImm32(d28.Reg, 0)
 						ctx.EmitSetcc(r0, CondEqual)
 						d29 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -3449,58 +3449,115 @@ func (ctx *JITContext) collectLiveFPRegsForCall(buf *[16]Reg) []Reg {
 // resultsBuf: caller-provided [16]Reg buffer for results (no heap alloc).
 // Returns a slice into resultsBuf holding the result registers.
 // All live JIT registers are saved/restored around the call.
+const jitMaxParallelRegMoves = 16
+
 type jitRegMove struct {
 	dst Reg
 	src Reg
 }
 
-// emitParallelRegMoves preserves every source until its last consumer has
-// moved. R12 breaks cycles, but it is also the long-lived input-slice base, so
-// cycle resolution preserves it on the stack. R11 cannot be scratch here
-// because it is Go ABIInternal's ninth integer argument register.
-func (ctx *JITContext) emitParallelRegMoves(moves []jitRegMove) {
+// jitParallelRegMoveBatch describes one simultaneous register assignment.
+// It is deliberately fixed-size: argument/result boundaries are emitted in a
+// hot compiler path and must not allocate merely to shuffle machine words.
+// Sources may repeat, destinations may not, and identity moves are discarded.
+type jitParallelRegMoveBatch struct {
+	moves [jitMaxParallelRegMoves]jitRegMove
+	count uint8
+}
+
+func (batch *jitParallelRegMoveBatch) add(dst, src Reg) {
+	if dst == src {
+		return
+	}
+	for index := uint8(0); index < batch.count; index++ {
+		if batch.moves[index].dst == dst {
+			panic("jit: parallel move has duplicate destination")
+		}
+	}
+	if batch.count == jitMaxParallelRegMoves {
+		panic("jit: parallel move batch overflow")
+	}
+	batch.moves[batch.count] = jitRegMove{dst: dst, src: src}
+	batch.count++
+}
+
+func (batch *jitParallelRegMoveBatch) uses(reg Reg) bool {
+	for index := uint8(0); index < batch.count; index++ {
+		if batch.moves[index].src == reg || batch.moves[index].dst == reg {
+			return true
+		}
+	}
+	return false
+}
+
+// parallelMoveScratch chooses by architecture role and register-bank order,
+// never by a hard-coded x86 register number. The scratch value is saved only
+// when a cycle actually needs it, so an allocated outer value remains intact.
+func (ctx *JITContext) parallelMoveScratch(batch *jitParallelRegMoveBatch) Reg {
+	if !batch.uses(ctx.SliceBase) {
+		return ctx.SliceBase
+	}
+	if !batch.uses(ctx.ScratchReg) {
+		return ctx.ScratchReg
+	}
+	for index := uint8(0); index < ctx.RegisterBank.Count; index++ {
+		candidate := ctx.RegisterBank.Registers[index]
+		if !batch.uses(candidate) {
+			return candidate
+		}
+	}
+	panic("jit: parallel register cycle has no scratch register")
+}
+
+// emitParallelRegMoveBatch preserves every source until its last consumer has
+// moved. Acyclic assignments are emitted in dependency order. Cycles use one
+// backend-selected register whose previous value is preserved on the native
+// stack. The batch is copied because solving rewrites and removes its edges.
+func (ctx *JITContext) emitParallelRegMoveBatch(input *jitParallelRegMoveBatch) {
+	batch := *input
 	scratchSaved := false
+	scratch := Reg(0)
 	defer func() {
 		if scratchSaved {
-			ctx.EmitPopReg(RegR12)
+			ctx.EmitPopReg(scratch)
 		}
 	}()
-	for len(moves) > 0 {
+	for batch.count > 0 {
 		emitIdx := -1
-		for i := range moves {
+		for i := uint8(0); i < batch.count; i++ {
 			dstIsPendingSrc := false
-			for j := range moves {
-				if i != j && moves[j].src == moves[i].dst {
+			for j := uint8(0); j < batch.count; j++ {
+				if i != j && batch.moves[j].src == batch.moves[i].dst {
 					dstIsPendingSrc = true
 					break
 				}
 			}
 			if !dstIsPendingSrc {
-				emitIdx = i
+				emitIdx = int(i)
 				break
 			}
 		}
 		if emitIdx == -1 {
 			if !scratchSaved {
-				ctx.EmitPushReg(RegR12)
+				scratch = ctx.parallelMoveScratch(&batch)
+				ctx.EmitPushReg(scratch)
 				scratchSaved = true
 			}
-			cycleDst := moves[0].dst
-			if cycleDst != RegR12 {
-				ctx.emitMovRegReg(RegR12, cycleDst)
-			}
-			for i := range moves {
-				if moves[i].src == cycleDst {
-					moves[i].src = RegR12
+			cycleDst := batch.moves[0].dst
+			ctx.emitMovRegReg(scratch, cycleDst)
+			for i := uint8(0); i < batch.count; i++ {
+				if batch.moves[i].src == cycleDst {
+					batch.moves[i].src = scratch
 				}
 			}
 			continue
 		}
-		mv := moves[emitIdx]
-		if mv.dst != mv.src {
-			ctx.emitMovRegReg(mv.dst, mv.src)
+		mv := batch.moves[emitIdx]
+		ctx.emitMovRegReg(mv.dst, mv.src)
+		for index := emitIdx; index+1 < int(batch.count); index++ {
+			batch.moves[index] = batch.moves[index+1]
 		}
-		moves = append(moves[:emitIdx], moves[emitIdx+1:]...)
+		batch.count--
 	}
 }
 
@@ -3633,17 +3690,17 @@ func (ctx *JITContext) emitGoCall(funcAddr uint64, argWords []goCallArgWord, num
 			}
 		}
 
-		moves := make([]jitRegMove, 0, len(argWords))
+		var moves jitParallelRegMoveBatch
 		for i := range argWords {
 			if !argLocations[i].inReg {
 				continue
 			}
 			target := argLocations[i].reg
 			if argWords[i].loc == LocReg && argWords[i].reg != target {
-				moves = append(moves, jitRegMove{dst: target, src: argWords[i].reg})
+				moves.add(target, argWords[i].reg)
 			}
 		}
-		ctx.emitParallelRegMoves(moves)
+		ctx.emitParallelRegMoveBatch(&moves)
 
 		for i := range argWords {
 			if !argLocations[i].inReg {
@@ -3687,7 +3744,7 @@ func (ctx *JITContext) emitGoCall(funcAddr uint64, argWords []goCallArgWord, num
 			}
 			return nil
 		}
-		moves := make([]jitRegMove, 0, numResultWords)
+		var moves jitParallelRegMoveBatch
 		for i := 0; i < numResultWords; i++ {
 			var r Reg
 			if i < len(resultTargets) {
@@ -3700,11 +3757,11 @@ func (ctx *JITContext) emitGoCall(funcAddr uint64, argWords []goCallArgWord, num
 				r = ctx.AllocRegExcept(GoABIIntRegs[:numResultWords]...)
 			}
 			if r != GoABIIntRegs[i] {
-				moves = append(moves, jitRegMove{dst: r, src: GoABIIntRegs[i]})
+				moves.add(r, GoABIIntRegs[i])
 			}
 			resultsBuf[i] = r
 		}
-		ctx.emitParallelRegMoves(moves)
+		ctx.emitParallelRegMoveBatch(&moves)
 		return resultsBuf[:numResultWords]
 	}
 
@@ -4471,38 +4528,30 @@ func init_jit() {
 				_ = d5
 				var d6 JITValueDesc
 				_ = d6
-				var d8 JITValueDesc
-				_ = d8
-				var d20 JITValueDesc
-				_ = d20
-				var d30 JITValueDesc
-				_ = d30
-				var d31 JITValueDesc
-				_ = d31
-				var d32 JITValueDesc
-				_ = d32
+				var d7 JITValueDesc
+				_ = d7
+				var d9 JITValueDesc
+				_ = d9
+				var d22 JITValueDesc
+				_ = d22
 				var d33 JITValueDesc
 				_ = d33
+				var d34 JITValueDesc
+				_ = d34
+				var d35 JITValueDesc
+				_ = d35
 				var d36 JITValueDesc
 				_ = d36
-				var d53 JITValueDesc
-				_ = d53
-				var d69 JITValueDesc
-				_ = d69
-				var d70 JITValueDesc
-				_ = d70
-				var d71 JITValueDesc
-				_ = d71
-				var d72 JITValueDesc
-				_ = d72
-				var d73 JITValueDesc
-				_ = d73
-				var d74 JITValueDesc
-				_ = d74
-				var d76 JITValueDesc
-				_ = d76
+				var d37 JITValueDesc
+				_ = d37
+				var d40 JITValueDesc
+				_ = d40
+				var d59 JITValueDesc
+				_ = d59
 				var d77 JITValueDesc
 				_ = d77
+				var d78 JITValueDesc
+				_ = d78
 				var d79 JITValueDesc
 				_ = d79
 				var d80 JITValueDesc
@@ -4511,12 +4560,24 @@ func init_jit() {
 				_ = d81
 				var d82 JITValueDesc
 				_ = d82
-				var d83 JITValueDesc
-				_ = d83
-				var d86 JITValueDesc
-				_ = d86
-				var d118 JITValueDesc
-				_ = d118
+				var d84 JITValueDesc
+				_ = d84
+				var d85 JITValueDesc
+				_ = d85
+				var d87 JITValueDesc
+				_ = d87
+				var d88 JITValueDesc
+				_ = d88
+				var d89 JITValueDesc
+				_ = d89
+				var d90 JITValueDesc
+				_ = d90
+				var d91 JITValueDesc
+				_ = d91
+				var d94 JITValueDesc
+				_ = d94
+				var d128 JITValueDesc
+				_ = d128
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				phiBase0 := ctx.AllocStack(int32(32))
 				var bbs [6]BBDescriptor
@@ -4596,135 +4657,146 @@ func init_jit() {
 					ctx.ReclaimUntrackedRegs()
 					d3 = args[0]
 					d3.ID = 0
-					d4 = ctx.EmitGetTagDesc(&d3, JITValueDesc{Loc: LocAny})
+					d4 = d3
+					d4.ID = 0
+					d5 = ctx.EmitGetTagDesc(&d4, JITValueDesc{Loc: LocAny})
 					ctx.FreeDesc(&d3)
-					ctx.EnsureDesc(&d4)
-					var d5 JITValueDesc
-					if d4.Loc == LocImm {
-						d5 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d4.Imm.Int()) == uint64(0xb))}
+					ctx.EnsureDesc(&d5)
+					var d6 JITValueDesc
+					if d5.Loc == LocImm {
+						d6 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d5.Imm.Int()) == uint64(0xb))}
 					} else {
 						r0 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d4.Reg, 11)
-						d5 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
-						ctx.BindReg(r0, &d5)
+						ctx.EmitCmpRegImm32(d5.Reg, 11)
+						d6 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
+						ctx.BindReg(r0, &d6)
 					}
-					ctx.FreeDesc(&d4)
-					d6 = d5
-					ctx.EnsureDesc(&d6)
-					if d6.Loc != LocImm && d6.Loc != LocFlags {
+					ctx.FreeDesc(&d5)
+					d7 = d6
+					ctx.EnsureDesc(&d7)
+					if d7.Loc != LocImm && d7.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d6.Loc == LocImm {
-						if d6.Imm.Bool() {
+					if d7.Loc == LocImm {
+						if d7.Imm.Bool() {
 							if ps.General {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 							}
-							ps7 := PhiState{General: ps.General}
-							ps7.OverlayValues = make([]JITValueDesc, 7)
-							ps7.OverlayValues[1] = d1
-							ps7.OverlayValues[2] = d2
-							ps7.OverlayValues[3] = d3
-							ps7.OverlayValues[4] = d4
-							ps7.OverlayValues[5] = d5
-							ps7.OverlayValues[6] = d6
-							ps7.PhiValues = make([]JITValueDesc, 1)
-							d8 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
-							ps7.PhiValues[0] = d8
-							return bbs[2].RenderPS(ps7)
+							ps8 := PhiState{General: ps.General}
+							ps8.OverlayValues = make([]JITValueDesc, 8)
+							ps8.OverlayValues[1] = d1
+							ps8.OverlayValues[2] = d2
+							ps8.OverlayValues[3] = d3
+							ps8.OverlayValues[4] = d4
+							ps8.OverlayValues[5] = d5
+							ps8.OverlayValues[6] = d6
+							ps8.OverlayValues[7] = d7
+							ps8.PhiValues = make([]JITValueDesc, 1)
+							d9 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
+							ps8.PhiValues[0] = d9
+							return bbs[2].RenderPS(ps8)
 						}
 						if ps.General {
 						}
-						ps9 := PhiState{General: ps.General}
-						ps9.OverlayValues = make([]JITValueDesc, 9)
-						ps9.OverlayValues[1] = d1
-						ps9.OverlayValues[2] = d2
-						ps9.OverlayValues[3] = d3
-						ps9.OverlayValues[4] = d4
-						ps9.OverlayValues[5] = d5
-						ps9.OverlayValues[6] = d6
-						ps9.OverlayValues[8] = d8
-						return bbs[1].RenderPS(ps9)
+						ps10 := PhiState{General: ps.General}
+						ps10.OverlayValues = make([]JITValueDesc, 10)
+						ps10.OverlayValues[1] = d1
+						ps10.OverlayValues[2] = d2
+						ps10.OverlayValues[3] = d3
+						ps10.OverlayValues[4] = d4
+						ps10.OverlayValues[5] = d5
+						ps10.OverlayValues[6] = d6
+						ps10.OverlayValues[7] = d7
+						ps10.OverlayValues[9] = d9
+						return bbs[1].RenderPS(ps10)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[0].RenderPS(ps)
 					}
 					lbl7 := ctx.ReserveLabel()
-					ctx.EmitJump(d6.Condition, lbl7)
+					ctx.EmitJump(d7.Condition, lbl7)
 					ctx.EmitJmp(lbl2)
-					ctx.FreeDesc(&d5)
-					snap10 := d1
-					snap11 := d2
-					snap12 := d3
-					snap13 := d4
-					snap14 := d5
-					snap15 := d6
-					snap16 := d8
-					alloc17 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d6)
+					snap11 := d1
+					snap12 := d2
+					snap13 := d3
+					snap14 := d4
+					snap15 := d5
+					snap16 := d6
+					snap17 := d7
+					snap18 := d9
+					alloc19 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl7)
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 					ctx.EmitJmp(lbl3)
-					ctx.RestoreAllocState(alloc17)
-					d1 = snap10
-					d2 = snap11
-					d3 = snap12
-					d4 = snap13
-					d5 = snap14
-					d6 = snap15
-					d8 = snap16
-					ctx.RestoreAllocState(alloc17)
-					d1 = snap10
-					d2 = snap11
-					d3 = snap12
-					d4 = snap13
-					d5 = snap14
-					d6 = snap15
-					d8 = snap16
-					ps18 := PhiState{General: true}
-					ps18.OverlayValues = make([]JITValueDesc, 9)
-					ps18.OverlayValues[1] = d1
-					ps18.OverlayValues[2] = d2
-					ps18.OverlayValues[3] = d3
-					ps18.OverlayValues[4] = d4
-					ps18.OverlayValues[5] = d5
-					ps18.OverlayValues[6] = d6
-					ps18.OverlayValues[8] = d8
-					ps18.PhiValues = make([]JITValueDesc, 1)
-					d20 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
-					ps18.PhiValues[0] = d20
-					ps19 := PhiState{General: true}
-					ps19.OverlayValues = make([]JITValueDesc, 21)
-					ps19.OverlayValues[1] = d1
-					ps19.OverlayValues[2] = d2
-					ps19.OverlayValues[3] = d3
-					ps19.OverlayValues[4] = d4
-					ps19.OverlayValues[5] = d5
-					ps19.OverlayValues[6] = d6
-					ps19.OverlayValues[8] = d8
-					ps19.OverlayValues[20] = d20
-					snap21 := d1
-					snap22 := d2
-					snap23 := d3
-					snap24 := d4
-					snap25 := d5
-					snap26 := d6
-					snap27 := d8
-					snap28 := d20
-					alloc29 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc19)
+					d1 = snap11
+					d2 = snap12
+					d3 = snap13
+					d4 = snap14
+					d5 = snap15
+					d6 = snap16
+					d7 = snap17
+					d9 = snap18
+					ctx.RestoreAllocState(alloc19)
+					d1 = snap11
+					d2 = snap12
+					d3 = snap13
+					d4 = snap14
+					d5 = snap15
+					d6 = snap16
+					d7 = snap17
+					d9 = snap18
+					ps20 := PhiState{General: true}
+					ps20.OverlayValues = make([]JITValueDesc, 10)
+					ps20.OverlayValues[1] = d1
+					ps20.OverlayValues[2] = d2
+					ps20.OverlayValues[3] = d3
+					ps20.OverlayValues[4] = d4
+					ps20.OverlayValues[5] = d5
+					ps20.OverlayValues[6] = d6
+					ps20.OverlayValues[7] = d7
+					ps20.OverlayValues[9] = d9
+					ps20.PhiValues = make([]JITValueDesc, 1)
+					d22 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
+					ps20.PhiValues[0] = d22
+					ps21 := PhiState{General: true}
+					ps21.OverlayValues = make([]JITValueDesc, 23)
+					ps21.OverlayValues[1] = d1
+					ps21.OverlayValues[2] = d2
+					ps21.OverlayValues[3] = d3
+					ps21.OverlayValues[4] = d4
+					ps21.OverlayValues[5] = d5
+					ps21.OverlayValues[6] = d6
+					ps21.OverlayValues[7] = d7
+					ps21.OverlayValues[9] = d9
+					ps21.OverlayValues[22] = d22
+					snap23 := d1
+					snap24 := d2
+					snap25 := d3
+					snap26 := d4
+					snap27 := d5
+					snap28 := d6
+					snap29 := d7
+					snap30 := d9
+					snap31 := d22
+					alloc32 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps18)
+						bbs[2].RenderPS(ps20)
 					}
-					ctx.RestoreAllocState(alloc29)
-					d1 = snap21
-					d2 = snap22
-					d3 = snap23
-					d4 = snap24
-					d5 = snap25
-					d6 = snap26
-					d8 = snap27
-					d20 = snap28
+					ctx.RestoreAllocState(alloc32)
+					d1 = snap23
+					d2 = snap24
+					d3 = snap25
+					d4 = snap26
+					d5 = snap27
+					d6 = snap28
+					d7 = snap29
+					d9 = snap30
+					d22 = snap31
 					if !bbs[1].Rendered {
-						return bbs[1].RenderPS(ps19)
+						return bbs[1].RenderPS(ps21)
 					}
 					return result
 					return result
@@ -4768,196 +4840,219 @@ func init_jit() {
 					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
 						d6 = ps.OverlayValues[6]
 					}
-					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
-						d8 = ps.OverlayValues[8]
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d30 = args[0]
-					d30.ID = 0
-					d31 = ctx.EmitGetTagDesc(&d30, JITValueDesc{Loc: LocAny})
-					ctx.FreeDesc(&d30)
-					ctx.EnsureDesc(&d31)
-					var d32 JITValueDesc
-					if d31.Loc == LocImm {
-						d32 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d31.Imm.Int()) == uint64(0xa))}
+					d33 = args[0]
+					d33.ID = 0
+					d34 = d33
+					d34.ID = 0
+					d35 = ctx.EmitGetTagDesc(&d34, JITValueDesc{Loc: LocAny})
+					ctx.FreeDesc(&d33)
+					ctx.EnsureDesc(&d35)
+					var d36 JITValueDesc
+					if d35.Loc == LocImm {
+						d36 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d35.Imm.Int()) == uint64(0xa))}
 					} else {
 						r1 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d31.Reg, 10)
-						d32 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondEqual}
-						ctx.BindReg(r1, &d32)
+						ctx.EmitCmpRegImm32(d35.Reg, 10)
+						d36 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondEqual}
+						ctx.BindReg(r1, &d36)
 					}
-					ctx.FreeDesc(&d31)
-					d33 = d32
-					ctx.EnsureDesc(&d33)
-					if d33.Loc != LocImm && d33.Loc != LocFlags {
+					ctx.FreeDesc(&d35)
+					d37 = d36
+					ctx.EnsureDesc(&d37)
+					if d37.Loc != LocImm && d37.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d33.Loc == LocImm {
-						if d33.Imm.Bool() {
+					if d37.Loc == LocImm {
+						if d37.Imm.Bool() {
 							if ps.General {
 							}
-							ps34 := PhiState{General: ps.General}
-							ps34.OverlayValues = make([]JITValueDesc, 34)
-							ps34.OverlayValues[1] = d1
-							ps34.OverlayValues[2] = d2
-							ps34.OverlayValues[3] = d3
-							ps34.OverlayValues[4] = d4
-							ps34.OverlayValues[5] = d5
-							ps34.OverlayValues[6] = d6
-							ps34.OverlayValues[8] = d8
-							ps34.OverlayValues[20] = d20
-							ps34.OverlayValues[30] = d30
-							ps34.OverlayValues[31] = d31
-							ps34.OverlayValues[32] = d32
-							ps34.OverlayValues[33] = d33
-							return bbs[5].RenderPS(ps34)
+							ps38 := PhiState{General: ps.General}
+							ps38.OverlayValues = make([]JITValueDesc, 38)
+							ps38.OverlayValues[1] = d1
+							ps38.OverlayValues[2] = d2
+							ps38.OverlayValues[3] = d3
+							ps38.OverlayValues[4] = d4
+							ps38.OverlayValues[5] = d5
+							ps38.OverlayValues[6] = d6
+							ps38.OverlayValues[7] = d7
+							ps38.OverlayValues[9] = d9
+							ps38.OverlayValues[22] = d22
+							ps38.OverlayValues[33] = d33
+							ps38.OverlayValues[34] = d34
+							ps38.OverlayValues[35] = d35
+							ps38.OverlayValues[36] = d36
+							ps38.OverlayValues[37] = d37
+							return bbs[5].RenderPS(ps38)
 						}
 						if ps.General {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(0))
 						}
-						ps35 := PhiState{General: ps.General}
-						ps35.OverlayValues = make([]JITValueDesc, 34)
-						ps35.OverlayValues[1] = d1
-						ps35.OverlayValues[2] = d2
-						ps35.OverlayValues[3] = d3
-						ps35.OverlayValues[4] = d4
-						ps35.OverlayValues[5] = d5
-						ps35.OverlayValues[6] = d6
-						ps35.OverlayValues[8] = d8
-						ps35.OverlayValues[20] = d20
-						ps35.OverlayValues[30] = d30
-						ps35.OverlayValues[31] = d31
-						ps35.OverlayValues[32] = d32
-						ps35.OverlayValues[33] = d33
-						ps35.PhiValues = make([]JITValueDesc, 1)
-						d36 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
-						ps35.PhiValues[0] = d36
-						return bbs[4].RenderPS(ps35)
+						ps39 := PhiState{General: ps.General}
+						ps39.OverlayValues = make([]JITValueDesc, 38)
+						ps39.OverlayValues[1] = d1
+						ps39.OverlayValues[2] = d2
+						ps39.OverlayValues[3] = d3
+						ps39.OverlayValues[4] = d4
+						ps39.OverlayValues[5] = d5
+						ps39.OverlayValues[6] = d6
+						ps39.OverlayValues[7] = d7
+						ps39.OverlayValues[9] = d9
+						ps39.OverlayValues[22] = d22
+						ps39.OverlayValues[33] = d33
+						ps39.OverlayValues[34] = d34
+						ps39.OverlayValues[35] = d35
+						ps39.OverlayValues[36] = d36
+						ps39.OverlayValues[37] = d37
+						ps39.PhiValues = make([]JITValueDesc, 1)
+						d40 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+						ps39.PhiValues[0] = d40
+						return bbs[4].RenderPS(ps39)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[1].RenderPS(ps)
 					}
 					lbl8 := ctx.ReserveLabel()
-					ctx.EmitJump(d33.Condition, lbl6)
+					ctx.EmitJump(d37.Condition, lbl6)
 					ctx.EmitJmp(lbl8)
-					ctx.FreeDesc(&d32)
-					snap37 := d1
-					snap38 := d2
-					snap39 := d3
-					snap40 := d4
-					snap41 := d5
-					snap42 := d6
-					snap43 := d8
-					snap44 := d20
-					snap45 := d30
-					snap46 := d31
-					snap47 := d32
-					snap48 := d33
-					snap49 := d36
-					alloc50 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc50)
-					d1 = snap37
-					d2 = snap38
-					d3 = snap39
-					d4 = snap40
-					d5 = snap41
-					d6 = snap42
-					d8 = snap43
-					d20 = snap44
-					d30 = snap45
-					d31 = snap46
-					d32 = snap47
-					d33 = snap48
-					d36 = snap49
+					ctx.FreeDesc(&d36)
+					snap41 := d1
+					snap42 := d2
+					snap43 := d3
+					snap44 := d4
+					snap45 := d5
+					snap46 := d6
+					snap47 := d7
+					snap48 := d9
+					snap49 := d22
+					snap50 := d33
+					snap51 := d34
+					snap52 := d35
+					snap53 := d36
+					snap54 := d37
+					snap55 := d40
+					alloc56 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc56)
+					d1 = snap41
+					d2 = snap42
+					d3 = snap43
+					d4 = snap44
+					d5 = snap45
+					d6 = snap46
+					d7 = snap47
+					d9 = snap48
+					d22 = snap49
+					d33 = snap50
+					d34 = snap51
+					d35 = snap52
+					d36 = snap53
+					d37 = snap54
+					d40 = snap55
 					ctx.MarkLabel(lbl8)
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(0))
 					ctx.EmitJmp(lbl5)
-					ctx.RestoreAllocState(alloc50)
-					d1 = snap37
-					d2 = snap38
-					d3 = snap39
-					d4 = snap40
-					d5 = snap41
-					d6 = snap42
-					d8 = snap43
-					d20 = snap44
-					d30 = snap45
-					d31 = snap46
-					d32 = snap47
-					d33 = snap48
-					d36 = snap49
-					ps51 := PhiState{General: true}
-					ps51.OverlayValues = make([]JITValueDesc, 37)
-					ps51.OverlayValues[1] = d1
-					ps51.OverlayValues[2] = d2
-					ps51.OverlayValues[3] = d3
-					ps51.OverlayValues[4] = d4
-					ps51.OverlayValues[5] = d5
-					ps51.OverlayValues[6] = d6
-					ps51.OverlayValues[8] = d8
-					ps51.OverlayValues[20] = d20
-					ps51.OverlayValues[30] = d30
-					ps51.OverlayValues[31] = d31
-					ps51.OverlayValues[32] = d32
-					ps51.OverlayValues[33] = d33
-					ps51.OverlayValues[36] = d36
-					ps52 := PhiState{General: true}
-					ps52.OverlayValues = make([]JITValueDesc, 37)
-					ps52.OverlayValues[1] = d1
-					ps52.OverlayValues[2] = d2
-					ps52.OverlayValues[3] = d3
-					ps52.OverlayValues[4] = d4
-					ps52.OverlayValues[5] = d5
-					ps52.OverlayValues[6] = d6
-					ps52.OverlayValues[8] = d8
-					ps52.OverlayValues[20] = d20
-					ps52.OverlayValues[30] = d30
-					ps52.OverlayValues[31] = d31
-					ps52.OverlayValues[32] = d32
-					ps52.OverlayValues[33] = d33
-					ps52.OverlayValues[36] = d36
-					ps52.PhiValues = make([]JITValueDesc, 1)
-					d53 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
-					ps52.PhiValues[0] = d53
-					snap54 := d1
-					snap55 := d2
-					snap56 := d3
-					snap57 := d4
-					snap58 := d5
-					snap59 := d6
-					snap60 := d8
-					snap61 := d20
-					snap62 := d30
-					snap63 := d31
-					snap64 := d32
-					snap65 := d33
-					snap66 := d36
-					snap67 := d53
-					alloc68 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc56)
+					d1 = snap41
+					d2 = snap42
+					d3 = snap43
+					d4 = snap44
+					d5 = snap45
+					d6 = snap46
+					d7 = snap47
+					d9 = snap48
+					d22 = snap49
+					d33 = snap50
+					d34 = snap51
+					d35 = snap52
+					d36 = snap53
+					d37 = snap54
+					d40 = snap55
+					ps57 := PhiState{General: true}
+					ps57.OverlayValues = make([]JITValueDesc, 41)
+					ps57.OverlayValues[1] = d1
+					ps57.OverlayValues[2] = d2
+					ps57.OverlayValues[3] = d3
+					ps57.OverlayValues[4] = d4
+					ps57.OverlayValues[5] = d5
+					ps57.OverlayValues[6] = d6
+					ps57.OverlayValues[7] = d7
+					ps57.OverlayValues[9] = d9
+					ps57.OverlayValues[22] = d22
+					ps57.OverlayValues[33] = d33
+					ps57.OverlayValues[34] = d34
+					ps57.OverlayValues[35] = d35
+					ps57.OverlayValues[36] = d36
+					ps57.OverlayValues[37] = d37
+					ps57.OverlayValues[40] = d40
+					ps58 := PhiState{General: true}
+					ps58.OverlayValues = make([]JITValueDesc, 41)
+					ps58.OverlayValues[1] = d1
+					ps58.OverlayValues[2] = d2
+					ps58.OverlayValues[3] = d3
+					ps58.OverlayValues[4] = d4
+					ps58.OverlayValues[5] = d5
+					ps58.OverlayValues[6] = d6
+					ps58.OverlayValues[7] = d7
+					ps58.OverlayValues[9] = d9
+					ps58.OverlayValues[22] = d22
+					ps58.OverlayValues[33] = d33
+					ps58.OverlayValues[34] = d34
+					ps58.OverlayValues[35] = d35
+					ps58.OverlayValues[36] = d36
+					ps58.OverlayValues[37] = d37
+					ps58.OverlayValues[40] = d40
+					ps58.PhiValues = make([]JITValueDesc, 1)
+					d59 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+					ps58.PhiValues[0] = d59
+					snap60 := d1
+					snap61 := d2
+					snap62 := d3
+					snap63 := d4
+					snap64 := d5
+					snap65 := d6
+					snap66 := d7
+					snap67 := d9
+					snap68 := d22
+					snap69 := d33
+					snap70 := d34
+					snap71 := d35
+					snap72 := d36
+					snap73 := d37
+					snap74 := d40
+					snap75 := d59
+					alloc76 := ctx.SnapshotAllocState()
 					if !bbs[4].Rendered {
-						bbs[4].RenderPS(ps52)
+						bbs[4].RenderPS(ps58)
 					}
-					ctx.RestoreAllocState(alloc68)
-					d1 = snap54
-					d2 = snap55
-					d3 = snap56
-					d4 = snap57
-					d5 = snap58
-					d6 = snap59
-					d8 = snap60
-					d20 = snap61
-					d30 = snap62
-					d31 = snap63
-					d32 = snap64
-					d33 = snap65
-					d36 = snap66
-					d53 = snap67
+					ctx.RestoreAllocState(alloc76)
+					d1 = snap60
+					d2 = snap61
+					d3 = snap62
+					d4 = snap63
+					d5 = snap64
+					d6 = snap65
+					d7 = snap66
+					d9 = snap67
+					d22 = snap68
+					d33 = snap69
+					d34 = snap70
+					d35 = snap71
+					d36 = snap72
+					d37 = snap73
+					d40 = snap74
+					d59 = snap75
 					if !bbs[5].Rendered {
-						return bbs[5].RenderPS(ps51)
+						return bbs[5].RenderPS(ps57)
 					}
 					return result
 					return result
@@ -4965,9 +5060,9 @@ func init_jit() {
 				bbs[2].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d69 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d69)
-							ctx.EmitStoreToStack(d69, int32(bbs[2].PhiBase)+int32(0))
+							d77 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d77)
+							ctx.EmitStoreToStack(d77, int32(bbs[2].PhiBase)+int32(0))
 						}
 						if bbs[2].VisitCount >= 0 {
 							ps.General = true
@@ -5006,32 +5101,38 @@ func init_jit() {
 					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
 						d6 = ps.OverlayValues[6]
 					}
-					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
-						d8 = ps.OverlayValues[8]
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
-						d30 = ps.OverlayValues[30]
-					}
-					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
-						d31 = ps.OverlayValues[31]
-					}
-					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
-						d32 = ps.OverlayValues[32]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
 					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
 						d33 = ps.OverlayValues[33]
 					}
+					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
+						d34 = ps.OverlayValues[34]
+					}
+					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
+						d35 = ps.OverlayValues[35]
+					}
 					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
 						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 53 && ps.OverlayValues[53].Loc != LocNone {
-						d53 = ps.OverlayValues[53]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 40 && ps.OverlayValues[40].Loc != LocNone {
+						d40 = ps.OverlayValues[40]
+					}
+					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
+						d59 = ps.OverlayValues[59]
+					}
+					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
+						d77 = ps.OverlayValues[77]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
 						d1 = ps.PhiValues[0]
@@ -5042,8 +5143,8 @@ func init_jit() {
 						ctx.EmitMakeBool(result, d1)
 					} else {
 						ctx.EmitMovToReg(result.Reg2, d1)
-						d70 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeBool(result, d70)
+						d78 := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeBool(result, d78)
 						if d1.Loc == LocReg && d1.Reg != result.Reg2 {
 							ctx.FreeReg(d1.Reg)
 						}
@@ -5091,115 +5192,123 @@ func init_jit() {
 					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
 						d6 = ps.OverlayValues[6]
 					}
-					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
-						d8 = ps.OverlayValues[8]
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
-						d30 = ps.OverlayValues[30]
-					}
-					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
-						d31 = ps.OverlayValues[31]
-					}
-					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
-						d32 = ps.OverlayValues[32]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
 					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
 						d33 = ps.OverlayValues[33]
 					}
+					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
+						d34 = ps.OverlayValues[34]
+					}
+					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
+						d35 = ps.OverlayValues[35]
+					}
 					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
 						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 53 && ps.OverlayValues[53].Loc != LocNone {
-						d53 = ps.OverlayValues[53]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 40 && ps.OverlayValues[40].Loc != LocNone {
+						d40 = ps.OverlayValues[40]
 					}
-					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
-						d70 = ps.OverlayValues[70]
+					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
+						d59 = ps.OverlayValues[59]
+					}
+					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
+						d77 = ps.OverlayValues[77]
+					}
+					if len(ps.OverlayValues) > 78 && ps.OverlayValues[78].Loc != LocNone {
+						d78 = ps.OverlayValues[78]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d71 = args[0]
-					d71.ID = 0
-					d71 = JITPrepareScmerGoArg(ctx, d71)
-					ctx.SyncDesc(&d71)
-					d72 = ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d71}, 1)
-					d72.NoHeapPointer = false
-					ctx.BindReg(d72.Reg, &d72)
-					ctx.FreeDesc(&d71)
-					var d73 JITValueDesc
-					ctx.EnsureDesc(&d72)
-					if d72.Loc == LocImm {
-						fieldAddr := uintptr(d72.Imm.Int()) + 0
+					d79 = args[0]
+					d79.ID = 0
+					d79 = JITPrepareScmerGoArg(ctx, d79)
+					ctx.SyncDesc(&d79)
+					d80 = ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d79}, 1)
+					d80.NoHeapPointer = false
+					ctx.BindReg(d80.Reg, &d80)
+					ctx.FreeDesc(&d79)
+					var d81 JITValueDesc
+					ctx.EnsureDesc(&d80)
+					if d80.Loc == LocImm {
+						fieldAddr := uintptr(d80.Imm.Int()) + 0
 						r2 := ctx.AllocReg()
 						ctx.EmitMovRegMem64(r2, fieldAddr)
-						d73 = JITValueDesc{Loc: LocReg, Reg: r2}
-						ctx.BindReg(r2, &d73)
+						d81 = JITValueDesc{Loc: LocReg, Reg: r2}
+						ctx.BindReg(r2, &d81)
 					} else {
 						off := int32(0)
-						baseReg := d72.Reg
+						baseReg := d80.Reg
 						r3 := ctx.AllocRegExcept(baseReg)
 						ctx.EmitMovRegMem(r3, baseReg, off)
-						d73 = JITValueDesc{Loc: LocReg, Reg: r3}
-						ctx.BindReg(r3, &d73)
+						d81 = JITValueDesc{Loc: LocReg, Reg: r3}
+						ctx.BindReg(r3, &d81)
 					}
-					ctx.FreeDesc(&d72)
-					ctx.EnsureDesc(&d73)
-					var d74 JITValueDesc
-					if d73.Loc == LocImm {
-						d74 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d73.Imm.Int()) != uint64(0x0))}
+					ctx.FreeDesc(&d80)
+					ctx.EnsureDesc(&d81)
+					var d82 JITValueDesc
+					if d81.Loc == LocImm {
+						d82 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d81.Imm.Int()) != uint64(0x0))}
 					} else {
-						ctx.EmitCmpRegImm32(d73.Reg, 0)
-						r4 := ctx.AllocReg()
+						ctx.EmitCmpRegImm32(d81.Reg, 0)
+						r4 := ctx.AllocRegExcept(d81.Reg)
 						ctx.EmitSetcc(r4, CondNotEqual)
-						d74 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r4}
-						ctx.BindReg(r4, &d74)
+						d82 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r4}
+						ctx.BindReg(r4, &d82)
 					}
-					ctx.EnsureDesc(&d74)
-					ctx.EmitStoreToStack(d74, int32(bbs[4].PhiBase)+int32(0))
-					ctx.StabilizeDescForControlFlow(&d74)
-					ctx.FreeDesc(&d73)
+					ctx.EnsureDesc(&d82)
+					ctx.EmitStoreToStack(d82, int32(bbs[4].PhiBase)+int32(0))
+					ctx.StabilizeDescForControlFlow(&d82)
+					ctx.FreeDesc(&d81)
 					if ps.General {
 					}
-					ps75 := PhiState{General: ps.General}
-					ps75.OverlayValues = make([]JITValueDesc, 75)
-					ps75.OverlayValues[1] = d1
-					ps75.OverlayValues[2] = d2
-					ps75.OverlayValues[3] = d3
-					ps75.OverlayValues[4] = d4
-					ps75.OverlayValues[5] = d5
-					ps75.OverlayValues[6] = d6
-					ps75.OverlayValues[8] = d8
-					ps75.OverlayValues[20] = d20
-					ps75.OverlayValues[30] = d30
-					ps75.OverlayValues[31] = d31
-					ps75.OverlayValues[32] = d32
-					ps75.OverlayValues[33] = d33
-					ps75.OverlayValues[36] = d36
-					ps75.OverlayValues[53] = d53
-					ps75.OverlayValues[69] = d69
-					ps75.OverlayValues[70] = d70
-					ps75.OverlayValues[71] = d71
-					ps75.OverlayValues[72] = d72
-					ps75.OverlayValues[73] = d73
-					ps75.OverlayValues[74] = d74
-					ps75.PhiValues = make([]JITValueDesc, 1)
-					if ps75.General && bbs[4].Rendered {
+					ps83 := PhiState{General: ps.General}
+					ps83.OverlayValues = make([]JITValueDesc, 83)
+					ps83.OverlayValues[1] = d1
+					ps83.OverlayValues[2] = d2
+					ps83.OverlayValues[3] = d3
+					ps83.OverlayValues[4] = d4
+					ps83.OverlayValues[5] = d5
+					ps83.OverlayValues[6] = d6
+					ps83.OverlayValues[7] = d7
+					ps83.OverlayValues[9] = d9
+					ps83.OverlayValues[22] = d22
+					ps83.OverlayValues[33] = d33
+					ps83.OverlayValues[34] = d34
+					ps83.OverlayValues[35] = d35
+					ps83.OverlayValues[36] = d36
+					ps83.OverlayValues[37] = d37
+					ps83.OverlayValues[40] = d40
+					ps83.OverlayValues[59] = d59
+					ps83.OverlayValues[77] = d77
+					ps83.OverlayValues[78] = d78
+					ps83.OverlayValues[79] = d79
+					ps83.OverlayValues[80] = d80
+					ps83.OverlayValues[81] = d81
+					ps83.OverlayValues[82] = d82
+					ps83.PhiValues = make([]JITValueDesc, 1)
+					if ps83.General && bbs[4].Rendered {
 						ctx.EmitJmp(lbl5)
 						return result
 					}
-					return bbs[4].RenderPS(ps75)
+					return bbs[4].RenderPS(ps83)
 					return result
 				}
 				bbs[4].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d76 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d76)
-							ctx.EmitStoreToStack(d76, int32(bbs[4].PhiBase)+int32(0))
+							d84 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d84)
+							ctx.EmitStoreToStack(d84, int32(bbs[4].PhiBase)+int32(0))
 						}
 						if bbs[4].VisitCount >= 0 {
 							ps.General = true
@@ -5238,50 +5347,56 @@ func init_jit() {
 					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
 						d6 = ps.OverlayValues[6]
 					}
-					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
-						d8 = ps.OverlayValues[8]
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
-						d30 = ps.OverlayValues[30]
-					}
-					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
-						d31 = ps.OverlayValues[31]
-					}
-					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
-						d32 = ps.OverlayValues[32]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
 					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
 						d33 = ps.OverlayValues[33]
 					}
+					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
+						d34 = ps.OverlayValues[34]
+					}
+					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
+						d35 = ps.OverlayValues[35]
+					}
 					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
 						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 53 && ps.OverlayValues[53].Loc != LocNone {
-						d53 = ps.OverlayValues[53]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 40 && ps.OverlayValues[40].Loc != LocNone {
+						d40 = ps.OverlayValues[40]
 					}
-					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
-						d70 = ps.OverlayValues[70]
+					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
+						d59 = ps.OverlayValues[59]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
+						d77 = ps.OverlayValues[77]
 					}
-					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
-						d72 = ps.OverlayValues[72]
+					if len(ps.OverlayValues) > 78 && ps.OverlayValues[78].Loc != LocNone {
+						d78 = ps.OverlayValues[78]
 					}
-					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
-						d73 = ps.OverlayValues[73]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
-					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
-						d74 = ps.OverlayValues[74]
+					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
+						d80 = ps.OverlayValues[80]
 					}
-					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
-						d76 = ps.OverlayValues[76]
+					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+						d81 = ps.OverlayValues[81]
+					}
+					if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+						d82 = ps.OverlayValues[82]
+					}
+					if len(ps.OverlayValues) > 84 && ps.OverlayValues[84].Loc != LocNone {
+						d84 = ps.OverlayValues[84]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
 						d2 = ps.PhiValues[0]
@@ -5290,57 +5405,59 @@ func init_jit() {
 					ctx.StabilizeDescForControlFlow(&d2)
 					if ps.General {
 						ctx.SyncDesc(&d2)
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.ProtectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.ProtectReg(d2.Reg)
 							ctx.ProtectReg(d2.Reg2)
 						}
-						d77 = d2
-						if d77.Loc == LocNone {
+						d85 = d2
+						if d85.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.EnsureDesc(&d77)
-						ctx.EmitStoreToStack(d77, int32(bbs[2].PhiBase)+int32(0))
-						if d2.Loc == LocReg {
+						ctx.EnsureDesc(&d85)
+						ctx.EmitStoreToStack(d85, int32(bbs[2].PhiBase)+int32(0))
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.UnprotectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.UnprotectReg(d2.Reg)
 							ctx.UnprotectReg(d2.Reg2)
 						}
 					}
-					ps78 := PhiState{General: ps.General}
-					ps78.OverlayValues = make([]JITValueDesc, 78)
-					ps78.OverlayValues[1] = d1
-					ps78.OverlayValues[2] = d2
-					ps78.OverlayValues[3] = d3
-					ps78.OverlayValues[4] = d4
-					ps78.OverlayValues[5] = d5
-					ps78.OverlayValues[6] = d6
-					ps78.OverlayValues[8] = d8
-					ps78.OverlayValues[20] = d20
-					ps78.OverlayValues[30] = d30
-					ps78.OverlayValues[31] = d31
-					ps78.OverlayValues[32] = d32
-					ps78.OverlayValues[33] = d33
-					ps78.OverlayValues[36] = d36
-					ps78.OverlayValues[53] = d53
-					ps78.OverlayValues[69] = d69
-					ps78.OverlayValues[70] = d70
-					ps78.OverlayValues[71] = d71
-					ps78.OverlayValues[72] = d72
-					ps78.OverlayValues[73] = d73
-					ps78.OverlayValues[74] = d74
-					ps78.OverlayValues[76] = d76
-					ps78.OverlayValues[77] = d77
-					ps78.PhiValues = make([]JITValueDesc, 1)
-					d79 = d2
-					ps78.PhiValues[0] = d79
-					if ps78.General && bbs[2].Rendered {
+					ps86 := PhiState{General: ps.General}
+					ps86.OverlayValues = make([]JITValueDesc, 86)
+					ps86.OverlayValues[1] = d1
+					ps86.OverlayValues[2] = d2
+					ps86.OverlayValues[3] = d3
+					ps86.OverlayValues[4] = d4
+					ps86.OverlayValues[5] = d5
+					ps86.OverlayValues[6] = d6
+					ps86.OverlayValues[7] = d7
+					ps86.OverlayValues[9] = d9
+					ps86.OverlayValues[22] = d22
+					ps86.OverlayValues[33] = d33
+					ps86.OverlayValues[34] = d34
+					ps86.OverlayValues[35] = d35
+					ps86.OverlayValues[36] = d36
+					ps86.OverlayValues[37] = d37
+					ps86.OverlayValues[40] = d40
+					ps86.OverlayValues[59] = d59
+					ps86.OverlayValues[77] = d77
+					ps86.OverlayValues[78] = d78
+					ps86.OverlayValues[79] = d79
+					ps86.OverlayValues[80] = d80
+					ps86.OverlayValues[81] = d81
+					ps86.OverlayValues[82] = d82
+					ps86.OverlayValues[84] = d84
+					ps86.OverlayValues[85] = d85
+					ps86.PhiValues = make([]JITValueDesc, 1)
+					d87 = d2
+					ps86.PhiValues[0] = d87
+					if ps86.General && bbs[2].Rendered {
 						ctx.EmitJmp(lbl3)
 						return result
 					}
-					return bbs[2].RenderPS(ps78)
+					return bbs[2].RenderPS(ps86)
 					return result
 				}
 				bbs[5].RenderPS = func(ps PhiState) JITValueDesc {
@@ -5382,392 +5499,416 @@ func init_jit() {
 					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
 						d6 = ps.OverlayValues[6]
 					}
-					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
-						d8 = ps.OverlayValues[8]
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
 					}
-					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
-						d30 = ps.OverlayValues[30]
-					}
-					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
-						d31 = ps.OverlayValues[31]
-					}
-					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
-						d32 = ps.OverlayValues[32]
+					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
+						d22 = ps.OverlayValues[22]
 					}
 					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
 						d33 = ps.OverlayValues[33]
 					}
+					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
+						d34 = ps.OverlayValues[34]
+					}
+					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
+						d35 = ps.OverlayValues[35]
+					}
 					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
 						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 53 && ps.OverlayValues[53].Loc != LocNone {
-						d53 = ps.OverlayValues[53]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
-					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
-						d69 = ps.OverlayValues[69]
+					if len(ps.OverlayValues) > 40 && ps.OverlayValues[40].Loc != LocNone {
+						d40 = ps.OverlayValues[40]
 					}
-					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
-						d70 = ps.OverlayValues[70]
-					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
-					}
-					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
-						d72 = ps.OverlayValues[72]
-					}
-					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
-						d73 = ps.OverlayValues[73]
-					}
-					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
-						d74 = ps.OverlayValues[74]
-					}
-					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
-						d76 = ps.OverlayValues[76]
+					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
+						d59 = ps.OverlayValues[59]
 					}
 					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
 						d77 = ps.OverlayValues[77]
 					}
+					if len(ps.OverlayValues) > 78 && ps.OverlayValues[78].Loc != LocNone {
+						d78 = ps.OverlayValues[78]
+					}
 					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
 						d79 = ps.OverlayValues[79]
 					}
+					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
+						d80 = ps.OverlayValues[80]
+					}
+					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+						d81 = ps.OverlayValues[81]
+					}
+					if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+						d82 = ps.OverlayValues[82]
+					}
+					if len(ps.OverlayValues) > 84 && ps.OverlayValues[84].Loc != LocNone {
+						d84 = ps.OverlayValues[84]
+					}
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
+					}
+					if len(ps.OverlayValues) > 87 && ps.OverlayValues[87].Loc != LocNone {
+						d87 = ps.OverlayValues[87]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d80 = args[0]
-					d80.ID = 0
-					d80 = JITPrepareScmerGoArg(ctx, d80)
-					ctx.SyncDesc(&d80)
-					d81 = ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d80}, 1)
-					d81.NoHeapPointer = false
-					ctx.BindReg(d81.Reg, &d81)
-					ctx.FreeDesc(&d80)
-					ctx.EnsureDesc(&d81)
-					var d82 JITValueDesc
-					if d81.Loc == LocImm {
-						d82 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d81.Imm.IsNil() != true)}
+					d88 = args[0]
+					d88.ID = 0
+					d88 = JITPrepareScmerGoArg(ctx, d88)
+					ctx.SyncDesc(&d88)
+					d89 = ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d88}, 1)
+					d89.NoHeapPointer = false
+					ctx.BindReg(d89.Reg, &d89)
+					ctx.FreeDesc(&d88)
+					ctx.EnsureDesc(&d89)
+					var d90 JITValueDesc
+					if d89.Loc == LocImm {
+						d90 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d89.Imm.IsNil() != true)}
 					} else {
-						ctx.EnsureDesc(&d81)
-						if d81.Loc != LocReg && d81.Loc != LocRegPair && d81.Loc != LocRegTriple {
+						ctx.EnsureDesc(&d89)
+						if d89.Loc != LocReg && d89.Loc != LocRegPair && d89.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r5 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d81.Reg, 0)
+						r5 := ctx.AllocRegExcept(d89.Reg)
+						ctx.EmitCmpRegImm32(d89.Reg, 0)
 						ctx.EmitSetcc(r5, CondNotEqual)
-						d82 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r5}
-						ctx.BindReg(r5, &d82)
+						d90 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r5}
+						ctx.BindReg(r5, &d90)
 					}
-					ctx.FreeDesc(&d81)
-					d83 = d82
-					ctx.EnsureDesc(&d83)
-					if d83.Loc != LocImm && d83.Loc != LocReg {
+					ctx.FreeDesc(&d89)
+					d91 = d90
+					ctx.EnsureDesc(&d91)
+					if d91.Loc != LocImm && d91.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d83.Loc == LocImm {
-						if d83.Imm.Bool() {
+					if d91.Loc == LocImm {
+						if d91.Imm.Bool() {
 							if ps.General {
 							}
-							ps84 := PhiState{General: ps.General}
-							ps84.OverlayValues = make([]JITValueDesc, 84)
-							ps84.OverlayValues[1] = d1
-							ps84.OverlayValues[2] = d2
-							ps84.OverlayValues[3] = d3
-							ps84.OverlayValues[4] = d4
-							ps84.OverlayValues[5] = d5
-							ps84.OverlayValues[6] = d6
-							ps84.OverlayValues[8] = d8
-							ps84.OverlayValues[20] = d20
-							ps84.OverlayValues[30] = d30
-							ps84.OverlayValues[31] = d31
-							ps84.OverlayValues[32] = d32
-							ps84.OverlayValues[33] = d33
-							ps84.OverlayValues[36] = d36
-							ps84.OverlayValues[53] = d53
-							ps84.OverlayValues[69] = d69
-							ps84.OverlayValues[70] = d70
-							ps84.OverlayValues[71] = d71
-							ps84.OverlayValues[72] = d72
-							ps84.OverlayValues[73] = d73
-							ps84.OverlayValues[74] = d74
-							ps84.OverlayValues[76] = d76
-							ps84.OverlayValues[77] = d77
-							ps84.OverlayValues[79] = d79
-							ps84.OverlayValues[80] = d80
-							ps84.OverlayValues[81] = d81
-							ps84.OverlayValues[82] = d82
-							ps84.OverlayValues[83] = d83
-							return bbs[3].RenderPS(ps84)
+							ps92 := PhiState{General: ps.General}
+							ps92.OverlayValues = make([]JITValueDesc, 92)
+							ps92.OverlayValues[1] = d1
+							ps92.OverlayValues[2] = d2
+							ps92.OverlayValues[3] = d3
+							ps92.OverlayValues[4] = d4
+							ps92.OverlayValues[5] = d5
+							ps92.OverlayValues[6] = d6
+							ps92.OverlayValues[7] = d7
+							ps92.OverlayValues[9] = d9
+							ps92.OverlayValues[22] = d22
+							ps92.OverlayValues[33] = d33
+							ps92.OverlayValues[34] = d34
+							ps92.OverlayValues[35] = d35
+							ps92.OverlayValues[36] = d36
+							ps92.OverlayValues[37] = d37
+							ps92.OverlayValues[40] = d40
+							ps92.OverlayValues[59] = d59
+							ps92.OverlayValues[77] = d77
+							ps92.OverlayValues[78] = d78
+							ps92.OverlayValues[79] = d79
+							ps92.OverlayValues[80] = d80
+							ps92.OverlayValues[81] = d81
+							ps92.OverlayValues[82] = d82
+							ps92.OverlayValues[84] = d84
+							ps92.OverlayValues[85] = d85
+							ps92.OverlayValues[87] = d87
+							ps92.OverlayValues[88] = d88
+							ps92.OverlayValues[89] = d89
+							ps92.OverlayValues[90] = d90
+							ps92.OverlayValues[91] = d91
+							return bbs[3].RenderPS(ps92)
 						}
 						if ps.General {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(0))
 						}
-						ps85 := PhiState{General: ps.General}
-						ps85.OverlayValues = make([]JITValueDesc, 84)
-						ps85.OverlayValues[1] = d1
-						ps85.OverlayValues[2] = d2
-						ps85.OverlayValues[3] = d3
-						ps85.OverlayValues[4] = d4
-						ps85.OverlayValues[5] = d5
-						ps85.OverlayValues[6] = d6
-						ps85.OverlayValues[8] = d8
-						ps85.OverlayValues[20] = d20
-						ps85.OverlayValues[30] = d30
-						ps85.OverlayValues[31] = d31
-						ps85.OverlayValues[32] = d32
-						ps85.OverlayValues[33] = d33
-						ps85.OverlayValues[36] = d36
-						ps85.OverlayValues[53] = d53
-						ps85.OverlayValues[69] = d69
-						ps85.OverlayValues[70] = d70
-						ps85.OverlayValues[71] = d71
-						ps85.OverlayValues[72] = d72
-						ps85.OverlayValues[73] = d73
-						ps85.OverlayValues[74] = d74
-						ps85.OverlayValues[76] = d76
-						ps85.OverlayValues[77] = d77
-						ps85.OverlayValues[79] = d79
-						ps85.OverlayValues[80] = d80
-						ps85.OverlayValues[81] = d81
-						ps85.OverlayValues[82] = d82
-						ps85.OverlayValues[83] = d83
-						ps85.PhiValues = make([]JITValueDesc, 1)
-						d86 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
-						ps85.PhiValues[0] = d86
-						return bbs[4].RenderPS(ps85)
+						ps93 := PhiState{General: ps.General}
+						ps93.OverlayValues = make([]JITValueDesc, 92)
+						ps93.OverlayValues[1] = d1
+						ps93.OverlayValues[2] = d2
+						ps93.OverlayValues[3] = d3
+						ps93.OverlayValues[4] = d4
+						ps93.OverlayValues[5] = d5
+						ps93.OverlayValues[6] = d6
+						ps93.OverlayValues[7] = d7
+						ps93.OverlayValues[9] = d9
+						ps93.OverlayValues[22] = d22
+						ps93.OverlayValues[33] = d33
+						ps93.OverlayValues[34] = d34
+						ps93.OverlayValues[35] = d35
+						ps93.OverlayValues[36] = d36
+						ps93.OverlayValues[37] = d37
+						ps93.OverlayValues[40] = d40
+						ps93.OverlayValues[59] = d59
+						ps93.OverlayValues[77] = d77
+						ps93.OverlayValues[78] = d78
+						ps93.OverlayValues[79] = d79
+						ps93.OverlayValues[80] = d80
+						ps93.OverlayValues[81] = d81
+						ps93.OverlayValues[82] = d82
+						ps93.OverlayValues[84] = d84
+						ps93.OverlayValues[85] = d85
+						ps93.OverlayValues[87] = d87
+						ps93.OverlayValues[88] = d88
+						ps93.OverlayValues[89] = d89
+						ps93.OverlayValues[90] = d90
+						ps93.OverlayValues[91] = d91
+						ps93.PhiValues = make([]JITValueDesc, 1)
+						d94 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+						ps93.PhiValues[0] = d94
+						return bbs[4].RenderPS(ps93)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[5].RenderPS(ps)
 					}
 					lbl9 := ctx.ReserveLabel()
-					ctx.EmitCmpRegImm32(d83.Reg, 0)
+					ctx.EmitCmpRegImm32(d91.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl4)
 					ctx.EmitJmp(lbl9)
-					snap87 := d1
-					snap88 := d2
-					snap89 := d3
-					snap90 := d4
-					snap91 := d5
-					snap92 := d6
-					snap93 := d8
-					snap94 := d20
-					snap95 := d30
-					snap96 := d31
-					snap97 := d32
-					snap98 := d33
-					snap99 := d36
-					snap100 := d53
-					snap101 := d69
-					snap102 := d70
-					snap103 := d71
-					snap104 := d72
-					snap105 := d73
-					snap106 := d74
-					snap107 := d76
-					snap108 := d77
-					snap109 := d79
-					snap110 := d80
-					snap111 := d81
-					snap112 := d82
-					snap113 := d83
-					snap114 := d86
-					alloc115 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc115)
-					d1 = snap87
-					d2 = snap88
-					d3 = snap89
-					d4 = snap90
-					d5 = snap91
-					d6 = snap92
-					d8 = snap93
-					d20 = snap94
-					d30 = snap95
-					d31 = snap96
-					d32 = snap97
-					d33 = snap98
-					d36 = snap99
-					d53 = snap100
-					d69 = snap101
-					d70 = snap102
-					d71 = snap103
-					d72 = snap104
-					d73 = snap105
-					d74 = snap106
-					d76 = snap107
-					d77 = snap108
-					d79 = snap109
-					d80 = snap110
-					d81 = snap111
-					d82 = snap112
-					d83 = snap113
-					d86 = snap114
+					snap95 := d1
+					snap96 := d2
+					snap97 := d3
+					snap98 := d4
+					snap99 := d5
+					snap100 := d6
+					snap101 := d7
+					snap102 := d9
+					snap103 := d22
+					snap104 := d33
+					snap105 := d34
+					snap106 := d35
+					snap107 := d36
+					snap108 := d37
+					snap109 := d40
+					snap110 := d59
+					snap111 := d77
+					snap112 := d78
+					snap113 := d79
+					snap114 := d80
+					snap115 := d81
+					snap116 := d82
+					snap117 := d84
+					snap118 := d85
+					snap119 := d87
+					snap120 := d88
+					snap121 := d89
+					snap122 := d90
+					snap123 := d91
+					snap124 := d94
+					alloc125 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc125)
+					d1 = snap95
+					d2 = snap96
+					d3 = snap97
+					d4 = snap98
+					d5 = snap99
+					d6 = snap100
+					d7 = snap101
+					d9 = snap102
+					d22 = snap103
+					d33 = snap104
+					d34 = snap105
+					d35 = snap106
+					d36 = snap107
+					d37 = snap108
+					d40 = snap109
+					d59 = snap110
+					d77 = snap111
+					d78 = snap112
+					d79 = snap113
+					d80 = snap114
+					d81 = snap115
+					d82 = snap116
+					d84 = snap117
+					d85 = snap118
+					d87 = snap119
+					d88 = snap120
+					d89 = snap121
+					d90 = snap122
+					d91 = snap123
+					d94 = snap124
 					ctx.MarkLabel(lbl9)
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(0))
 					ctx.EmitJmp(lbl5)
-					ctx.RestoreAllocState(alloc115)
-					d1 = snap87
-					d2 = snap88
-					d3 = snap89
-					d4 = snap90
-					d5 = snap91
-					d6 = snap92
-					d8 = snap93
-					d20 = snap94
-					d30 = snap95
-					d31 = snap96
-					d32 = snap97
-					d33 = snap98
-					d36 = snap99
-					d53 = snap100
-					d69 = snap101
-					d70 = snap102
-					d71 = snap103
-					d72 = snap104
-					d73 = snap105
-					d74 = snap106
-					d76 = snap107
-					d77 = snap108
-					d79 = snap109
-					d80 = snap110
-					d81 = snap111
-					d82 = snap112
-					d83 = snap113
-					d86 = snap114
-					ps116 := PhiState{General: true}
-					ps116.OverlayValues = make([]JITValueDesc, 87)
-					ps116.OverlayValues[1] = d1
-					ps116.OverlayValues[2] = d2
-					ps116.OverlayValues[3] = d3
-					ps116.OverlayValues[4] = d4
-					ps116.OverlayValues[5] = d5
-					ps116.OverlayValues[6] = d6
-					ps116.OverlayValues[8] = d8
-					ps116.OverlayValues[20] = d20
-					ps116.OverlayValues[30] = d30
-					ps116.OverlayValues[31] = d31
-					ps116.OverlayValues[32] = d32
-					ps116.OverlayValues[33] = d33
-					ps116.OverlayValues[36] = d36
-					ps116.OverlayValues[53] = d53
-					ps116.OverlayValues[69] = d69
-					ps116.OverlayValues[70] = d70
-					ps116.OverlayValues[71] = d71
-					ps116.OverlayValues[72] = d72
-					ps116.OverlayValues[73] = d73
-					ps116.OverlayValues[74] = d74
-					ps116.OverlayValues[76] = d76
-					ps116.OverlayValues[77] = d77
-					ps116.OverlayValues[79] = d79
-					ps116.OverlayValues[80] = d80
-					ps116.OverlayValues[81] = d81
-					ps116.OverlayValues[82] = d82
-					ps116.OverlayValues[83] = d83
-					ps116.OverlayValues[86] = d86
-					ps117 := PhiState{General: true}
-					ps117.OverlayValues = make([]JITValueDesc, 87)
-					ps117.OverlayValues[1] = d1
-					ps117.OverlayValues[2] = d2
-					ps117.OverlayValues[3] = d3
-					ps117.OverlayValues[4] = d4
-					ps117.OverlayValues[5] = d5
-					ps117.OverlayValues[6] = d6
-					ps117.OverlayValues[8] = d8
-					ps117.OverlayValues[20] = d20
-					ps117.OverlayValues[30] = d30
-					ps117.OverlayValues[31] = d31
-					ps117.OverlayValues[32] = d32
-					ps117.OverlayValues[33] = d33
-					ps117.OverlayValues[36] = d36
-					ps117.OverlayValues[53] = d53
-					ps117.OverlayValues[69] = d69
-					ps117.OverlayValues[70] = d70
-					ps117.OverlayValues[71] = d71
-					ps117.OverlayValues[72] = d72
-					ps117.OverlayValues[73] = d73
-					ps117.OverlayValues[74] = d74
-					ps117.OverlayValues[76] = d76
-					ps117.OverlayValues[77] = d77
-					ps117.OverlayValues[79] = d79
-					ps117.OverlayValues[80] = d80
-					ps117.OverlayValues[81] = d81
-					ps117.OverlayValues[82] = d82
-					ps117.OverlayValues[83] = d83
-					ps117.OverlayValues[86] = d86
-					ps117.PhiValues = make([]JITValueDesc, 1)
-					d118 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
-					ps117.PhiValues[0] = d118
-					snap119 := d1
-					snap120 := d2
-					snap121 := d3
-					snap122 := d4
-					snap123 := d5
-					snap124 := d6
-					snap125 := d8
-					snap126 := d20
-					snap127 := d30
-					snap128 := d31
-					snap129 := d32
-					snap130 := d33
-					snap131 := d36
-					snap132 := d53
-					snap133 := d69
-					snap134 := d70
-					snap135 := d71
-					snap136 := d72
-					snap137 := d73
-					snap138 := d74
-					snap139 := d76
-					snap140 := d77
-					snap141 := d79
-					snap142 := d80
-					snap143 := d81
-					snap144 := d82
-					snap145 := d83
-					snap146 := d86
-					snap147 := d118
-					alloc148 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc125)
+					d1 = snap95
+					d2 = snap96
+					d3 = snap97
+					d4 = snap98
+					d5 = snap99
+					d6 = snap100
+					d7 = snap101
+					d9 = snap102
+					d22 = snap103
+					d33 = snap104
+					d34 = snap105
+					d35 = snap106
+					d36 = snap107
+					d37 = snap108
+					d40 = snap109
+					d59 = snap110
+					d77 = snap111
+					d78 = snap112
+					d79 = snap113
+					d80 = snap114
+					d81 = snap115
+					d82 = snap116
+					d84 = snap117
+					d85 = snap118
+					d87 = snap119
+					d88 = snap120
+					d89 = snap121
+					d90 = snap122
+					d91 = snap123
+					d94 = snap124
+					ps126 := PhiState{General: true}
+					ps126.OverlayValues = make([]JITValueDesc, 95)
+					ps126.OverlayValues[1] = d1
+					ps126.OverlayValues[2] = d2
+					ps126.OverlayValues[3] = d3
+					ps126.OverlayValues[4] = d4
+					ps126.OverlayValues[5] = d5
+					ps126.OverlayValues[6] = d6
+					ps126.OverlayValues[7] = d7
+					ps126.OverlayValues[9] = d9
+					ps126.OverlayValues[22] = d22
+					ps126.OverlayValues[33] = d33
+					ps126.OverlayValues[34] = d34
+					ps126.OverlayValues[35] = d35
+					ps126.OverlayValues[36] = d36
+					ps126.OverlayValues[37] = d37
+					ps126.OverlayValues[40] = d40
+					ps126.OverlayValues[59] = d59
+					ps126.OverlayValues[77] = d77
+					ps126.OverlayValues[78] = d78
+					ps126.OverlayValues[79] = d79
+					ps126.OverlayValues[80] = d80
+					ps126.OverlayValues[81] = d81
+					ps126.OverlayValues[82] = d82
+					ps126.OverlayValues[84] = d84
+					ps126.OverlayValues[85] = d85
+					ps126.OverlayValues[87] = d87
+					ps126.OverlayValues[88] = d88
+					ps126.OverlayValues[89] = d89
+					ps126.OverlayValues[90] = d90
+					ps126.OverlayValues[91] = d91
+					ps126.OverlayValues[94] = d94
+					ps127 := PhiState{General: true}
+					ps127.OverlayValues = make([]JITValueDesc, 95)
+					ps127.OverlayValues[1] = d1
+					ps127.OverlayValues[2] = d2
+					ps127.OverlayValues[3] = d3
+					ps127.OverlayValues[4] = d4
+					ps127.OverlayValues[5] = d5
+					ps127.OverlayValues[6] = d6
+					ps127.OverlayValues[7] = d7
+					ps127.OverlayValues[9] = d9
+					ps127.OverlayValues[22] = d22
+					ps127.OverlayValues[33] = d33
+					ps127.OverlayValues[34] = d34
+					ps127.OverlayValues[35] = d35
+					ps127.OverlayValues[36] = d36
+					ps127.OverlayValues[37] = d37
+					ps127.OverlayValues[40] = d40
+					ps127.OverlayValues[59] = d59
+					ps127.OverlayValues[77] = d77
+					ps127.OverlayValues[78] = d78
+					ps127.OverlayValues[79] = d79
+					ps127.OverlayValues[80] = d80
+					ps127.OverlayValues[81] = d81
+					ps127.OverlayValues[82] = d82
+					ps127.OverlayValues[84] = d84
+					ps127.OverlayValues[85] = d85
+					ps127.OverlayValues[87] = d87
+					ps127.OverlayValues[88] = d88
+					ps127.OverlayValues[89] = d89
+					ps127.OverlayValues[90] = d90
+					ps127.OverlayValues[91] = d91
+					ps127.OverlayValues[94] = d94
+					ps127.PhiValues = make([]JITValueDesc, 1)
+					d128 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+					ps127.PhiValues[0] = d128
+					snap129 := d1
+					snap130 := d2
+					snap131 := d3
+					snap132 := d4
+					snap133 := d5
+					snap134 := d6
+					snap135 := d7
+					snap136 := d9
+					snap137 := d22
+					snap138 := d33
+					snap139 := d34
+					snap140 := d35
+					snap141 := d36
+					snap142 := d37
+					snap143 := d40
+					snap144 := d59
+					snap145 := d77
+					snap146 := d78
+					snap147 := d79
+					snap148 := d80
+					snap149 := d81
+					snap150 := d82
+					snap151 := d84
+					snap152 := d85
+					snap153 := d87
+					snap154 := d88
+					snap155 := d89
+					snap156 := d90
+					snap157 := d91
+					snap158 := d94
+					snap159 := d128
+					alloc160 := ctx.SnapshotAllocState()
 					if !bbs[4].Rendered {
-						bbs[4].RenderPS(ps117)
+						bbs[4].RenderPS(ps127)
 					}
-					ctx.RestoreAllocState(alloc148)
-					d1 = snap119
-					d2 = snap120
-					d3 = snap121
-					d4 = snap122
-					d5 = snap123
-					d6 = snap124
-					d8 = snap125
-					d20 = snap126
-					d30 = snap127
-					d31 = snap128
-					d32 = snap129
-					d33 = snap130
-					d36 = snap131
-					d53 = snap132
-					d69 = snap133
-					d70 = snap134
-					d71 = snap135
-					d72 = snap136
-					d73 = snap137
-					d74 = snap138
-					d76 = snap139
-					d77 = snap140
-					d79 = snap141
-					d80 = snap142
-					d81 = snap143
-					d82 = snap144
-					d83 = snap145
-					d86 = snap146
-					d118 = snap147
+					ctx.RestoreAllocState(alloc160)
+					d1 = snap129
+					d2 = snap130
+					d3 = snap131
+					d4 = snap132
+					d5 = snap133
+					d6 = snap134
+					d7 = snap135
+					d9 = snap136
+					d22 = snap137
+					d33 = snap138
+					d34 = snap139
+					d35 = snap140
+					d36 = snap141
+					d37 = snap142
+					d40 = snap143
+					d59 = snap144
+					d77 = snap145
+					d78 = snap146
+					d79 = snap147
+					d80 = snap148
+					d81 = snap149
+					d82 = snap150
+					d84 = snap151
+					d85 = snap152
+					d87 = snap153
+					d88 = snap154
+					d89 = snap155
+					d90 = snap156
+					d91 = snap157
+					d94 = snap158
+					d128 = snap159
 					if !bbs[3].Rendered {
-						return bbs[3].RenderPS(ps116)
+						return bbs[3].RenderPS(ps126)
 					}
 					return result
-					ctx.FreeDesc(&d82)
+					ctx.FreeDesc(&d90)
 					return result
 				}
-				ps149 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps149)
+				ps161 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps161)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -5815,90 +5956,94 @@ func init_jit() {
 				_ = d6
 				var d7 JITValueDesc
 				_ = d7
-				var d9 JITValueDesc
-				_ = d9
-				var d22 JITValueDesc
-				_ = d22
-				var d33 JITValueDesc
-				_ = d33
-				var d34 JITValueDesc
-				_ = d34
-				var d35 JITValueDesc
-				_ = d35
+				var d8 JITValueDesc
+				_ = d8
+				var d10 JITValueDesc
+				_ = d10
+				var d24 JITValueDesc
+				_ = d24
+				var d36 JITValueDesc
+				_ = d36
+				var d37 JITValueDesc
+				_ = d37
 				var d38 JITValueDesc
 				_ = d38
-				var d55 JITValueDesc
-				_ = d55
-				var d71 JITValueDesc
-				_ = d71
-				var d73 JITValueDesc
-				_ = d73
-				var d74 JITValueDesc
-				_ = d74
-				var d75 JITValueDesc
-				_ = d75
-				var d77 JITValueDesc
-				_ = d77
-				var d78 JITValueDesc
-				_ = d78
-				var d80 JITValueDesc
-				_ = d80
+				var d39 JITValueDesc
+				_ = d39
+				var d42 JITValueDesc
+				_ = d42
+				var d61 JITValueDesc
+				_ = d61
+				var d79 JITValueDesc
+				_ = d79
 				var d81 JITValueDesc
 				_ = d81
 				var d82 JITValueDesc
 				_ = d82
 				var d83 JITValueDesc
 				_ = d83
+				var d85 JITValueDesc
+				_ = d85
 				var d86 JITValueDesc
 				_ = d86
-				var d115 JITValueDesc
-				_ = d115
-				var d143 JITValueDesc
-				_ = d143
-				var d144 JITValueDesc
-				_ = d144
-				var d145 JITValueDesc
-				_ = d145
-				var d146 JITValueDesc
-				_ = d146
-				var d147 JITValueDesc
-				_ = d147
-				var d149 JITValueDesc
-				_ = d149
-				var d151 JITValueDesc
-				_ = d151
-				var d186 JITValueDesc
-				_ = d186
-				var d189 JITValueDesc
-				_ = d189
-				var d226 JITValueDesc
-				_ = d226
-				var d305 JITValueDesc
-				_ = d305
-				var d306 JITValueDesc
-				_ = d306
-				var d307 JITValueDesc
-				_ = d307
-				var d308 JITValueDesc
-				_ = d308
-				var d310 JITValueDesc
-				_ = d310
-				var d311 JITValueDesc
-				_ = d311
-				var d312 JITValueDesc
-				_ = d312
-				var d313 JITValueDesc
-				_ = d313
-				var d314 JITValueDesc
-				_ = d314
-				var d316 JITValueDesc
-				_ = d316
-				var d317 JITValueDesc
-				_ = d317
-				var d319 JITValueDesc
-				_ = d319
-				var d320 JITValueDesc
-				_ = d320
+				var d88 JITValueDesc
+				_ = d88
+				var d89 JITValueDesc
+				_ = d89
+				var d90 JITValueDesc
+				_ = d90
+				var d91 JITValueDesc
+				_ = d91
+				var d94 JITValueDesc
+				_ = d94
+				var d125 JITValueDesc
+				_ = d125
+				var d155 JITValueDesc
+				_ = d155
+				var d156 JITValueDesc
+				_ = d156
+				var d157 JITValueDesc
+				_ = d157
+				var d158 JITValueDesc
+				_ = d158
+				var d159 JITValueDesc
+				_ = d159
+				var d161 JITValueDesc
+				_ = d161
+				var d163 JITValueDesc
+				_ = d163
+				var d200 JITValueDesc
+				_ = d200
+				var d203 JITValueDesc
+				_ = d203
+				var d242 JITValueDesc
+				_ = d242
+				var d325 JITValueDesc
+				_ = d325
+				var d326 JITValueDesc
+				_ = d326
+				var d327 JITValueDesc
+				_ = d327
+				var d328 JITValueDesc
+				_ = d328
+				var d330 JITValueDesc
+				_ = d330
+				var d331 JITValueDesc
+				_ = d331
+				var d332 JITValueDesc
+				_ = d332
+				var d333 JITValueDesc
+				_ = d333
+				var d334 JITValueDesc
+				_ = d334
+				var d336 JITValueDesc
+				_ = d336
+				var d337 JITValueDesc
+				_ = d337
+				var d339 JITValueDesc
+				_ = d339
+				var d340 JITValueDesc
+				_ = d340
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				phiBase0 := ctx.AllocStack(int32(48))
 				var bbs [11]BBDescriptor
@@ -6008,143 +6153,154 @@ func init_jit() {
 					d4 = args[0]
 					d4.ID = 0
 					ctx.StabilizeDescForControlFlow(&d4)
-					d5 = ctx.EmitGetTagDesc(&d4, JITValueDesc{Loc: LocAny})
-					ctx.EnsureDesc(&d5)
-					var d6 JITValueDesc
-					if d5.Loc == LocImm {
-						d6 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d5.Imm.Int()) == uint64(0xb))}
+					d5 = d4
+					d5.ID = 0
+					d6 = ctx.EmitGetTagDesc(&d5, JITValueDesc{Loc: LocAny})
+					ctx.EnsureDesc(&d6)
+					var d7 JITValueDesc
+					if d6.Loc == LocImm {
+						d7 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d6.Imm.Int()) == uint64(0xb))}
 					} else {
 						r0 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d5.Reg, 11)
-						d6 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
-						ctx.BindReg(r0, &d6)
+						ctx.EmitCmpRegImm32(d6.Reg, 11)
+						d7 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
+						ctx.BindReg(r0, &d7)
 					}
-					ctx.FreeDesc(&d5)
-					d7 = d6
-					ctx.EnsureDesc(&d7)
-					if d7.Loc != LocImm && d7.Loc != LocFlags {
+					ctx.FreeDesc(&d6)
+					d8 = d7
+					ctx.EnsureDesc(&d8)
+					if d8.Loc != LocImm && d8.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d7.Loc == LocImm {
-						if d7.Imm.Bool() {
+					if d8.Loc == LocImm {
+						if d8.Imm.Bool() {
 							if ps.General {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 							}
-							ps8 := PhiState{General: ps.General}
-							ps8.OverlayValues = make([]JITValueDesc, 8)
-							ps8.OverlayValues[1] = d1
-							ps8.OverlayValues[2] = d2
-							ps8.OverlayValues[3] = d3
-							ps8.OverlayValues[4] = d4
-							ps8.OverlayValues[5] = d5
-							ps8.OverlayValues[6] = d6
-							ps8.OverlayValues[7] = d7
-							ps8.PhiValues = make([]JITValueDesc, 1)
-							d9 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
-							ps8.PhiValues[0] = d9
-							return bbs[2].RenderPS(ps8)
+							ps9 := PhiState{General: ps.General}
+							ps9.OverlayValues = make([]JITValueDesc, 9)
+							ps9.OverlayValues[1] = d1
+							ps9.OverlayValues[2] = d2
+							ps9.OverlayValues[3] = d3
+							ps9.OverlayValues[4] = d4
+							ps9.OverlayValues[5] = d5
+							ps9.OverlayValues[6] = d6
+							ps9.OverlayValues[7] = d7
+							ps9.OverlayValues[8] = d8
+							ps9.PhiValues = make([]JITValueDesc, 1)
+							d10 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
+							ps9.PhiValues[0] = d10
+							return bbs[2].RenderPS(ps9)
 						}
 						if ps.General {
 						}
-						ps10 := PhiState{General: ps.General}
-						ps10.OverlayValues = make([]JITValueDesc, 10)
-						ps10.OverlayValues[1] = d1
-						ps10.OverlayValues[2] = d2
-						ps10.OverlayValues[3] = d3
-						ps10.OverlayValues[4] = d4
-						ps10.OverlayValues[5] = d5
-						ps10.OverlayValues[6] = d6
-						ps10.OverlayValues[7] = d7
-						ps10.OverlayValues[9] = d9
-						return bbs[1].RenderPS(ps10)
+						ps11 := PhiState{General: ps.General}
+						ps11.OverlayValues = make([]JITValueDesc, 11)
+						ps11.OverlayValues[1] = d1
+						ps11.OverlayValues[2] = d2
+						ps11.OverlayValues[3] = d3
+						ps11.OverlayValues[4] = d4
+						ps11.OverlayValues[5] = d5
+						ps11.OverlayValues[6] = d6
+						ps11.OverlayValues[7] = d7
+						ps11.OverlayValues[8] = d8
+						ps11.OverlayValues[10] = d10
+						return bbs[1].RenderPS(ps11)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[0].RenderPS(ps)
 					}
 					lbl12 := ctx.ReserveLabel()
-					ctx.EmitJump(d7.Condition, lbl12)
+					ctx.EmitJump(d8.Condition, lbl12)
 					ctx.EmitJmp(lbl2)
-					ctx.FreeDesc(&d6)
-					snap11 := d1
-					snap12 := d2
-					snap13 := d3
-					snap14 := d4
-					snap15 := d5
-					snap16 := d6
-					snap17 := d7
-					snap18 := d9
-					alloc19 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d7)
+					snap12 := d1
+					snap13 := d2
+					snap14 := d3
+					snap15 := d4
+					snap16 := d5
+					snap17 := d6
+					snap18 := d7
+					snap19 := d8
+					snap20 := d10
+					alloc21 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl12)
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 					ctx.EmitJmp(lbl3)
-					ctx.RestoreAllocState(alloc19)
-					d1 = snap11
-					d2 = snap12
-					d3 = snap13
-					d4 = snap14
-					d5 = snap15
-					d6 = snap16
-					d7 = snap17
-					d9 = snap18
-					ctx.RestoreAllocState(alloc19)
-					d1 = snap11
-					d2 = snap12
-					d3 = snap13
-					d4 = snap14
-					d5 = snap15
-					d6 = snap16
-					d7 = snap17
-					d9 = snap18
-					ps20 := PhiState{General: true}
-					ps20.OverlayValues = make([]JITValueDesc, 10)
-					ps20.OverlayValues[1] = d1
-					ps20.OverlayValues[2] = d2
-					ps20.OverlayValues[3] = d3
-					ps20.OverlayValues[4] = d4
-					ps20.OverlayValues[5] = d5
-					ps20.OverlayValues[6] = d6
-					ps20.OverlayValues[7] = d7
-					ps20.OverlayValues[9] = d9
-					ps20.PhiValues = make([]JITValueDesc, 1)
-					d22 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
-					ps20.PhiValues[0] = d22
-					ps21 := PhiState{General: true}
-					ps21.OverlayValues = make([]JITValueDesc, 23)
-					ps21.OverlayValues[1] = d1
-					ps21.OverlayValues[2] = d2
-					ps21.OverlayValues[3] = d3
-					ps21.OverlayValues[4] = d4
-					ps21.OverlayValues[5] = d5
-					ps21.OverlayValues[6] = d6
-					ps21.OverlayValues[7] = d7
-					ps21.OverlayValues[9] = d9
-					ps21.OverlayValues[22] = d22
-					snap23 := d1
-					snap24 := d2
-					snap25 := d3
-					snap26 := d4
-					snap27 := d5
-					snap28 := d6
-					snap29 := d7
-					snap30 := d9
-					snap31 := d22
-					alloc32 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc21)
+					d1 = snap12
+					d2 = snap13
+					d3 = snap14
+					d4 = snap15
+					d5 = snap16
+					d6 = snap17
+					d7 = snap18
+					d8 = snap19
+					d10 = snap20
+					ctx.RestoreAllocState(alloc21)
+					d1 = snap12
+					d2 = snap13
+					d3 = snap14
+					d4 = snap15
+					d5 = snap16
+					d6 = snap17
+					d7 = snap18
+					d8 = snap19
+					d10 = snap20
+					ps22 := PhiState{General: true}
+					ps22.OverlayValues = make([]JITValueDesc, 11)
+					ps22.OverlayValues[1] = d1
+					ps22.OverlayValues[2] = d2
+					ps22.OverlayValues[3] = d3
+					ps22.OverlayValues[4] = d4
+					ps22.OverlayValues[5] = d5
+					ps22.OverlayValues[6] = d6
+					ps22.OverlayValues[7] = d7
+					ps22.OverlayValues[8] = d8
+					ps22.OverlayValues[10] = d10
+					ps22.PhiValues = make([]JITValueDesc, 1)
+					d24 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)}
+					ps22.PhiValues[0] = d24
+					ps23 := PhiState{General: true}
+					ps23.OverlayValues = make([]JITValueDesc, 25)
+					ps23.OverlayValues[1] = d1
+					ps23.OverlayValues[2] = d2
+					ps23.OverlayValues[3] = d3
+					ps23.OverlayValues[4] = d4
+					ps23.OverlayValues[5] = d5
+					ps23.OverlayValues[6] = d6
+					ps23.OverlayValues[7] = d7
+					ps23.OverlayValues[8] = d8
+					ps23.OverlayValues[10] = d10
+					ps23.OverlayValues[24] = d24
+					snap25 := d1
+					snap26 := d2
+					snap27 := d3
+					snap28 := d4
+					snap29 := d5
+					snap30 := d6
+					snap31 := d7
+					snap32 := d8
+					snap33 := d10
+					snap34 := d24
+					alloc35 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps20)
+						bbs[2].RenderPS(ps22)
 					}
-					ctx.RestoreAllocState(alloc32)
-					d1 = snap23
-					d2 = snap24
-					d3 = snap25
-					d4 = snap26
-					d5 = snap27
-					d6 = snap28
-					d7 = snap29
-					d9 = snap30
-					d22 = snap31
+					ctx.RestoreAllocState(alloc35)
+					d1 = snap25
+					d2 = snap26
+					d3 = snap27
+					d4 = snap28
+					d5 = snap29
+					d6 = snap30
+					d7 = snap31
+					d8 = snap32
+					d10 = snap33
+					d24 = snap34
 					if !bbs[1].Rendered {
-						return bbs[1].RenderPS(ps21)
+						return bbs[1].RenderPS(ps23)
 					}
 					return result
 					return result
@@ -6192,193 +6348,216 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d33 = ctx.EmitGetTagDesc(&d4, JITValueDesc{Loc: LocAny})
-					ctx.EnsureDesc(&d33)
-					var d34 JITValueDesc
-					if d33.Loc == LocImm {
-						d34 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d33.Imm.Int()) == uint64(0xa))}
+					d36 = d4
+					d36.ID = 0
+					d37 = ctx.EmitGetTagDesc(&d36, JITValueDesc{Loc: LocAny})
+					ctx.EnsureDesc(&d37)
+					var d38 JITValueDesc
+					if d37.Loc == LocImm {
+						d38 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d37.Imm.Int()) == uint64(0xa))}
 					} else {
 						r1 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d33.Reg, 10)
-						d34 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondEqual}
-						ctx.BindReg(r1, &d34)
+						ctx.EmitCmpRegImm32(d37.Reg, 10)
+						d38 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondEqual}
+						ctx.BindReg(r1, &d38)
 					}
-					ctx.FreeDesc(&d33)
-					d35 = d34
-					ctx.EnsureDesc(&d35)
-					if d35.Loc != LocImm && d35.Loc != LocFlags {
+					ctx.FreeDesc(&d37)
+					d39 = d38
+					ctx.EnsureDesc(&d39)
+					if d39.Loc != LocImm && d39.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d35.Loc == LocImm {
-						if d35.Imm.Bool() {
+					if d39.Loc == LocImm {
+						if d39.Imm.Bool() {
 							if ps.General {
 							}
-							ps36 := PhiState{General: ps.General}
-							ps36.OverlayValues = make([]JITValueDesc, 36)
-							ps36.OverlayValues[1] = d1
-							ps36.OverlayValues[2] = d2
-							ps36.OverlayValues[3] = d3
-							ps36.OverlayValues[4] = d4
-							ps36.OverlayValues[5] = d5
-							ps36.OverlayValues[6] = d6
-							ps36.OverlayValues[7] = d7
-							ps36.OverlayValues[9] = d9
-							ps36.OverlayValues[22] = d22
-							ps36.OverlayValues[33] = d33
-							ps36.OverlayValues[34] = d34
-							ps36.OverlayValues[35] = d35
-							return bbs[5].RenderPS(ps36)
+							ps40 := PhiState{General: ps.General}
+							ps40.OverlayValues = make([]JITValueDesc, 40)
+							ps40.OverlayValues[1] = d1
+							ps40.OverlayValues[2] = d2
+							ps40.OverlayValues[3] = d3
+							ps40.OverlayValues[4] = d4
+							ps40.OverlayValues[5] = d5
+							ps40.OverlayValues[6] = d6
+							ps40.OverlayValues[7] = d7
+							ps40.OverlayValues[8] = d8
+							ps40.OverlayValues[10] = d10
+							ps40.OverlayValues[24] = d24
+							ps40.OverlayValues[36] = d36
+							ps40.OverlayValues[37] = d37
+							ps40.OverlayValues[38] = d38
+							ps40.OverlayValues[39] = d39
+							return bbs[5].RenderPS(ps40)
 						}
 						if ps.General {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(0))
 						}
-						ps37 := PhiState{General: ps.General}
-						ps37.OverlayValues = make([]JITValueDesc, 36)
-						ps37.OverlayValues[1] = d1
-						ps37.OverlayValues[2] = d2
-						ps37.OverlayValues[3] = d3
-						ps37.OverlayValues[4] = d4
-						ps37.OverlayValues[5] = d5
-						ps37.OverlayValues[6] = d6
-						ps37.OverlayValues[7] = d7
-						ps37.OverlayValues[9] = d9
-						ps37.OverlayValues[22] = d22
-						ps37.OverlayValues[33] = d33
-						ps37.OverlayValues[34] = d34
-						ps37.OverlayValues[35] = d35
-						ps37.PhiValues = make([]JITValueDesc, 1)
-						d38 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
-						ps37.PhiValues[0] = d38
-						return bbs[4].RenderPS(ps37)
+						ps41 := PhiState{General: ps.General}
+						ps41.OverlayValues = make([]JITValueDesc, 40)
+						ps41.OverlayValues[1] = d1
+						ps41.OverlayValues[2] = d2
+						ps41.OverlayValues[3] = d3
+						ps41.OverlayValues[4] = d4
+						ps41.OverlayValues[5] = d5
+						ps41.OverlayValues[6] = d6
+						ps41.OverlayValues[7] = d7
+						ps41.OverlayValues[8] = d8
+						ps41.OverlayValues[10] = d10
+						ps41.OverlayValues[24] = d24
+						ps41.OverlayValues[36] = d36
+						ps41.OverlayValues[37] = d37
+						ps41.OverlayValues[38] = d38
+						ps41.OverlayValues[39] = d39
+						ps41.PhiValues = make([]JITValueDesc, 1)
+						d42 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+						ps41.PhiValues[0] = d42
+						return bbs[4].RenderPS(ps41)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[1].RenderPS(ps)
 					}
 					lbl13 := ctx.ReserveLabel()
-					ctx.EmitJump(d35.Condition, lbl6)
+					ctx.EmitJump(d39.Condition, lbl6)
 					ctx.EmitJmp(lbl13)
-					ctx.FreeDesc(&d34)
-					snap39 := d1
-					snap40 := d2
-					snap41 := d3
-					snap42 := d4
-					snap43 := d5
-					snap44 := d6
-					snap45 := d7
-					snap46 := d9
-					snap47 := d22
-					snap48 := d33
-					snap49 := d34
-					snap50 := d35
-					snap51 := d38
-					alloc52 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc52)
-					d1 = snap39
-					d2 = snap40
-					d3 = snap41
-					d4 = snap42
-					d5 = snap43
-					d6 = snap44
-					d7 = snap45
-					d9 = snap46
-					d22 = snap47
-					d33 = snap48
-					d34 = snap49
-					d35 = snap50
-					d38 = snap51
+					ctx.FreeDesc(&d38)
+					snap43 := d1
+					snap44 := d2
+					snap45 := d3
+					snap46 := d4
+					snap47 := d5
+					snap48 := d6
+					snap49 := d7
+					snap50 := d8
+					snap51 := d10
+					snap52 := d24
+					snap53 := d36
+					snap54 := d37
+					snap55 := d38
+					snap56 := d39
+					snap57 := d42
+					alloc58 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc58)
+					d1 = snap43
+					d2 = snap44
+					d3 = snap45
+					d4 = snap46
+					d5 = snap47
+					d6 = snap48
+					d7 = snap49
+					d8 = snap50
+					d10 = snap51
+					d24 = snap52
+					d36 = snap53
+					d37 = snap54
+					d38 = snap55
+					d39 = snap56
+					d42 = snap57
 					ctx.MarkLabel(lbl13)
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(0))
 					ctx.EmitJmp(lbl5)
-					ctx.RestoreAllocState(alloc52)
-					d1 = snap39
-					d2 = snap40
-					d3 = snap41
-					d4 = snap42
-					d5 = snap43
-					d6 = snap44
-					d7 = snap45
-					d9 = snap46
-					d22 = snap47
-					d33 = snap48
-					d34 = snap49
-					d35 = snap50
-					d38 = snap51
-					ps53 := PhiState{General: true}
-					ps53.OverlayValues = make([]JITValueDesc, 39)
-					ps53.OverlayValues[1] = d1
-					ps53.OverlayValues[2] = d2
-					ps53.OverlayValues[3] = d3
-					ps53.OverlayValues[4] = d4
-					ps53.OverlayValues[5] = d5
-					ps53.OverlayValues[6] = d6
-					ps53.OverlayValues[7] = d7
-					ps53.OverlayValues[9] = d9
-					ps53.OverlayValues[22] = d22
-					ps53.OverlayValues[33] = d33
-					ps53.OverlayValues[34] = d34
-					ps53.OverlayValues[35] = d35
-					ps53.OverlayValues[38] = d38
-					ps54 := PhiState{General: true}
-					ps54.OverlayValues = make([]JITValueDesc, 39)
-					ps54.OverlayValues[1] = d1
-					ps54.OverlayValues[2] = d2
-					ps54.OverlayValues[3] = d3
-					ps54.OverlayValues[4] = d4
-					ps54.OverlayValues[5] = d5
-					ps54.OverlayValues[6] = d6
-					ps54.OverlayValues[7] = d7
-					ps54.OverlayValues[9] = d9
-					ps54.OverlayValues[22] = d22
-					ps54.OverlayValues[33] = d33
-					ps54.OverlayValues[34] = d34
-					ps54.OverlayValues[35] = d35
-					ps54.OverlayValues[38] = d38
-					ps54.PhiValues = make([]JITValueDesc, 1)
-					d55 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
-					ps54.PhiValues[0] = d55
-					snap56 := d1
-					snap57 := d2
-					snap58 := d3
-					snap59 := d4
-					snap60 := d5
-					snap61 := d6
-					snap62 := d7
-					snap63 := d9
-					snap64 := d22
-					snap65 := d33
-					snap66 := d34
-					snap67 := d35
-					snap68 := d38
-					snap69 := d55
-					alloc70 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc58)
+					d1 = snap43
+					d2 = snap44
+					d3 = snap45
+					d4 = snap46
+					d5 = snap47
+					d6 = snap48
+					d7 = snap49
+					d8 = snap50
+					d10 = snap51
+					d24 = snap52
+					d36 = snap53
+					d37 = snap54
+					d38 = snap55
+					d39 = snap56
+					d42 = snap57
+					ps59 := PhiState{General: true}
+					ps59.OverlayValues = make([]JITValueDesc, 43)
+					ps59.OverlayValues[1] = d1
+					ps59.OverlayValues[2] = d2
+					ps59.OverlayValues[3] = d3
+					ps59.OverlayValues[4] = d4
+					ps59.OverlayValues[5] = d5
+					ps59.OverlayValues[6] = d6
+					ps59.OverlayValues[7] = d7
+					ps59.OverlayValues[8] = d8
+					ps59.OverlayValues[10] = d10
+					ps59.OverlayValues[24] = d24
+					ps59.OverlayValues[36] = d36
+					ps59.OverlayValues[37] = d37
+					ps59.OverlayValues[38] = d38
+					ps59.OverlayValues[39] = d39
+					ps59.OverlayValues[42] = d42
+					ps60 := PhiState{General: true}
+					ps60.OverlayValues = make([]JITValueDesc, 43)
+					ps60.OverlayValues[1] = d1
+					ps60.OverlayValues[2] = d2
+					ps60.OverlayValues[3] = d3
+					ps60.OverlayValues[4] = d4
+					ps60.OverlayValues[5] = d5
+					ps60.OverlayValues[6] = d6
+					ps60.OverlayValues[7] = d7
+					ps60.OverlayValues[8] = d8
+					ps60.OverlayValues[10] = d10
+					ps60.OverlayValues[24] = d24
+					ps60.OverlayValues[36] = d36
+					ps60.OverlayValues[37] = d37
+					ps60.OverlayValues[38] = d38
+					ps60.OverlayValues[39] = d39
+					ps60.OverlayValues[42] = d42
+					ps60.PhiValues = make([]JITValueDesc, 1)
+					d61 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+					ps60.PhiValues[0] = d61
+					snap62 := d1
+					snap63 := d2
+					snap64 := d3
+					snap65 := d4
+					snap66 := d5
+					snap67 := d6
+					snap68 := d7
+					snap69 := d8
+					snap70 := d10
+					snap71 := d24
+					snap72 := d36
+					snap73 := d37
+					snap74 := d38
+					snap75 := d39
+					snap76 := d42
+					snap77 := d61
+					alloc78 := ctx.SnapshotAllocState()
 					if !bbs[4].Rendered {
-						bbs[4].RenderPS(ps54)
+						bbs[4].RenderPS(ps60)
 					}
-					ctx.RestoreAllocState(alloc70)
-					d1 = snap56
-					d2 = snap57
-					d3 = snap58
-					d4 = snap59
-					d5 = snap60
-					d6 = snap61
-					d7 = snap62
-					d9 = snap63
-					d22 = snap64
-					d33 = snap65
-					d34 = snap66
-					d35 = snap67
-					d38 = snap68
-					d55 = snap69
+					ctx.RestoreAllocState(alloc78)
+					d1 = snap62
+					d2 = snap63
+					d3 = snap64
+					d4 = snap65
+					d5 = snap66
+					d6 = snap67
+					d7 = snap68
+					d8 = snap69
+					d10 = snap70
+					d24 = snap71
+					d36 = snap72
+					d37 = snap73
+					d38 = snap74
+					d39 = snap75
+					d42 = snap76
+					d61 = snap77
 					if !bbs[5].Rendered {
-						return bbs[5].RenderPS(ps53)
+						return bbs[5].RenderPS(ps59)
 					}
 					return result
 					return result
@@ -6386,9 +6565,9 @@ func init_jit() {
 				bbs[2].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d71 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d71)
-							ctx.EmitStoreToStack(d71, int32(bbs[2].PhiBase)+int32(0))
+							d79 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d79)
+							ctx.EmitStoreToStack(d79, int32(bbs[2].PhiBase)+int32(0))
 						}
 						if bbs[2].VisitCount >= 0 {
 							ps.General = true
@@ -6431,53 +6610,61 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
-						d33 = ps.OverlayValues[33]
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
-					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
-						d34 = ps.OverlayValues[34]
+					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
+						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
-						d35 = ps.OverlayValues[35]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
 					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
 						d38 = ps.OverlayValues[38]
 					}
-					if len(ps.OverlayValues) > 55 && ps.OverlayValues[55].Loc != LocNone {
-						d55 = ps.OverlayValues[55]
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
+					}
+					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
+						d61 = ps.OverlayValues[61]
+					}
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
 						d1 = ps.PhiValues[0]
 					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.StabilizeDescForControlFlow(&d1)
-					ps72 := PhiState{General: ps.General}
-					ps72.OverlayValues = make([]JITValueDesc, 72)
-					ps72.OverlayValues[1] = d1
-					ps72.OverlayValues[2] = d2
-					ps72.OverlayValues[3] = d3
-					ps72.OverlayValues[4] = d4
-					ps72.OverlayValues[5] = d5
-					ps72.OverlayValues[6] = d6
-					ps72.OverlayValues[7] = d7
-					ps72.OverlayValues[9] = d9
-					ps72.OverlayValues[22] = d22
-					ps72.OverlayValues[33] = d33
-					ps72.OverlayValues[34] = d34
-					ps72.OverlayValues[35] = d35
-					ps72.OverlayValues[38] = d38
-					ps72.OverlayValues[55] = d55
-					ps72.OverlayValues[71] = d71
-					return bbs[7].RenderPS(ps72)
+					ps80 := PhiState{General: ps.General}
+					ps80.OverlayValues = make([]JITValueDesc, 80)
+					ps80.OverlayValues[1] = d1
+					ps80.OverlayValues[2] = d2
+					ps80.OverlayValues[3] = d3
+					ps80.OverlayValues[4] = d4
+					ps80.OverlayValues[5] = d5
+					ps80.OverlayValues[6] = d6
+					ps80.OverlayValues[7] = d7
+					ps80.OverlayValues[8] = d8
+					ps80.OverlayValues[10] = d10
+					ps80.OverlayValues[24] = d24
+					ps80.OverlayValues[36] = d36
+					ps80.OverlayValues[37] = d37
+					ps80.OverlayValues[38] = d38
+					ps80.OverlayValues[39] = d39
+					ps80.OverlayValues[42] = d42
+					ps80.OverlayValues[61] = d61
+					ps80.OverlayValues[79] = d79
+					return bbs[7].RenderPS(ps80)
 					return result
 				}
 				bbs[3].RenderPS = func(ps PhiState) JITValueDesc {
@@ -6523,104 +6710,112 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
-						d33 = ps.OverlayValues[33]
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
-					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
-						d34 = ps.OverlayValues[34]
+					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
+						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
-						d35 = ps.OverlayValues[35]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
 					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
 						d38 = ps.OverlayValues[38]
 					}
-					if len(ps.OverlayValues) > 55 && ps.OverlayValues[55].Loc != LocNone {
-						d55 = ps.OverlayValues[55]
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
+					}
+					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
+						d61 = ps.OverlayValues[61]
+					}
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					ctx.ReclaimUntrackedRegs()
 					d4 = JITPrepareScmerGoArg(ctx, d4)
 					ctx.SyncDesc(&d4)
-					d73 = ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d4}, 1)
-					d73.NoHeapPointer = false
-					ctx.BindReg(d73.Reg, &d73)
-					var d74 JITValueDesc
-					ctx.EnsureDesc(&d73)
-					if d73.Loc == LocImm {
-						fieldAddr := uintptr(d73.Imm.Int()) + 0
+					d81 = ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d4}, 1)
+					d81.NoHeapPointer = false
+					ctx.BindReg(d81.Reg, &d81)
+					var d82 JITValueDesc
+					ctx.EnsureDesc(&d81)
+					if d81.Loc == LocImm {
+						fieldAddr := uintptr(d81.Imm.Int()) + 0
 						r2 := ctx.AllocReg()
 						ctx.EmitMovRegMem64(r2, fieldAddr)
-						d74 = JITValueDesc{Loc: LocReg, Reg: r2}
-						ctx.BindReg(r2, &d74)
+						d82 = JITValueDesc{Loc: LocReg, Reg: r2}
+						ctx.BindReg(r2, &d82)
 					} else {
 						off := int32(0)
-						baseReg := d73.Reg
+						baseReg := d81.Reg
 						r3 := ctx.AllocRegExcept(baseReg)
 						ctx.EmitMovRegMem(r3, baseReg, off)
-						d74 = JITValueDesc{Loc: LocReg, Reg: r3}
-						ctx.BindReg(r3, &d74)
+						d82 = JITValueDesc{Loc: LocReg, Reg: r3}
+						ctx.BindReg(r3, &d82)
 					}
-					ctx.FreeDesc(&d73)
-					ctx.EnsureDesc(&d74)
-					var d75 JITValueDesc
-					if d74.Loc == LocImm {
-						d75 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d74.Imm.Int()) != uint64(0x0))}
+					ctx.FreeDesc(&d81)
+					ctx.EnsureDesc(&d82)
+					var d83 JITValueDesc
+					if d82.Loc == LocImm {
+						d83 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d82.Imm.Int()) != uint64(0x0))}
 					} else {
-						ctx.EmitCmpRegImm32(d74.Reg, 0)
-						r4 := ctx.AllocReg()
+						ctx.EmitCmpRegImm32(d82.Reg, 0)
+						r4 := ctx.AllocRegExcept(d82.Reg)
 						ctx.EmitSetcc(r4, CondNotEqual)
-						d75 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r4}
-						ctx.BindReg(r4, &d75)
+						d83 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r4}
+						ctx.BindReg(r4, &d83)
 					}
-					ctx.EnsureDesc(&d75)
-					ctx.EmitStoreToStack(d75, int32(bbs[4].PhiBase)+int32(0))
-					ctx.StabilizeDescForControlFlow(&d75)
-					ctx.FreeDesc(&d74)
+					ctx.EnsureDesc(&d83)
+					ctx.EmitStoreToStack(d83, int32(bbs[4].PhiBase)+int32(0))
+					ctx.StabilizeDescForControlFlow(&d83)
+					ctx.FreeDesc(&d82)
 					if ps.General {
 					}
-					ps76 := PhiState{General: ps.General}
-					ps76.OverlayValues = make([]JITValueDesc, 76)
-					ps76.OverlayValues[1] = d1
-					ps76.OverlayValues[2] = d2
-					ps76.OverlayValues[3] = d3
-					ps76.OverlayValues[4] = d4
-					ps76.OverlayValues[5] = d5
-					ps76.OverlayValues[6] = d6
-					ps76.OverlayValues[7] = d7
-					ps76.OverlayValues[9] = d9
-					ps76.OverlayValues[22] = d22
-					ps76.OverlayValues[33] = d33
-					ps76.OverlayValues[34] = d34
-					ps76.OverlayValues[35] = d35
-					ps76.OverlayValues[38] = d38
-					ps76.OverlayValues[55] = d55
-					ps76.OverlayValues[71] = d71
-					ps76.OverlayValues[73] = d73
-					ps76.OverlayValues[74] = d74
-					ps76.OverlayValues[75] = d75
-					ps76.PhiValues = make([]JITValueDesc, 1)
-					if ps76.General && bbs[4].Rendered {
+					ps84 := PhiState{General: ps.General}
+					ps84.OverlayValues = make([]JITValueDesc, 84)
+					ps84.OverlayValues[1] = d1
+					ps84.OverlayValues[2] = d2
+					ps84.OverlayValues[3] = d3
+					ps84.OverlayValues[4] = d4
+					ps84.OverlayValues[5] = d5
+					ps84.OverlayValues[6] = d6
+					ps84.OverlayValues[7] = d7
+					ps84.OverlayValues[8] = d8
+					ps84.OverlayValues[10] = d10
+					ps84.OverlayValues[24] = d24
+					ps84.OverlayValues[36] = d36
+					ps84.OverlayValues[37] = d37
+					ps84.OverlayValues[38] = d38
+					ps84.OverlayValues[39] = d39
+					ps84.OverlayValues[42] = d42
+					ps84.OverlayValues[61] = d61
+					ps84.OverlayValues[79] = d79
+					ps84.OverlayValues[81] = d81
+					ps84.OverlayValues[82] = d82
+					ps84.OverlayValues[83] = d83
+					ps84.PhiValues = make([]JITValueDesc, 1)
+					if ps84.General && bbs[4].Rendered {
 						ctx.EmitJmp(lbl5)
 						return result
 					}
-					return bbs[4].RenderPS(ps76)
+					return bbs[4].RenderPS(ps84)
 					return result
 				}
 				bbs[4].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d77 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d77)
-							ctx.EmitStoreToStack(d77, int32(bbs[4].PhiBase)+int32(0))
+							d85 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d85)
+							ctx.EmitStoreToStack(d85, int32(bbs[4].PhiBase)+int32(0))
 						}
 						if bbs[4].VisitCount >= 0 {
 							ps.General = true
@@ -6663,41 +6858,47 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
-						d33 = ps.OverlayValues[33]
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
-					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
-						d34 = ps.OverlayValues[34]
+					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
+						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
-						d35 = ps.OverlayValues[35]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
 					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
 						d38 = ps.OverlayValues[38]
 					}
-					if len(ps.OverlayValues) > 55 && ps.OverlayValues[55].Loc != LocNone {
-						d55 = ps.OverlayValues[55]
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
 					}
-					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
-						d73 = ps.OverlayValues[73]
+					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
+						d61 = ps.OverlayValues[61]
 					}
-					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
-						d74 = ps.OverlayValues[74]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
-					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
-						d75 = ps.OverlayValues[75]
+					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+						d81 = ps.OverlayValues[81]
 					}
-					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
-						d77 = ps.OverlayValues[77]
+					if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+						d82 = ps.OverlayValues[82]
+					}
+					if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+						d83 = ps.OverlayValues[83]
+					}
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
 						d2 = ps.PhiValues[0]
@@ -6706,55 +6907,57 @@ func init_jit() {
 					ctx.StabilizeDescForControlFlow(&d2)
 					if ps.General {
 						ctx.SyncDesc(&d2)
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.ProtectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.ProtectReg(d2.Reg)
 							ctx.ProtectReg(d2.Reg2)
 						}
-						d78 = d2
-						if d78.Loc == LocNone {
+						d86 = d2
+						if d86.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.EnsureDesc(&d78)
-						ctx.EmitStoreToStack(d78, int32(bbs[2].PhiBase)+int32(0))
-						if d2.Loc == LocReg {
+						ctx.EnsureDesc(&d86)
+						ctx.EmitStoreToStack(d86, int32(bbs[2].PhiBase)+int32(0))
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.UnprotectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.UnprotectReg(d2.Reg)
 							ctx.UnprotectReg(d2.Reg2)
 						}
 					}
-					ps79 := PhiState{General: ps.General}
-					ps79.OverlayValues = make([]JITValueDesc, 79)
-					ps79.OverlayValues[1] = d1
-					ps79.OverlayValues[2] = d2
-					ps79.OverlayValues[3] = d3
-					ps79.OverlayValues[4] = d4
-					ps79.OverlayValues[5] = d5
-					ps79.OverlayValues[6] = d6
-					ps79.OverlayValues[7] = d7
-					ps79.OverlayValues[9] = d9
-					ps79.OverlayValues[22] = d22
-					ps79.OverlayValues[33] = d33
-					ps79.OverlayValues[34] = d34
-					ps79.OverlayValues[35] = d35
-					ps79.OverlayValues[38] = d38
-					ps79.OverlayValues[55] = d55
-					ps79.OverlayValues[71] = d71
-					ps79.OverlayValues[73] = d73
-					ps79.OverlayValues[74] = d74
-					ps79.OverlayValues[75] = d75
-					ps79.OverlayValues[77] = d77
-					ps79.OverlayValues[78] = d78
-					ps79.PhiValues = make([]JITValueDesc, 1)
-					d80 = d2
-					ps79.PhiValues[0] = d80
-					if ps79.General && bbs[2].Rendered {
+					ps87 := PhiState{General: ps.General}
+					ps87.OverlayValues = make([]JITValueDesc, 87)
+					ps87.OverlayValues[1] = d1
+					ps87.OverlayValues[2] = d2
+					ps87.OverlayValues[3] = d3
+					ps87.OverlayValues[4] = d4
+					ps87.OverlayValues[5] = d5
+					ps87.OverlayValues[6] = d6
+					ps87.OverlayValues[7] = d7
+					ps87.OverlayValues[8] = d8
+					ps87.OverlayValues[10] = d10
+					ps87.OverlayValues[24] = d24
+					ps87.OverlayValues[36] = d36
+					ps87.OverlayValues[37] = d37
+					ps87.OverlayValues[38] = d38
+					ps87.OverlayValues[39] = d39
+					ps87.OverlayValues[42] = d42
+					ps87.OverlayValues[61] = d61
+					ps87.OverlayValues[79] = d79
+					ps87.OverlayValues[81] = d81
+					ps87.OverlayValues[82] = d82
+					ps87.OverlayValues[83] = d83
+					ps87.OverlayValues[85] = d85
+					ps87.OverlayValues[86] = d86
+					ps87.PhiValues = make([]JITValueDesc, 1)
+					d88 = d2
+					ps87.PhiValues[0] = d88
+					if ps87.General && bbs[2].Rendered {
 						ctx.EmitJmp(lbl3)
 						return result
 					}
-					return bbs[2].RenderPS(ps79)
+					return bbs[2].RenderPS(ps87)
 					return result
 				}
 				bbs[5].RenderPS = func(ps PhiState) JITValueDesc {
@@ -6800,349 +7003,373 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
-						d33 = ps.OverlayValues[33]
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
-					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
-						d34 = ps.OverlayValues[34]
+					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
+						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
-						d35 = ps.OverlayValues[35]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
 					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
 						d38 = ps.OverlayValues[38]
 					}
-					if len(ps.OverlayValues) > 55 && ps.OverlayValues[55].Loc != LocNone {
-						d55 = ps.OverlayValues[55]
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
 					}
-					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
-						d73 = ps.OverlayValues[73]
+					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
+						d61 = ps.OverlayValues[61]
 					}
-					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
-						d74 = ps.OverlayValues[74]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
-					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
-						d75 = ps.OverlayValues[75]
+					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+						d81 = ps.OverlayValues[81]
 					}
-					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
-						d77 = ps.OverlayValues[77]
+					if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+						d82 = ps.OverlayValues[82]
 					}
-					if len(ps.OverlayValues) > 78 && ps.OverlayValues[78].Loc != LocNone {
-						d78 = ps.OverlayValues[78]
+					if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
+						d83 = ps.OverlayValues[83]
 					}
-					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
-						d80 = ps.OverlayValues[80]
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
+					}
+					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
+						d86 = ps.OverlayValues[86]
+					}
+					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
+						d88 = ps.OverlayValues[88]
 					}
 					ctx.ReclaimUntrackedRegs()
 					d4 = JITPrepareScmerGoArg(ctx, d4)
 					ctx.SyncDesc(&d4)
-					d81 = ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d4}, 1)
-					d81.NoHeapPointer = false
-					ctx.BindReg(d81.Reg, &d81)
-					ctx.EnsureDesc(&d81)
-					var d82 JITValueDesc
-					if d81.Loc == LocImm {
-						d82 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d81.Imm.IsNil() != true)}
+					d89 = ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d4}, 1)
+					d89.NoHeapPointer = false
+					ctx.BindReg(d89.Reg, &d89)
+					ctx.EnsureDesc(&d89)
+					var d90 JITValueDesc
+					if d89.Loc == LocImm {
+						d90 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d89.Imm.IsNil() != true)}
 					} else {
-						ctx.EnsureDesc(&d81)
-						if d81.Loc != LocReg && d81.Loc != LocRegPair && d81.Loc != LocRegTriple {
+						ctx.EnsureDesc(&d89)
+						if d89.Loc != LocReg && d89.Loc != LocRegPair && d89.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r5 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d81.Reg, 0)
+						r5 := ctx.AllocRegExcept(d89.Reg)
+						ctx.EmitCmpRegImm32(d89.Reg, 0)
 						ctx.EmitSetcc(r5, CondNotEqual)
-						d82 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r5}
-						ctx.BindReg(r5, &d82)
+						d90 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r5}
+						ctx.BindReg(r5, &d90)
 					}
-					ctx.FreeDesc(&d81)
-					d83 = d82
-					ctx.EnsureDesc(&d83)
-					if d83.Loc != LocImm && d83.Loc != LocReg {
+					ctx.FreeDesc(&d89)
+					d91 = d90
+					ctx.EnsureDesc(&d91)
+					if d91.Loc != LocImm && d91.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d83.Loc == LocImm {
-						if d83.Imm.Bool() {
+					if d91.Loc == LocImm {
+						if d91.Imm.Bool() {
 							if ps.General {
 							}
-							ps84 := PhiState{General: ps.General}
-							ps84.OverlayValues = make([]JITValueDesc, 84)
-							ps84.OverlayValues[1] = d1
-							ps84.OverlayValues[2] = d2
-							ps84.OverlayValues[3] = d3
-							ps84.OverlayValues[4] = d4
-							ps84.OverlayValues[5] = d5
-							ps84.OverlayValues[6] = d6
-							ps84.OverlayValues[7] = d7
-							ps84.OverlayValues[9] = d9
-							ps84.OverlayValues[22] = d22
-							ps84.OverlayValues[33] = d33
-							ps84.OverlayValues[34] = d34
-							ps84.OverlayValues[35] = d35
-							ps84.OverlayValues[38] = d38
-							ps84.OverlayValues[55] = d55
-							ps84.OverlayValues[71] = d71
-							ps84.OverlayValues[73] = d73
-							ps84.OverlayValues[74] = d74
-							ps84.OverlayValues[75] = d75
-							ps84.OverlayValues[77] = d77
-							ps84.OverlayValues[78] = d78
-							ps84.OverlayValues[80] = d80
-							ps84.OverlayValues[81] = d81
-							ps84.OverlayValues[82] = d82
-							ps84.OverlayValues[83] = d83
-							return bbs[3].RenderPS(ps84)
+							ps92 := PhiState{General: ps.General}
+							ps92.OverlayValues = make([]JITValueDesc, 92)
+							ps92.OverlayValues[1] = d1
+							ps92.OverlayValues[2] = d2
+							ps92.OverlayValues[3] = d3
+							ps92.OverlayValues[4] = d4
+							ps92.OverlayValues[5] = d5
+							ps92.OverlayValues[6] = d6
+							ps92.OverlayValues[7] = d7
+							ps92.OverlayValues[8] = d8
+							ps92.OverlayValues[10] = d10
+							ps92.OverlayValues[24] = d24
+							ps92.OverlayValues[36] = d36
+							ps92.OverlayValues[37] = d37
+							ps92.OverlayValues[38] = d38
+							ps92.OverlayValues[39] = d39
+							ps92.OverlayValues[42] = d42
+							ps92.OverlayValues[61] = d61
+							ps92.OverlayValues[79] = d79
+							ps92.OverlayValues[81] = d81
+							ps92.OverlayValues[82] = d82
+							ps92.OverlayValues[83] = d83
+							ps92.OverlayValues[85] = d85
+							ps92.OverlayValues[86] = d86
+							ps92.OverlayValues[88] = d88
+							ps92.OverlayValues[89] = d89
+							ps92.OverlayValues[90] = d90
+							ps92.OverlayValues[91] = d91
+							return bbs[3].RenderPS(ps92)
 						}
 						if ps.General {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(0))
 						}
-						ps85 := PhiState{General: ps.General}
-						ps85.OverlayValues = make([]JITValueDesc, 84)
-						ps85.OverlayValues[1] = d1
-						ps85.OverlayValues[2] = d2
-						ps85.OverlayValues[3] = d3
-						ps85.OverlayValues[4] = d4
-						ps85.OverlayValues[5] = d5
-						ps85.OverlayValues[6] = d6
-						ps85.OverlayValues[7] = d7
-						ps85.OverlayValues[9] = d9
-						ps85.OverlayValues[22] = d22
-						ps85.OverlayValues[33] = d33
-						ps85.OverlayValues[34] = d34
-						ps85.OverlayValues[35] = d35
-						ps85.OverlayValues[38] = d38
-						ps85.OverlayValues[55] = d55
-						ps85.OverlayValues[71] = d71
-						ps85.OverlayValues[73] = d73
-						ps85.OverlayValues[74] = d74
-						ps85.OverlayValues[75] = d75
-						ps85.OverlayValues[77] = d77
-						ps85.OverlayValues[78] = d78
-						ps85.OverlayValues[80] = d80
-						ps85.OverlayValues[81] = d81
-						ps85.OverlayValues[82] = d82
-						ps85.OverlayValues[83] = d83
-						ps85.PhiValues = make([]JITValueDesc, 1)
-						d86 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
-						ps85.PhiValues[0] = d86
-						return bbs[4].RenderPS(ps85)
+						ps93 := PhiState{General: ps.General}
+						ps93.OverlayValues = make([]JITValueDesc, 92)
+						ps93.OverlayValues[1] = d1
+						ps93.OverlayValues[2] = d2
+						ps93.OverlayValues[3] = d3
+						ps93.OverlayValues[4] = d4
+						ps93.OverlayValues[5] = d5
+						ps93.OverlayValues[6] = d6
+						ps93.OverlayValues[7] = d7
+						ps93.OverlayValues[8] = d8
+						ps93.OverlayValues[10] = d10
+						ps93.OverlayValues[24] = d24
+						ps93.OverlayValues[36] = d36
+						ps93.OverlayValues[37] = d37
+						ps93.OverlayValues[38] = d38
+						ps93.OverlayValues[39] = d39
+						ps93.OverlayValues[42] = d42
+						ps93.OverlayValues[61] = d61
+						ps93.OverlayValues[79] = d79
+						ps93.OverlayValues[81] = d81
+						ps93.OverlayValues[82] = d82
+						ps93.OverlayValues[83] = d83
+						ps93.OverlayValues[85] = d85
+						ps93.OverlayValues[86] = d86
+						ps93.OverlayValues[88] = d88
+						ps93.OverlayValues[89] = d89
+						ps93.OverlayValues[90] = d90
+						ps93.OverlayValues[91] = d91
+						ps93.PhiValues = make([]JITValueDesc, 1)
+						d94 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+						ps93.PhiValues[0] = d94
+						return bbs[4].RenderPS(ps93)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[5].RenderPS(ps)
 					}
 					lbl14 := ctx.ReserveLabel()
-					ctx.EmitCmpRegImm32(d83.Reg, 0)
+					ctx.EmitCmpRegImm32(d91.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl4)
 					ctx.EmitJmp(lbl14)
-					snap87 := d1
-					snap88 := d2
-					snap89 := d3
-					snap90 := d4
-					snap91 := d5
-					snap92 := d6
-					snap93 := d7
-					snap94 := d9
-					snap95 := d22
-					snap96 := d33
-					snap97 := d34
-					snap98 := d35
-					snap99 := d38
-					snap100 := d55
-					snap101 := d71
-					snap102 := d73
-					snap103 := d74
-					snap104 := d75
-					snap105 := d77
-					snap106 := d78
-					snap107 := d80
-					snap108 := d81
-					snap109 := d82
-					snap110 := d83
-					snap111 := d86
-					alloc112 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc112)
-					d1 = snap87
-					d2 = snap88
-					d3 = snap89
-					d4 = snap90
-					d5 = snap91
-					d6 = snap92
-					d7 = snap93
-					d9 = snap94
-					d22 = snap95
-					d33 = snap96
-					d34 = snap97
-					d35 = snap98
-					d38 = snap99
-					d55 = snap100
-					d71 = snap101
-					d73 = snap102
-					d74 = snap103
-					d75 = snap104
-					d77 = snap105
-					d78 = snap106
-					d80 = snap107
-					d81 = snap108
-					d82 = snap109
-					d83 = snap110
-					d86 = snap111
+					snap95 := d1
+					snap96 := d2
+					snap97 := d3
+					snap98 := d4
+					snap99 := d5
+					snap100 := d6
+					snap101 := d7
+					snap102 := d8
+					snap103 := d10
+					snap104 := d24
+					snap105 := d36
+					snap106 := d37
+					snap107 := d38
+					snap108 := d39
+					snap109 := d42
+					snap110 := d61
+					snap111 := d79
+					snap112 := d81
+					snap113 := d82
+					snap114 := d83
+					snap115 := d85
+					snap116 := d86
+					snap117 := d88
+					snap118 := d89
+					snap119 := d90
+					snap120 := d91
+					snap121 := d94
+					alloc122 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc122)
+					d1 = snap95
+					d2 = snap96
+					d3 = snap97
+					d4 = snap98
+					d5 = snap99
+					d6 = snap100
+					d7 = snap101
+					d8 = snap102
+					d10 = snap103
+					d24 = snap104
+					d36 = snap105
+					d37 = snap106
+					d38 = snap107
+					d39 = snap108
+					d42 = snap109
+					d61 = snap110
+					d79 = snap111
+					d81 = snap112
+					d82 = snap113
+					d83 = snap114
+					d85 = snap115
+					d86 = snap116
+					d88 = snap117
+					d89 = snap118
+					d90 = snap119
+					d91 = snap120
+					d94 = snap121
 					ctx.MarkLabel(lbl14)
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(0))
 					ctx.EmitJmp(lbl5)
-					ctx.RestoreAllocState(alloc112)
-					d1 = snap87
-					d2 = snap88
-					d3 = snap89
-					d4 = snap90
-					d5 = snap91
-					d6 = snap92
-					d7 = snap93
-					d9 = snap94
-					d22 = snap95
-					d33 = snap96
-					d34 = snap97
-					d35 = snap98
-					d38 = snap99
-					d55 = snap100
-					d71 = snap101
-					d73 = snap102
-					d74 = snap103
-					d75 = snap104
-					d77 = snap105
-					d78 = snap106
-					d80 = snap107
-					d81 = snap108
-					d82 = snap109
-					d83 = snap110
-					d86 = snap111
-					ps113 := PhiState{General: true}
-					ps113.OverlayValues = make([]JITValueDesc, 87)
-					ps113.OverlayValues[1] = d1
-					ps113.OverlayValues[2] = d2
-					ps113.OverlayValues[3] = d3
-					ps113.OverlayValues[4] = d4
-					ps113.OverlayValues[5] = d5
-					ps113.OverlayValues[6] = d6
-					ps113.OverlayValues[7] = d7
-					ps113.OverlayValues[9] = d9
-					ps113.OverlayValues[22] = d22
-					ps113.OverlayValues[33] = d33
-					ps113.OverlayValues[34] = d34
-					ps113.OverlayValues[35] = d35
-					ps113.OverlayValues[38] = d38
-					ps113.OverlayValues[55] = d55
-					ps113.OverlayValues[71] = d71
-					ps113.OverlayValues[73] = d73
-					ps113.OverlayValues[74] = d74
-					ps113.OverlayValues[75] = d75
-					ps113.OverlayValues[77] = d77
-					ps113.OverlayValues[78] = d78
-					ps113.OverlayValues[80] = d80
-					ps113.OverlayValues[81] = d81
-					ps113.OverlayValues[82] = d82
-					ps113.OverlayValues[83] = d83
-					ps113.OverlayValues[86] = d86
-					ps114 := PhiState{General: true}
-					ps114.OverlayValues = make([]JITValueDesc, 87)
-					ps114.OverlayValues[1] = d1
-					ps114.OverlayValues[2] = d2
-					ps114.OverlayValues[3] = d3
-					ps114.OverlayValues[4] = d4
-					ps114.OverlayValues[5] = d5
-					ps114.OverlayValues[6] = d6
-					ps114.OverlayValues[7] = d7
-					ps114.OverlayValues[9] = d9
-					ps114.OverlayValues[22] = d22
-					ps114.OverlayValues[33] = d33
-					ps114.OverlayValues[34] = d34
-					ps114.OverlayValues[35] = d35
-					ps114.OverlayValues[38] = d38
-					ps114.OverlayValues[55] = d55
-					ps114.OverlayValues[71] = d71
-					ps114.OverlayValues[73] = d73
-					ps114.OverlayValues[74] = d74
-					ps114.OverlayValues[75] = d75
-					ps114.OverlayValues[77] = d77
-					ps114.OverlayValues[78] = d78
-					ps114.OverlayValues[80] = d80
-					ps114.OverlayValues[81] = d81
-					ps114.OverlayValues[82] = d82
-					ps114.OverlayValues[83] = d83
-					ps114.OverlayValues[86] = d86
-					ps114.PhiValues = make([]JITValueDesc, 1)
-					d115 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
-					ps114.PhiValues[0] = d115
-					snap116 := d1
-					snap117 := d2
-					snap118 := d3
-					snap119 := d4
-					snap120 := d5
-					snap121 := d6
-					snap122 := d7
-					snap123 := d9
-					snap124 := d22
-					snap125 := d33
-					snap126 := d34
-					snap127 := d35
-					snap128 := d38
-					snap129 := d55
-					snap130 := d71
-					snap131 := d73
-					snap132 := d74
-					snap133 := d75
-					snap134 := d77
-					snap135 := d78
-					snap136 := d80
-					snap137 := d81
-					snap138 := d82
-					snap139 := d83
-					snap140 := d86
-					snap141 := d115
-					alloc142 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc122)
+					d1 = snap95
+					d2 = snap96
+					d3 = snap97
+					d4 = snap98
+					d5 = snap99
+					d6 = snap100
+					d7 = snap101
+					d8 = snap102
+					d10 = snap103
+					d24 = snap104
+					d36 = snap105
+					d37 = snap106
+					d38 = snap107
+					d39 = snap108
+					d42 = snap109
+					d61 = snap110
+					d79 = snap111
+					d81 = snap112
+					d82 = snap113
+					d83 = snap114
+					d85 = snap115
+					d86 = snap116
+					d88 = snap117
+					d89 = snap118
+					d90 = snap119
+					d91 = snap120
+					d94 = snap121
+					ps123 := PhiState{General: true}
+					ps123.OverlayValues = make([]JITValueDesc, 95)
+					ps123.OverlayValues[1] = d1
+					ps123.OverlayValues[2] = d2
+					ps123.OverlayValues[3] = d3
+					ps123.OverlayValues[4] = d4
+					ps123.OverlayValues[5] = d5
+					ps123.OverlayValues[6] = d6
+					ps123.OverlayValues[7] = d7
+					ps123.OverlayValues[8] = d8
+					ps123.OverlayValues[10] = d10
+					ps123.OverlayValues[24] = d24
+					ps123.OverlayValues[36] = d36
+					ps123.OverlayValues[37] = d37
+					ps123.OverlayValues[38] = d38
+					ps123.OverlayValues[39] = d39
+					ps123.OverlayValues[42] = d42
+					ps123.OverlayValues[61] = d61
+					ps123.OverlayValues[79] = d79
+					ps123.OverlayValues[81] = d81
+					ps123.OverlayValues[82] = d82
+					ps123.OverlayValues[83] = d83
+					ps123.OverlayValues[85] = d85
+					ps123.OverlayValues[86] = d86
+					ps123.OverlayValues[88] = d88
+					ps123.OverlayValues[89] = d89
+					ps123.OverlayValues[90] = d90
+					ps123.OverlayValues[91] = d91
+					ps123.OverlayValues[94] = d94
+					ps124 := PhiState{General: true}
+					ps124.OverlayValues = make([]JITValueDesc, 95)
+					ps124.OverlayValues[1] = d1
+					ps124.OverlayValues[2] = d2
+					ps124.OverlayValues[3] = d3
+					ps124.OverlayValues[4] = d4
+					ps124.OverlayValues[5] = d5
+					ps124.OverlayValues[6] = d6
+					ps124.OverlayValues[7] = d7
+					ps124.OverlayValues[8] = d8
+					ps124.OverlayValues[10] = d10
+					ps124.OverlayValues[24] = d24
+					ps124.OverlayValues[36] = d36
+					ps124.OverlayValues[37] = d37
+					ps124.OverlayValues[38] = d38
+					ps124.OverlayValues[39] = d39
+					ps124.OverlayValues[42] = d42
+					ps124.OverlayValues[61] = d61
+					ps124.OverlayValues[79] = d79
+					ps124.OverlayValues[81] = d81
+					ps124.OverlayValues[82] = d82
+					ps124.OverlayValues[83] = d83
+					ps124.OverlayValues[85] = d85
+					ps124.OverlayValues[86] = d86
+					ps124.OverlayValues[88] = d88
+					ps124.OverlayValues[89] = d89
+					ps124.OverlayValues[90] = d90
+					ps124.OverlayValues[91] = d91
+					ps124.OverlayValues[94] = d94
+					ps124.PhiValues = make([]JITValueDesc, 1)
+					d125 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+					ps124.PhiValues[0] = d125
+					snap126 := d1
+					snap127 := d2
+					snap128 := d3
+					snap129 := d4
+					snap130 := d5
+					snap131 := d6
+					snap132 := d7
+					snap133 := d8
+					snap134 := d10
+					snap135 := d24
+					snap136 := d36
+					snap137 := d37
+					snap138 := d38
+					snap139 := d39
+					snap140 := d42
+					snap141 := d61
+					snap142 := d79
+					snap143 := d81
+					snap144 := d82
+					snap145 := d83
+					snap146 := d85
+					snap147 := d86
+					snap148 := d88
+					snap149 := d89
+					snap150 := d90
+					snap151 := d91
+					snap152 := d94
+					snap153 := d125
+					alloc154 := ctx.SnapshotAllocState()
 					if !bbs[4].Rendered {
-						bbs[4].RenderPS(ps114)
+						bbs[4].RenderPS(ps124)
 					}
-					ctx.RestoreAllocState(alloc142)
-					d1 = snap116
-					d2 = snap117
-					d3 = snap118
-					d4 = snap119
-					d5 = snap120
-					d6 = snap121
-					d7 = snap122
-					d9 = snap123
-					d22 = snap124
-					d33 = snap125
-					d34 = snap126
-					d35 = snap127
-					d38 = snap128
-					d55 = snap129
-					d71 = snap130
-					d73 = snap131
-					d74 = snap132
-					d75 = snap133
-					d77 = snap134
-					d78 = snap135
-					d80 = snap136
-					d81 = snap137
-					d82 = snap138
-					d83 = snap139
-					d86 = snap140
-					d115 = snap141
+					ctx.RestoreAllocState(alloc154)
+					d1 = snap126
+					d2 = snap127
+					d3 = snap128
+					d4 = snap129
+					d5 = snap130
+					d6 = snap131
+					d7 = snap132
+					d8 = snap133
+					d10 = snap134
+					d24 = snap135
+					d36 = snap136
+					d37 = snap137
+					d38 = snap138
+					d39 = snap139
+					d42 = snap140
+					d61 = snap141
+					d79 = snap142
+					d81 = snap143
+					d82 = snap144
+					d83 = snap145
+					d85 = snap146
+					d86 = snap147
+					d88 = snap148
+					d89 = snap149
+					d90 = snap150
+					d91 = snap151
+					d94 = snap152
+					d125 = snap153
 					if !bbs[3].Rendered {
-						return bbs[3].RenderPS(ps113)
+						return bbs[3].RenderPS(ps123)
 					}
 					return result
-					ctx.FreeDesc(&d82)
+					ctx.FreeDesc(&d90)
 					return result
 				}
 				bbs[6].RenderPS = func(ps PhiState) JITValueDesc {
@@ -7188,47 +7415,35 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
-						d33 = ps.OverlayValues[33]
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
-					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
-						d34 = ps.OverlayValues[34]
+					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
+						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
-						d35 = ps.OverlayValues[35]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
 					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
 						d38 = ps.OverlayValues[38]
 					}
-					if len(ps.OverlayValues) > 55 && ps.OverlayValues[55].Loc != LocNone {
-						d55 = ps.OverlayValues[55]
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
 					}
-					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
-						d73 = ps.OverlayValues[73]
+					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
+						d61 = ps.OverlayValues[61]
 					}
-					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
-						d74 = ps.OverlayValues[74]
-					}
-					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
-						d75 = ps.OverlayValues[75]
-					}
-					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
-						d77 = ps.OverlayValues[77]
-					}
-					if len(ps.OverlayValues) > 78 && ps.OverlayValues[78].Loc != LocNone {
-						d78 = ps.OverlayValues[78]
-					}
-					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
-						d80 = ps.OverlayValues[80]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
 						d81 = ps.OverlayValues[81]
@@ -7239,446 +7454,482 @@ func init_jit() {
 					if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
 						d83 = ps.OverlayValues[83]
 					}
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
+					}
 					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
 						d86 = ps.OverlayValues[86]
 					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
+					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
+						d88 = ps.OverlayValues[88]
+					}
+					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
+						d89 = ps.OverlayValues[89]
+					}
+					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
+						d90 = ps.OverlayValues[90]
+					}
+					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
+						d91 = ps.OverlayValues[91]
+					}
+					if len(ps.OverlayValues) > 94 && ps.OverlayValues[94].Loc != LocNone {
+						d94 = ps.OverlayValues[94]
+					}
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
 					ctx.ReclaimUntrackedRegs()
 					d4 = JITPrepareScmerGoArg(ctx, d4)
-					d143 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(unsafe.Pointer(&Globalenv)))), NoHeapPointer: true, Rooted: true}
-					if d143.Loc == LocRegPair || d143.Loc == LocStackPair || d143.Loc == LocRegTriple || d143.Loc == LocStackTriple {
+					d155 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(unsafe.Pointer(&Globalenv)))), NoHeapPointer: true, Rooted: true}
+					if d155.Loc == LocRegPair || d155.Loc == LocStackPair || d155.Loc == LocRegTriple || d155.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
 					ctx.SyncDesc(&d4)
-					ctx.SyncDesc(&d143)
-					d144 = ctx.EmitGoCallScalar(GoFuncAddr(SerializeToString), []JITValueDesc{d4, d143}, 2)
-					d144.NoHeapPointer = false
-					ctx.BindReg(d144.Reg, &d144)
-					ctx.BindReg(d144.Reg2, &d144)
-					ctx.StabilizeDescForControlFlow(&d144)
-					d145 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
-					ctx.EnsureDesc(&d145)
-					var d146 JITValueDesc
-					if d145.Loc == LocImm {
-						d146 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d145.Imm.Int() > 1)}
+					ctx.SyncDesc(&d155)
+					d156 = ctx.EmitGoCallScalar(GoFuncAddr(SerializeToString), []JITValueDesc{d4, d155}, 2)
+					d156.NoHeapPointer = false
+					ctx.BindReg(d156.Reg, &d156)
+					ctx.BindReg(d156.Reg2, &d156)
+					ctx.StabilizeDescForControlFlow(&d156)
+					d157 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
+					ctx.EnsureDesc(&d157)
+					var d158 JITValueDesc
+					if d157.Loc == LocImm {
+						d158 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d157.Imm.Int() > 1)}
 					} else {
 						r6 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d145.Reg, 1)
-						d146 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r6, Condition: CondSignedGreater}
-						ctx.BindReg(r6, &d146)
+						ctx.EmitCmpRegImm32(d157.Reg, 1)
+						d158 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r6, Condition: CondSignedGreater}
+						ctx.BindReg(r6, &d158)
 					}
-					ctx.FreeDesc(&d145)
-					d147 = d146
-					ctx.EnsureDesc(&d147)
-					if d147.Loc != LocImm && d147.Loc != LocFlags {
+					ctx.FreeDesc(&d157)
+					d159 = d158
+					ctx.EnsureDesc(&d159)
+					if d159.Loc != LocImm && d159.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d147.Loc == LocImm {
-						if d147.Imm.Bool() {
+					if d159.Loc == LocImm {
+						if d159.Imm.Bool() {
 							if ps.General {
 							}
-							ps148 := PhiState{General: ps.General}
-							ps148.OverlayValues = make([]JITValueDesc, 148)
-							ps148.OverlayValues[1] = d1
-							ps148.OverlayValues[2] = d2
-							ps148.OverlayValues[3] = d3
-							ps148.OverlayValues[4] = d4
-							ps148.OverlayValues[5] = d5
-							ps148.OverlayValues[6] = d6
-							ps148.OverlayValues[7] = d7
-							ps148.OverlayValues[9] = d9
-							ps148.OverlayValues[22] = d22
-							ps148.OverlayValues[33] = d33
-							ps148.OverlayValues[34] = d34
-							ps148.OverlayValues[35] = d35
-							ps148.OverlayValues[38] = d38
-							ps148.OverlayValues[55] = d55
-							ps148.OverlayValues[71] = d71
-							ps148.OverlayValues[73] = d73
-							ps148.OverlayValues[74] = d74
-							ps148.OverlayValues[75] = d75
-							ps148.OverlayValues[77] = d77
-							ps148.OverlayValues[78] = d78
-							ps148.OverlayValues[80] = d80
-							ps148.OverlayValues[81] = d81
-							ps148.OverlayValues[82] = d82
-							ps148.OverlayValues[83] = d83
-							ps148.OverlayValues[86] = d86
-							ps148.OverlayValues[115] = d115
-							ps148.OverlayValues[143] = d143
-							ps148.OverlayValues[144] = d144
-							ps148.OverlayValues[145] = d145
-							ps148.OverlayValues[146] = d146
-							ps148.OverlayValues[147] = d147
-							return bbs[9].RenderPS(ps148)
+							ps160 := PhiState{General: ps.General}
+							ps160.OverlayValues = make([]JITValueDesc, 160)
+							ps160.OverlayValues[1] = d1
+							ps160.OverlayValues[2] = d2
+							ps160.OverlayValues[3] = d3
+							ps160.OverlayValues[4] = d4
+							ps160.OverlayValues[5] = d5
+							ps160.OverlayValues[6] = d6
+							ps160.OverlayValues[7] = d7
+							ps160.OverlayValues[8] = d8
+							ps160.OverlayValues[10] = d10
+							ps160.OverlayValues[24] = d24
+							ps160.OverlayValues[36] = d36
+							ps160.OverlayValues[37] = d37
+							ps160.OverlayValues[38] = d38
+							ps160.OverlayValues[39] = d39
+							ps160.OverlayValues[42] = d42
+							ps160.OverlayValues[61] = d61
+							ps160.OverlayValues[79] = d79
+							ps160.OverlayValues[81] = d81
+							ps160.OverlayValues[82] = d82
+							ps160.OverlayValues[83] = d83
+							ps160.OverlayValues[85] = d85
+							ps160.OverlayValues[86] = d86
+							ps160.OverlayValues[88] = d88
+							ps160.OverlayValues[89] = d89
+							ps160.OverlayValues[90] = d90
+							ps160.OverlayValues[91] = d91
+							ps160.OverlayValues[94] = d94
+							ps160.OverlayValues[125] = d125
+							ps160.OverlayValues[155] = d155
+							ps160.OverlayValues[156] = d156
+							ps160.OverlayValues[157] = d157
+							ps160.OverlayValues[158] = d158
+							ps160.OverlayValues[159] = d159
+							return bbs[9].RenderPS(ps160)
 						}
 						if ps.General {
-							ctx.SyncDesc(&d144)
-							if d144.Loc == LocReg {
-								ctx.ProtectReg(d144.Reg)
-							} else if d144.Loc == LocRegPair {
-								ctx.ProtectReg(d144.Reg)
-								ctx.ProtectReg(d144.Reg2)
+							ctx.SyncDesc(&d156)
+							if d156.Loc == LocReg || d156.Loc == LocFPReg {
+								ctx.ProtectReg(d156.Reg)
+							} else if d156.Loc == LocRegPair {
+								ctx.ProtectReg(d156.Reg)
+								ctx.ProtectReg(d156.Reg2)
 							}
-							d149 = d144
-							if d149.Loc == LocNone {
+							d161 = d156
+							if d161.Loc == LocNone {
 								panic("jit: phi source has no location")
 							}
-							ctx.SyncDesc(&d149)
-							if d149.Loc == LocStackPair {
-								ctx.EmitCopyStackWords(d149, int32(bbs[10].PhiBase)+int32(0), 2)
-							} else if d149.Loc == LocInputPair {
-								ctx.EnsureDesc(&d149)
-								ctx.EmitStoreScmerToStack(d149, int32(bbs[10].PhiBase)+int32(0))
-							} else if d149.Loc == LocRegPair || d149.Loc == LocImm {
-								ctx.EmitStoreScmerToStack(d149, int32(bbs[10].PhiBase)+int32(0))
+							ctx.SyncDesc(&d161)
+							if d161.Loc == LocStackPair {
+								ctx.EmitCopyStackWords(d161, int32(bbs[10].PhiBase)+int32(0), 2)
+							} else if d161.Loc == LocInputPair {
+								ctx.EnsureDesc(&d161)
+								ctx.EmitStoreScmerToStack(d161, int32(bbs[10].PhiBase)+int32(0))
+							} else if d161.Loc == LocRegPair || d161.Loc == LocImm {
+								ctx.EmitStoreScmerToStack(d161, int32(bbs[10].PhiBase)+int32(0))
 							} else {
-								ctx.EnsureDesc(&d149)
-								ctx.EmitStoreToStack(d149, int32(bbs[10].PhiBase)+int32(0))
+								ctx.EnsureDesc(&d161)
+								ctx.EmitStoreToStack(d161, int32(bbs[10].PhiBase)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[10].PhiBase)+int32(0))+8)
 							}
-							if d144.Loc == LocReg {
-								ctx.UnprotectReg(d144.Reg)
-							} else if d144.Loc == LocRegPair {
-								ctx.UnprotectReg(d144.Reg)
-								ctx.UnprotectReg(d144.Reg2)
+							if d156.Loc == LocReg || d156.Loc == LocFPReg {
+								ctx.UnprotectReg(d156.Reg)
+							} else if d156.Loc == LocRegPair {
+								ctx.UnprotectReg(d156.Reg)
+								ctx.UnprotectReg(d156.Reg2)
 							}
 						}
-						ps150 := PhiState{General: ps.General}
-						ps150.OverlayValues = make([]JITValueDesc, 150)
-						ps150.OverlayValues[1] = d1
-						ps150.OverlayValues[2] = d2
-						ps150.OverlayValues[3] = d3
-						ps150.OverlayValues[4] = d4
-						ps150.OverlayValues[5] = d5
-						ps150.OverlayValues[6] = d6
-						ps150.OverlayValues[7] = d7
-						ps150.OverlayValues[9] = d9
-						ps150.OverlayValues[22] = d22
-						ps150.OverlayValues[33] = d33
-						ps150.OverlayValues[34] = d34
-						ps150.OverlayValues[35] = d35
-						ps150.OverlayValues[38] = d38
-						ps150.OverlayValues[55] = d55
-						ps150.OverlayValues[71] = d71
-						ps150.OverlayValues[73] = d73
-						ps150.OverlayValues[74] = d74
-						ps150.OverlayValues[75] = d75
-						ps150.OverlayValues[77] = d77
-						ps150.OverlayValues[78] = d78
-						ps150.OverlayValues[80] = d80
-						ps150.OverlayValues[81] = d81
-						ps150.OverlayValues[82] = d82
-						ps150.OverlayValues[83] = d83
-						ps150.OverlayValues[86] = d86
-						ps150.OverlayValues[115] = d115
-						ps150.OverlayValues[143] = d143
-						ps150.OverlayValues[144] = d144
-						ps150.OverlayValues[145] = d145
-						ps150.OverlayValues[146] = d146
-						ps150.OverlayValues[147] = d147
-						ps150.OverlayValues[149] = d149
-						ps150.PhiValues = make([]JITValueDesc, 1)
-						d151 = d144
-						ps150.PhiValues[0] = d151
-						return bbs[10].RenderPS(ps150)
+						ps162 := PhiState{General: ps.General}
+						ps162.OverlayValues = make([]JITValueDesc, 162)
+						ps162.OverlayValues[1] = d1
+						ps162.OverlayValues[2] = d2
+						ps162.OverlayValues[3] = d3
+						ps162.OverlayValues[4] = d4
+						ps162.OverlayValues[5] = d5
+						ps162.OverlayValues[6] = d6
+						ps162.OverlayValues[7] = d7
+						ps162.OverlayValues[8] = d8
+						ps162.OverlayValues[10] = d10
+						ps162.OverlayValues[24] = d24
+						ps162.OverlayValues[36] = d36
+						ps162.OverlayValues[37] = d37
+						ps162.OverlayValues[38] = d38
+						ps162.OverlayValues[39] = d39
+						ps162.OverlayValues[42] = d42
+						ps162.OverlayValues[61] = d61
+						ps162.OverlayValues[79] = d79
+						ps162.OverlayValues[81] = d81
+						ps162.OverlayValues[82] = d82
+						ps162.OverlayValues[83] = d83
+						ps162.OverlayValues[85] = d85
+						ps162.OverlayValues[86] = d86
+						ps162.OverlayValues[88] = d88
+						ps162.OverlayValues[89] = d89
+						ps162.OverlayValues[90] = d90
+						ps162.OverlayValues[91] = d91
+						ps162.OverlayValues[94] = d94
+						ps162.OverlayValues[125] = d125
+						ps162.OverlayValues[155] = d155
+						ps162.OverlayValues[156] = d156
+						ps162.OverlayValues[157] = d157
+						ps162.OverlayValues[158] = d158
+						ps162.OverlayValues[159] = d159
+						ps162.OverlayValues[161] = d161
+						ps162.PhiValues = make([]JITValueDesc, 1)
+						d163 = d156
+						ps162.PhiValues[0] = d163
+						return bbs[10].RenderPS(ps162)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[6].RenderPS(ps)
 					}
 					lbl15 := ctx.ReserveLabel()
-					ctx.EmitJump(d147.Condition, lbl10)
+					ctx.EmitJump(d159.Condition, lbl10)
 					ctx.EmitJmp(lbl15)
-					ctx.FreeDesc(&d146)
-					snap152 := d1
-					snap153 := d2
-					snap154 := d3
-					snap155 := d4
-					snap156 := d5
-					snap157 := d6
-					snap158 := d7
-					snap159 := d9
-					snap160 := d22
-					snap161 := d33
-					snap162 := d34
-					snap163 := d35
-					snap164 := d38
-					snap165 := d55
-					snap166 := d71
-					snap167 := d73
-					snap168 := d74
-					snap169 := d75
-					snap170 := d77
-					snap171 := d78
-					snap172 := d80
-					snap173 := d81
-					snap174 := d82
-					snap175 := d83
-					snap176 := d86
-					snap177 := d115
-					snap178 := d143
-					snap179 := d144
-					snap180 := d145
-					snap181 := d146
-					snap182 := d147
-					snap183 := d149
-					snap184 := d151
-					alloc185 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc185)
-					d1 = snap152
-					d2 = snap153
-					d3 = snap154
-					d4 = snap155
-					d5 = snap156
-					d6 = snap157
-					d7 = snap158
-					d9 = snap159
-					d22 = snap160
-					d33 = snap161
-					d34 = snap162
-					d35 = snap163
-					d38 = snap164
-					d55 = snap165
-					d71 = snap166
-					d73 = snap167
-					d74 = snap168
-					d75 = snap169
-					d77 = snap170
-					d78 = snap171
-					d80 = snap172
-					d81 = snap173
-					d82 = snap174
-					d83 = snap175
-					d86 = snap176
-					d115 = snap177
-					d143 = snap178
-					d144 = snap179
-					d145 = snap180
-					d146 = snap181
-					d147 = snap182
-					d149 = snap183
-					d151 = snap184
+					ctx.FreeDesc(&d158)
+					snap164 := d1
+					snap165 := d2
+					snap166 := d3
+					snap167 := d4
+					snap168 := d5
+					snap169 := d6
+					snap170 := d7
+					snap171 := d8
+					snap172 := d10
+					snap173 := d24
+					snap174 := d36
+					snap175 := d37
+					snap176 := d38
+					snap177 := d39
+					snap178 := d42
+					snap179 := d61
+					snap180 := d79
+					snap181 := d81
+					snap182 := d82
+					snap183 := d83
+					snap184 := d85
+					snap185 := d86
+					snap186 := d88
+					snap187 := d89
+					snap188 := d90
+					snap189 := d91
+					snap190 := d94
+					snap191 := d125
+					snap192 := d155
+					snap193 := d156
+					snap194 := d157
+					snap195 := d158
+					snap196 := d159
+					snap197 := d161
+					snap198 := d163
+					alloc199 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc199)
+					d1 = snap164
+					d2 = snap165
+					d3 = snap166
+					d4 = snap167
+					d5 = snap168
+					d6 = snap169
+					d7 = snap170
+					d8 = snap171
+					d10 = snap172
+					d24 = snap173
+					d36 = snap174
+					d37 = snap175
+					d38 = snap176
+					d39 = snap177
+					d42 = snap178
+					d61 = snap179
+					d79 = snap180
+					d81 = snap181
+					d82 = snap182
+					d83 = snap183
+					d85 = snap184
+					d86 = snap185
+					d88 = snap186
+					d89 = snap187
+					d90 = snap188
+					d91 = snap189
+					d94 = snap190
+					d125 = snap191
+					d155 = snap192
+					d156 = snap193
+					d157 = snap194
+					d158 = snap195
+					d159 = snap196
+					d161 = snap197
+					d163 = snap198
 					ctx.MarkLabel(lbl15)
-					ctx.SyncDesc(&d144)
-					if d144.Loc == LocReg {
-						ctx.ProtectReg(d144.Reg)
-					} else if d144.Loc == LocRegPair {
-						ctx.ProtectReg(d144.Reg)
-						ctx.ProtectReg(d144.Reg2)
+					ctx.SyncDesc(&d156)
+					if d156.Loc == LocReg || d156.Loc == LocFPReg {
+						ctx.ProtectReg(d156.Reg)
+					} else if d156.Loc == LocRegPair {
+						ctx.ProtectReg(d156.Reg)
+						ctx.ProtectReg(d156.Reg2)
 					}
-					d186 = d144
-					if d186.Loc == LocNone {
+					d200 = d156
+					if d200.Loc == LocNone {
 						panic("jit: phi source has no location")
 					}
-					ctx.SyncDesc(&d186)
-					if d186.Loc == LocStackPair {
-						ctx.EmitCopyStackWords(d186, int32(bbs[10].PhiBase)+int32(0), 2)
-					} else if d186.Loc == LocInputPair {
-						ctx.EnsureDesc(&d186)
-						ctx.EmitStoreScmerToStack(d186, int32(bbs[10].PhiBase)+int32(0))
-					} else if d186.Loc == LocRegPair || d186.Loc == LocImm {
-						ctx.EmitStoreScmerToStack(d186, int32(bbs[10].PhiBase)+int32(0))
+					ctx.SyncDesc(&d200)
+					if d200.Loc == LocStackPair {
+						ctx.EmitCopyStackWords(d200, int32(bbs[10].PhiBase)+int32(0), 2)
+					} else if d200.Loc == LocInputPair {
+						ctx.EnsureDesc(&d200)
+						ctx.EmitStoreScmerToStack(d200, int32(bbs[10].PhiBase)+int32(0))
+					} else if d200.Loc == LocRegPair || d200.Loc == LocImm {
+						ctx.EmitStoreScmerToStack(d200, int32(bbs[10].PhiBase)+int32(0))
 					} else {
-						ctx.EnsureDesc(&d186)
-						ctx.EmitStoreToStack(d186, int32(bbs[10].PhiBase)+int32(0))
+						ctx.EnsureDesc(&d200)
+						ctx.EmitStoreToStack(d200, int32(bbs[10].PhiBase)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[10].PhiBase)+int32(0))+8)
 					}
-					if d144.Loc == LocReg {
-						ctx.UnprotectReg(d144.Reg)
-					} else if d144.Loc == LocRegPair {
-						ctx.UnprotectReg(d144.Reg)
-						ctx.UnprotectReg(d144.Reg2)
+					if d156.Loc == LocReg || d156.Loc == LocFPReg {
+						ctx.UnprotectReg(d156.Reg)
+					} else if d156.Loc == LocRegPair {
+						ctx.UnprotectReg(d156.Reg)
+						ctx.UnprotectReg(d156.Reg2)
 					}
 					ctx.EmitJmp(lbl11)
-					ctx.RestoreAllocState(alloc185)
-					d1 = snap152
-					d2 = snap153
-					d3 = snap154
-					d4 = snap155
-					d5 = snap156
-					d6 = snap157
-					d7 = snap158
-					d9 = snap159
-					d22 = snap160
-					d33 = snap161
-					d34 = snap162
-					d35 = snap163
-					d38 = snap164
-					d55 = snap165
-					d71 = snap166
-					d73 = snap167
-					d74 = snap168
-					d75 = snap169
-					d77 = snap170
-					d78 = snap171
-					d80 = snap172
-					d81 = snap173
-					d82 = snap174
-					d83 = snap175
-					d86 = snap176
-					d115 = snap177
-					d143 = snap178
-					d144 = snap179
-					d145 = snap180
-					d146 = snap181
-					d147 = snap182
-					d149 = snap183
-					d151 = snap184
-					ps187 := PhiState{General: true}
-					ps187.OverlayValues = make([]JITValueDesc, 187)
-					ps187.OverlayValues[1] = d1
-					ps187.OverlayValues[2] = d2
-					ps187.OverlayValues[3] = d3
-					ps187.OverlayValues[4] = d4
-					ps187.OverlayValues[5] = d5
-					ps187.OverlayValues[6] = d6
-					ps187.OverlayValues[7] = d7
-					ps187.OverlayValues[9] = d9
-					ps187.OverlayValues[22] = d22
-					ps187.OverlayValues[33] = d33
-					ps187.OverlayValues[34] = d34
-					ps187.OverlayValues[35] = d35
-					ps187.OverlayValues[38] = d38
-					ps187.OverlayValues[55] = d55
-					ps187.OverlayValues[71] = d71
-					ps187.OverlayValues[73] = d73
-					ps187.OverlayValues[74] = d74
-					ps187.OverlayValues[75] = d75
-					ps187.OverlayValues[77] = d77
-					ps187.OverlayValues[78] = d78
-					ps187.OverlayValues[80] = d80
-					ps187.OverlayValues[81] = d81
-					ps187.OverlayValues[82] = d82
-					ps187.OverlayValues[83] = d83
-					ps187.OverlayValues[86] = d86
-					ps187.OverlayValues[115] = d115
-					ps187.OverlayValues[143] = d143
-					ps187.OverlayValues[144] = d144
-					ps187.OverlayValues[145] = d145
-					ps187.OverlayValues[146] = d146
-					ps187.OverlayValues[147] = d147
-					ps187.OverlayValues[149] = d149
-					ps187.OverlayValues[151] = d151
-					ps187.OverlayValues[186] = d186
-					ps188 := PhiState{General: true}
-					ps188.OverlayValues = make([]JITValueDesc, 187)
-					ps188.OverlayValues[1] = d1
-					ps188.OverlayValues[2] = d2
-					ps188.OverlayValues[3] = d3
-					ps188.OverlayValues[4] = d4
-					ps188.OverlayValues[5] = d5
-					ps188.OverlayValues[6] = d6
-					ps188.OverlayValues[7] = d7
-					ps188.OverlayValues[9] = d9
-					ps188.OverlayValues[22] = d22
-					ps188.OverlayValues[33] = d33
-					ps188.OverlayValues[34] = d34
-					ps188.OverlayValues[35] = d35
-					ps188.OverlayValues[38] = d38
-					ps188.OverlayValues[55] = d55
-					ps188.OverlayValues[71] = d71
-					ps188.OverlayValues[73] = d73
-					ps188.OverlayValues[74] = d74
-					ps188.OverlayValues[75] = d75
-					ps188.OverlayValues[77] = d77
-					ps188.OverlayValues[78] = d78
-					ps188.OverlayValues[80] = d80
-					ps188.OverlayValues[81] = d81
-					ps188.OverlayValues[82] = d82
-					ps188.OverlayValues[83] = d83
-					ps188.OverlayValues[86] = d86
-					ps188.OverlayValues[115] = d115
-					ps188.OverlayValues[143] = d143
-					ps188.OverlayValues[144] = d144
-					ps188.OverlayValues[145] = d145
-					ps188.OverlayValues[146] = d146
-					ps188.OverlayValues[147] = d147
-					ps188.OverlayValues[149] = d149
-					ps188.OverlayValues[151] = d151
-					ps188.OverlayValues[186] = d186
-					ps188.PhiValues = make([]JITValueDesc, 1)
-					d189 = d144
-					ps188.PhiValues[0] = d189
-					snap190 := d1
-					snap191 := d2
-					snap192 := d3
-					snap193 := d4
-					snap194 := d5
-					snap195 := d6
-					snap196 := d7
-					snap197 := d9
-					snap198 := d22
-					snap199 := d33
-					snap200 := d34
-					snap201 := d35
-					snap202 := d38
-					snap203 := d55
-					snap204 := d71
-					snap205 := d73
-					snap206 := d74
-					snap207 := d75
-					snap208 := d77
-					snap209 := d78
-					snap210 := d80
-					snap211 := d81
-					snap212 := d82
-					snap213 := d83
-					snap214 := d86
-					snap215 := d115
-					snap216 := d143
-					snap217 := d144
-					snap218 := d145
-					snap219 := d146
-					snap220 := d147
-					snap221 := d149
-					snap222 := d151
-					snap223 := d186
-					snap224 := d189
-					alloc225 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc199)
+					d1 = snap164
+					d2 = snap165
+					d3 = snap166
+					d4 = snap167
+					d5 = snap168
+					d6 = snap169
+					d7 = snap170
+					d8 = snap171
+					d10 = snap172
+					d24 = snap173
+					d36 = snap174
+					d37 = snap175
+					d38 = snap176
+					d39 = snap177
+					d42 = snap178
+					d61 = snap179
+					d79 = snap180
+					d81 = snap181
+					d82 = snap182
+					d83 = snap183
+					d85 = snap184
+					d86 = snap185
+					d88 = snap186
+					d89 = snap187
+					d90 = snap188
+					d91 = snap189
+					d94 = snap190
+					d125 = snap191
+					d155 = snap192
+					d156 = snap193
+					d157 = snap194
+					d158 = snap195
+					d159 = snap196
+					d161 = snap197
+					d163 = snap198
+					ps201 := PhiState{General: true}
+					ps201.OverlayValues = make([]JITValueDesc, 201)
+					ps201.OverlayValues[1] = d1
+					ps201.OverlayValues[2] = d2
+					ps201.OverlayValues[3] = d3
+					ps201.OverlayValues[4] = d4
+					ps201.OverlayValues[5] = d5
+					ps201.OverlayValues[6] = d6
+					ps201.OverlayValues[7] = d7
+					ps201.OverlayValues[8] = d8
+					ps201.OverlayValues[10] = d10
+					ps201.OverlayValues[24] = d24
+					ps201.OverlayValues[36] = d36
+					ps201.OverlayValues[37] = d37
+					ps201.OverlayValues[38] = d38
+					ps201.OverlayValues[39] = d39
+					ps201.OverlayValues[42] = d42
+					ps201.OverlayValues[61] = d61
+					ps201.OverlayValues[79] = d79
+					ps201.OverlayValues[81] = d81
+					ps201.OverlayValues[82] = d82
+					ps201.OverlayValues[83] = d83
+					ps201.OverlayValues[85] = d85
+					ps201.OverlayValues[86] = d86
+					ps201.OverlayValues[88] = d88
+					ps201.OverlayValues[89] = d89
+					ps201.OverlayValues[90] = d90
+					ps201.OverlayValues[91] = d91
+					ps201.OverlayValues[94] = d94
+					ps201.OverlayValues[125] = d125
+					ps201.OverlayValues[155] = d155
+					ps201.OverlayValues[156] = d156
+					ps201.OverlayValues[157] = d157
+					ps201.OverlayValues[158] = d158
+					ps201.OverlayValues[159] = d159
+					ps201.OverlayValues[161] = d161
+					ps201.OverlayValues[163] = d163
+					ps201.OverlayValues[200] = d200
+					ps202 := PhiState{General: true}
+					ps202.OverlayValues = make([]JITValueDesc, 201)
+					ps202.OverlayValues[1] = d1
+					ps202.OverlayValues[2] = d2
+					ps202.OverlayValues[3] = d3
+					ps202.OverlayValues[4] = d4
+					ps202.OverlayValues[5] = d5
+					ps202.OverlayValues[6] = d6
+					ps202.OverlayValues[7] = d7
+					ps202.OverlayValues[8] = d8
+					ps202.OverlayValues[10] = d10
+					ps202.OverlayValues[24] = d24
+					ps202.OverlayValues[36] = d36
+					ps202.OverlayValues[37] = d37
+					ps202.OverlayValues[38] = d38
+					ps202.OverlayValues[39] = d39
+					ps202.OverlayValues[42] = d42
+					ps202.OverlayValues[61] = d61
+					ps202.OverlayValues[79] = d79
+					ps202.OverlayValues[81] = d81
+					ps202.OverlayValues[82] = d82
+					ps202.OverlayValues[83] = d83
+					ps202.OverlayValues[85] = d85
+					ps202.OverlayValues[86] = d86
+					ps202.OverlayValues[88] = d88
+					ps202.OverlayValues[89] = d89
+					ps202.OverlayValues[90] = d90
+					ps202.OverlayValues[91] = d91
+					ps202.OverlayValues[94] = d94
+					ps202.OverlayValues[125] = d125
+					ps202.OverlayValues[155] = d155
+					ps202.OverlayValues[156] = d156
+					ps202.OverlayValues[157] = d157
+					ps202.OverlayValues[158] = d158
+					ps202.OverlayValues[159] = d159
+					ps202.OverlayValues[161] = d161
+					ps202.OverlayValues[163] = d163
+					ps202.OverlayValues[200] = d200
+					ps202.PhiValues = make([]JITValueDesc, 1)
+					d203 = d156
+					ps202.PhiValues[0] = d203
+					snap204 := d1
+					snap205 := d2
+					snap206 := d3
+					snap207 := d4
+					snap208 := d5
+					snap209 := d6
+					snap210 := d7
+					snap211 := d8
+					snap212 := d10
+					snap213 := d24
+					snap214 := d36
+					snap215 := d37
+					snap216 := d38
+					snap217 := d39
+					snap218 := d42
+					snap219 := d61
+					snap220 := d79
+					snap221 := d81
+					snap222 := d82
+					snap223 := d83
+					snap224 := d85
+					snap225 := d86
+					snap226 := d88
+					snap227 := d89
+					snap228 := d90
+					snap229 := d91
+					snap230 := d94
+					snap231 := d125
+					snap232 := d155
+					snap233 := d156
+					snap234 := d157
+					snap235 := d158
+					snap236 := d159
+					snap237 := d161
+					snap238 := d163
+					snap239 := d200
+					snap240 := d203
+					alloc241 := ctx.SnapshotAllocState()
 					if !bbs[10].Rendered {
-						bbs[10].RenderPS(ps188)
+						bbs[10].RenderPS(ps202)
 					}
-					ctx.RestoreAllocState(alloc225)
-					d1 = snap190
-					d2 = snap191
-					d3 = snap192
-					d4 = snap193
-					d5 = snap194
-					d6 = snap195
-					d7 = snap196
-					d9 = snap197
-					d22 = snap198
-					d33 = snap199
-					d34 = snap200
-					d35 = snap201
-					d38 = snap202
-					d55 = snap203
-					d71 = snap204
-					d73 = snap205
-					d74 = snap206
-					d75 = snap207
-					d77 = snap208
-					d78 = snap209
-					d80 = snap210
-					d81 = snap211
-					d82 = snap212
-					d83 = snap213
-					d86 = snap214
-					d115 = snap215
-					d143 = snap216
-					d144 = snap217
-					d145 = snap218
-					d146 = snap219
-					d147 = snap220
-					d149 = snap221
-					d151 = snap222
-					d186 = snap223
-					d189 = snap224
+					ctx.RestoreAllocState(alloc241)
+					d1 = snap204
+					d2 = snap205
+					d3 = snap206
+					d4 = snap207
+					d5 = snap208
+					d6 = snap209
+					d7 = snap210
+					d8 = snap211
+					d10 = snap212
+					d24 = snap213
+					d36 = snap214
+					d37 = snap215
+					d38 = snap216
+					d39 = snap217
+					d42 = snap218
+					d61 = snap219
+					d79 = snap220
+					d81 = snap221
+					d82 = snap222
+					d83 = snap223
+					d85 = snap224
+					d86 = snap225
+					d88 = snap226
+					d89 = snap227
+					d90 = snap228
+					d91 = snap229
+					d94 = snap230
+					d125 = snap231
+					d155 = snap232
+					d156 = snap233
+					d157 = snap234
+					d158 = snap235
+					d159 = snap236
+					d161 = snap237
+					d163 = snap238
+					d200 = snap239
+					d203 = snap240
 					if !bbs[9].Rendered {
-						return bbs[9].RenderPS(ps187)
+						return bbs[9].RenderPS(ps201)
 					}
 					return result
 					return result
@@ -7726,47 +7977,35 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
-						d33 = ps.OverlayValues[33]
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
-					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
-						d34 = ps.OverlayValues[34]
+					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
+						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
-						d35 = ps.OverlayValues[35]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
 					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
 						d38 = ps.OverlayValues[38]
 					}
-					if len(ps.OverlayValues) > 55 && ps.OverlayValues[55].Loc != LocNone {
-						d55 = ps.OverlayValues[55]
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
 					}
-					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
-						d73 = ps.OverlayValues[73]
+					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
+						d61 = ps.OverlayValues[61]
 					}
-					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
-						d74 = ps.OverlayValues[74]
-					}
-					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
-						d75 = ps.OverlayValues[75]
-					}
-					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
-						d77 = ps.OverlayValues[77]
-					}
-					if len(ps.OverlayValues) > 78 && ps.OverlayValues[78].Loc != LocNone {
-						d78 = ps.OverlayValues[78]
-					}
-					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
-						d80 = ps.OverlayValues[80]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
 						d81 = ps.OverlayValues[81]
@@ -7777,38 +8016,56 @@ func init_jit() {
 					if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
 						d83 = ps.OverlayValues[83]
 					}
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
+					}
 					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
 						d86 = ps.OverlayValues[86]
 					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
+					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
+						d88 = ps.OverlayValues[88]
 					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
+						d89 = ps.OverlayValues[89]
 					}
-					if len(ps.OverlayValues) > 144 && ps.OverlayValues[144].Loc != LocNone {
-						d144 = ps.OverlayValues[144]
+					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
+						d90 = ps.OverlayValues[90]
 					}
-					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
-						d145 = ps.OverlayValues[145]
+					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
+						d91 = ps.OverlayValues[91]
 					}
-					if len(ps.OverlayValues) > 146 && ps.OverlayValues[146].Loc != LocNone {
-						d146 = ps.OverlayValues[146]
+					if len(ps.OverlayValues) > 94 && ps.OverlayValues[94].Loc != LocNone {
+						d94 = ps.OverlayValues[94]
 					}
-					if len(ps.OverlayValues) > 147 && ps.OverlayValues[147].Loc != LocNone {
-						d147 = ps.OverlayValues[147]
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
-					if len(ps.OverlayValues) > 149 && ps.OverlayValues[149].Loc != LocNone {
-						d149 = ps.OverlayValues[149]
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
+					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
+						d156 = ps.OverlayValues[156]
 					}
-					if len(ps.OverlayValues) > 186 && ps.OverlayValues[186].Loc != LocNone {
-						d186 = ps.OverlayValues[186]
+					if len(ps.OverlayValues) > 157 && ps.OverlayValues[157].Loc != LocNone {
+						d157 = ps.OverlayValues[157]
 					}
-					if len(ps.OverlayValues) > 189 && ps.OverlayValues[189].Loc != LocNone {
-						d189 = ps.OverlayValues[189]
+					if len(ps.OverlayValues) > 158 && ps.OverlayValues[158].Loc != LocNone {
+						d158 = ps.OverlayValues[158]
+					}
+					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
+						d159 = ps.OverlayValues[159]
+					}
+					if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+						d161 = ps.OverlayValues[161]
+					}
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
+					}
+					if len(ps.OverlayValues) > 200 && ps.OverlayValues[200].Loc != LocNone {
+						d200 = ps.OverlayValues[200]
+					}
+					if len(ps.OverlayValues) > 203 && ps.OverlayValues[203].Loc != LocNone {
+						d203 = ps.OverlayValues[203]
 					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d4)
@@ -7880,47 +8137,35 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
-						d33 = ps.OverlayValues[33]
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
-					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
-						d34 = ps.OverlayValues[34]
+					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
+						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
-						d35 = ps.OverlayValues[35]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
 					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
 						d38 = ps.OverlayValues[38]
 					}
-					if len(ps.OverlayValues) > 55 && ps.OverlayValues[55].Loc != LocNone {
-						d55 = ps.OverlayValues[55]
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
 					}
-					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
-						d73 = ps.OverlayValues[73]
+					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
+						d61 = ps.OverlayValues[61]
 					}
-					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
-						d74 = ps.OverlayValues[74]
-					}
-					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
-						d75 = ps.OverlayValues[75]
-					}
-					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
-						d77 = ps.OverlayValues[77]
-					}
-					if len(ps.OverlayValues) > 78 && ps.OverlayValues[78].Loc != LocNone {
-						d78 = ps.OverlayValues[78]
-					}
-					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
-						d80 = ps.OverlayValues[80]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
 						d81 = ps.OverlayValues[81]
@@ -7931,406 +8176,442 @@ func init_jit() {
 					if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
 						d83 = ps.OverlayValues[83]
 					}
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
+					}
 					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
 						d86 = ps.OverlayValues[86]
 					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
+					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
+						d88 = ps.OverlayValues[88]
 					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
+						d89 = ps.OverlayValues[89]
 					}
-					if len(ps.OverlayValues) > 144 && ps.OverlayValues[144].Loc != LocNone {
-						d144 = ps.OverlayValues[144]
+					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
+						d90 = ps.OverlayValues[90]
 					}
-					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
-						d145 = ps.OverlayValues[145]
+					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
+						d91 = ps.OverlayValues[91]
 					}
-					if len(ps.OverlayValues) > 146 && ps.OverlayValues[146].Loc != LocNone {
-						d146 = ps.OverlayValues[146]
+					if len(ps.OverlayValues) > 94 && ps.OverlayValues[94].Loc != LocNone {
+						d94 = ps.OverlayValues[94]
 					}
-					if len(ps.OverlayValues) > 147 && ps.OverlayValues[147].Loc != LocNone {
-						d147 = ps.OverlayValues[147]
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
-					if len(ps.OverlayValues) > 149 && ps.OverlayValues[149].Loc != LocNone {
-						d149 = ps.OverlayValues[149]
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
+					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
+						d156 = ps.OverlayValues[156]
 					}
-					if len(ps.OverlayValues) > 186 && ps.OverlayValues[186].Loc != LocNone {
-						d186 = ps.OverlayValues[186]
+					if len(ps.OverlayValues) > 157 && ps.OverlayValues[157].Loc != LocNone {
+						d157 = ps.OverlayValues[157]
 					}
-					if len(ps.OverlayValues) > 189 && ps.OverlayValues[189].Loc != LocNone {
-						d189 = ps.OverlayValues[189]
+					if len(ps.OverlayValues) > 158 && ps.OverlayValues[158].Loc != LocNone {
+						d158 = ps.OverlayValues[158]
+					}
+					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
+						d159 = ps.OverlayValues[159]
+					}
+					if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+						d161 = ps.OverlayValues[161]
+					}
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
+					}
+					if len(ps.OverlayValues) > 200 && ps.OverlayValues[200].Loc != LocNone {
+						d200 = ps.OverlayValues[200]
+					}
+					if len(ps.OverlayValues) > 203 && ps.OverlayValues[203].Loc != LocNone {
+						d203 = ps.OverlayValues[203]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d226 = d1
-					ctx.EnsureDesc(&d226)
-					if d226.Loc != LocImm && d226.Loc != LocReg {
+					d242 = d1
+					ctx.EnsureDesc(&d242)
+					if d242.Loc != LocImm && d242.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d226.Loc == LocImm {
-						if d226.Imm.Bool() {
+					if d242.Loc == LocImm {
+						if d242.Imm.Bool() {
 							if ps.General {
 							}
-							ps227 := PhiState{General: ps.General}
-							ps227.OverlayValues = make([]JITValueDesc, 227)
-							ps227.OverlayValues[1] = d1
-							ps227.OverlayValues[2] = d2
-							ps227.OverlayValues[3] = d3
-							ps227.OverlayValues[4] = d4
-							ps227.OverlayValues[5] = d5
-							ps227.OverlayValues[6] = d6
-							ps227.OverlayValues[7] = d7
-							ps227.OverlayValues[9] = d9
-							ps227.OverlayValues[22] = d22
-							ps227.OverlayValues[33] = d33
-							ps227.OverlayValues[34] = d34
-							ps227.OverlayValues[35] = d35
-							ps227.OverlayValues[38] = d38
-							ps227.OverlayValues[55] = d55
-							ps227.OverlayValues[71] = d71
-							ps227.OverlayValues[73] = d73
-							ps227.OverlayValues[74] = d74
-							ps227.OverlayValues[75] = d75
-							ps227.OverlayValues[77] = d77
-							ps227.OverlayValues[78] = d78
-							ps227.OverlayValues[80] = d80
-							ps227.OverlayValues[81] = d81
-							ps227.OverlayValues[82] = d82
-							ps227.OverlayValues[83] = d83
-							ps227.OverlayValues[86] = d86
-							ps227.OverlayValues[115] = d115
-							ps227.OverlayValues[143] = d143
-							ps227.OverlayValues[144] = d144
-							ps227.OverlayValues[145] = d145
-							ps227.OverlayValues[146] = d146
-							ps227.OverlayValues[147] = d147
-							ps227.OverlayValues[149] = d149
-							ps227.OverlayValues[151] = d151
-							ps227.OverlayValues[186] = d186
-							ps227.OverlayValues[189] = d189
-							ps227.OverlayValues[226] = d226
-							return bbs[7].RenderPS(ps227)
+							ps243 := PhiState{General: ps.General}
+							ps243.OverlayValues = make([]JITValueDesc, 243)
+							ps243.OverlayValues[1] = d1
+							ps243.OverlayValues[2] = d2
+							ps243.OverlayValues[3] = d3
+							ps243.OverlayValues[4] = d4
+							ps243.OverlayValues[5] = d5
+							ps243.OverlayValues[6] = d6
+							ps243.OverlayValues[7] = d7
+							ps243.OverlayValues[8] = d8
+							ps243.OverlayValues[10] = d10
+							ps243.OverlayValues[24] = d24
+							ps243.OverlayValues[36] = d36
+							ps243.OverlayValues[37] = d37
+							ps243.OverlayValues[38] = d38
+							ps243.OverlayValues[39] = d39
+							ps243.OverlayValues[42] = d42
+							ps243.OverlayValues[61] = d61
+							ps243.OverlayValues[79] = d79
+							ps243.OverlayValues[81] = d81
+							ps243.OverlayValues[82] = d82
+							ps243.OverlayValues[83] = d83
+							ps243.OverlayValues[85] = d85
+							ps243.OverlayValues[86] = d86
+							ps243.OverlayValues[88] = d88
+							ps243.OverlayValues[89] = d89
+							ps243.OverlayValues[90] = d90
+							ps243.OverlayValues[91] = d91
+							ps243.OverlayValues[94] = d94
+							ps243.OverlayValues[125] = d125
+							ps243.OverlayValues[155] = d155
+							ps243.OverlayValues[156] = d156
+							ps243.OverlayValues[157] = d157
+							ps243.OverlayValues[158] = d158
+							ps243.OverlayValues[159] = d159
+							ps243.OverlayValues[161] = d161
+							ps243.OverlayValues[163] = d163
+							ps243.OverlayValues[200] = d200
+							ps243.OverlayValues[203] = d203
+							ps243.OverlayValues[242] = d242
+							return bbs[7].RenderPS(ps243)
 						}
 						if ps.General {
 						}
-						ps228 := PhiState{General: ps.General}
-						ps228.OverlayValues = make([]JITValueDesc, 227)
-						ps228.OverlayValues[1] = d1
-						ps228.OverlayValues[2] = d2
-						ps228.OverlayValues[3] = d3
-						ps228.OverlayValues[4] = d4
-						ps228.OverlayValues[5] = d5
-						ps228.OverlayValues[6] = d6
-						ps228.OverlayValues[7] = d7
-						ps228.OverlayValues[9] = d9
-						ps228.OverlayValues[22] = d22
-						ps228.OverlayValues[33] = d33
-						ps228.OverlayValues[34] = d34
-						ps228.OverlayValues[35] = d35
-						ps228.OverlayValues[38] = d38
-						ps228.OverlayValues[55] = d55
-						ps228.OverlayValues[71] = d71
-						ps228.OverlayValues[73] = d73
-						ps228.OverlayValues[74] = d74
-						ps228.OverlayValues[75] = d75
-						ps228.OverlayValues[77] = d77
-						ps228.OverlayValues[78] = d78
-						ps228.OverlayValues[80] = d80
-						ps228.OverlayValues[81] = d81
-						ps228.OverlayValues[82] = d82
-						ps228.OverlayValues[83] = d83
-						ps228.OverlayValues[86] = d86
-						ps228.OverlayValues[115] = d115
-						ps228.OverlayValues[143] = d143
-						ps228.OverlayValues[144] = d144
-						ps228.OverlayValues[145] = d145
-						ps228.OverlayValues[146] = d146
-						ps228.OverlayValues[147] = d147
-						ps228.OverlayValues[149] = d149
-						ps228.OverlayValues[151] = d151
-						ps228.OverlayValues[186] = d186
-						ps228.OverlayValues[189] = d189
-						ps228.OverlayValues[226] = d226
-						return bbs[6].RenderPS(ps228)
+						ps244 := PhiState{General: ps.General}
+						ps244.OverlayValues = make([]JITValueDesc, 243)
+						ps244.OverlayValues[1] = d1
+						ps244.OverlayValues[2] = d2
+						ps244.OverlayValues[3] = d3
+						ps244.OverlayValues[4] = d4
+						ps244.OverlayValues[5] = d5
+						ps244.OverlayValues[6] = d6
+						ps244.OverlayValues[7] = d7
+						ps244.OverlayValues[8] = d8
+						ps244.OverlayValues[10] = d10
+						ps244.OverlayValues[24] = d24
+						ps244.OverlayValues[36] = d36
+						ps244.OverlayValues[37] = d37
+						ps244.OverlayValues[38] = d38
+						ps244.OverlayValues[39] = d39
+						ps244.OverlayValues[42] = d42
+						ps244.OverlayValues[61] = d61
+						ps244.OverlayValues[79] = d79
+						ps244.OverlayValues[81] = d81
+						ps244.OverlayValues[82] = d82
+						ps244.OverlayValues[83] = d83
+						ps244.OverlayValues[85] = d85
+						ps244.OverlayValues[86] = d86
+						ps244.OverlayValues[88] = d88
+						ps244.OverlayValues[89] = d89
+						ps244.OverlayValues[90] = d90
+						ps244.OverlayValues[91] = d91
+						ps244.OverlayValues[94] = d94
+						ps244.OverlayValues[125] = d125
+						ps244.OverlayValues[155] = d155
+						ps244.OverlayValues[156] = d156
+						ps244.OverlayValues[157] = d157
+						ps244.OverlayValues[158] = d158
+						ps244.OverlayValues[159] = d159
+						ps244.OverlayValues[161] = d161
+						ps244.OverlayValues[163] = d163
+						ps244.OverlayValues[200] = d200
+						ps244.OverlayValues[203] = d203
+						ps244.OverlayValues[242] = d242
+						return bbs[6].RenderPS(ps244)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[8].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d226.Reg, 0)
+					ctx.EmitCmpRegImm32(d242.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl8)
 					if bbs[6].Rendered {
 						ctx.EmitJmp(lbl7)
 					}
-					snap229 := d1
-					snap230 := d2
-					snap231 := d3
-					snap232 := d4
-					snap233 := d5
-					snap234 := d6
-					snap235 := d7
-					snap236 := d9
-					snap237 := d22
-					snap238 := d33
-					snap239 := d34
-					snap240 := d35
-					snap241 := d38
-					snap242 := d55
-					snap243 := d71
-					snap244 := d73
-					snap245 := d74
-					snap246 := d75
-					snap247 := d77
-					snap248 := d78
-					snap249 := d80
-					snap250 := d81
-					snap251 := d82
-					snap252 := d83
-					snap253 := d86
-					snap254 := d115
-					snap255 := d143
-					snap256 := d144
-					snap257 := d145
-					snap258 := d146
-					snap259 := d147
-					snap260 := d149
-					snap261 := d151
-					snap262 := d186
-					snap263 := d189
-					snap264 := d226
-					alloc265 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc265)
-					d1 = snap229
-					d2 = snap230
-					d3 = snap231
-					d4 = snap232
-					d5 = snap233
-					d6 = snap234
-					d7 = snap235
-					d9 = snap236
-					d22 = snap237
-					d33 = snap238
-					d34 = snap239
-					d35 = snap240
-					d38 = snap241
-					d55 = snap242
-					d71 = snap243
-					d73 = snap244
-					d74 = snap245
-					d75 = snap246
-					d77 = snap247
-					d78 = snap248
-					d80 = snap249
-					d81 = snap250
-					d82 = snap251
-					d83 = snap252
-					d86 = snap253
-					d115 = snap254
-					d143 = snap255
-					d144 = snap256
-					d145 = snap257
-					d146 = snap258
-					d147 = snap259
-					d149 = snap260
-					d151 = snap261
-					d186 = snap262
-					d189 = snap263
-					d226 = snap264
-					ctx.RestoreAllocState(alloc265)
-					d1 = snap229
-					d2 = snap230
-					d3 = snap231
-					d4 = snap232
-					d5 = snap233
-					d6 = snap234
-					d7 = snap235
-					d9 = snap236
-					d22 = snap237
-					d33 = snap238
-					d34 = snap239
-					d35 = snap240
-					d38 = snap241
-					d55 = snap242
-					d71 = snap243
-					d73 = snap244
-					d74 = snap245
-					d75 = snap246
-					d77 = snap247
-					d78 = snap248
-					d80 = snap249
-					d81 = snap250
-					d82 = snap251
-					d83 = snap252
-					d86 = snap253
-					d115 = snap254
-					d143 = snap255
-					d144 = snap256
-					d145 = snap257
-					d146 = snap258
-					d147 = snap259
-					d149 = snap260
-					d151 = snap261
-					d186 = snap262
-					d189 = snap263
-					d226 = snap264
-					ps266 := PhiState{General: true}
-					ps266.OverlayValues = make([]JITValueDesc, 227)
-					ps266.OverlayValues[1] = d1
-					ps266.OverlayValues[2] = d2
-					ps266.OverlayValues[3] = d3
-					ps266.OverlayValues[4] = d4
-					ps266.OverlayValues[5] = d5
-					ps266.OverlayValues[6] = d6
-					ps266.OverlayValues[7] = d7
-					ps266.OverlayValues[9] = d9
-					ps266.OverlayValues[22] = d22
-					ps266.OverlayValues[33] = d33
-					ps266.OverlayValues[34] = d34
-					ps266.OverlayValues[35] = d35
-					ps266.OverlayValues[38] = d38
-					ps266.OverlayValues[55] = d55
-					ps266.OverlayValues[71] = d71
-					ps266.OverlayValues[73] = d73
-					ps266.OverlayValues[74] = d74
-					ps266.OverlayValues[75] = d75
-					ps266.OverlayValues[77] = d77
-					ps266.OverlayValues[78] = d78
-					ps266.OverlayValues[80] = d80
-					ps266.OverlayValues[81] = d81
-					ps266.OverlayValues[82] = d82
-					ps266.OverlayValues[83] = d83
-					ps266.OverlayValues[86] = d86
-					ps266.OverlayValues[115] = d115
-					ps266.OverlayValues[143] = d143
-					ps266.OverlayValues[144] = d144
-					ps266.OverlayValues[145] = d145
-					ps266.OverlayValues[146] = d146
-					ps266.OverlayValues[147] = d147
-					ps266.OverlayValues[149] = d149
-					ps266.OverlayValues[151] = d151
-					ps266.OverlayValues[186] = d186
-					ps266.OverlayValues[189] = d189
-					ps266.OverlayValues[226] = d226
-					ps267 := PhiState{General: true}
-					ps267.OverlayValues = make([]JITValueDesc, 227)
-					ps267.OverlayValues[1] = d1
-					ps267.OverlayValues[2] = d2
-					ps267.OverlayValues[3] = d3
-					ps267.OverlayValues[4] = d4
-					ps267.OverlayValues[5] = d5
-					ps267.OverlayValues[6] = d6
-					ps267.OverlayValues[7] = d7
-					ps267.OverlayValues[9] = d9
-					ps267.OverlayValues[22] = d22
-					ps267.OverlayValues[33] = d33
-					ps267.OverlayValues[34] = d34
-					ps267.OverlayValues[35] = d35
-					ps267.OverlayValues[38] = d38
-					ps267.OverlayValues[55] = d55
-					ps267.OverlayValues[71] = d71
-					ps267.OverlayValues[73] = d73
-					ps267.OverlayValues[74] = d74
-					ps267.OverlayValues[75] = d75
-					ps267.OverlayValues[77] = d77
-					ps267.OverlayValues[78] = d78
-					ps267.OverlayValues[80] = d80
-					ps267.OverlayValues[81] = d81
-					ps267.OverlayValues[82] = d82
-					ps267.OverlayValues[83] = d83
-					ps267.OverlayValues[86] = d86
-					ps267.OverlayValues[115] = d115
-					ps267.OverlayValues[143] = d143
-					ps267.OverlayValues[144] = d144
-					ps267.OverlayValues[145] = d145
-					ps267.OverlayValues[146] = d146
-					ps267.OverlayValues[147] = d147
-					ps267.OverlayValues[149] = d149
-					ps267.OverlayValues[151] = d151
-					ps267.OverlayValues[186] = d186
-					ps267.OverlayValues[189] = d189
-					ps267.OverlayValues[226] = d226
-					snap268 := d1
-					snap269 := d2
-					snap270 := d3
-					snap271 := d4
-					snap272 := d5
-					snap273 := d6
-					snap274 := d7
-					snap275 := d9
-					snap276 := d22
-					snap277 := d33
-					snap278 := d34
-					snap279 := d35
-					snap280 := d38
-					snap281 := d55
-					snap282 := d71
-					snap283 := d73
-					snap284 := d74
-					snap285 := d75
-					snap286 := d77
-					snap287 := d78
-					snap288 := d80
-					snap289 := d81
-					snap290 := d82
-					snap291 := d83
-					snap292 := d86
-					snap293 := d115
-					snap294 := d143
-					snap295 := d144
-					snap296 := d145
-					snap297 := d146
-					snap298 := d147
-					snap299 := d149
-					snap300 := d151
-					snap301 := d186
-					snap302 := d189
-					snap303 := d226
-					alloc304 := ctx.SnapshotAllocState()
+					snap245 := d1
+					snap246 := d2
+					snap247 := d3
+					snap248 := d4
+					snap249 := d5
+					snap250 := d6
+					snap251 := d7
+					snap252 := d8
+					snap253 := d10
+					snap254 := d24
+					snap255 := d36
+					snap256 := d37
+					snap257 := d38
+					snap258 := d39
+					snap259 := d42
+					snap260 := d61
+					snap261 := d79
+					snap262 := d81
+					snap263 := d82
+					snap264 := d83
+					snap265 := d85
+					snap266 := d86
+					snap267 := d88
+					snap268 := d89
+					snap269 := d90
+					snap270 := d91
+					snap271 := d94
+					snap272 := d125
+					snap273 := d155
+					snap274 := d156
+					snap275 := d157
+					snap276 := d158
+					snap277 := d159
+					snap278 := d161
+					snap279 := d163
+					snap280 := d200
+					snap281 := d203
+					snap282 := d242
+					alloc283 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc283)
+					d1 = snap245
+					d2 = snap246
+					d3 = snap247
+					d4 = snap248
+					d5 = snap249
+					d6 = snap250
+					d7 = snap251
+					d8 = snap252
+					d10 = snap253
+					d24 = snap254
+					d36 = snap255
+					d37 = snap256
+					d38 = snap257
+					d39 = snap258
+					d42 = snap259
+					d61 = snap260
+					d79 = snap261
+					d81 = snap262
+					d82 = snap263
+					d83 = snap264
+					d85 = snap265
+					d86 = snap266
+					d88 = snap267
+					d89 = snap268
+					d90 = snap269
+					d91 = snap270
+					d94 = snap271
+					d125 = snap272
+					d155 = snap273
+					d156 = snap274
+					d157 = snap275
+					d158 = snap276
+					d159 = snap277
+					d161 = snap278
+					d163 = snap279
+					d200 = snap280
+					d203 = snap281
+					d242 = snap282
+					ctx.RestoreAllocState(alloc283)
+					d1 = snap245
+					d2 = snap246
+					d3 = snap247
+					d4 = snap248
+					d5 = snap249
+					d6 = snap250
+					d7 = snap251
+					d8 = snap252
+					d10 = snap253
+					d24 = snap254
+					d36 = snap255
+					d37 = snap256
+					d38 = snap257
+					d39 = snap258
+					d42 = snap259
+					d61 = snap260
+					d79 = snap261
+					d81 = snap262
+					d82 = snap263
+					d83 = snap264
+					d85 = snap265
+					d86 = snap266
+					d88 = snap267
+					d89 = snap268
+					d90 = snap269
+					d91 = snap270
+					d94 = snap271
+					d125 = snap272
+					d155 = snap273
+					d156 = snap274
+					d157 = snap275
+					d158 = snap276
+					d159 = snap277
+					d161 = snap278
+					d163 = snap279
+					d200 = snap280
+					d203 = snap281
+					d242 = snap282
+					ps284 := PhiState{General: true}
+					ps284.OverlayValues = make([]JITValueDesc, 243)
+					ps284.OverlayValues[1] = d1
+					ps284.OverlayValues[2] = d2
+					ps284.OverlayValues[3] = d3
+					ps284.OverlayValues[4] = d4
+					ps284.OverlayValues[5] = d5
+					ps284.OverlayValues[6] = d6
+					ps284.OverlayValues[7] = d7
+					ps284.OverlayValues[8] = d8
+					ps284.OverlayValues[10] = d10
+					ps284.OverlayValues[24] = d24
+					ps284.OverlayValues[36] = d36
+					ps284.OverlayValues[37] = d37
+					ps284.OverlayValues[38] = d38
+					ps284.OverlayValues[39] = d39
+					ps284.OverlayValues[42] = d42
+					ps284.OverlayValues[61] = d61
+					ps284.OverlayValues[79] = d79
+					ps284.OverlayValues[81] = d81
+					ps284.OverlayValues[82] = d82
+					ps284.OverlayValues[83] = d83
+					ps284.OverlayValues[85] = d85
+					ps284.OverlayValues[86] = d86
+					ps284.OverlayValues[88] = d88
+					ps284.OverlayValues[89] = d89
+					ps284.OverlayValues[90] = d90
+					ps284.OverlayValues[91] = d91
+					ps284.OverlayValues[94] = d94
+					ps284.OverlayValues[125] = d125
+					ps284.OverlayValues[155] = d155
+					ps284.OverlayValues[156] = d156
+					ps284.OverlayValues[157] = d157
+					ps284.OverlayValues[158] = d158
+					ps284.OverlayValues[159] = d159
+					ps284.OverlayValues[161] = d161
+					ps284.OverlayValues[163] = d163
+					ps284.OverlayValues[200] = d200
+					ps284.OverlayValues[203] = d203
+					ps284.OverlayValues[242] = d242
+					ps285 := PhiState{General: true}
+					ps285.OverlayValues = make([]JITValueDesc, 243)
+					ps285.OverlayValues[1] = d1
+					ps285.OverlayValues[2] = d2
+					ps285.OverlayValues[3] = d3
+					ps285.OverlayValues[4] = d4
+					ps285.OverlayValues[5] = d5
+					ps285.OverlayValues[6] = d6
+					ps285.OverlayValues[7] = d7
+					ps285.OverlayValues[8] = d8
+					ps285.OverlayValues[10] = d10
+					ps285.OverlayValues[24] = d24
+					ps285.OverlayValues[36] = d36
+					ps285.OverlayValues[37] = d37
+					ps285.OverlayValues[38] = d38
+					ps285.OverlayValues[39] = d39
+					ps285.OverlayValues[42] = d42
+					ps285.OverlayValues[61] = d61
+					ps285.OverlayValues[79] = d79
+					ps285.OverlayValues[81] = d81
+					ps285.OverlayValues[82] = d82
+					ps285.OverlayValues[83] = d83
+					ps285.OverlayValues[85] = d85
+					ps285.OverlayValues[86] = d86
+					ps285.OverlayValues[88] = d88
+					ps285.OverlayValues[89] = d89
+					ps285.OverlayValues[90] = d90
+					ps285.OverlayValues[91] = d91
+					ps285.OverlayValues[94] = d94
+					ps285.OverlayValues[125] = d125
+					ps285.OverlayValues[155] = d155
+					ps285.OverlayValues[156] = d156
+					ps285.OverlayValues[157] = d157
+					ps285.OverlayValues[158] = d158
+					ps285.OverlayValues[159] = d159
+					ps285.OverlayValues[161] = d161
+					ps285.OverlayValues[163] = d163
+					ps285.OverlayValues[200] = d200
+					ps285.OverlayValues[203] = d203
+					ps285.OverlayValues[242] = d242
+					snap286 := d1
+					snap287 := d2
+					snap288 := d3
+					snap289 := d4
+					snap290 := d5
+					snap291 := d6
+					snap292 := d7
+					snap293 := d8
+					snap294 := d10
+					snap295 := d24
+					snap296 := d36
+					snap297 := d37
+					snap298 := d38
+					snap299 := d39
+					snap300 := d42
+					snap301 := d61
+					snap302 := d79
+					snap303 := d81
+					snap304 := d82
+					snap305 := d83
+					snap306 := d85
+					snap307 := d86
+					snap308 := d88
+					snap309 := d89
+					snap310 := d90
+					snap311 := d91
+					snap312 := d94
+					snap313 := d125
+					snap314 := d155
+					snap315 := d156
+					snap316 := d157
+					snap317 := d158
+					snap318 := d159
+					snap319 := d161
+					snap320 := d163
+					snap321 := d200
+					snap322 := d203
+					snap323 := d242
+					alloc324 := ctx.SnapshotAllocState()
 					if !bbs[6].Rendered {
-						bbs[6].RenderPS(ps267)
+						bbs[6].RenderPS(ps285)
 					}
-					ctx.RestoreAllocState(alloc304)
-					d1 = snap268
-					d2 = snap269
-					d3 = snap270
-					d4 = snap271
-					d5 = snap272
-					d6 = snap273
-					d7 = snap274
-					d9 = snap275
-					d22 = snap276
-					d33 = snap277
-					d34 = snap278
-					d35 = snap279
-					d38 = snap280
-					d55 = snap281
-					d71 = snap282
-					d73 = snap283
-					d74 = snap284
-					d75 = snap285
-					d77 = snap286
-					d78 = snap287
-					d80 = snap288
-					d81 = snap289
-					d82 = snap290
-					d83 = snap291
-					d86 = snap292
-					d115 = snap293
-					d143 = snap294
-					d144 = snap295
-					d145 = snap296
-					d146 = snap297
-					d147 = snap298
-					d149 = snap299
-					d151 = snap300
-					d186 = snap301
-					d189 = snap302
-					d226 = snap303
+					ctx.RestoreAllocState(alloc324)
+					d1 = snap286
+					d2 = snap287
+					d3 = snap288
+					d4 = snap289
+					d5 = snap290
+					d6 = snap291
+					d7 = snap292
+					d8 = snap293
+					d10 = snap294
+					d24 = snap295
+					d36 = snap296
+					d37 = snap297
+					d38 = snap298
+					d39 = snap299
+					d42 = snap300
+					d61 = snap301
+					d79 = snap302
+					d81 = snap303
+					d82 = snap304
+					d83 = snap305
+					d85 = snap306
+					d86 = snap307
+					d88 = snap308
+					d89 = snap309
+					d90 = snap310
+					d91 = snap311
+					d94 = snap312
+					d125 = snap313
+					d155 = snap314
+					d156 = snap315
+					d157 = snap316
+					d158 = snap317
+					d159 = snap318
+					d161 = snap319
+					d163 = snap320
+					d200 = snap321
+					d203 = snap322
+					d242 = snap323
 					if !bbs[7].Rendered {
-						return bbs[7].RenderPS(ps266)
+						return bbs[7].RenderPS(ps284)
 					}
 					return result
 					return result
@@ -8378,47 +8659,35 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
-						d33 = ps.OverlayValues[33]
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
-					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
-						d34 = ps.OverlayValues[34]
+					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
+						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
-						d35 = ps.OverlayValues[35]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
 					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
 						d38 = ps.OverlayValues[38]
 					}
-					if len(ps.OverlayValues) > 55 && ps.OverlayValues[55].Loc != LocNone {
-						d55 = ps.OverlayValues[55]
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
 					}
-					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
-						d73 = ps.OverlayValues[73]
+					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
+						d61 = ps.OverlayValues[61]
 					}
-					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
-						d74 = ps.OverlayValues[74]
-					}
-					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
-						d75 = ps.OverlayValues[75]
-					}
-					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
-						d77 = ps.OverlayValues[77]
-					}
-					if len(ps.OverlayValues) > 78 && ps.OverlayValues[78].Loc != LocNone {
-						d78 = ps.OverlayValues[78]
-					}
-					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
-						d80 = ps.OverlayValues[80]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
 						d81 = ps.OverlayValues[81]
@@ -8429,153 +8698,173 @@ func init_jit() {
 					if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
 						d83 = ps.OverlayValues[83]
 					}
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
+					}
 					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
 						d86 = ps.OverlayValues[86]
 					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
+					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
+						d88 = ps.OverlayValues[88]
 					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
+						d89 = ps.OverlayValues[89]
 					}
-					if len(ps.OverlayValues) > 144 && ps.OverlayValues[144].Loc != LocNone {
-						d144 = ps.OverlayValues[144]
+					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
+						d90 = ps.OverlayValues[90]
 					}
-					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
-						d145 = ps.OverlayValues[145]
+					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
+						d91 = ps.OverlayValues[91]
 					}
-					if len(ps.OverlayValues) > 146 && ps.OverlayValues[146].Loc != LocNone {
-						d146 = ps.OverlayValues[146]
+					if len(ps.OverlayValues) > 94 && ps.OverlayValues[94].Loc != LocNone {
+						d94 = ps.OverlayValues[94]
 					}
-					if len(ps.OverlayValues) > 147 && ps.OverlayValues[147].Loc != LocNone {
-						d147 = ps.OverlayValues[147]
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
-					if len(ps.OverlayValues) > 149 && ps.OverlayValues[149].Loc != LocNone {
-						d149 = ps.OverlayValues[149]
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
+					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
+						d156 = ps.OverlayValues[156]
 					}
-					if len(ps.OverlayValues) > 186 && ps.OverlayValues[186].Loc != LocNone {
-						d186 = ps.OverlayValues[186]
+					if len(ps.OverlayValues) > 157 && ps.OverlayValues[157].Loc != LocNone {
+						d157 = ps.OverlayValues[157]
 					}
-					if len(ps.OverlayValues) > 189 && ps.OverlayValues[189].Loc != LocNone {
-						d189 = ps.OverlayValues[189]
+					if len(ps.OverlayValues) > 158 && ps.OverlayValues[158].Loc != LocNone {
+						d158 = ps.OverlayValues[158]
 					}
-					if len(ps.OverlayValues) > 226 && ps.OverlayValues[226].Loc != LocNone {
-						d226 = ps.OverlayValues[226]
+					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
+						d159 = ps.OverlayValues[159]
+					}
+					if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+						d161 = ps.OverlayValues[161]
+					}
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
+					}
+					if len(ps.OverlayValues) > 200 && ps.OverlayValues[200].Loc != LocNone {
+						d200 = ps.OverlayValues[200]
+					}
+					if len(ps.OverlayValues) > 203 && ps.OverlayValues[203].Loc != LocNone {
+						d203 = ps.OverlayValues[203]
+					}
+					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
+						d242 = ps.OverlayValues[242]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d305 = args[1]
-					d305.ID = 0
-					d307 = d305
-					ctx.SyncDesc(&d307)
-					if d307.Loc == LocMem {
-						tmpScalar := JITValueDesc{Loc: LocReg, Type: d307.Type, Reg: ctx.AllocReg()}
+					d325 = args[1]
+					d325.ID = 0
+					d327 = d325
+					ctx.SyncDesc(&d327)
+					if d327.Loc == LocMem {
+						tmpScalar := JITValueDesc{Loc: LocReg, Type: d327.Type, Reg: ctx.AllocReg()}
 						scratch := ctx.AllocRegExcept(tmpScalar.Reg)
-						ctx.EmitMovRegImm64(scratch, uint64(d307.MemPtr))
+						ctx.EmitMovRegImm64(scratch, uint64(d327.MemPtr))
 						ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
 						ctx.FreeReg(scratch)
 						ctx.BindReg(tmpScalar.Reg, &tmpScalar)
-						d307 = tmpScalar
+						d327 = tmpScalar
 					}
-					d307 = JITPrepareScmerGoArg(ctx, d307)
-					if d307.Loc != LocRegPair && d307.Loc != LocStackPair && d307.Loc != LocInputPair {
+					d327 = JITPrepareScmerGoArg(ctx, d327)
+					if d327.Loc != LocRegPair && d327.Loc != LocStackPair && d327.Loc != LocInputPair {
 						panic("jit: Scmer.String receiver not materialized as pair")
 					}
-					d306 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d307}, 2)
-					ctx.StabilizeDescForControlFlow(&d306)
-					ctx.FreeDesc(&d305)
+					d326 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d327}, 2)
+					ctx.StabilizeDescForControlFlow(&d326)
+					ctx.FreeDesc(&d325)
 					if ps.General {
-						ctx.SyncDesc(&d306)
-						if d306.Loc == LocReg {
-							ctx.ProtectReg(d306.Reg)
-						} else if d306.Loc == LocRegPair {
-							ctx.ProtectReg(d306.Reg)
-							ctx.ProtectReg(d306.Reg2)
+						ctx.SyncDesc(&d326)
+						if d326.Loc == LocReg || d326.Loc == LocFPReg {
+							ctx.ProtectReg(d326.Reg)
+						} else if d326.Loc == LocRegPair {
+							ctx.ProtectReg(d326.Reg)
+							ctx.ProtectReg(d326.Reg2)
 						}
-						d308 = d306
-						if d308.Loc == LocNone {
+						d328 = d326
+						if d328.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.SyncDesc(&d308)
-						if d308.Loc == LocStackPair {
-							ctx.EmitCopyStackWords(d308, int32(bbs[10].PhiBase)+int32(0), 2)
-						} else if d308.Loc == LocInputPair {
-							ctx.EnsureDesc(&d308)
-							ctx.EmitStoreScmerToStack(d308, int32(bbs[10].PhiBase)+int32(0))
-						} else if d308.Loc == LocRegPair || d308.Loc == LocImm {
-							ctx.EmitStoreScmerToStack(d308, int32(bbs[10].PhiBase)+int32(0))
+						ctx.SyncDesc(&d328)
+						if d328.Loc == LocStackPair {
+							ctx.EmitCopyStackWords(d328, int32(bbs[10].PhiBase)+int32(0), 2)
+						} else if d328.Loc == LocInputPair {
+							ctx.EnsureDesc(&d328)
+							ctx.EmitStoreScmerToStack(d328, int32(bbs[10].PhiBase)+int32(0))
+						} else if d328.Loc == LocRegPair || d328.Loc == LocImm {
+							ctx.EmitStoreScmerToStack(d328, int32(bbs[10].PhiBase)+int32(0))
 						} else {
-							ctx.EnsureDesc(&d308)
-							ctx.EmitStoreToStack(d308, int32(bbs[10].PhiBase)+int32(0))
+							ctx.EnsureDesc(&d328)
+							ctx.EmitStoreToStack(d328, int32(bbs[10].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[10].PhiBase)+int32(0))+8)
 						}
-						if d306.Loc == LocReg {
-							ctx.UnprotectReg(d306.Reg)
-						} else if d306.Loc == LocRegPair {
-							ctx.UnprotectReg(d306.Reg)
-							ctx.UnprotectReg(d306.Reg2)
+						if d326.Loc == LocReg || d326.Loc == LocFPReg {
+							ctx.UnprotectReg(d326.Reg)
+						} else if d326.Loc == LocRegPair {
+							ctx.UnprotectReg(d326.Reg)
+							ctx.UnprotectReg(d326.Reg2)
 						}
 					}
-					ps309 := PhiState{General: ps.General}
-					ps309.OverlayValues = make([]JITValueDesc, 309)
-					ps309.OverlayValues[1] = d1
-					ps309.OverlayValues[2] = d2
-					ps309.OverlayValues[3] = d3
-					ps309.OverlayValues[4] = d4
-					ps309.OverlayValues[5] = d5
-					ps309.OverlayValues[6] = d6
-					ps309.OverlayValues[7] = d7
-					ps309.OverlayValues[9] = d9
-					ps309.OverlayValues[22] = d22
-					ps309.OverlayValues[33] = d33
-					ps309.OverlayValues[34] = d34
-					ps309.OverlayValues[35] = d35
-					ps309.OverlayValues[38] = d38
-					ps309.OverlayValues[55] = d55
-					ps309.OverlayValues[71] = d71
-					ps309.OverlayValues[73] = d73
-					ps309.OverlayValues[74] = d74
-					ps309.OverlayValues[75] = d75
-					ps309.OverlayValues[77] = d77
-					ps309.OverlayValues[78] = d78
-					ps309.OverlayValues[80] = d80
-					ps309.OverlayValues[81] = d81
-					ps309.OverlayValues[82] = d82
-					ps309.OverlayValues[83] = d83
-					ps309.OverlayValues[86] = d86
-					ps309.OverlayValues[115] = d115
-					ps309.OverlayValues[143] = d143
-					ps309.OverlayValues[144] = d144
-					ps309.OverlayValues[145] = d145
-					ps309.OverlayValues[146] = d146
-					ps309.OverlayValues[147] = d147
-					ps309.OverlayValues[149] = d149
-					ps309.OverlayValues[151] = d151
-					ps309.OverlayValues[186] = d186
-					ps309.OverlayValues[189] = d189
-					ps309.OverlayValues[226] = d226
-					ps309.OverlayValues[305] = d305
-					ps309.OverlayValues[306] = d306
-					ps309.OverlayValues[307] = d307
-					ps309.OverlayValues[308] = d308
-					ps309.PhiValues = make([]JITValueDesc, 1)
-					d310 = d306
-					ps309.PhiValues[0] = d310
-					if ps309.General && bbs[10].Rendered {
+					ps329 := PhiState{General: ps.General}
+					ps329.OverlayValues = make([]JITValueDesc, 329)
+					ps329.OverlayValues[1] = d1
+					ps329.OverlayValues[2] = d2
+					ps329.OverlayValues[3] = d3
+					ps329.OverlayValues[4] = d4
+					ps329.OverlayValues[5] = d5
+					ps329.OverlayValues[6] = d6
+					ps329.OverlayValues[7] = d7
+					ps329.OverlayValues[8] = d8
+					ps329.OverlayValues[10] = d10
+					ps329.OverlayValues[24] = d24
+					ps329.OverlayValues[36] = d36
+					ps329.OverlayValues[37] = d37
+					ps329.OverlayValues[38] = d38
+					ps329.OverlayValues[39] = d39
+					ps329.OverlayValues[42] = d42
+					ps329.OverlayValues[61] = d61
+					ps329.OverlayValues[79] = d79
+					ps329.OverlayValues[81] = d81
+					ps329.OverlayValues[82] = d82
+					ps329.OverlayValues[83] = d83
+					ps329.OverlayValues[85] = d85
+					ps329.OverlayValues[86] = d86
+					ps329.OverlayValues[88] = d88
+					ps329.OverlayValues[89] = d89
+					ps329.OverlayValues[90] = d90
+					ps329.OverlayValues[91] = d91
+					ps329.OverlayValues[94] = d94
+					ps329.OverlayValues[125] = d125
+					ps329.OverlayValues[155] = d155
+					ps329.OverlayValues[156] = d156
+					ps329.OverlayValues[157] = d157
+					ps329.OverlayValues[158] = d158
+					ps329.OverlayValues[159] = d159
+					ps329.OverlayValues[161] = d161
+					ps329.OverlayValues[163] = d163
+					ps329.OverlayValues[200] = d200
+					ps329.OverlayValues[203] = d203
+					ps329.OverlayValues[242] = d242
+					ps329.OverlayValues[325] = d325
+					ps329.OverlayValues[326] = d326
+					ps329.OverlayValues[327] = d327
+					ps329.OverlayValues[328] = d328
+					ps329.PhiValues = make([]JITValueDesc, 1)
+					d330 = d326
+					ps329.PhiValues[0] = d330
+					if ps329.General && bbs[10].Rendered {
 						ctx.EmitJmp(lbl11)
 						return result
 					}
-					return bbs[10].RenderPS(ps309)
+					return bbs[10].RenderPS(ps329)
 					return result
 				}
 				bbs[10].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d311 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d311)
-							ctx.EmitStoreScmerToStack(d311, int32(bbs[10].PhiBase)+int32(0))
+							d331 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d331)
+							ctx.EmitStoreScmerToStack(d331, int32(bbs[10].PhiBase)+int32(0))
 						}
 						if bbs[10].VisitCount >= 0 {
 							ps.General = true
@@ -8618,47 +8907,35 @@ func init_jit() {
 					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
 						d7 = ps.OverlayValues[7]
 					}
-					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
-						d9 = ps.OverlayValues[9]
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
 					}
-					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
-						d33 = ps.OverlayValues[33]
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
 					}
-					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
-						d34 = ps.OverlayValues[34]
+					if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != LocNone {
+						d36 = ps.OverlayValues[36]
 					}
-					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
-						d35 = ps.OverlayValues[35]
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
 					}
 					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
 						d38 = ps.OverlayValues[38]
 					}
-					if len(ps.OverlayValues) > 55 && ps.OverlayValues[55].Loc != LocNone {
-						d55 = ps.OverlayValues[55]
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
 					}
-					if len(ps.OverlayValues) > 71 && ps.OverlayValues[71].Loc != LocNone {
-						d71 = ps.OverlayValues[71]
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
 					}
-					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
-						d73 = ps.OverlayValues[73]
+					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
+						d61 = ps.OverlayValues[61]
 					}
-					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
-						d74 = ps.OverlayValues[74]
-					}
-					if len(ps.OverlayValues) > 75 && ps.OverlayValues[75].Loc != LocNone {
-						d75 = ps.OverlayValues[75]
-					}
-					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
-						d77 = ps.OverlayValues[77]
-					}
-					if len(ps.OverlayValues) > 78 && ps.OverlayValues[78].Loc != LocNone {
-						d78 = ps.OverlayValues[78]
-					}
-					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
-						d80 = ps.OverlayValues[80]
+					if len(ps.OverlayValues) > 79 && ps.OverlayValues[79].Loc != LocNone {
+						d79 = ps.OverlayValues[79]
 					}
 					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
 						d81 = ps.OverlayValues[81]
@@ -8669,174 +8946,194 @@ func init_jit() {
 					if len(ps.OverlayValues) > 83 && ps.OverlayValues[83].Loc != LocNone {
 						d83 = ps.OverlayValues[83]
 					}
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
+					}
 					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
 						d86 = ps.OverlayValues[86]
 					}
-					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
-						d115 = ps.OverlayValues[115]
+					if len(ps.OverlayValues) > 88 && ps.OverlayValues[88].Loc != LocNone {
+						d88 = ps.OverlayValues[88]
 					}
-					if len(ps.OverlayValues) > 143 && ps.OverlayValues[143].Loc != LocNone {
-						d143 = ps.OverlayValues[143]
+					if len(ps.OverlayValues) > 89 && ps.OverlayValues[89].Loc != LocNone {
+						d89 = ps.OverlayValues[89]
 					}
-					if len(ps.OverlayValues) > 144 && ps.OverlayValues[144].Loc != LocNone {
-						d144 = ps.OverlayValues[144]
+					if len(ps.OverlayValues) > 90 && ps.OverlayValues[90].Loc != LocNone {
+						d90 = ps.OverlayValues[90]
 					}
-					if len(ps.OverlayValues) > 145 && ps.OverlayValues[145].Loc != LocNone {
-						d145 = ps.OverlayValues[145]
+					if len(ps.OverlayValues) > 91 && ps.OverlayValues[91].Loc != LocNone {
+						d91 = ps.OverlayValues[91]
 					}
-					if len(ps.OverlayValues) > 146 && ps.OverlayValues[146].Loc != LocNone {
-						d146 = ps.OverlayValues[146]
+					if len(ps.OverlayValues) > 94 && ps.OverlayValues[94].Loc != LocNone {
+						d94 = ps.OverlayValues[94]
 					}
-					if len(ps.OverlayValues) > 147 && ps.OverlayValues[147].Loc != LocNone {
-						d147 = ps.OverlayValues[147]
+					if len(ps.OverlayValues) > 125 && ps.OverlayValues[125].Loc != LocNone {
+						d125 = ps.OverlayValues[125]
 					}
-					if len(ps.OverlayValues) > 149 && ps.OverlayValues[149].Loc != LocNone {
-						d149 = ps.OverlayValues[149]
+					if len(ps.OverlayValues) > 155 && ps.OverlayValues[155].Loc != LocNone {
+						d155 = ps.OverlayValues[155]
 					}
-					if len(ps.OverlayValues) > 151 && ps.OverlayValues[151].Loc != LocNone {
-						d151 = ps.OverlayValues[151]
+					if len(ps.OverlayValues) > 156 && ps.OverlayValues[156].Loc != LocNone {
+						d156 = ps.OverlayValues[156]
 					}
-					if len(ps.OverlayValues) > 186 && ps.OverlayValues[186].Loc != LocNone {
-						d186 = ps.OverlayValues[186]
+					if len(ps.OverlayValues) > 157 && ps.OverlayValues[157].Loc != LocNone {
+						d157 = ps.OverlayValues[157]
 					}
-					if len(ps.OverlayValues) > 189 && ps.OverlayValues[189].Loc != LocNone {
-						d189 = ps.OverlayValues[189]
+					if len(ps.OverlayValues) > 158 && ps.OverlayValues[158].Loc != LocNone {
+						d158 = ps.OverlayValues[158]
 					}
-					if len(ps.OverlayValues) > 226 && ps.OverlayValues[226].Loc != LocNone {
-						d226 = ps.OverlayValues[226]
+					if len(ps.OverlayValues) > 159 && ps.OverlayValues[159].Loc != LocNone {
+						d159 = ps.OverlayValues[159]
 					}
-					if len(ps.OverlayValues) > 305 && ps.OverlayValues[305].Loc != LocNone {
-						d305 = ps.OverlayValues[305]
+					if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != LocNone {
+						d161 = ps.OverlayValues[161]
 					}
-					if len(ps.OverlayValues) > 306 && ps.OverlayValues[306].Loc != LocNone {
-						d306 = ps.OverlayValues[306]
+					if len(ps.OverlayValues) > 163 && ps.OverlayValues[163].Loc != LocNone {
+						d163 = ps.OverlayValues[163]
 					}
-					if len(ps.OverlayValues) > 307 && ps.OverlayValues[307].Loc != LocNone {
-						d307 = ps.OverlayValues[307]
+					if len(ps.OverlayValues) > 200 && ps.OverlayValues[200].Loc != LocNone {
+						d200 = ps.OverlayValues[200]
 					}
-					if len(ps.OverlayValues) > 308 && ps.OverlayValues[308].Loc != LocNone {
-						d308 = ps.OverlayValues[308]
+					if len(ps.OverlayValues) > 203 && ps.OverlayValues[203].Loc != LocNone {
+						d203 = ps.OverlayValues[203]
 					}
-					if len(ps.OverlayValues) > 310 && ps.OverlayValues[310].Loc != LocNone {
-						d310 = ps.OverlayValues[310]
+					if len(ps.OverlayValues) > 242 && ps.OverlayValues[242].Loc != LocNone {
+						d242 = ps.OverlayValues[242]
 					}
-					if len(ps.OverlayValues) > 311 && ps.OverlayValues[311].Loc != LocNone {
-						d311 = ps.OverlayValues[311]
+					if len(ps.OverlayValues) > 325 && ps.OverlayValues[325].Loc != LocNone {
+						d325 = ps.OverlayValues[325]
+					}
+					if len(ps.OverlayValues) > 326 && ps.OverlayValues[326].Loc != LocNone {
+						d326 = ps.OverlayValues[326]
+					}
+					if len(ps.OverlayValues) > 327 && ps.OverlayValues[327].Loc != LocNone {
+						d327 = ps.OverlayValues[327]
+					}
+					if len(ps.OverlayValues) > 328 && ps.OverlayValues[328].Loc != LocNone {
+						d328 = ps.OverlayValues[328]
+					}
+					if len(ps.OverlayValues) > 330 && ps.OverlayValues[330].Loc != LocNone {
+						d330 = ps.OverlayValues[330]
+					}
+					if len(ps.OverlayValues) > 331 && ps.OverlayValues[331].Loc != LocNone {
+						d331 = ps.OverlayValues[331]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
 						d3 = ps.PhiValues[0]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d312 = ctx.EmitGoCallScalar(GoFuncAddr(func() *[1]any { return new([1]any) }), nil, 1)
-					d313 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					d332 = ctx.EmitGoCallScalar(GoFuncAddr(func() *[1]any { return new([1]any) }), nil, 1)
+					d333 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
 					ctx.EnsureDesc(&d3)
-					d314 = ctx.EmitGoCallScalar(GoFuncAddr(func(value string) any { return value }), []JITValueDesc{d3}, 2)
+					d334 = ctx.EmitGoCallScalar(GoFuncAddr(func(value string) any { return value }), []JITValueDesc{d3}, 2)
 					ctx.FreeDesc(&d3)
-					ctx.EnsureDesc(&d314)
-					ctx.EmitGoCallVoid(GoFuncAddr(func(dst *[1]any, index int, value any) { dst[index] = value }), []JITValueDesc{d312, d313, d314})
-					sliceResults315 := JITEmitGoCallResults(ctx, GoFuncAddr(func(value *[1]any) []any { return value[0:1:1] }), []JITValueDesc{d312}, []uint8{3}, []uint8{1})
-					d316 = sliceResults315[0]
-					d317 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("warning: JIT fallback: %s\n")}
-					ctx.EnsureDesc(&d317)
-					if d317.Loc == LocImm {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d317.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.TrackImm(d317.Imm)
-						ptrWord, _ := d317.Imm.RawWords()
+					ctx.EnsureDesc(&d334)
+					ctx.EmitGoCallVoid(GoFuncAddr(func(dst *[1]any, index int, value any) { dst[index] = value }), []JITValueDesc{d332, d333, d334})
+					sliceResults335 := JITEmitGoCallResults(ctx, GoFuncAddr(func(value *[1]any) []any { return value[0:1:1] }), []JITValueDesc{d332}, []uint8{3}, []uint8{1})
+					d336 = sliceResults335[0]
+					d337 = JITValueDesc{Loc: LocImm, Type: tagString, Imm: NewString("warning: JIT fallback: %s\n")}
+					ctx.EnsureDesc(&d337)
+					if d337.Loc == LocImm {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d337.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.TrackImm(d337.Imm)
+						ptrWord, _ := d337.Imm.RawWords()
 						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d317.Imm.String())))
-						d317 = tmpPair
-					} else if d317.Loc == LocReg {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d317.Type, Reg: ctx.AllocRegExcept(d317.Reg), Reg2: ctx.AllocRegExcept(d317.Reg)}
-						switch d317.Type {
+						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d337.Imm.String())))
+						d337 = tmpPair
+					} else if d337.Loc == LocReg {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d337.Type, Reg: ctx.AllocRegExcept(d337.Reg), Reg2: ctx.AllocRegExcept(d337.Reg)}
+						switch d337.Type {
 						case tagBool:
-							ctx.EmitMakeBool(tmpPair, d317)
+							ctx.EmitMakeBool(tmpPair, d337)
 						case tagInt:
-							ctx.EmitMakeInt(tmpPair, d317)
+							ctx.EmitMakeInt(tmpPair, d337)
 						case tagFloat:
-							ctx.EmitMakeFloat(tmpPair, d317)
+							ctx.EmitMakeFloat(tmpPair, d337)
 						default:
 							panic("jit: generic call arg scalar type unknown for 2-word value")
 						}
-						ctx.FreeDesc(&d317)
-						d317 = tmpPair
+						ctx.FreeDesc(&d337)
+						d337 = tmpPair
 					}
-					if d317.Loc != LocRegPair && d317.Loc != LocStackPair && d317.Loc != LocInputPair {
+					if d337.Loc != LocRegPair && d337.Loc != LocStackPair && d337.Loc != LocInputPair {
 						panic("jit: generic call arg expects 2-word value (fmt.Printf arg0)")
 					}
-					d316 = JITPrepareGoSliceArg(ctx, d316)
-					if d316.Loc != LocRegTriple && d316.Loc != LocStackTriple {
+					d336 = JITPrepareGoSliceArg(ctx, d336)
+					if d336.Loc != LocRegTriple && d336.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice (fmt.Printf arg1)")
 					}
-					ctx.SyncDesc(&d317)
-					ctx.SyncDesc(&d316)
-					callResults318 := JITEmitGoCallResults(ctx, GoFuncAddr(fmt.Printf), []JITValueDesc{d317, d316}, []uint8{1, 2}, []uint8{0, 3})
-					ctx.FreeDesc(&d317)
-					d319 = callResults318[0]
-					_ = d319
-					d320 = callResults318[1]
-					_ = d320
+					ctx.SyncDesc(&d337)
+					ctx.SyncDesc(&d336)
+					callResults338 := JITEmitGoCallResults(ctx, GoFuncAddr(fmt.Printf), []JITValueDesc{d337, d336}, []uint8{1, 2}, []uint8{0, 3})
+					ctx.FreeDesc(&d337)
+					d339 = callResults338[0]
+					_ = d339
+					d340 = callResults338[1]
+					_ = d340
 					if ps.General {
 					}
-					ps321 := PhiState{General: ps.General}
-					ps321.OverlayValues = make([]JITValueDesc, 321)
-					ps321.OverlayValues[1] = d1
-					ps321.OverlayValues[2] = d2
-					ps321.OverlayValues[3] = d3
-					ps321.OverlayValues[4] = d4
-					ps321.OverlayValues[5] = d5
-					ps321.OverlayValues[6] = d6
-					ps321.OverlayValues[7] = d7
-					ps321.OverlayValues[9] = d9
-					ps321.OverlayValues[22] = d22
-					ps321.OverlayValues[33] = d33
-					ps321.OverlayValues[34] = d34
-					ps321.OverlayValues[35] = d35
-					ps321.OverlayValues[38] = d38
-					ps321.OverlayValues[55] = d55
-					ps321.OverlayValues[71] = d71
-					ps321.OverlayValues[73] = d73
-					ps321.OverlayValues[74] = d74
-					ps321.OverlayValues[75] = d75
-					ps321.OverlayValues[77] = d77
-					ps321.OverlayValues[78] = d78
-					ps321.OverlayValues[80] = d80
-					ps321.OverlayValues[81] = d81
-					ps321.OverlayValues[82] = d82
-					ps321.OverlayValues[83] = d83
-					ps321.OverlayValues[86] = d86
-					ps321.OverlayValues[115] = d115
-					ps321.OverlayValues[143] = d143
-					ps321.OverlayValues[144] = d144
-					ps321.OverlayValues[145] = d145
-					ps321.OverlayValues[146] = d146
-					ps321.OverlayValues[147] = d147
-					ps321.OverlayValues[149] = d149
-					ps321.OverlayValues[151] = d151
-					ps321.OverlayValues[186] = d186
-					ps321.OverlayValues[189] = d189
-					ps321.OverlayValues[226] = d226
-					ps321.OverlayValues[305] = d305
-					ps321.OverlayValues[306] = d306
-					ps321.OverlayValues[307] = d307
-					ps321.OverlayValues[308] = d308
-					ps321.OverlayValues[310] = d310
-					ps321.OverlayValues[311] = d311
-					ps321.OverlayValues[312] = d312
-					ps321.OverlayValues[313] = d313
-					ps321.OverlayValues[314] = d314
-					ps321.OverlayValues[316] = d316
-					ps321.OverlayValues[317] = d317
-					ps321.OverlayValues[319] = d319
-					ps321.OverlayValues[320] = d320
-					if ps321.General && bbs[7].Rendered {
+					ps341 := PhiState{General: ps.General}
+					ps341.OverlayValues = make([]JITValueDesc, 341)
+					ps341.OverlayValues[1] = d1
+					ps341.OverlayValues[2] = d2
+					ps341.OverlayValues[3] = d3
+					ps341.OverlayValues[4] = d4
+					ps341.OverlayValues[5] = d5
+					ps341.OverlayValues[6] = d6
+					ps341.OverlayValues[7] = d7
+					ps341.OverlayValues[8] = d8
+					ps341.OverlayValues[10] = d10
+					ps341.OverlayValues[24] = d24
+					ps341.OverlayValues[36] = d36
+					ps341.OverlayValues[37] = d37
+					ps341.OverlayValues[38] = d38
+					ps341.OverlayValues[39] = d39
+					ps341.OverlayValues[42] = d42
+					ps341.OverlayValues[61] = d61
+					ps341.OverlayValues[79] = d79
+					ps341.OverlayValues[81] = d81
+					ps341.OverlayValues[82] = d82
+					ps341.OverlayValues[83] = d83
+					ps341.OverlayValues[85] = d85
+					ps341.OverlayValues[86] = d86
+					ps341.OverlayValues[88] = d88
+					ps341.OverlayValues[89] = d89
+					ps341.OverlayValues[90] = d90
+					ps341.OverlayValues[91] = d91
+					ps341.OverlayValues[94] = d94
+					ps341.OverlayValues[125] = d125
+					ps341.OverlayValues[155] = d155
+					ps341.OverlayValues[156] = d156
+					ps341.OverlayValues[157] = d157
+					ps341.OverlayValues[158] = d158
+					ps341.OverlayValues[159] = d159
+					ps341.OverlayValues[161] = d161
+					ps341.OverlayValues[163] = d163
+					ps341.OverlayValues[200] = d200
+					ps341.OverlayValues[203] = d203
+					ps341.OverlayValues[242] = d242
+					ps341.OverlayValues[325] = d325
+					ps341.OverlayValues[326] = d326
+					ps341.OverlayValues[327] = d327
+					ps341.OverlayValues[328] = d328
+					ps341.OverlayValues[330] = d330
+					ps341.OverlayValues[331] = d331
+					ps341.OverlayValues[332] = d332
+					ps341.OverlayValues[333] = d333
+					ps341.OverlayValues[334] = d334
+					ps341.OverlayValues[336] = d336
+					ps341.OverlayValues[337] = d337
+					ps341.OverlayValues[339] = d339
+					ps341.OverlayValues[340] = d340
+					if ps341.General && bbs[7].Rendered {
 						ctx.EmitJmp(lbl8)
 						return result
 					}
-					return bbs[7].RenderPS(ps321)
+					return bbs[7].RenderPS(ps341)
 					return result
 				}
-				ps322 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps322)
+				ps342 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps342)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -3494,15 +3494,21 @@ func (batch *jitParallelRegMoveBatch) uses(reg Reg) bool {
 // never by a hard-coded x86 register number. The scratch value is saved only
 // when a cycle actually needs it, so an allocated outer value remains intact.
 func (ctx *JITContext) parallelMoveScratch(batch *jitParallelRegMoveBatch) Reg {
-	if !batch.uses(ctx.SliceBase) {
+	eligible := func(reg Reg) bool {
+		// The stack and frame registers define the generated frame. A backend may
+		// also expose one as a value base (notably SliceBase=RSP), but a parallel
+		// assignment must never rewrite either register while breaking a cycle.
+		return reg != ctx.StackReg && reg != ctx.FrameReg && !batch.uses(reg)
+	}
+	if eligible(ctx.SliceBase) {
 		return ctx.SliceBase
 	}
-	if !batch.uses(ctx.ScratchReg) {
+	if eligible(ctx.ScratchReg) {
 		return ctx.ScratchReg
 	}
 	for index := uint8(0); index < ctx.RegisterBank.Count; index++ {
 		candidate := ctx.RegisterBank.Registers[index]
-		if !batch.uses(candidate) {
+		if eligible(candidate) {
 			return candidate
 		}
 	}

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -224,10 +224,10 @@ func jitPlaceIntoPair(ctx *JITContext, src *JITValueDesc, target JITValueDesc) J
 		ctx.EnsureDesc(src)
 		return jitPlaceIntoPair(ctx, src, target)
 	case LocRegPair:
-		ctx.emitParallelRegMoves([]jitRegMove{
-			{dst: target.Reg, src: src.Reg},
-			{dst: target.Reg2, src: src.Reg2},
-		})
+		var moves jitParallelRegMoveBatch
+		moves.add(target.Reg, src.Reg)
+		moves.add(target.Reg2, src.Reg2)
+		ctx.emitParallelRegMoveBatch(&moves)
 		if src.Reg != target.Reg && src.Reg2 != target.Reg2 {
 			ctx.FreeDesc(src)
 		}

--- a/scm/jit_storage_abi_test.go
+++ b/scm/jit_storage_abi_test.go
@@ -45,6 +45,68 @@ func TestEmitCmpFloat64AvoidsDuplicateSameOperandMove(t *testing.T) {
 	}
 }
 
+func emitParallelMoveTestCode(t *testing.T, batch *jitParallelRegMoveBatch) []byte {
+	t.Helper()
+	code := make([]byte, 128)
+	ctx := &JITContext{
+		Start:        unsafe.Pointer(&code[0]),
+		Ptr:          unsafe.Pointer(&code[0]),
+		End:          unsafe.Pointer(&code[len(code)-1]),
+		SliceBase:    RegR12,
+		ScratchReg:   RegR11,
+		StackReg:     RegRSP,
+		RegisterBank: jitX86RegisterBank,
+	}
+	ctx.emitParallelRegMoveBatch(batch)
+	if ctx.DynamicSP != 0 {
+		t.Fatalf("parallel move left dynamic stack offset %d", ctx.DynamicSP)
+	}
+	return code[:uintptr(ctx.Ptr)-uintptr(ctx.Start)]
+}
+
+func TestParallelMoveBatchElidesIdentityAndOrdersDependencies(t *testing.T) {
+	var batch jitParallelRegMoveBatch
+	batch.add(RegRDX, RegRDX)
+	batch.add(RegRAX, RegRBX)
+	batch.add(RegRCX, RegRAX)
+
+	// RCX must consume the old RAX before RAX is overwritten by RBX. Both x86
+	// register moves are three bytes; the identity must emit nothing.
+	code := emitParallelMoveTestCode(t, &batch)
+	want := []byte{0x48, 0x89, 0xc1, 0x48, 0x89, 0xd8}
+	if !bytes.Equal(code, want) {
+		t.Fatalf("parallel dependency moves = %x, want %x", code, want)
+	}
+}
+
+func TestParallelMoveBatchBreaksCycleWithOneSavedScratch(t *testing.T) {
+	var batch jitParallelRegMoveBatch
+	batch.add(RegRAX, RegRBX)
+	batch.add(RegRBX, RegRAX)
+
+	code := emitParallelMoveTestCode(t, &batch)
+	// PUSH/POP R12 surround exactly three MOVs: save old RAX in scratch,
+	// rotate RBX into RAX, then scratch into RBX.
+	if len(code) != 13 || !bytes.Equal(code[:2], []byte{0x41, 0x54}) || !bytes.Equal(code[len(code)-2:], []byte{0x41, 0x5c}) {
+		t.Fatalf("parallel cycle is not one saved-scratch rotation: %x", code)
+	}
+}
+
+func TestParallelMoveBatchChoosesScratchOutsideCycle(t *testing.T) {
+	var batch jitParallelRegMoveBatch
+	batch.add(RegR12, RegR11)
+	batch.add(RegR11, RegR12)
+
+	// Both preferred role registers participate in the cycle. The solver must
+	// select another register from the architecture-provided bank; reusing either
+	// cycle member would fail to break the dependency (the old R12-specific
+	// implementation could loop forever for this shape).
+	code := emitParallelMoveTestCode(t, &batch)
+	if len(code) != 13 {
+		t.Fatalf("role-register cycle emitted %d bytes, want one saved-scratch rotation (13): %x", len(code), code)
+	}
+}
+
 func jitFourScalarResults(seed uint32) (int64, bool, int64, int64) {
 	return int64(seed) + 1, seed&1 != 0, int64(seed) + 3, int64(seed) + 5
 }
@@ -106,6 +168,29 @@ func TestJITStorageScalarInputSurvivesScratchReclamation(t *testing.T) {
 	}
 	if got, want := fn(17), NewInt(17); !Equal(got, want) {
 		t.Fatalf("scalar input after scratch reclamation = %v, want %v", got, want)
+	}
+}
+
+func TestJITLessHelperEmitsKnownIntegerComparison(t *testing.T) {
+	fn := CompileJITStorageGetValue(func(ctx *JITContext, source, target JITValueDesc) JITValueDesc {
+		source.Type = tagInt
+		comparison := jitEmitLess(ctx, []JITValueDesc{
+			source,
+			{Loc: LocImm, Type: tagInt, Imm: NewInt(511)},
+		}, JITValueDesc{Loc: LocReg, Type: tagBool, Reg: target.Reg2, ID: 0})
+		ctx.EmitMakeBool(target, comparison)
+		return target
+	})
+	if fn == nil {
+		t.Fatal("known integer Less helper did not compile")
+	}
+	for _, test := range []struct {
+		value uint32
+		want  bool
+	}{{510, true}, {511, false}, {512, false}} {
+		if got := fn(test.value).Bool(); got != test.want {
+			t.Fatalf("(< %d 511) = %v, want %v", test.value, got, test.want)
+		}
 	}
 }
 

--- a/scm/jit_storage_abi_test.go
+++ b/scm/jit_storage_abi_test.go
@@ -55,6 +55,7 @@ func emitParallelMoveTestCode(t *testing.T, batch *jitParallelRegMoveBatch) []by
 		SliceBase:    RegR12,
 		ScratchReg:   RegR11,
 		StackReg:     RegRSP,
+		FrameReg:     RegRBP,
 		RegisterBank: jitX86RegisterBank,
 	}
 	ctx.emitParallelRegMoveBatch(batch)
@@ -104,6 +105,25 @@ func TestParallelMoveBatchChoosesScratchOutsideCycle(t *testing.T) {
 	code := emitParallelMoveTestCode(t, &batch)
 	if len(code) != 13 {
 		t.Fatalf("role-register cycle emitted %d bytes, want one saved-scratch rotation (13): %x", len(code), code)
+	}
+}
+
+func TestParallelMoveBatchNeverUsesStackOrFrameRegisterAsScratch(t *testing.T) {
+	var batch jitParallelRegMoveBatch
+	batch.add(RegRAX, RegRBX)
+	batch.add(RegRBX, RegRAX)
+
+	ctx := JITContext{
+		// Stack-backed argument lists deliberately use RSP as SliceBase. This
+		// makes it a valid address base, not a writable temporary register.
+		SliceBase:    RegRSP,
+		ScratchReg:   RegR11,
+		StackReg:     RegRSP,
+		FrameReg:     RegRBP,
+		RegisterBank: jitX86RegisterBank,
+	}
+	if scratch := ctx.parallelMoveScratch(&batch); scratch != RegR11 {
+		t.Fatalf("parallel cycle scratch = %d, want non-frame scratch %d", scratch, RegR11)
 	}
 }
 

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -2536,11 +2536,11 @@ func (ctx *JITContext) emitFuncValueCall(fn, argslice, result JITValueDesc, kind
 	// Stage the slice and function value as one parallel move. The allocator may
 	// place the function value in RAX/RBX or either slice word in RDX; sequential
 	// moves would then destroy a source before its final consumer reads it.
-	ctx.emitParallelRegMoves([]jitRegMove{
-		{dst: RegRAX, src: argslice.Reg},
-		{dst: RegRBX, src: argslice.Reg2},
-		{dst: RegRDX, src: fn.Reg},
-	})
+	var moves jitParallelRegMoveBatch
+	moves.add(RegRAX, argslice.Reg)
+	moves.add(RegRBX, argslice.Reg2)
+	moves.add(RegRDX, fn.Reg)
+	ctx.emitParallelRegMoveBatch(&moves)
 	ctx.EmitMovRegReg(RegRCX, RegRBX)
 	ctx.EmitMovRegMem(RegR11, RegRDX, 0)
 

--- a/scm/list.go
+++ b/scm/list.go
@@ -1854,12 +1854,8 @@ func init_list() {
 				_ = d2
 				var d3 JITValueDesc
 				_ = d3
-				var d18 JITValueDesc
-				_ = d18
-				var d19 JITValueDesc
-				_ = d19
-				var d20 JITValueDesc
-				_ = d20
+				var d4 JITValueDesc
+				_ = d4
 				var d21 JITValueDesc
 				_ = d21
 				var d22 JITValueDesc
@@ -1872,26 +1868,34 @@ func init_list() {
 				_ = d25
 				var d26 JITValueDesc
 				_ = d26
-				var d59 JITValueDesc
-				_ = d59
-				var d60 JITValueDesc
-				_ = d60
-				var d61 JITValueDesc
-				_ = d61
-				var d62 JITValueDesc
-				_ = d62
-				var d103 JITValueDesc
-				_ = d103
-				var d104 JITValueDesc
-				_ = d104
-				var d105 JITValueDesc
-				_ = d105
-				var d106 JITValueDesc
-				_ = d106
-				var d107 JITValueDesc
-				_ = d107
-				var d108 JITValueDesc
-				_ = d108
+				var d27 JITValueDesc
+				_ = d27
+				var d28 JITValueDesc
+				_ = d28
+				var d29 JITValueDesc
+				_ = d29
+				var d30 JITValueDesc
+				_ = d30
+				var d67 JITValueDesc
+				_ = d67
+				var d68 JITValueDesc
+				_ = d68
+				var d69 JITValueDesc
+				_ = d69
+				var d70 JITValueDesc
+				_ = d70
+				var d115 JITValueDesc
+				_ = d115
+				var d116 JITValueDesc
+				_ = d116
+				var d117 JITValueDesc
+				_ = d117
+				var d118 JITValueDesc
+				_ = d118
+				var d119 JITValueDesc
+				_ = d119
+				var d120 JITValueDesc
+				_ = d120
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				var bbs [7]BBDescriptor
 				for i := range args {
@@ -1958,97 +1962,108 @@ func init_list() {
 					ctx.ReclaimUntrackedRegs()
 					d0 = args[0]
 					d0.ID = 0
-					d1 = ctx.EmitGetTagDesc(&d0, JITValueDesc{Loc: LocAny})
+					d1 = d0
+					d1.ID = 0
+					d2 = ctx.EmitGetTagDesc(&d1, JITValueDesc{Loc: LocAny})
 					ctx.FreeDesc(&d0)
-					ctx.EnsureDesc(&d1)
-					var d2 JITValueDesc
-					if d1.Loc == LocImm {
-						d2 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d1.Imm.Int()) == uint64(0x6))}
+					ctx.EnsureDesc(&d2)
+					var d3 JITValueDesc
+					if d2.Loc == LocImm {
+						d3 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d2.Imm.Int()) == uint64(0x6))}
 					} else {
 						r0 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d1.Reg, 6)
-						d2 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
-						ctx.BindReg(r0, &d2)
+						ctx.EmitCmpRegImm32(d2.Reg, 6)
+						d3 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
+						ctx.BindReg(r0, &d3)
 					}
-					ctx.FreeDesc(&d1)
-					d3 = d2
-					ctx.EnsureDesc(&d3)
-					if d3.Loc != LocImm && d3.Loc != LocFlags {
+					ctx.FreeDesc(&d2)
+					d4 = d3
+					ctx.EnsureDesc(&d4)
+					if d4.Loc != LocImm && d4.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d3.Loc == LocImm {
-						if d3.Imm.Bool() {
+					if d4.Loc == LocImm {
+						if d4.Imm.Bool() {
 							if ps.General {
 							}
-							ps4 := PhiState{General: ps.General}
-							ps4.OverlayValues = make([]JITValueDesc, 4)
-							ps4.OverlayValues[0] = d0
-							ps4.OverlayValues[1] = d1
-							ps4.OverlayValues[2] = d2
-							ps4.OverlayValues[3] = d3
-							return bbs[1].RenderPS(ps4)
+							ps5 := PhiState{General: ps.General}
+							ps5.OverlayValues = make([]JITValueDesc, 5)
+							ps5.OverlayValues[0] = d0
+							ps5.OverlayValues[1] = d1
+							ps5.OverlayValues[2] = d2
+							ps5.OverlayValues[3] = d3
+							ps5.OverlayValues[4] = d4
+							return bbs[1].RenderPS(ps5)
 						}
 						if ps.General {
 						}
-						ps5 := PhiState{General: ps.General}
-						ps5.OverlayValues = make([]JITValueDesc, 4)
-						ps5.OverlayValues[0] = d0
-						ps5.OverlayValues[1] = d1
-						ps5.OverlayValues[2] = d2
-						ps5.OverlayValues[3] = d3
-						return bbs[2].RenderPS(ps5)
+						ps6 := PhiState{General: ps.General}
+						ps6.OverlayValues = make([]JITValueDesc, 5)
+						ps6.OverlayValues[0] = d0
+						ps6.OverlayValues[1] = d1
+						ps6.OverlayValues[2] = d2
+						ps6.OverlayValues[3] = d3
+						ps6.OverlayValues[4] = d4
+						return bbs[2].RenderPS(ps6)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[0].RenderPS(ps)
 					}
-					ctx.EmitJump(d3.Condition, lbl2)
+					ctx.EmitJump(d4.Condition, lbl2)
 					if bbs[2].Rendered {
 						ctx.EmitJmp(lbl3)
 					}
-					ctx.FreeDesc(&d2)
-					snap6 := d0
-					snap7 := d1
-					snap8 := d2
-					snap9 := d3
-					alloc10 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc10)
-					d0 = snap6
-					d1 = snap7
-					d2 = snap8
-					d3 = snap9
-					ctx.RestoreAllocState(alloc10)
-					d0 = snap6
-					d1 = snap7
-					d2 = snap8
-					d3 = snap9
-					ps11 := PhiState{General: true}
-					ps11.OverlayValues = make([]JITValueDesc, 4)
-					ps11.OverlayValues[0] = d0
-					ps11.OverlayValues[1] = d1
-					ps11.OverlayValues[2] = d2
-					ps11.OverlayValues[3] = d3
-					ps12 := PhiState{General: true}
-					ps12.OverlayValues = make([]JITValueDesc, 4)
-					ps12.OverlayValues[0] = d0
-					ps12.OverlayValues[1] = d1
-					ps12.OverlayValues[2] = d2
-					ps12.OverlayValues[3] = d3
-					snap13 := d0
-					snap14 := d1
-					snap15 := d2
-					snap16 := d3
-					alloc17 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d3)
+					snap7 := d0
+					snap8 := d1
+					snap9 := d2
+					snap10 := d3
+					snap11 := d4
+					alloc12 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc12)
+					d0 = snap7
+					d1 = snap8
+					d2 = snap9
+					d3 = snap10
+					d4 = snap11
+					ctx.RestoreAllocState(alloc12)
+					d0 = snap7
+					d1 = snap8
+					d2 = snap9
+					d3 = snap10
+					d4 = snap11
+					ps13 := PhiState{General: true}
+					ps13.OverlayValues = make([]JITValueDesc, 5)
+					ps13.OverlayValues[0] = d0
+					ps13.OverlayValues[1] = d1
+					ps13.OverlayValues[2] = d2
+					ps13.OverlayValues[3] = d3
+					ps13.OverlayValues[4] = d4
+					ps14 := PhiState{General: true}
+					ps14.OverlayValues = make([]JITValueDesc, 5)
+					ps14.OverlayValues[0] = d0
+					ps14.OverlayValues[1] = d1
+					ps14.OverlayValues[2] = d2
+					ps14.OverlayValues[3] = d3
+					ps14.OverlayValues[4] = d4
+					snap15 := d0
+					snap16 := d1
+					snap17 := d2
+					snap18 := d3
+					snap19 := d4
+					alloc20 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps12)
+						bbs[2].RenderPS(ps14)
 					}
-					ctx.RestoreAllocState(alloc17)
-					d0 = snap13
-					d1 = snap14
-					d2 = snap15
-					d3 = snap16
+					ctx.RestoreAllocState(alloc20)
+					d0 = snap15
+					d1 = snap16
+					d2 = snap17
+					d3 = snap18
+					d4 = snap19
 					if !bbs[1].Rendered {
-						return bbs[1].RenderPS(ps11)
+						return bbs[1].RenderPS(ps13)
 					}
 					return result
 					return result
@@ -2084,39 +2099,42 @@ func init_list() {
 					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
 						d3 = ps.OverlayValues[3]
 					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d18 = args[0]
-					d18.ID = 0
-					d19 = jitKnownSliceHeader(ctx, &d18)
-					ctx.FreeDesc(&d18)
-					var d20 JITValueDesc
-					if d19.SliceSizeKnown {
-						d20 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.KnownSliceLen))}
-					} else if d19.Loc == LocImm {
-						d20 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.StackOff))}
-					} else if d19.Loc == LocStackTriple {
-						d20 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d19.StackOff + 8, NoHeapPointer: true}
+					d21 = args[0]
+					d21.ID = 0
+					d22 = jitKnownSliceHeader(ctx, &d21)
+					ctx.FreeDesc(&d21)
+					var d23 JITValueDesc
+					if d22.SliceSizeKnown {
+						d23 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d22.KnownSliceLen))}
+					} else if d22.Loc == LocImm {
+						d23 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d22.StackOff))}
+					} else if d22.Loc == LocStackTriple {
+						d23 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d22.StackOff + 8, NoHeapPointer: true}
 					} else {
-						ctx.EnsureDesc(&d19)
-						if d19.Loc == LocRegPair || d19.Loc == LocRegTriple {
-							d20 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg2, ID: 0}
-						} else if d19.Loc == LocReg {
-							d20 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg, ID: 0}
+						ctx.EnsureDesc(&d22)
+						if d22.Loc == LocRegPair || d22.Loc == LocRegTriple {
+							d23 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d22.Reg2, ID: 0}
+						} else if d22.Loc == LocReg {
+							d23 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d22.Reg, ID: 0}
 						} else {
 							panic("len on unsupported descriptor location")
 						}
 					}
-					ctx.EnsureDesc(&d20)
-					ctx.EnsureDesc(&d20)
-					ctx.EnsureDesc(&d20)
-					if d20.Loc == LocImm {
-						ctx.EmitMakeInt(result, d20)
+					ctx.EnsureDesc(&d23)
+					ctx.EnsureDesc(&d23)
+					ctx.EnsureDesc(&d23)
+					if d23.Loc == LocImm {
+						ctx.EmitMakeInt(result, d23)
 					} else {
-						ctx.EmitMovToReg(result.Reg2, d20)
-						d22 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeInt(result, d22)
-						if d20.Loc == LocReg && d20.Reg != result.Reg2 {
-							ctx.FreeReg(d20.Reg)
+						ctx.EmitMovToReg(result.Reg2, d23)
+						d25 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d25)
+						if d23.Loc == LocReg && d23.Reg != result.Reg2 {
+							ctx.FreeReg(d23.Reg)
 						}
 					}
 					result.Type = tagInt
@@ -2154,14 +2172,8 @@ func init_list() {
 					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
 						d3 = ps.OverlayValues[3]
 					}
-					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
-						d18 = ps.OverlayValues[18]
-					}
-					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
-						d19 = ps.OverlayValues[19]
-					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
 					}
 					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
 						d21 = ps.OverlayValues[21]
@@ -2169,181 +2181,210 @@ func init_list() {
 					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
 						d22 = ps.OverlayValues[22]
 					}
+					if len(ps.OverlayValues) > 23 && ps.OverlayValues[23].Loc != LocNone {
+						d23 = ps.OverlayValues[23]
+					}
+					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
+						d24 = ps.OverlayValues[24]
+					}
+					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
+						d25 = ps.OverlayValues[25]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d23 = args[0]
-					d23.ID = 0
-					d24 = ctx.EmitGetTagDesc(&d23, JITValueDesc{Loc: LocAny})
-					ctx.FreeDesc(&d23)
-					ctx.EnsureDesc(&d24)
-					var d25 JITValueDesc
-					if d24.Loc == LocImm {
-						d25 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d24.Imm.Int()) == uint64(0xf))}
+					d26 = args[0]
+					d26.ID = 0
+					d27 = d26
+					d27.ID = 0
+					d28 = ctx.EmitGetTagDesc(&d27, JITValueDesc{Loc: LocAny})
+					ctx.FreeDesc(&d26)
+					ctx.EnsureDesc(&d28)
+					var d29 JITValueDesc
+					if d28.Loc == LocImm {
+						d29 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d28.Imm.Int()) == uint64(0xf))}
 					} else {
 						r1 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d24.Reg, 15)
-						d25 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondEqual}
-						ctx.BindReg(r1, &d25)
+						ctx.EmitCmpRegImm32(d28.Reg, 15)
+						d29 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondEqual}
+						ctx.BindReg(r1, &d29)
 					}
-					ctx.FreeDesc(&d24)
-					d26 = d25
-					ctx.EnsureDesc(&d26)
-					if d26.Loc != LocImm && d26.Loc != LocFlags {
+					ctx.FreeDesc(&d28)
+					d30 = d29
+					ctx.EnsureDesc(&d30)
+					if d30.Loc != LocImm && d30.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d26.Loc == LocImm {
-						if d26.Imm.Bool() {
+					if d30.Loc == LocImm {
+						if d30.Imm.Bool() {
 							if ps.General {
 							}
-							ps27 := PhiState{General: ps.General}
-							ps27.OverlayValues = make([]JITValueDesc, 27)
-							ps27.OverlayValues[0] = d0
-							ps27.OverlayValues[1] = d1
-							ps27.OverlayValues[2] = d2
-							ps27.OverlayValues[3] = d3
-							ps27.OverlayValues[18] = d18
-							ps27.OverlayValues[19] = d19
-							ps27.OverlayValues[20] = d20
-							ps27.OverlayValues[21] = d21
-							ps27.OverlayValues[22] = d22
-							ps27.OverlayValues[23] = d23
-							ps27.OverlayValues[24] = d24
-							ps27.OverlayValues[25] = d25
-							ps27.OverlayValues[26] = d26
-							return bbs[3].RenderPS(ps27)
+							ps31 := PhiState{General: ps.General}
+							ps31.OverlayValues = make([]JITValueDesc, 31)
+							ps31.OverlayValues[0] = d0
+							ps31.OverlayValues[1] = d1
+							ps31.OverlayValues[2] = d2
+							ps31.OverlayValues[3] = d3
+							ps31.OverlayValues[4] = d4
+							ps31.OverlayValues[21] = d21
+							ps31.OverlayValues[22] = d22
+							ps31.OverlayValues[23] = d23
+							ps31.OverlayValues[24] = d24
+							ps31.OverlayValues[25] = d25
+							ps31.OverlayValues[26] = d26
+							ps31.OverlayValues[27] = d27
+							ps31.OverlayValues[28] = d28
+							ps31.OverlayValues[29] = d29
+							ps31.OverlayValues[30] = d30
+							return bbs[3].RenderPS(ps31)
 						}
 						if ps.General {
 						}
-						ps28 := PhiState{General: ps.General}
-						ps28.OverlayValues = make([]JITValueDesc, 27)
-						ps28.OverlayValues[0] = d0
-						ps28.OverlayValues[1] = d1
-						ps28.OverlayValues[2] = d2
-						ps28.OverlayValues[3] = d3
-						ps28.OverlayValues[18] = d18
-						ps28.OverlayValues[19] = d19
-						ps28.OverlayValues[20] = d20
-						ps28.OverlayValues[21] = d21
-						ps28.OverlayValues[22] = d22
-						ps28.OverlayValues[23] = d23
-						ps28.OverlayValues[24] = d24
-						ps28.OverlayValues[25] = d25
-						ps28.OverlayValues[26] = d26
-						return bbs[4].RenderPS(ps28)
+						ps32 := PhiState{General: ps.General}
+						ps32.OverlayValues = make([]JITValueDesc, 31)
+						ps32.OverlayValues[0] = d0
+						ps32.OverlayValues[1] = d1
+						ps32.OverlayValues[2] = d2
+						ps32.OverlayValues[3] = d3
+						ps32.OverlayValues[4] = d4
+						ps32.OverlayValues[21] = d21
+						ps32.OverlayValues[22] = d22
+						ps32.OverlayValues[23] = d23
+						ps32.OverlayValues[24] = d24
+						ps32.OverlayValues[25] = d25
+						ps32.OverlayValues[26] = d26
+						ps32.OverlayValues[27] = d27
+						ps32.OverlayValues[28] = d28
+						ps32.OverlayValues[29] = d29
+						ps32.OverlayValues[30] = d30
+						return bbs[4].RenderPS(ps32)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[2].RenderPS(ps)
 					}
-					ctx.EmitJump(d26.Condition, lbl4)
+					ctx.EmitJump(d30.Condition, lbl4)
 					if bbs[4].Rendered {
 						ctx.EmitJmp(lbl5)
 					}
-					ctx.FreeDesc(&d25)
-					snap29 := d0
-					snap30 := d1
-					snap31 := d2
-					snap32 := d3
-					snap33 := d18
-					snap34 := d19
-					snap35 := d20
-					snap36 := d21
-					snap37 := d22
-					snap38 := d23
-					snap39 := d24
-					snap40 := d25
-					snap41 := d26
-					alloc42 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc42)
-					d0 = snap29
-					d1 = snap30
-					d2 = snap31
-					d3 = snap32
-					d18 = snap33
-					d19 = snap34
-					d20 = snap35
-					d21 = snap36
-					d22 = snap37
-					d23 = snap38
-					d24 = snap39
-					d25 = snap40
-					d26 = snap41
-					ctx.RestoreAllocState(alloc42)
-					d0 = snap29
-					d1 = snap30
-					d2 = snap31
-					d3 = snap32
-					d18 = snap33
-					d19 = snap34
-					d20 = snap35
-					d21 = snap36
-					d22 = snap37
-					d23 = snap38
-					d24 = snap39
-					d25 = snap40
-					d26 = snap41
-					ps43 := PhiState{General: true}
-					ps43.OverlayValues = make([]JITValueDesc, 27)
-					ps43.OverlayValues[0] = d0
-					ps43.OverlayValues[1] = d1
-					ps43.OverlayValues[2] = d2
-					ps43.OverlayValues[3] = d3
-					ps43.OverlayValues[18] = d18
-					ps43.OverlayValues[19] = d19
-					ps43.OverlayValues[20] = d20
-					ps43.OverlayValues[21] = d21
-					ps43.OverlayValues[22] = d22
-					ps43.OverlayValues[23] = d23
-					ps43.OverlayValues[24] = d24
-					ps43.OverlayValues[25] = d25
-					ps43.OverlayValues[26] = d26
-					ps44 := PhiState{General: true}
-					ps44.OverlayValues = make([]JITValueDesc, 27)
-					ps44.OverlayValues[0] = d0
-					ps44.OverlayValues[1] = d1
-					ps44.OverlayValues[2] = d2
-					ps44.OverlayValues[3] = d3
-					ps44.OverlayValues[18] = d18
-					ps44.OverlayValues[19] = d19
-					ps44.OverlayValues[20] = d20
-					ps44.OverlayValues[21] = d21
-					ps44.OverlayValues[22] = d22
-					ps44.OverlayValues[23] = d23
-					ps44.OverlayValues[24] = d24
-					ps44.OverlayValues[25] = d25
-					ps44.OverlayValues[26] = d26
-					snap45 := d0
-					snap46 := d1
-					snap47 := d2
-					snap48 := d3
-					snap49 := d18
-					snap50 := d19
-					snap51 := d20
-					snap52 := d21
-					snap53 := d22
-					snap54 := d23
-					snap55 := d24
-					snap56 := d25
-					snap57 := d26
-					alloc58 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d29)
+					snap33 := d0
+					snap34 := d1
+					snap35 := d2
+					snap36 := d3
+					snap37 := d4
+					snap38 := d21
+					snap39 := d22
+					snap40 := d23
+					snap41 := d24
+					snap42 := d25
+					snap43 := d26
+					snap44 := d27
+					snap45 := d28
+					snap46 := d29
+					snap47 := d30
+					alloc48 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc48)
+					d0 = snap33
+					d1 = snap34
+					d2 = snap35
+					d3 = snap36
+					d4 = snap37
+					d21 = snap38
+					d22 = snap39
+					d23 = snap40
+					d24 = snap41
+					d25 = snap42
+					d26 = snap43
+					d27 = snap44
+					d28 = snap45
+					d29 = snap46
+					d30 = snap47
+					ctx.RestoreAllocState(alloc48)
+					d0 = snap33
+					d1 = snap34
+					d2 = snap35
+					d3 = snap36
+					d4 = snap37
+					d21 = snap38
+					d22 = snap39
+					d23 = snap40
+					d24 = snap41
+					d25 = snap42
+					d26 = snap43
+					d27 = snap44
+					d28 = snap45
+					d29 = snap46
+					d30 = snap47
+					ps49 := PhiState{General: true}
+					ps49.OverlayValues = make([]JITValueDesc, 31)
+					ps49.OverlayValues[0] = d0
+					ps49.OverlayValues[1] = d1
+					ps49.OverlayValues[2] = d2
+					ps49.OverlayValues[3] = d3
+					ps49.OverlayValues[4] = d4
+					ps49.OverlayValues[21] = d21
+					ps49.OverlayValues[22] = d22
+					ps49.OverlayValues[23] = d23
+					ps49.OverlayValues[24] = d24
+					ps49.OverlayValues[25] = d25
+					ps49.OverlayValues[26] = d26
+					ps49.OverlayValues[27] = d27
+					ps49.OverlayValues[28] = d28
+					ps49.OverlayValues[29] = d29
+					ps49.OverlayValues[30] = d30
+					ps50 := PhiState{General: true}
+					ps50.OverlayValues = make([]JITValueDesc, 31)
+					ps50.OverlayValues[0] = d0
+					ps50.OverlayValues[1] = d1
+					ps50.OverlayValues[2] = d2
+					ps50.OverlayValues[3] = d3
+					ps50.OverlayValues[4] = d4
+					ps50.OverlayValues[21] = d21
+					ps50.OverlayValues[22] = d22
+					ps50.OverlayValues[23] = d23
+					ps50.OverlayValues[24] = d24
+					ps50.OverlayValues[25] = d25
+					ps50.OverlayValues[26] = d26
+					ps50.OverlayValues[27] = d27
+					ps50.OverlayValues[28] = d28
+					ps50.OverlayValues[29] = d29
+					ps50.OverlayValues[30] = d30
+					snap51 := d0
+					snap52 := d1
+					snap53 := d2
+					snap54 := d3
+					snap55 := d4
+					snap56 := d21
+					snap57 := d22
+					snap58 := d23
+					snap59 := d24
+					snap60 := d25
+					snap61 := d26
+					snap62 := d27
+					snap63 := d28
+					snap64 := d29
+					snap65 := d30
+					alloc66 := ctx.SnapshotAllocState()
 					if !bbs[4].Rendered {
-						bbs[4].RenderPS(ps44)
+						bbs[4].RenderPS(ps50)
 					}
-					ctx.RestoreAllocState(alloc58)
-					d0 = snap45
-					d1 = snap46
-					d2 = snap47
-					d3 = snap48
-					d18 = snap49
-					d19 = snap50
-					d20 = snap51
-					d21 = snap52
-					d22 = snap53
-					d23 = snap54
-					d24 = snap55
-					d25 = snap56
-					d26 = snap57
+					ctx.RestoreAllocState(alloc66)
+					d0 = snap51
+					d1 = snap52
+					d2 = snap53
+					d3 = snap54
+					d4 = snap55
+					d21 = snap56
+					d22 = snap57
+					d23 = snap58
+					d24 = snap59
+					d25 = snap60
+					d26 = snap61
+					d27 = snap62
+					d28 = snap63
+					d29 = snap64
+					d30 = snap65
 					if !bbs[3].Rendered {
-						return bbs[3].RenderPS(ps43)
+						return bbs[3].RenderPS(ps49)
 					}
 					return result
 					return result
@@ -2379,14 +2420,8 @@ func init_list() {
 					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
 						d3 = ps.OverlayValues[3]
 					}
-					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
-						d18 = ps.OverlayValues[18]
-					}
-					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
-						d19 = ps.OverlayValues[19]
-					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
 					}
 					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
 						d21 = ps.OverlayValues[21]
@@ -2406,238 +2441,268 @@ func init_list() {
 					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
 						d26 = ps.OverlayValues[26]
 					}
+					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
+						d27 = ps.OverlayValues[27]
+					}
+					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
+						d28 = ps.OverlayValues[28]
+					}
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
+					}
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d59 = args[0]
-					d59.ID = 0
-					var d60 JITValueDesc
-					ctx.EnsureDesc(&d59)
-					if d59.Loc == LocImm {
+					d67 = args[0]
+					d67.ID = 0
+					var d68 JITValueDesc
+					ctx.EnsureDesc(&d67)
+					if d67.Loc == LocImm {
 						panic("FastDict: LocImm not expected at JIT compile time")
-					} else if d59.Loc != LocRegPair {
+					} else if d67.Loc != LocRegPair {
 						panic("FastDict: expected Scmer register pair")
 					} else {
-						ctx.FreeReg(d59.Reg2)
-						d60 = JITValueDesc{Loc: LocReg, Reg: d59.Reg}
-						ctx.BindReg(d59.Reg, &d60)
-						ctx.TransferReg(d59.Reg)
-						ctx.BindReg(d59.Reg, &d60)
-						d59.Loc = LocNone
+						ctx.FreeReg(d67.Reg2)
+						d68 = JITValueDesc{Loc: LocReg, Reg: d67.Reg}
+						ctx.BindReg(d67.Reg, &d68)
+						ctx.TransferReg(d67.Reg)
+						ctx.BindReg(d67.Reg, &d68)
+						d67.Loc = LocNone
 					}
-					ctx.StabilizeDescForControlFlow(&d60)
-					ctx.FreeDesc(&d59)
-					ctx.EnsureDesc(&d60)
-					var d61 JITValueDesc
-					if d60.Loc == LocImm {
-						d61 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d60.Imm.IsNil() == true)}
+					ctx.StabilizeDescForControlFlow(&d68)
+					ctx.FreeDesc(&d67)
+					ctx.EnsureDesc(&d68)
+					var d69 JITValueDesc
+					if d68.Loc == LocImm {
+						d69 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d68.Imm.IsNil() == true)}
 					} else {
-						ctx.EnsureDesc(&d60)
-						if d60.Loc != LocReg && d60.Loc != LocRegPair && d60.Loc != LocRegTriple {
+						ctx.EnsureDesc(&d68)
+						if d68.Loc != LocReg && d68.Loc != LocRegPair && d68.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r2 := ctx.AllocRegExcept(d60.Reg)
-						ctx.EmitCmpRegImm32(d60.Reg, 0)
+						r2 := ctx.AllocRegExcept(d68.Reg)
+						ctx.EmitCmpRegImm32(d68.Reg, 0)
 						ctx.EmitSetcc(r2, CondEqual)
-						d61 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r2}
-						ctx.BindReg(r2, &d61)
+						d69 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r2}
+						ctx.BindReg(r2, &d69)
 					}
-					d62 = d61
-					ctx.EnsureDesc(&d62)
-					if d62.Loc != LocImm && d62.Loc != LocReg {
+					d70 = d69
+					ctx.EnsureDesc(&d70)
+					if d70.Loc != LocImm && d70.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d62.Loc == LocImm {
-						if d62.Imm.Bool() {
+					if d70.Loc == LocImm {
+						if d70.Imm.Bool() {
 							if ps.General {
 							}
-							ps63 := PhiState{General: ps.General}
-							ps63.OverlayValues = make([]JITValueDesc, 63)
-							ps63.OverlayValues[0] = d0
-							ps63.OverlayValues[1] = d1
-							ps63.OverlayValues[2] = d2
-							ps63.OverlayValues[3] = d3
-							ps63.OverlayValues[18] = d18
-							ps63.OverlayValues[19] = d19
-							ps63.OverlayValues[20] = d20
-							ps63.OverlayValues[21] = d21
-							ps63.OverlayValues[22] = d22
-							ps63.OverlayValues[23] = d23
-							ps63.OverlayValues[24] = d24
-							ps63.OverlayValues[25] = d25
-							ps63.OverlayValues[26] = d26
-							ps63.OverlayValues[59] = d59
-							ps63.OverlayValues[60] = d60
-							ps63.OverlayValues[61] = d61
-							ps63.OverlayValues[62] = d62
-							return bbs[5].RenderPS(ps63)
+							ps71 := PhiState{General: ps.General}
+							ps71.OverlayValues = make([]JITValueDesc, 71)
+							ps71.OverlayValues[0] = d0
+							ps71.OverlayValues[1] = d1
+							ps71.OverlayValues[2] = d2
+							ps71.OverlayValues[3] = d3
+							ps71.OverlayValues[4] = d4
+							ps71.OverlayValues[21] = d21
+							ps71.OverlayValues[22] = d22
+							ps71.OverlayValues[23] = d23
+							ps71.OverlayValues[24] = d24
+							ps71.OverlayValues[25] = d25
+							ps71.OverlayValues[26] = d26
+							ps71.OverlayValues[27] = d27
+							ps71.OverlayValues[28] = d28
+							ps71.OverlayValues[29] = d29
+							ps71.OverlayValues[30] = d30
+							ps71.OverlayValues[67] = d67
+							ps71.OverlayValues[68] = d68
+							ps71.OverlayValues[69] = d69
+							ps71.OverlayValues[70] = d70
+							return bbs[5].RenderPS(ps71)
 						}
 						if ps.General {
 						}
-						ps64 := PhiState{General: ps.General}
-						ps64.OverlayValues = make([]JITValueDesc, 63)
-						ps64.OverlayValues[0] = d0
-						ps64.OverlayValues[1] = d1
-						ps64.OverlayValues[2] = d2
-						ps64.OverlayValues[3] = d3
-						ps64.OverlayValues[18] = d18
-						ps64.OverlayValues[19] = d19
-						ps64.OverlayValues[20] = d20
-						ps64.OverlayValues[21] = d21
-						ps64.OverlayValues[22] = d22
-						ps64.OverlayValues[23] = d23
-						ps64.OverlayValues[24] = d24
-						ps64.OverlayValues[25] = d25
-						ps64.OverlayValues[26] = d26
-						ps64.OverlayValues[59] = d59
-						ps64.OverlayValues[60] = d60
-						ps64.OverlayValues[61] = d61
-						ps64.OverlayValues[62] = d62
-						return bbs[6].RenderPS(ps64)
+						ps72 := PhiState{General: ps.General}
+						ps72.OverlayValues = make([]JITValueDesc, 71)
+						ps72.OverlayValues[0] = d0
+						ps72.OverlayValues[1] = d1
+						ps72.OverlayValues[2] = d2
+						ps72.OverlayValues[3] = d3
+						ps72.OverlayValues[4] = d4
+						ps72.OverlayValues[21] = d21
+						ps72.OverlayValues[22] = d22
+						ps72.OverlayValues[23] = d23
+						ps72.OverlayValues[24] = d24
+						ps72.OverlayValues[25] = d25
+						ps72.OverlayValues[26] = d26
+						ps72.OverlayValues[27] = d27
+						ps72.OverlayValues[28] = d28
+						ps72.OverlayValues[29] = d29
+						ps72.OverlayValues[30] = d30
+						ps72.OverlayValues[67] = d67
+						ps72.OverlayValues[68] = d68
+						ps72.OverlayValues[69] = d69
+						ps72.OverlayValues[70] = d70
+						return bbs[6].RenderPS(ps72)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[3].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d62.Reg, 0)
+					ctx.EmitCmpRegImm32(d70.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl6)
 					if bbs[6].Rendered {
 						ctx.EmitJmp(lbl7)
 					}
-					snap65 := d0
-					snap66 := d1
-					snap67 := d2
-					snap68 := d3
-					snap69 := d18
-					snap70 := d19
-					snap71 := d20
-					snap72 := d21
-					snap73 := d22
-					snap74 := d23
-					snap75 := d24
-					snap76 := d25
-					snap77 := d26
-					snap78 := d59
-					snap79 := d60
-					snap80 := d61
-					snap81 := d62
-					alloc82 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc82)
-					d0 = snap65
-					d1 = snap66
-					d2 = snap67
-					d3 = snap68
-					d18 = snap69
-					d19 = snap70
-					d20 = snap71
-					d21 = snap72
-					d22 = snap73
-					d23 = snap74
-					d24 = snap75
-					d25 = snap76
-					d26 = snap77
-					d59 = snap78
-					d60 = snap79
-					d61 = snap80
-					d62 = snap81
-					ctx.RestoreAllocState(alloc82)
-					d0 = snap65
-					d1 = snap66
-					d2 = snap67
-					d3 = snap68
-					d18 = snap69
-					d19 = snap70
-					d20 = snap71
-					d21 = snap72
-					d22 = snap73
-					d23 = snap74
-					d24 = snap75
-					d25 = snap76
-					d26 = snap77
-					d59 = snap78
-					d60 = snap79
-					d61 = snap80
-					d62 = snap81
-					ps83 := PhiState{General: true}
-					ps83.OverlayValues = make([]JITValueDesc, 63)
-					ps83.OverlayValues[0] = d0
-					ps83.OverlayValues[1] = d1
-					ps83.OverlayValues[2] = d2
-					ps83.OverlayValues[3] = d3
-					ps83.OverlayValues[18] = d18
-					ps83.OverlayValues[19] = d19
-					ps83.OverlayValues[20] = d20
-					ps83.OverlayValues[21] = d21
-					ps83.OverlayValues[22] = d22
-					ps83.OverlayValues[23] = d23
-					ps83.OverlayValues[24] = d24
-					ps83.OverlayValues[25] = d25
-					ps83.OverlayValues[26] = d26
-					ps83.OverlayValues[59] = d59
-					ps83.OverlayValues[60] = d60
-					ps83.OverlayValues[61] = d61
-					ps83.OverlayValues[62] = d62
-					ps84 := PhiState{General: true}
-					ps84.OverlayValues = make([]JITValueDesc, 63)
-					ps84.OverlayValues[0] = d0
-					ps84.OverlayValues[1] = d1
-					ps84.OverlayValues[2] = d2
-					ps84.OverlayValues[3] = d3
-					ps84.OverlayValues[18] = d18
-					ps84.OverlayValues[19] = d19
-					ps84.OverlayValues[20] = d20
-					ps84.OverlayValues[21] = d21
-					ps84.OverlayValues[22] = d22
-					ps84.OverlayValues[23] = d23
-					ps84.OverlayValues[24] = d24
-					ps84.OverlayValues[25] = d25
-					ps84.OverlayValues[26] = d26
-					ps84.OverlayValues[59] = d59
-					ps84.OverlayValues[60] = d60
-					ps84.OverlayValues[61] = d61
-					ps84.OverlayValues[62] = d62
-					snap85 := d0
-					snap86 := d1
-					snap87 := d2
-					snap88 := d3
-					snap89 := d18
-					snap90 := d19
-					snap91 := d20
-					snap92 := d21
-					snap93 := d22
-					snap94 := d23
-					snap95 := d24
-					snap96 := d25
-					snap97 := d26
-					snap98 := d59
-					snap99 := d60
-					snap100 := d61
-					snap101 := d62
-					alloc102 := ctx.SnapshotAllocState()
+					snap73 := d0
+					snap74 := d1
+					snap75 := d2
+					snap76 := d3
+					snap77 := d4
+					snap78 := d21
+					snap79 := d22
+					snap80 := d23
+					snap81 := d24
+					snap82 := d25
+					snap83 := d26
+					snap84 := d27
+					snap85 := d28
+					snap86 := d29
+					snap87 := d30
+					snap88 := d67
+					snap89 := d68
+					snap90 := d69
+					snap91 := d70
+					alloc92 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc92)
+					d0 = snap73
+					d1 = snap74
+					d2 = snap75
+					d3 = snap76
+					d4 = snap77
+					d21 = snap78
+					d22 = snap79
+					d23 = snap80
+					d24 = snap81
+					d25 = snap82
+					d26 = snap83
+					d27 = snap84
+					d28 = snap85
+					d29 = snap86
+					d30 = snap87
+					d67 = snap88
+					d68 = snap89
+					d69 = snap90
+					d70 = snap91
+					ctx.RestoreAllocState(alloc92)
+					d0 = snap73
+					d1 = snap74
+					d2 = snap75
+					d3 = snap76
+					d4 = snap77
+					d21 = snap78
+					d22 = snap79
+					d23 = snap80
+					d24 = snap81
+					d25 = snap82
+					d26 = snap83
+					d27 = snap84
+					d28 = snap85
+					d29 = snap86
+					d30 = snap87
+					d67 = snap88
+					d68 = snap89
+					d69 = snap90
+					d70 = snap91
+					ps93 := PhiState{General: true}
+					ps93.OverlayValues = make([]JITValueDesc, 71)
+					ps93.OverlayValues[0] = d0
+					ps93.OverlayValues[1] = d1
+					ps93.OverlayValues[2] = d2
+					ps93.OverlayValues[3] = d3
+					ps93.OverlayValues[4] = d4
+					ps93.OverlayValues[21] = d21
+					ps93.OverlayValues[22] = d22
+					ps93.OverlayValues[23] = d23
+					ps93.OverlayValues[24] = d24
+					ps93.OverlayValues[25] = d25
+					ps93.OverlayValues[26] = d26
+					ps93.OverlayValues[27] = d27
+					ps93.OverlayValues[28] = d28
+					ps93.OverlayValues[29] = d29
+					ps93.OverlayValues[30] = d30
+					ps93.OverlayValues[67] = d67
+					ps93.OverlayValues[68] = d68
+					ps93.OverlayValues[69] = d69
+					ps93.OverlayValues[70] = d70
+					ps94 := PhiState{General: true}
+					ps94.OverlayValues = make([]JITValueDesc, 71)
+					ps94.OverlayValues[0] = d0
+					ps94.OverlayValues[1] = d1
+					ps94.OverlayValues[2] = d2
+					ps94.OverlayValues[3] = d3
+					ps94.OverlayValues[4] = d4
+					ps94.OverlayValues[21] = d21
+					ps94.OverlayValues[22] = d22
+					ps94.OverlayValues[23] = d23
+					ps94.OverlayValues[24] = d24
+					ps94.OverlayValues[25] = d25
+					ps94.OverlayValues[26] = d26
+					ps94.OverlayValues[27] = d27
+					ps94.OverlayValues[28] = d28
+					ps94.OverlayValues[29] = d29
+					ps94.OverlayValues[30] = d30
+					ps94.OverlayValues[67] = d67
+					ps94.OverlayValues[68] = d68
+					ps94.OverlayValues[69] = d69
+					ps94.OverlayValues[70] = d70
+					snap95 := d0
+					snap96 := d1
+					snap97 := d2
+					snap98 := d3
+					snap99 := d4
+					snap100 := d21
+					snap101 := d22
+					snap102 := d23
+					snap103 := d24
+					snap104 := d25
+					snap105 := d26
+					snap106 := d27
+					snap107 := d28
+					snap108 := d29
+					snap109 := d30
+					snap110 := d67
+					snap111 := d68
+					snap112 := d69
+					snap113 := d70
+					alloc114 := ctx.SnapshotAllocState()
 					if !bbs[6].Rendered {
-						bbs[6].RenderPS(ps84)
+						bbs[6].RenderPS(ps94)
 					}
-					ctx.RestoreAllocState(alloc102)
-					d0 = snap85
-					d1 = snap86
-					d2 = snap87
-					d3 = snap88
-					d18 = snap89
-					d19 = snap90
-					d20 = snap91
-					d21 = snap92
-					d22 = snap93
-					d23 = snap94
-					d24 = snap95
-					d25 = snap96
-					d26 = snap97
-					d59 = snap98
-					d60 = snap99
-					d61 = snap100
-					d62 = snap101
+					ctx.RestoreAllocState(alloc114)
+					d0 = snap95
+					d1 = snap96
+					d2 = snap97
+					d3 = snap98
+					d4 = snap99
+					d21 = snap100
+					d22 = snap101
+					d23 = snap102
+					d24 = snap103
+					d25 = snap104
+					d26 = snap105
+					d27 = snap106
+					d28 = snap107
+					d29 = snap108
+					d30 = snap109
+					d67 = snap110
+					d68 = snap111
+					d69 = snap112
+					d70 = snap113
 					if !bbs[5].Rendered {
-						return bbs[5].RenderPS(ps83)
+						return bbs[5].RenderPS(ps93)
 					}
 					return result
-					ctx.FreeDesc(&d61)
+					ctx.FreeDesc(&d69)
 					return result
 				}
 				bbs[4].RenderPS = func(ps PhiState) JITValueDesc {
@@ -2671,14 +2736,8 @@ func init_list() {
 					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
 						d3 = ps.OverlayValues[3]
 					}
-					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
-						d18 = ps.OverlayValues[18]
-					}
-					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
-						d19 = ps.OverlayValues[19]
-					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
 					}
 					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
 						d21 = ps.OverlayValues[21]
@@ -2698,17 +2757,29 @@ func init_list() {
 					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
 						d26 = ps.OverlayValues[26]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
+						d27 = ps.OverlayValues[27]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
+						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 62 && ps.OverlayValues[62].Loc != LocNone {
-						d62 = ps.OverlayValues[62]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
+					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
+						d67 = ps.OverlayValues[67]
+					}
+					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
+						d68 = ps.OverlayValues[68]
+					}
+					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
+						d69 = ps.OverlayValues[69]
+					}
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
 					}
 					ctx.ReclaimUntrackedRegs()
 					_ = jitEmitGoVariadicCallFromDescs(ctx, declarations["count"].Fn, args, result)
@@ -2746,14 +2817,8 @@ func init_list() {
 					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
 						d3 = ps.OverlayValues[3]
 					}
-					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
-						d18 = ps.OverlayValues[18]
-					}
-					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
-						d19 = ps.OverlayValues[19]
-					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
 					}
 					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
 						d21 = ps.OverlayValues[21]
@@ -2773,28 +2838,40 @@ func init_list() {
 					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
 						d26 = ps.OverlayValues[26]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
+						d27 = ps.OverlayValues[27]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
+						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 62 && ps.OverlayValues[62].Loc != LocNone {
-						d62 = ps.OverlayValues[62]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
+					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
+						d67 = ps.OverlayValues[67]
+					}
+					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
+						d68 = ps.OverlayValues[68]
+					}
+					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
+						d69 = ps.OverlayValues[69]
+					}
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d103 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					if d103.Loc == LocImm {
-						ctx.EmitMakeInt(result, d103)
+					d115 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					if d115.Loc == LocImm {
+						ctx.EmitMakeInt(result, d115)
 					} else {
-						ctx.EmitMovToReg(result.Reg2, d103)
-						d104 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeInt(result, d104)
-						if d103.Loc == LocReg && d103.Reg != result.Reg2 {
-							ctx.FreeReg(d103.Reg)
+						ctx.EmitMovToReg(result.Reg2, d115)
+						d116 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d116)
+						if d115.Loc == LocReg && d115.Reg != result.Reg2 {
+							ctx.FreeReg(d115.Reg)
 						}
 					}
 					result.Type = tagInt
@@ -2832,14 +2909,8 @@ func init_list() {
 					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
 						d3 = ps.OverlayValues[3]
 					}
-					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
-						d18 = ps.OverlayValues[18]
-					}
-					if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != LocNone {
-						d19 = ps.OverlayValues[19]
-					}
-					if len(ps.OverlayValues) > 20 && ps.OverlayValues[20].Loc != LocNone {
-						d20 = ps.OverlayValues[20]
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
 					}
 					if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != LocNone {
 						d21 = ps.OverlayValues[21]
@@ -2859,89 +2930,101 @@ func init_list() {
 					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
 						d26 = ps.OverlayValues[26]
 					}
-					if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != LocNone {
-						d59 = ps.OverlayValues[59]
+					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
+						d27 = ps.OverlayValues[27]
 					}
-					if len(ps.OverlayValues) > 60 && ps.OverlayValues[60].Loc != LocNone {
-						d60 = ps.OverlayValues[60]
+					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
+						d28 = ps.OverlayValues[28]
 					}
-					if len(ps.OverlayValues) > 61 && ps.OverlayValues[61].Loc != LocNone {
-						d61 = ps.OverlayValues[61]
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
 					}
-					if len(ps.OverlayValues) > 62 && ps.OverlayValues[62].Loc != LocNone {
-						d62 = ps.OverlayValues[62]
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
 					}
-					if len(ps.OverlayValues) > 103 && ps.OverlayValues[103].Loc != LocNone {
-						d103 = ps.OverlayValues[103]
+					if len(ps.OverlayValues) > 67 && ps.OverlayValues[67].Loc != LocNone {
+						d67 = ps.OverlayValues[67]
 					}
-					if len(ps.OverlayValues) > 104 && ps.OverlayValues[104].Loc != LocNone {
-						d104 = ps.OverlayValues[104]
+					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
+						d68 = ps.OverlayValues[68]
+					}
+					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
+						d69 = ps.OverlayValues[69]
+					}
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 115 && ps.OverlayValues[115].Loc != LocNone {
+						d115 = ps.OverlayValues[115]
+					}
+					if len(ps.OverlayValues) > 116 && ps.OverlayValues[116].Loc != LocNone {
+						d116 = ps.OverlayValues[116]
 					}
 					ctx.ReclaimUntrackedRegs()
-					var d105 JITValueDesc
-					ctx.EnsureDesc(&d60)
-					if d60.Loc == LocImm {
-						fieldAddr := uintptr(d60.Imm.Int()) + 0
+					var d117 JITValueDesc
+					ctx.EnsureDesc(&d68)
+					if d68.Loc == LocImm {
+						fieldAddr := uintptr(d68.Imm.Int()) + 0
 						r3 := ctx.AllocReg()
 						r4 := ctx.AllocRegExcept(r3)
 						r5 := ctx.AllocRegExcept(r3, r4)
 						ctx.EmitMovRegMem64(r3, fieldAddr)
 						ctx.EmitMovRegMem64(r4, fieldAddr+8)
 						ctx.EmitMovRegMem64(r5, fieldAddr+16)
-						d105 = JITValueDesc{Loc: LocRegTriple, Reg: r3, Reg2: r4, Reg3: r5}
-						ctx.BindReg(r3, &d105)
-						ctx.BindReg(r4, &d105)
-						ctx.BindReg(r5, &d105)
+						d117 = JITValueDesc{Loc: LocRegTriple, Reg: r3, Reg2: r4, Reg3: r5}
+						ctx.BindReg(r3, &d117)
+						ctx.BindReg(r4, &d117)
+						ctx.BindReg(r5, &d117)
 					} else {
 						off := int32(0)
-						baseReg := d60.Reg
+						baseReg := d68.Reg
 						r6 := ctx.AllocRegExcept(baseReg)
 						r7 := ctx.AllocRegExcept(baseReg, r6)
 						r8 := ctx.AllocRegExcept(baseReg, r6, r7)
 						ctx.EmitMovRegMem(r6, baseReg, off)
 						ctx.EmitMovRegMem(r7, baseReg, off+8)
 						ctx.EmitMovRegMem(r8, baseReg, off+16)
-						d105 = JITValueDesc{Loc: LocRegTriple, Reg: r6, Reg2: r7, Reg3: r8}
-						ctx.BindReg(r6, &d105)
-						ctx.BindReg(r7, &d105)
-						ctx.BindReg(r8, &d105)
+						d117 = JITValueDesc{Loc: LocRegTriple, Reg: r6, Reg2: r7, Reg3: r8}
+						ctx.BindReg(r6, &d117)
+						ctx.BindReg(r7, &d117)
+						ctx.BindReg(r8, &d117)
 					}
-					var d106 JITValueDesc
-					if d105.SliceSizeKnown {
-						d106 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d105.KnownSliceLen))}
-					} else if d105.Loc == LocImm {
-						d106 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d105.StackOff))}
-					} else if d105.Loc == LocStackTriple {
-						d106 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d105.StackOff + 8, NoHeapPointer: true}
+					var d118 JITValueDesc
+					if d117.SliceSizeKnown {
+						d118 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d117.KnownSliceLen))}
+					} else if d117.Loc == LocImm {
+						d118 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d117.StackOff))}
+					} else if d117.Loc == LocStackTriple {
+						d118 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d117.StackOff + 8, NoHeapPointer: true}
 					} else {
-						ctx.EnsureDesc(&d105)
-						if d105.Loc == LocRegPair || d105.Loc == LocRegTriple {
-							d106 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d105.Reg2, ID: 0}
-						} else if d105.Loc == LocReg {
-							d106 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d105.Reg, ID: 0}
+						ctx.EnsureDesc(&d117)
+						if d117.Loc == LocRegPair || d117.Loc == LocRegTriple {
+							d118 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d117.Reg2, ID: 0}
+						} else if d117.Loc == LocReg {
+							d118 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d117.Reg, ID: 0}
 						} else {
 							panic("len on unsupported descriptor location")
 						}
 					}
-					ctx.EnsureDesc(&d106)
-					ctx.EnsureDesc(&d106)
-					ctx.EnsureDesc(&d106)
-					if d106.Loc == LocImm {
-						ctx.EmitMakeInt(result, d106)
+					ctx.EnsureDesc(&d118)
+					ctx.EnsureDesc(&d118)
+					ctx.EnsureDesc(&d118)
+					if d118.Loc == LocImm {
+						ctx.EmitMakeInt(result, d118)
 					} else {
-						ctx.EmitMovToReg(result.Reg2, d106)
-						d108 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
-						ctx.EmitMakeInt(result, d108)
-						if d106.Loc == LocReg && d106.Reg != result.Reg2 {
-							ctx.FreeReg(d106.Reg)
+						ctx.EmitMovToReg(result.Reg2, d118)
+						d120 := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: result.Reg2, ID: 0}
+						ctx.EmitMakeInt(result, d120)
+						if d118.Loc == LocReg && d118.Reg != result.Reg2 {
+							ctx.FreeReg(d118.Reg)
 						}
 					}
 					result.Type = tagInt
 					ctx.EmitJmp(lbl0)
 					return result
 				}
-				ps109 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps109)
+				ps121 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps121)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -4567,7 +4650,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d6)
-							if d6.Loc == LocReg {
+							if d6.Loc == LocReg || d6.Loc == LocFPReg {
 								ctx.ProtectReg(d6.Reg)
 							} else if d6.Loc == LocRegPair {
 								ctx.ProtectReg(d6.Reg)
@@ -4579,7 +4662,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d14)
 							ctx.EmitStoreToStack(d14, int32(bbs[2].PhiBase)+int32(0))
-							if d6.Loc == LocReg {
+							if d6.Loc == LocReg || d6.Loc == LocFPReg {
 								ctx.UnprotectReg(d6.Reg)
 							} else if d6.Loc == LocRegPair {
 								ctx.UnprotectReg(d6.Reg)
@@ -4646,7 +4729,7 @@ func init_list() {
 					d16 = snap30
 					ctx.MarkLabel(lbl8)
 					ctx.SyncDesc(&d6)
-					if d6.Loc == LocReg {
+					if d6.Loc == LocReg || d6.Loc == LocFPReg {
 						ctx.ProtectReg(d6.Reg)
 					} else if d6.Loc == LocRegPair {
 						ctx.ProtectReg(d6.Reg)
@@ -4658,7 +4741,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d32)
 					ctx.EmitStoreToStack(d32, int32(bbs[2].PhiBase)+int32(0))
-					if d6.Loc == LocReg {
+					if d6.Loc == LocReg || d6.Loc == LocFPReg {
 						ctx.UnprotectReg(d6.Reg)
 					} else if d6.Loc == LocRegPair {
 						ctx.UnprotectReg(d6.Reg)
@@ -5028,7 +5111,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d9)
-							if d9.Loc == LocReg {
+							if d9.Loc == LocReg || d9.Loc == LocFPReg {
 								ctx.ProtectReg(d9.Reg)
 							} else if d9.Loc == LocRegPair {
 								ctx.ProtectReg(d9.Reg)
@@ -5040,7 +5123,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d60)
 							ctx.EmitStoreToStack(d60, int32(bbs[4].PhiBase)+int32(0))
-							if d9.Loc == LocReg {
+							if d9.Loc == LocReg || d9.Loc == LocFPReg {
 								ctx.UnprotectReg(d9.Reg)
 							} else if d9.Loc == LocRegPair {
 								ctx.UnprotectReg(d9.Reg)
@@ -5141,7 +5224,7 @@ func init_list() {
 					d63 = snap87
 					ctx.MarkLabel(lbl9)
 					ctx.SyncDesc(&d9)
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.ProtectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.ProtectReg(d9.Reg)
@@ -5153,7 +5236,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d89)
 					ctx.EmitStoreToStack(d89, int32(bbs[4].PhiBase)+int32(0))
-					if d9.Loc == LocReg {
+					if d9.Loc == LocReg || d9.Loc == LocFPReg {
 						ctx.UnprotectReg(d9.Reg)
 					} else if d9.Loc == LocRegPair {
 						ctx.UnprotectReg(d9.Reg)
@@ -5425,7 +5508,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d120)
 					if ps.General {
 						ctx.SyncDesc(&d120)
-						if d120.Loc == LocReg {
+						if d120.Loc == LocReg || d120.Loc == LocFPReg {
 							ctx.ProtectReg(d120.Reg)
 						} else if d120.Loc == LocRegPair {
 							ctx.ProtectReg(d120.Reg)
@@ -5437,7 +5520,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d121)
 						ctx.EmitStoreToStack(d121, int32(bbs[4].PhiBase)+int32(0))
-						if d120.Loc == LocReg {
+						if d120.Loc == LocReg || d120.Loc == LocFPReg {
 							ctx.UnprotectReg(d120.Reg)
 						} else if d120.Loc == LocRegPair {
 							ctx.UnprotectReg(d120.Reg)
@@ -8630,7 +8713,7 @@ func init_list() {
 						if d134.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d16)
-								if d16.Loc == LocReg {
+								if d16.Loc == LocReg || d16.Loc == LocFPReg {
 									ctx.ProtectReg(d16.Reg)
 								} else if d16.Loc == LocRegPair {
 									ctx.ProtectReg(d16.Reg)
@@ -8642,7 +8725,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d135)
 								ctx.EmitStoreToStack(d135, int32(bbs[1].PhiBase)+int32(24))
-								if d16.Loc == LocReg {
+								if d16.Loc == LocReg || d16.Loc == LocFPReg {
 									ctx.UnprotectReg(d16.Reg)
 								} else if d16.Loc == LocRegPair {
 									ctx.UnprotectReg(d16.Reg)
@@ -8689,7 +8772,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d69)
-							if d69.Loc == LocReg {
+							if d69.Loc == LocReg || d69.Loc == LocFPReg {
 								ctx.ProtectReg(d69.Reg)
 							} else if d69.Loc == LocRegPair {
 								ctx.ProtectReg(d69.Reg)
@@ -8701,7 +8784,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d138)
 							ctx.EmitStoreToStack(d138, int32(bbs[4].PhiBase)+int32(0))
-							if d69.Loc == LocReg {
+							if d69.Loc == LocReg || d69.Loc == LocFPReg {
 								ctx.UnprotectReg(d69.Reg)
 							} else if d69.Loc == LocRegPair {
 								ctx.UnprotectReg(d69.Reg)
@@ -8794,7 +8877,7 @@ func init_list() {
 					alloc175 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl10)
 					ctx.SyncDesc(&d16)
-					if d16.Loc == LocReg {
+					if d16.Loc == LocReg || d16.Loc == LocFPReg {
 						ctx.ProtectReg(d16.Reg)
 					} else if d16.Loc == LocRegPair {
 						ctx.ProtectReg(d16.Reg)
@@ -8806,7 +8889,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d176)
 					ctx.EmitStoreToStack(d176, int32(bbs[1].PhiBase)+int32(24))
-					if d16.Loc == LocReg {
+					if d16.Loc == LocReg || d16.Loc == LocFPReg {
 						ctx.UnprotectReg(d16.Reg)
 					} else if d16.Loc == LocRegPair {
 						ctx.UnprotectReg(d16.Reg)
@@ -8850,7 +8933,7 @@ func init_list() {
 					d140 = snap174
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d69)
-					if d69.Loc == LocReg {
+					if d69.Loc == LocReg || d69.Loc == LocFPReg {
 						ctx.ProtectReg(d69.Reg)
 					} else if d69.Loc == LocRegPair {
 						ctx.ProtectReg(d69.Reg)
@@ -8862,7 +8945,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d177)
 					ctx.EmitStoreToStack(d177, int32(bbs[4].PhiBase)+int32(0))
-					if d69.Loc == LocReg {
+					if d69.Loc == LocReg || d69.Loc == LocFPReg {
 						ctx.UnprotectReg(d69.Reg)
 					} else if d69.Loc == LocRegPair {
 						ctx.UnprotectReg(d69.Reg)
@@ -9242,7 +9325,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d225)
 					if ps.General {
 						ctx.SyncDesc(&d16)
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.ProtectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.ProtectReg(d16.Reg)
@@ -9254,7 +9337,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d227)
 						ctx.EmitStoreToStack(d227, int32(bbs[1].PhiBase)+int32(24))
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.UnprotectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.UnprotectReg(d16.Reg)
@@ -9366,28 +9449,30 @@ func init_list() {
 				_ = d3
 				var d4 JITValueDesc
 				_ = d4
-				var stackArray21 int32
-				var d22 JITValueDesc
-				_ = d22
-				var d23 JITValueDesc
-				_ = d23
-				var d24 JITValueDesc
-				_ = d24
+				var d5 JITValueDesc
+				_ = d5
+				var stackArray24 int32
 				var d25 JITValueDesc
 				_ = d25
+				var d26 JITValueDesc
+				_ = d26
 				var d27 JITValueDesc
 				_ = d27
 				var d28 JITValueDesc
 				_ = d28
-				var stackArray29 int32
 				var d30 JITValueDesc
 				_ = d30
 				var d31 JITValueDesc
 				_ = d31
-				var d32 JITValueDesc
-				_ = d32
+				var stackArray32 int32
+				var d33 JITValueDesc
+				_ = d33
 				var d34 JITValueDesc
 				_ = d34
+				var d35 JITValueDesc
+				_ = d35
+				var d37 JITValueDesc
+				_ = d37
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				var bbs [3]BBDescriptor
 				for i := range args {
@@ -9441,106 +9526,117 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d0)
 					d1 = args[1]
 					d1.ID = 0
-					d2 = ctx.EmitGetTagDesc(&d1, JITValueDesc{Loc: LocAny})
+					d2 = d1
+					d2.ID = 0
+					d3 = ctx.EmitGetTagDesc(&d2, JITValueDesc{Loc: LocAny})
 					ctx.FreeDesc(&d1)
-					ctx.EnsureDesc(&d2)
-					var d3 JITValueDesc
-					if d2.Loc == LocImm {
-						d3 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d2.Imm.Int()) == uint64(0x6))}
+					ctx.EnsureDesc(&d3)
+					var d4 JITValueDesc
+					if d3.Loc == LocImm {
+						d4 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d3.Imm.Int()) == uint64(0x6))}
 					} else {
 						r0 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d2.Reg, 6)
-						d3 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
-						ctx.BindReg(r0, &d3)
+						ctx.EmitCmpRegImm32(d3.Reg, 6)
+						d4 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondEqual}
+						ctx.BindReg(r0, &d4)
 					}
-					ctx.FreeDesc(&d2)
-					d4 = d3
-					ctx.EnsureDesc(&d4)
-					if d4.Loc != LocImm && d4.Loc != LocFlags {
+					ctx.FreeDesc(&d3)
+					d5 = d4
+					ctx.EnsureDesc(&d5)
+					if d5.Loc != LocImm && d5.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d4.Loc == LocImm {
-						if d4.Imm.Bool() {
+					if d5.Loc == LocImm {
+						if d5.Imm.Bool() {
 							if ps.General {
 							}
-							ps5 := PhiState{General: ps.General}
-							ps5.OverlayValues = make([]JITValueDesc, 5)
-							ps5.OverlayValues[0] = d0
-							ps5.OverlayValues[1] = d1
-							ps5.OverlayValues[2] = d2
-							ps5.OverlayValues[3] = d3
-							ps5.OverlayValues[4] = d4
-							return bbs[1].RenderPS(ps5)
+							ps6 := PhiState{General: ps.General}
+							ps6.OverlayValues = make([]JITValueDesc, 6)
+							ps6.OverlayValues[0] = d0
+							ps6.OverlayValues[1] = d1
+							ps6.OverlayValues[2] = d2
+							ps6.OverlayValues[3] = d3
+							ps6.OverlayValues[4] = d4
+							ps6.OverlayValues[5] = d5
+							return bbs[1].RenderPS(ps6)
 						}
 						if ps.General {
 						}
-						ps6 := PhiState{General: ps.General}
-						ps6.OverlayValues = make([]JITValueDesc, 5)
-						ps6.OverlayValues[0] = d0
-						ps6.OverlayValues[1] = d1
-						ps6.OverlayValues[2] = d2
-						ps6.OverlayValues[3] = d3
-						ps6.OverlayValues[4] = d4
-						return bbs[2].RenderPS(ps6)
+						ps7 := PhiState{General: ps.General}
+						ps7.OverlayValues = make([]JITValueDesc, 6)
+						ps7.OverlayValues[0] = d0
+						ps7.OverlayValues[1] = d1
+						ps7.OverlayValues[2] = d2
+						ps7.OverlayValues[3] = d3
+						ps7.OverlayValues[4] = d4
+						ps7.OverlayValues[5] = d5
+						return bbs[2].RenderPS(ps7)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[0].RenderPS(ps)
 					}
-					ctx.EmitJump(d4.Condition, lbl2)
+					ctx.EmitJump(d5.Condition, lbl2)
 					if bbs[2].Rendered {
 						ctx.EmitJmp(lbl3)
 					}
-					ctx.FreeDesc(&d3)
-					snap7 := d0
-					snap8 := d1
-					snap9 := d2
-					snap10 := d3
-					snap11 := d4
-					alloc12 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc12)
-					d0 = snap7
-					d1 = snap8
-					d2 = snap9
-					d3 = snap10
-					d4 = snap11
-					ctx.RestoreAllocState(alloc12)
-					d0 = snap7
-					d1 = snap8
-					d2 = snap9
-					d3 = snap10
-					d4 = snap11
-					ps13 := PhiState{General: true}
-					ps13.OverlayValues = make([]JITValueDesc, 5)
-					ps13.OverlayValues[0] = d0
-					ps13.OverlayValues[1] = d1
-					ps13.OverlayValues[2] = d2
-					ps13.OverlayValues[3] = d3
-					ps13.OverlayValues[4] = d4
-					ps14 := PhiState{General: true}
-					ps14.OverlayValues = make([]JITValueDesc, 5)
-					ps14.OverlayValues[0] = d0
-					ps14.OverlayValues[1] = d1
-					ps14.OverlayValues[2] = d2
-					ps14.OverlayValues[3] = d3
-					ps14.OverlayValues[4] = d4
-					snap15 := d0
-					snap16 := d1
-					snap17 := d2
-					snap18 := d3
-					snap19 := d4
-					alloc20 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d4)
+					snap8 := d0
+					snap9 := d1
+					snap10 := d2
+					snap11 := d3
+					snap12 := d4
+					snap13 := d5
+					alloc14 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc14)
+					d0 = snap8
+					d1 = snap9
+					d2 = snap10
+					d3 = snap11
+					d4 = snap12
+					d5 = snap13
+					ctx.RestoreAllocState(alloc14)
+					d0 = snap8
+					d1 = snap9
+					d2 = snap10
+					d3 = snap11
+					d4 = snap12
+					d5 = snap13
+					ps15 := PhiState{General: true}
+					ps15.OverlayValues = make([]JITValueDesc, 6)
+					ps15.OverlayValues[0] = d0
+					ps15.OverlayValues[1] = d1
+					ps15.OverlayValues[2] = d2
+					ps15.OverlayValues[3] = d3
+					ps15.OverlayValues[4] = d4
+					ps15.OverlayValues[5] = d5
+					ps16 := PhiState{General: true}
+					ps16.OverlayValues = make([]JITValueDesc, 6)
+					ps16.OverlayValues[0] = d0
+					ps16.OverlayValues[1] = d1
+					ps16.OverlayValues[2] = d2
+					ps16.OverlayValues[3] = d3
+					ps16.OverlayValues[4] = d4
+					ps16.OverlayValues[5] = d5
+					snap17 := d0
+					snap18 := d1
+					snap19 := d2
+					snap20 := d3
+					snap21 := d4
+					snap22 := d5
+					alloc23 := ctx.SnapshotAllocState()
 					if !bbs[2].Rendered {
-						bbs[2].RenderPS(ps14)
+						bbs[2].RenderPS(ps16)
 					}
-					ctx.RestoreAllocState(alloc20)
-					d0 = snap15
-					d1 = snap16
-					d2 = snap17
-					d3 = snap18
-					d4 = snap19
+					ctx.RestoreAllocState(alloc23)
+					d0 = snap17
+					d1 = snap18
+					d2 = snap19
+					d3 = snap20
+					d4 = snap21
+					d5 = snap22
 					if !bbs[1].Rendered {
-						return bbs[1].RenderPS(ps13)
+						return bbs[1].RenderPS(ps15)
 					}
 					return result
 					return result
@@ -9579,51 +9675,54 @@ func init_list() {
 					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
 						d4 = ps.OverlayValues[4]
 					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
 					ctx.ReclaimUntrackedRegs()
-					stackArray21 = ctx.AllocStack(int32(16))
-					_ = stackArray21
+					stackArray24 = ctx.AllocStack(int32(16))
+					_ = stackArray24
 					ctx.SyncDesc(&d0)
-					ctx.EmitStoreScmerToStack(d0, int32(stackArray21)+int32(0))
-					d22 = JITValueDesc{Loc: LocVirtualSlice, Type: tagSlice, KnownSliceLen: int32(1), KnownSliceCap: int32(1), SliceSizeKnown: true}
-					_ = d22
-					d23 = args[1]
-					d23.ID = 0
-					d24 = jitKnownSliceHeader(ctx, &d23)
-					ctx.FreeDesc(&d23)
+					ctx.EmitStoreScmerToStack(d0, int32(stackArray24)+int32(0))
+					d25 = JITValueDesc{Loc: LocVirtualSlice, Type: tagSlice, KnownSliceLen: int32(1), KnownSliceCap: int32(1), SliceSizeKnown: true}
+					_ = d25
+					d26 = args[1]
+					d26.ID = 0
+					d27 = jitKnownSliceHeader(ctx, &d26)
+					ctx.FreeDesc(&d26)
 					r1 := ctx.AllocReg()
 					r2 := ctx.AllocRegExcept(r1)
 					r3 := ctx.AllocRegExcept(r1, r2)
-					d25 = JITValueDesc{Loc: LocRegTriple, Type: tagSlice, Reg: r1, Reg2: r2, Reg3: r3, NoHeapPointer: false}
-					ctx.BindReg(r1, &d25)
-					ctx.BindReg(r2, &d25)
-					ctx.BindReg(r3, &d25)
-					ctx.EmitLeaRegMem(d25.Reg, ctx.StackReg, int32(stackArray21))
-					ctx.EmitMovRegImm64(d25.Reg2, uint64(1))
-					ctx.EmitMovRegImm64(d25.Reg3, uint64(1))
-					callResults26 := JITEmitGoCallResults(ctx, GoFuncAddr(JITAppendScmerSliceCopy), []JITValueDesc{d25, d24}, []uint8{3}, []uint8{1})
-					d27 = callResults26[0]
-					d28 = ctx.EmitNewSliceFromGoSlice(&d27)
-					ctx.SyncDesc(&d28)
-					if d28.Loc == LocRegPair || d28.Loc == LocStackPair || d28.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d28, &result)
-						result.Type = d28.Type
+					d28 = JITValueDesc{Loc: LocRegTriple, Type: tagSlice, Reg: r1, Reg2: r2, Reg3: r3, NoHeapPointer: false}
+					ctx.BindReg(r1, &d28)
+					ctx.BindReg(r2, &d28)
+					ctx.BindReg(r3, &d28)
+					ctx.EmitLeaRegMem(d28.Reg, ctx.StackReg, int32(stackArray24))
+					ctx.EmitMovRegImm64(d28.Reg2, uint64(1))
+					ctx.EmitMovRegImm64(d28.Reg3, uint64(1))
+					callResults29 := JITEmitGoCallResults(ctx, GoFuncAddr(JITAppendScmerSliceCopy), []JITValueDesc{d28, d27}, []uint8{3}, []uint8{1})
+					d30 = callResults29[0]
+					d31 = ctx.EmitNewSliceFromGoSlice(&d30)
+					ctx.SyncDesc(&d31)
+					if d31.Loc == LocRegPair || d31.Loc == LocStackPair || d31.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d31, &result)
+						result.Type = d31.Type
 					} else {
-						switch d28.Type {
+						switch d31.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d28)
+							ctx.EmitMakeBool(result, d31)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d28)
+							ctx.EmitMakeInt(result, d31)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d28)
+							ctx.EmitMakeFloat(result, d31)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d28, &result)
-							result.Type = d28.Type
+							ctx.EmitMovPairToResult(&d31, &result)
+							result.Type = d31.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -9663,17 +9762,14 @@ func init_list() {
 					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
 						d4 = ps.OverlayValues[4]
 					}
-					if len(ps.OverlayValues) > 22 && ps.OverlayValues[22].Loc != LocNone {
-						d22 = ps.OverlayValues[22]
-					}
-					if len(ps.OverlayValues) > 23 && ps.OverlayValues[23].Loc != LocNone {
-						d23 = ps.OverlayValues[23]
-					}
-					if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != LocNone {
-						d24 = ps.OverlayValues[24]
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
 					}
 					if len(ps.OverlayValues) > 25 && ps.OverlayValues[25].Loc != LocNone {
 						d25 = ps.OverlayValues[25]
+					}
+					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+						d26 = ps.OverlayValues[26]
 					}
 					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
 						d27 = ps.OverlayValues[27]
@@ -9681,61 +9777,67 @@ func init_list() {
 					if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != LocNone {
 						d28 = ps.OverlayValues[28]
 					}
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
+					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
+						d31 = ps.OverlayValues[31]
+					}
 					ctx.ReclaimUntrackedRegs()
-					stackArray29 = ctx.AllocStack(int32(32))
-					_ = stackArray29
+					stackArray32 = ctx.AllocStack(int32(32))
+					_ = stackArray32
 					ctx.SyncDesc(&d0)
-					ctx.EmitStoreScmerToStack(d0, int32(stackArray29)+int32(0))
-					d30 = args[1]
-					d30.ID = 0
-					ctx.SyncDesc(&d30)
-					ctx.EmitStoreScmerToStack(d30, int32(stackArray29)+int32(16))
-					ctx.FreeDesc(&d30)
-					d31 = JITValueDesc{Loc: LocVirtualSlice, Type: tagSlice, KnownSliceLen: int32(2), KnownSliceCap: int32(2), SliceSizeKnown: true}
-					_ = d31
+					ctx.EmitStoreScmerToStack(d0, int32(stackArray32)+int32(0))
+					d33 = args[1]
+					d33.ID = 0
+					ctx.SyncDesc(&d33)
+					ctx.EmitStoreScmerToStack(d33, int32(stackArray32)+int32(16))
+					ctx.FreeDesc(&d33)
+					d34 = JITValueDesc{Loc: LocVirtualSlice, Type: tagSlice, KnownSliceLen: int32(2), KnownSliceCap: int32(2), SliceSizeKnown: true}
+					_ = d34
 					r4 := ctx.AllocReg()
 					r5 := ctx.AllocRegExcept(r4)
 					r6 := ctx.AllocRegExcept(r4, r5)
-					d32 = JITValueDesc{Loc: LocRegTriple, Type: JITTypeUnknown, Reg: r4, Reg2: r5, Reg3: r6}
-					ctx.BindReg(r4, &d32)
-					ctx.BindReg(r5, &d32)
-					ctx.BindReg(r6, &d32)
-					ctx.BindReg(r4, &d32)
-					ctx.BindReg(r5, &d32)
-					ctx.BindReg(r6, &d32)
-					ctx.EmitLeaRegMem(d32.Reg, ctx.StackReg, int32(stackArray29))
-					ctx.EmitMovRegImm64(d32.Reg2, uint64(2))
-					ctx.EmitMovRegImm64(d32.Reg3, uint64(2))
-					callResults33 := JITEmitGoCallResults(ctx, GoFuncAddr(JITNewSliceCopy), []JITValueDesc{d32}, []uint8{2}, []uint8{1})
-					d34 = callResults33[0]
-					ctx.SyncDesc(&d34)
-					if d34.Loc == LocRegPair || d34.Loc == LocStackPair || d34.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d34, &result)
-						result.Type = d34.Type
+					d35 = JITValueDesc{Loc: LocRegTriple, Type: JITTypeUnknown, Reg: r4, Reg2: r5, Reg3: r6}
+					ctx.BindReg(r4, &d35)
+					ctx.BindReg(r5, &d35)
+					ctx.BindReg(r6, &d35)
+					ctx.BindReg(r4, &d35)
+					ctx.BindReg(r5, &d35)
+					ctx.BindReg(r6, &d35)
+					ctx.EmitLeaRegMem(d35.Reg, ctx.StackReg, int32(stackArray32))
+					ctx.EmitMovRegImm64(d35.Reg2, uint64(2))
+					ctx.EmitMovRegImm64(d35.Reg3, uint64(2))
+					callResults36 := JITEmitGoCallResults(ctx, GoFuncAddr(JITNewSliceCopy), []JITValueDesc{d35}, []uint8{2}, []uint8{1})
+					d37 = callResults36[0]
+					ctx.SyncDesc(&d37)
+					if d37.Loc == LocRegPair || d37.Loc == LocStackPair || d37.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d37, &result)
+						result.Type = d37.Type
 					} else {
-						switch d34.Type {
+						switch d37.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d34)
+							ctx.EmitMakeBool(result, d37)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d34)
+							ctx.EmitMakeInt(result, d37)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d34)
+							ctx.EmitMakeFloat(result, d37)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d34, &result)
-							result.Type = d34.Type
+							ctx.EmitMovPairToResult(&d37, &result)
+							result.Type = d37.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
 					return result
 				}
-				ps35 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps35)
+				ps38 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps38)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -11363,7 +11465,7 @@ func init_list() {
 					ctx.FreeDesc(&d30)
 					if ps.General {
 						ctx.SyncDesc(&d31)
-						if d31.Loc == LocReg {
+						if d31.Loc == LocReg || d31.Loc == LocFPReg {
 							ctx.ProtectReg(d31.Reg)
 						} else if d31.Loc == LocRegPair {
 							ctx.ProtectReg(d31.Reg)
@@ -11384,7 +11486,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d32.Reg2, RegRSP, int32(bbs[2].PhiBase)+int32(0)+8)
 							ctx.EmitStoreRegMem(d32.Reg3, RegRSP, int32(bbs[2].PhiBase)+int32(0)+16)
 						}
-						if d31.Loc == LocReg {
+						if d31.Loc == LocReg || d31.Loc == LocFPReg {
 							ctx.UnprotectReg(d31.Reg)
 						} else if d31.Loc == LocRegPair {
 							ctx.UnprotectReg(d31.Reg)
@@ -14781,7 +14883,7 @@ func init_list() {
 					ctx.FreeDesc(&d377)
 					if ps.General {
 						ctx.SyncDesc(&d174)
-						if d174.Loc == LocReg {
+						if d174.Loc == LocReg || d174.Loc == LocFPReg {
 							ctx.ProtectReg(d174.Reg)
 						} else if d174.Loc == LocRegPair {
 							ctx.ProtectReg(d174.Reg)
@@ -14793,7 +14895,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d381)
 						ctx.EmitStoreToStack(d381, int32(bbs[8].PhiBase)+int32(0))
-						if d174.Loc == LocReg {
+						if d174.Loc == LocReg || d174.Loc == LocFPReg {
 							ctx.UnprotectReg(d174.Reg)
 						} else if d174.Loc == LocRegPair {
 							ctx.UnprotectReg(d174.Reg)
@@ -15346,7 +15448,7 @@ func init_list() {
 					ctx.FreeDesc(&d36)
 					if ps.General {
 						ctx.SyncDesc(&d37)
-						if d37.Loc == LocReg {
+						if d37.Loc == LocReg || d37.Loc == LocFPReg {
 							ctx.ProtectReg(d37.Reg)
 						} else if d37.Loc == LocRegPair {
 							ctx.ProtectReg(d37.Reg)
@@ -15367,7 +15469,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d38.Reg2, RegRSP, int32(bbs[2].PhiBase)+int32(0)+8)
 							ctx.EmitStoreRegMem(d38.Reg3, RegRSP, int32(bbs[2].PhiBase)+int32(0)+16)
 						}
-						if d37.Loc == LocReg {
+						if d37.Loc == LocReg || d37.Loc == LocFPReg {
 							ctx.UnprotectReg(d37.Reg)
 						} else if d37.Loc == LocRegPair {
 							ctx.UnprotectReg(d37.Reg)
@@ -16142,7 +16244,7 @@ func init_list() {
 					ctx.FreeDesc(&d112)
 					if ps.General {
 						ctx.SyncDesc(&d48)
-						if d48.Loc == LocReg {
+						if d48.Loc == LocReg || d48.Loc == LocFPReg {
 							ctx.ProtectReg(d48.Reg)
 						} else if d48.Loc == LocRegPair {
 							ctx.ProtectReg(d48.Reg)
@@ -16154,7 +16256,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d114)
 						ctx.EmitStoreToStack(d114, int32(bbs[3].PhiBase)+int32(16))
-						if d48.Loc == LocReg {
+						if d48.Loc == LocReg || d48.Loc == LocFPReg {
 							ctx.UnprotectReg(d48.Reg)
 						} else if d48.Loc == LocRegPair {
 							ctx.UnprotectReg(d48.Reg)
@@ -17253,7 +17355,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d229)
 					if ps.General {
 						ctx.SyncDesc(&d126)
-						if d126.Loc == LocReg {
+						if d126.Loc == LocReg || d126.Loc == LocFPReg {
 							ctx.ProtectReg(d126.Reg)
 						} else if d126.Loc == LocRegPair {
 							ctx.ProtectReg(d126.Reg)
@@ -17265,7 +17367,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d231)
 						ctx.EmitStoreToStack(d231, int32(bbs[6].PhiBase)+int32(24))
-						if d126.Loc == LocReg {
+						if d126.Loc == LocReg || d126.Loc == LocFPReg {
 							ctx.UnprotectReg(d126.Reg)
 						} else if d126.Loc == LocRegPair {
 							ctx.UnprotectReg(d126.Reg)
@@ -18237,7 +18339,7 @@ func init_list() {
 					ctx.FreeDesc(&d48)
 					if ps.General {
 						ctx.SyncDesc(&d49)
-						if d49.Loc == LocReg {
+						if d49.Loc == LocReg || d49.Loc == LocFPReg {
 							ctx.ProtectReg(d49.Reg)
 						} else if d49.Loc == LocRegPair {
 							ctx.ProtectReg(d49.Reg)
@@ -18258,7 +18360,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d50.Reg2, RegRSP, int32(bbs[2].PhiBase)+int32(0)+8)
 							ctx.EmitStoreRegMem(d50.Reg3, RegRSP, int32(bbs[2].PhiBase)+int32(0)+16)
 						}
-						if d49.Loc == LocReg {
+						if d49.Loc == LocReg || d49.Loc == LocFPReg {
 							ctx.UnprotectReg(d49.Reg)
 						} else if d49.Loc == LocRegPair {
 							ctx.UnprotectReg(d49.Reg)
@@ -19125,7 +19227,7 @@ func init_list() {
 					ctx.FreeDesc(&d132)
 					if ps.General {
 						ctx.SyncDesc(&d60)
-						if d60.Loc == LocReg {
+						if d60.Loc == LocReg || d60.Loc == LocFPReg {
 							ctx.ProtectReg(d60.Reg)
 						} else if d60.Loc == LocRegPair {
 							ctx.ProtectReg(d60.Reg)
@@ -19137,7 +19239,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d134)
 						ctx.EmitStoreToStack(d134, int32(bbs[3].PhiBase)+int32(16))
-						if d60.Loc == LocReg {
+						if d60.Loc == LocReg || d60.Loc == LocFPReg {
 							ctx.UnprotectReg(d60.Reg)
 						} else if d60.Loc == LocRegPair {
 							ctx.UnprotectReg(d60.Reg)
@@ -20340,7 +20442,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d256)
 					if ps.General {
 						ctx.SyncDesc(&d4)
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.ProtectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.ProtectReg(d4.Reg)
@@ -20362,7 +20464,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d257.Reg3, RegRSP, int32(bbs[9].PhiBase)+int32(0)+16)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[9].PhiBase)+int32(24))
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.UnprotectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.UnprotectReg(d4.Reg)
@@ -21003,14 +21105,14 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d6)
-							if d6.Loc == LocReg {
+							if d6.Loc == LocReg || d6.Loc == LocFPReg {
 								ctx.ProtectReg(d6.Reg)
 							} else if d6.Loc == LocRegPair {
 								ctx.ProtectReg(d6.Reg)
 								ctx.ProtectReg(d6.Reg2)
 							}
 							ctx.SyncDesc(&d146)
-							if d146.Loc == LocReg {
+							if d146.Loc == LocReg || d146.Loc == LocFPReg {
 								ctx.ProtectReg(d146.Reg)
 							} else if d146.Loc == LocRegPair {
 								ctx.ProtectReg(d146.Reg)
@@ -21037,13 +21139,13 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d269)
 							ctx.EmitStoreToStack(d269, int32(bbs[6].PhiBase)+int32(24))
-							if d6.Loc == LocReg {
+							if d6.Loc == LocReg || d6.Loc == LocFPReg {
 								ctx.UnprotectReg(d6.Reg)
 							} else if d6.Loc == LocRegPair {
 								ctx.UnprotectReg(d6.Reg)
 								ctx.UnprotectReg(d6.Reg2)
 							}
-							if d146.Loc == LocReg {
+							if d146.Loc == LocReg || d146.Loc == LocFPReg {
 								ctx.UnprotectReg(d146.Reg)
 							} else if d146.Loc == LocRegPair {
 								ctx.UnprotectReg(d146.Reg)
@@ -21280,14 +21382,14 @@ func init_list() {
 					d274 = snap341
 					ctx.MarkLabel(lbl18)
 					ctx.SyncDesc(&d6)
-					if d6.Loc == LocReg {
+					if d6.Loc == LocReg || d6.Loc == LocFPReg {
 						ctx.ProtectReg(d6.Reg)
 					} else if d6.Loc == LocRegPair {
 						ctx.ProtectReg(d6.Reg)
 						ctx.ProtectReg(d6.Reg2)
 					}
 					ctx.SyncDesc(&d146)
-					if d146.Loc == LocReg {
+					if d146.Loc == LocReg || d146.Loc == LocFPReg {
 						ctx.ProtectReg(d146.Reg)
 					} else if d146.Loc == LocRegPair {
 						ctx.ProtectReg(d146.Reg)
@@ -21314,13 +21416,13 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d344)
 					ctx.EmitStoreToStack(d344, int32(bbs[6].PhiBase)+int32(24))
-					if d6.Loc == LocReg {
+					if d6.Loc == LocReg || d6.Loc == LocFPReg {
 						ctx.UnprotectReg(d6.Reg)
 					} else if d6.Loc == LocRegPair {
 						ctx.UnprotectReg(d6.Reg)
 						ctx.UnprotectReg(d6.Reg2)
 					}
-					if d146.Loc == LocReg {
+					if d146.Loc == LocReg || d146.Loc == LocFPReg {
 						ctx.UnprotectReg(d146.Reg)
 					} else if d146.Loc == LocRegPair {
 						ctx.UnprotectReg(d146.Reg)
@@ -23549,7 +23651,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d427)
-							if d427.Loc == LocReg {
+							if d427.Loc == LocReg || d427.Loc == LocFPReg {
 								ctx.ProtectReg(d427.Reg)
 							} else if d427.Loc == LocRegPair {
 								ctx.ProtectReg(d427.Reg)
@@ -23561,7 +23663,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d607)
 							ctx.EmitStoreToStack(d607, int32(bbs[11].PhiBase)+int32(0))
-							if d427.Loc == LocReg {
+							if d427.Loc == LocReg || d427.Loc == LocFPReg {
 								ctx.UnprotectReg(d427.Reg)
 							} else if d427.Loc == LocRegPair {
 								ctx.UnprotectReg(d427.Reg)
@@ -23850,7 +23952,7 @@ func init_list() {
 					d609 = snap697
 					ctx.MarkLabel(lbl20)
 					ctx.SyncDesc(&d427)
-					if d427.Loc == LocReg {
+					if d427.Loc == LocReg || d427.Loc == LocFPReg {
 						ctx.ProtectReg(d427.Reg)
 					} else if d427.Loc == LocRegPair {
 						ctx.ProtectReg(d427.Reg)
@@ -23862,7 +23964,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d699)
 					ctx.EmitStoreToStack(d699, int32(bbs[11].PhiBase)+int32(0))
-					if d427.Loc == LocReg {
+					if d427.Loc == LocReg || d427.Loc == LocFPReg {
 						ctx.UnprotectReg(d427.Reg)
 					} else if d427.Loc == LocRegPair {
 						ctx.UnprotectReg(d427.Reg)
@@ -24654,7 +24756,7 @@ func init_list() {
 						if d795.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d264)
-								if d264.Loc == LocReg {
+								if d264.Loc == LocReg || d264.Loc == LocFPReg {
 									ctx.ProtectReg(d264.Reg)
 								} else if d264.Loc == LocRegPair {
 									ctx.ProtectReg(d264.Reg)
@@ -24666,7 +24768,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d796)
 								ctx.EmitStoreToStack(d796, int32(bbs[9].PhiBase)+int32(24))
-								if d264.Loc == LocReg {
+								if d264.Loc == LocReg || d264.Loc == LocFPReg {
 									ctx.UnprotectReg(d264.Reg)
 								} else if d264.Loc == LocRegPair {
 									ctx.UnprotectReg(d264.Reg)
@@ -24984,7 +25086,7 @@ func init_list() {
 					alloc896 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl21)
 					ctx.SyncDesc(&d264)
-					if d264.Loc == LocReg {
+					if d264.Loc == LocReg || d264.Loc == LocFPReg {
 						ctx.ProtectReg(d264.Reg)
 					} else if d264.Loc == LocRegPair {
 						ctx.ProtectReg(d264.Reg)
@@ -24996,7 +25098,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d897)
 					ctx.EmitStoreToStack(d897, int32(bbs[9].PhiBase)+int32(24))
-					if d264.Loc == LocReg {
+					if d264.Loc == LocReg || d264.Loc == LocFPReg {
 						ctx.UnprotectReg(d264.Reg)
 					} else if d264.Loc == LocRegPair {
 						ctx.UnprotectReg(d264.Reg)
@@ -26385,7 +26487,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d1005)
 					if ps.General {
 						ctx.SyncDesc(&d264)
-						if d264.Loc == LocReg {
+						if d264.Loc == LocReg || d264.Loc == LocFPReg {
 							ctx.ProtectReg(d264.Reg)
 						} else if d264.Loc == LocRegPair {
 							ctx.ProtectReg(d264.Reg)
@@ -26397,7 +26499,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d1007)
 						ctx.EmitStoreToStack(d1007, int32(bbs[9].PhiBase)+int32(24))
-						if d264.Loc == LocReg {
+						if d264.Loc == LocReg || d264.Loc == LocFPReg {
 							ctx.UnprotectReg(d264.Reg)
 						} else if d264.Loc == LocRegPair {
 							ctx.UnprotectReg(d264.Reg)
@@ -27055,7 +27157,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d8)
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.ProtectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.ProtectReg(d8.Reg)
@@ -27067,7 +27169,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d44)
 							ctx.EmitStoreToStack(d44, int32(bbs[1].PhiBase)+int32(0))
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.UnprotectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.UnprotectReg(d8.Reg)
@@ -27143,7 +27245,7 @@ func init_list() {
 					d46 = snap63
 					ctx.MarkLabel(lbl6)
 					ctx.SyncDesc(&d8)
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.ProtectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.ProtectReg(d8.Reg)
@@ -27155,7 +27257,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d65)
 					ctx.EmitStoreToStack(d65, int32(bbs[1].PhiBase)+int32(0))
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.UnprotectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.UnprotectReg(d8.Reg)
@@ -28283,7 +28385,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d18)
-							if d18.Loc == LocReg {
+							if d18.Loc == LocReg || d18.Loc == LocFPReg {
 								ctx.ProtectReg(d18.Reg)
 							} else if d18.Loc == LocRegPair {
 								ctx.ProtectReg(d18.Reg)
@@ -28295,7 +28397,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d83)
 							ctx.EmitStoreToStack(d83, int32(bbs[1].PhiBase)+int32(24))
-							if d18.Loc == LocReg {
+							if d18.Loc == LocReg || d18.Loc == LocFPReg {
 								ctx.UnprotectReg(d18.Reg)
 							} else if d18.Loc == LocRegPair {
 								ctx.UnprotectReg(d18.Reg)
@@ -28410,7 +28512,7 @@ func init_list() {
 					d85 = snap115
 					ctx.MarkLabel(lbl6)
 					ctx.SyncDesc(&d18)
-					if d18.Loc == LocReg {
+					if d18.Loc == LocReg || d18.Loc == LocFPReg {
 						ctx.ProtectReg(d18.Reg)
 					} else if d18.Loc == LocRegPair {
 						ctx.ProtectReg(d18.Reg)
@@ -28422,7 +28524,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d117)
 					ctx.EmitStoreToStack(d117, int32(bbs[1].PhiBase)+int32(24))
-					if d18.Loc == LocReg {
+					if d18.Loc == LocReg || d18.Loc == LocFPReg {
 						ctx.UnprotectReg(d18.Reg)
 					} else if d18.Loc == LocRegPair {
 						ctx.UnprotectReg(d18.Reg)
@@ -28901,7 +29003,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d159)
 					if ps.General {
 						ctx.SyncDesc(&d18)
-						if d18.Loc == LocReg {
+						if d18.Loc == LocReg || d18.Loc == LocFPReg {
 							ctx.ProtectReg(d18.Reg)
 						} else if d18.Loc == LocRegPair {
 							ctx.ProtectReg(d18.Reg)
@@ -28913,7 +29015,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d161)
 						ctx.EmitStoreToStack(d161, int32(bbs[1].PhiBase)+int32(24))
-						if d18.Loc == LocReg {
+						if d18.Loc == LocReg || d18.Loc == LocFPReg {
 							ctx.UnprotectReg(d18.Reg)
 						} else if d18.Loc == LocRegPair {
 							ctx.UnprotectReg(d18.Reg)
@@ -29613,7 +29715,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d11)
-							if d11.Loc == LocReg {
+							if d11.Loc == LocReg || d11.Loc == LocFPReg {
 								ctx.ProtectReg(d11.Reg)
 							} else if d11.Loc == LocRegPair {
 								ctx.ProtectReg(d11.Reg)
@@ -29625,7 +29727,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d61)
 							ctx.EmitStoreToStack(d61, int32(bbs[1].PhiBase)+int32(0))
-							if d11.Loc == LocReg {
+							if d11.Loc == LocReg || d11.Loc == LocFPReg {
 								ctx.UnprotectReg(d11.Reg)
 							} else if d11.Loc == LocRegPair {
 								ctx.UnprotectReg(d11.Reg)
@@ -29719,7 +29821,7 @@ func init_list() {
 					d63 = snap86
 					ctx.MarkLabel(lbl8)
 					ctx.SyncDesc(&d11)
-					if d11.Loc == LocReg {
+					if d11.Loc == LocReg || d11.Loc == LocFPReg {
 						ctx.ProtectReg(d11.Reg)
 					} else if d11.Loc == LocRegPair {
 						ctx.ProtectReg(d11.Reg)
@@ -29731,7 +29833,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d88)
 					ctx.EmitStoreToStack(d88, int32(bbs[1].PhiBase)+int32(0))
-					if d11.Loc == LocReg {
+					if d11.Loc == LocReg || d11.Loc == LocFPReg {
 						ctx.UnprotectReg(d11.Reg)
 					} else if d11.Loc == LocRegPair {
 						ctx.UnprotectReg(d11.Reg)
@@ -31334,7 +31436,7 @@ func init_list() {
 					ctx.FreeDesc(&d56)
 					if ps.General {
 						ctx.SyncDesc(&d14)
-						if d14.Loc == LocReg {
+						if d14.Loc == LocReg || d14.Loc == LocFPReg {
 							ctx.ProtectReg(d14.Reg)
 						} else if d14.Loc == LocRegPair {
 							ctx.ProtectReg(d14.Reg)
@@ -31346,7 +31448,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d66)
 						ctx.EmitStoreToStack(d66, int32(bbs[1].PhiBase)+int32(0))
-						if d14.Loc == LocReg {
+						if d14.Loc == LocReg || d14.Loc == LocFPReg {
 							ctx.UnprotectReg(d14.Reg)
 						} else if d14.Loc == LocRegPair {
 							ctx.UnprotectReg(d14.Reg)
@@ -32311,7 +32413,7 @@ func init_list() {
 					ctx.FreeDesc(&d57)
 					if ps.General {
 						ctx.SyncDesc(&d14)
-						if d14.Loc == LocReg {
+						if d14.Loc == LocReg || d14.Loc == LocFPReg {
 							ctx.ProtectReg(d14.Reg)
 						} else if d14.Loc == LocRegPair {
 							ctx.ProtectReg(d14.Reg)
@@ -32323,7 +32425,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d67)
 						ctx.EmitStoreToStack(d67, int32(bbs[1].PhiBase)+int32(0))
-						if d14.Loc == LocReg {
+						if d14.Loc == LocReg || d14.Loc == LocFPReg {
 							ctx.UnprotectReg(d14.Reg)
 						} else if d14.Loc == LocRegPair {
 							ctx.UnprotectReg(d14.Reg)
@@ -32942,7 +33044,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d38)
 					if ps.General {
 						ctx.SyncDesc(&d38)
-						if d38.Loc == LocReg {
+						if d38.Loc == LocReg || d38.Loc == LocFPReg {
 							ctx.ProtectReg(d38.Reg)
 						} else if d38.Loc == LocRegPair {
 							ctx.ProtectReg(d38.Reg)
@@ -32966,7 +33068,7 @@ func init_list() {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(16))
-						if d38.Loc == LocReg {
+						if d38.Loc == LocReg || d38.Loc == LocFPReg {
 							ctx.UnprotectReg(d38.Reg)
 						} else if d38.Loc == LocRegPair {
 							ctx.UnprotectReg(d38.Reg)
@@ -33123,7 +33225,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d8)
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.ProtectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.ProtectReg(d8.Reg)
@@ -33147,7 +33249,7 @@ func init_list() {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
 							}
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(16))
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.UnprotectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.UnprotectReg(d8.Reg)
@@ -33233,7 +33335,7 @@ func init_list() {
 					d50 = snap70
 					ctx.MarkLabel(lbl8)
 					ctx.SyncDesc(&d8)
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.ProtectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.ProtectReg(d8.Reg)
@@ -33257,7 +33359,7 @@ func init_list() {
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
 					}
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(16))
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.UnprotectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.UnprotectReg(d8.Reg)
@@ -33492,7 +33594,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d102)
 					if ps.General {
 						ctx.SyncDesc(&d102)
-						if d102.Loc == LocReg {
+						if d102.Loc == LocReg || d102.Loc == LocFPReg {
 							ctx.ProtectReg(d102.Reg)
 						} else if d102.Loc == LocRegPair {
 							ctx.ProtectReg(d102.Reg)
@@ -33516,7 +33618,7 @@ func init_list() {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(1)}, int32(bbs[6].PhiBase)+int32(16))
-						if d102.Loc == LocReg {
+						if d102.Loc == LocReg || d102.Loc == LocFPReg {
 							ctx.UnprotectReg(d102.Reg)
 						} else if d102.Loc == LocRegPair {
 							ctx.UnprotectReg(d102.Reg)
@@ -34802,14 +34904,14 @@ func init_list() {
 					ctx.FreeDesc(&d9)
 					if ps.General {
 						ctx.SyncDesc(&d4)
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.ProtectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.ProtectReg(d4.Reg)
 							ctx.ProtectReg(d4.Reg2)
 						}
 						ctx.SyncDesc(&d5)
-						if d5.Loc == LocReg {
+						if d5.Loc == LocReg || d5.Loc == LocFPReg {
 							ctx.ProtectReg(d5.Reg)
 						} else if d5.Loc == LocRegPair {
 							ctx.ProtectReg(d5.Reg)
@@ -34847,13 +34949,13 @@ func init_list() {
 							ctx.EmitStoreToStack(d13, int32(bbs[3].PhiBase)+int32(24))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[3].PhiBase)+int32(24))+8)
 						}
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.UnprotectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.UnprotectReg(d4.Reg)
 							ctx.UnprotectReg(d4.Reg2)
 						}
-						if d5.Loc == LocReg {
+						if d5.Loc == LocReg || d5.Loc == LocFPReg {
 							ctx.UnprotectReg(d5.Reg)
 						} else if d5.Loc == LocRegPair {
 							ctx.UnprotectReg(d5.Reg)
@@ -35931,7 +36033,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d5)
-							if d5.Loc == LocReg {
+							if d5.Loc == LocReg || d5.Loc == LocFPReg {
 								ctx.ProtectReg(d5.Reg)
 							} else if d5.Loc == LocRegPair {
 								ctx.ProtectReg(d5.Reg)
@@ -35943,7 +36045,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d10)
 							ctx.EmitStoreToStack(d10, int32(bbs[2].PhiBase)+int32(0))
-							if d5.Loc == LocReg {
+							if d5.Loc == LocReg || d5.Loc == LocFPReg {
 								ctx.UnprotectReg(d5.Reg)
 							} else if d5.Loc == LocRegPair {
 								ctx.UnprotectReg(d5.Reg)
@@ -35998,7 +36100,7 @@ func init_list() {
 					d12 = snap22
 					ctx.MarkLabel(lbl12)
 					ctx.SyncDesc(&d5)
-					if d5.Loc == LocReg {
+					if d5.Loc == LocReg || d5.Loc == LocFPReg {
 						ctx.ProtectReg(d5.Reg)
 					} else if d5.Loc == LocRegPair {
 						ctx.ProtectReg(d5.Reg)
@@ -36010,7 +36112,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d24)
 					ctx.EmitStoreToStack(d24, int32(bbs[2].PhiBase)+int32(0))
-					if d5.Loc == LocReg {
+					if d5.Loc == LocReg || d5.Loc == LocFPReg {
 						ctx.UnprotectReg(d5.Reg)
 					} else if d5.Loc == LocRegPair {
 						ctx.UnprotectReg(d5.Reg)
@@ -39301,7 +39403,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d5)
-							if d5.Loc == LocReg {
+							if d5.Loc == LocReg || d5.Loc == LocFPReg {
 								ctx.ProtectReg(d5.Reg)
 							} else if d5.Loc == LocRegPair {
 								ctx.ProtectReg(d5.Reg)
@@ -39313,7 +39415,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d10)
 							ctx.EmitStoreToStack(d10, int32(bbs[2].PhiBase)+int32(0))
-							if d5.Loc == LocReg {
+							if d5.Loc == LocReg || d5.Loc == LocFPReg {
 								ctx.UnprotectReg(d5.Reg)
 							} else if d5.Loc == LocRegPair {
 								ctx.UnprotectReg(d5.Reg)
@@ -39368,7 +39470,7 @@ func init_list() {
 					d12 = snap22
 					ctx.MarkLabel(lbl15)
 					ctx.SyncDesc(&d5)
-					if d5.Loc == LocReg {
+					if d5.Loc == LocReg || d5.Loc == LocFPReg {
 						ctx.ProtectReg(d5.Reg)
 					} else if d5.Loc == LocRegPair {
 						ctx.ProtectReg(d5.Reg)
@@ -39380,7 +39482,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d24)
 					ctx.EmitStoreToStack(d24, int32(bbs[2].PhiBase)+int32(0))
-					if d5.Loc == LocReg {
+					if d5.Loc == LocReg || d5.Loc == LocFPReg {
 						ctx.UnprotectReg(d5.Reg)
 					} else if d5.Loc == LocRegPair {
 						ctx.UnprotectReg(d5.Reg)
@@ -44364,7 +44466,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d8)
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.ProtectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.ProtectReg(d8.Reg)
@@ -44376,7 +44478,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d44)
 							ctx.EmitStoreToStack(d44, int32(bbs[1].PhiBase)+int32(0))
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.UnprotectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.UnprotectReg(d8.Reg)
@@ -44452,7 +44554,7 @@ func init_list() {
 					d46 = snap63
 					ctx.MarkLabel(lbl6)
 					ctx.SyncDesc(&d8)
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.ProtectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.ProtectReg(d8.Reg)
@@ -44464,7 +44566,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d65)
 					ctx.EmitStoreToStack(d65, int32(bbs[1].PhiBase)+int32(0))
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.UnprotectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.UnprotectReg(d8.Reg)
@@ -46529,7 +46631,7 @@ func init_list() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d38)
-						if d38.Loc == LocReg {
+						if d38.Loc == LocReg || d38.Loc == LocFPReg {
 							ctx.ProtectReg(d38.Reg)
 						} else if d38.Loc == LocRegPair {
 							ctx.ProtectReg(d38.Reg)
@@ -46542,7 +46644,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d213)
 						ctx.EmitStoreToStack(d213, int32(bbs[3].PhiBase)+int32(16))
-						if d38.Loc == LocReg {
+						if d38.Loc == LocReg || d38.Loc == LocFPReg {
 							ctx.UnprotectReg(d38.Reg)
 						} else if d38.Loc == LocRegPair {
 							ctx.UnprotectReg(d38.Reg)
@@ -46754,7 +46856,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d38)
-							if d38.Loc == LocReg {
+							if d38.Loc == LocReg || d38.Loc == LocFPReg {
 								ctx.ProtectReg(d38.Reg)
 							} else if d38.Loc == LocRegPair {
 								ctx.ProtectReg(d38.Reg)
@@ -46766,7 +46868,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d221)
 							ctx.EmitStoreToStack(d221, int32(bbs[3].PhiBase)+int32(16))
-							if d38.Loc == LocReg {
+							if d38.Loc == LocReg || d38.Loc == LocFPReg {
 								ctx.UnprotectReg(d38.Reg)
 							} else if d38.Loc == LocRegPair {
 								ctx.UnprotectReg(d38.Reg)
@@ -46896,7 +46998,7 @@ func init_list() {
 					d223 = snap258
 					ctx.MarkLabel(lbl12)
 					ctx.SyncDesc(&d38)
-					if d38.Loc == LocReg {
+					if d38.Loc == LocReg || d38.Loc == LocFPReg {
 						ctx.ProtectReg(d38.Reg)
 					} else if d38.Loc == LocRegPair {
 						ctx.ProtectReg(d38.Reg)
@@ -46908,7 +47010,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d260)
 					ctx.EmitStoreToStack(d260, int32(bbs[3].PhiBase)+int32(16))
-					if d38.Loc == LocReg {
+					if d38.Loc == LocReg || d38.Loc == LocFPReg {
 						ctx.UnprotectReg(d38.Reg)
 					} else if d38.Loc == LocRegPair {
 						ctx.UnprotectReg(d38.Reg)
@@ -52559,7 +52661,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d8)
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.ProtectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.ProtectReg(d8.Reg)
@@ -52571,7 +52673,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d44)
 							ctx.EmitStoreToStack(d44, int32(bbs[1].PhiBase)+int32(0))
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.UnprotectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.UnprotectReg(d8.Reg)
@@ -52647,7 +52749,7 @@ func init_list() {
 					d46 = snap63
 					ctx.MarkLabel(lbl10)
 					ctx.SyncDesc(&d8)
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.ProtectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.ProtectReg(d8.Reg)
@@ -52659,7 +52761,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d65)
 					ctx.EmitStoreToStack(d65, int32(bbs[1].PhiBase)+int32(0))
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.UnprotectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.UnprotectReg(d8.Reg)
@@ -53003,7 +53105,7 @@ func init_list() {
 						if d93.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d8)
-								if d8.Loc == LocReg {
+								if d8.Loc == LocReg || d8.Loc == LocFPReg {
 									ctx.ProtectReg(d8.Reg)
 								} else if d8.Loc == LocRegPair {
 									ctx.ProtectReg(d8.Reg)
@@ -53015,7 +53117,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d94)
 								ctx.EmitStoreToStack(d94, int32(bbs[1].PhiBase)+int32(0))
-								if d8.Loc == LocReg {
+								if d8.Loc == LocReg || d8.Loc == LocFPReg {
 									ctx.UnprotectReg(d8.Reg)
 								} else if d8.Loc == LocRegPair {
 									ctx.UnprotectReg(d8.Reg)
@@ -53123,7 +53225,7 @@ func init_list() {
 					alloc124 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d8)
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.ProtectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.ProtectReg(d8.Reg)
@@ -53135,7 +53237,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d125)
 					ctx.EmitStoreToStack(d125, int32(bbs[1].PhiBase)+int32(0))
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.UnprotectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.UnprotectReg(d8.Reg)
@@ -53971,7 +54073,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d8)
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.ProtectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.ProtectReg(d8.Reg)
@@ -53983,7 +54085,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d236)
 							ctx.EmitStoreToStack(d236, int32(bbs[1].PhiBase)+int32(0))
-							if d8.Loc == LocReg {
+							if d8.Loc == LocReg || d8.Loc == LocFPReg {
 								ctx.UnprotectReg(d8.Reg)
 							} else if d8.Loc == LocRegPair {
 								ctx.UnprotectReg(d8.Reg)
@@ -54125,7 +54227,7 @@ func init_list() {
 					d238 = snap277
 					ctx.MarkLabel(lbl12)
 					ctx.SyncDesc(&d8)
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.ProtectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.ProtectReg(d8.Reg)
@@ -54137,7 +54239,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d279)
 					ctx.EmitStoreToStack(d279, int32(bbs[1].PhiBase)+int32(0))
-					if d8.Loc == LocReg {
+					if d8.Loc == LocReg || d8.Loc == LocFPReg {
 						ctx.UnprotectReg(d8.Reg)
 					} else if d8.Loc == LocRegPair {
 						ctx.UnprotectReg(d8.Reg)
@@ -55804,7 +55906,7 @@ func init_list() {
 					ctx.FreeDesc(&d59)
 					if ps.General {
 						ctx.SyncDesc(&d15)
-						if d15.Loc == LocReg {
+						if d15.Loc == LocReg || d15.Loc == LocFPReg {
 							ctx.ProtectReg(d15.Reg)
 						} else if d15.Loc == LocRegPair {
 							ctx.ProtectReg(d15.Reg)
@@ -55816,7 +55918,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d62)
 						ctx.EmitStoreToStack(d62, int32(bbs[1].PhiBase)+int32(0))
-						if d15.Loc == LocReg {
+						if d15.Loc == LocReg || d15.Loc == LocFPReg {
 							ctx.UnprotectReg(d15.Reg)
 						} else if d15.Loc == LocRegPair {
 							ctx.UnprotectReg(d15.Reg)
@@ -55977,7 +56079,7 @@ func init_list() {
 						d70 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d69.Imm.Int() > 2)}
 					} else {
 						ctx.EmitCmpRegImm32(d69.Reg, 2)
-						r4 := ctx.AllocReg()
+						r4 := ctx.AllocRegExcept(d69.Reg)
 						ctx.EmitSetcc(r4, CondSignedGreater)
 						d70 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r4}
 						ctx.BindReg(r4, &d70)
@@ -56027,7 +56129,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d68)
-							if d68.Loc == LocReg {
+							if d68.Loc == LocReg || d68.Loc == LocFPReg {
 								ctx.ProtectReg(d68.Reg)
 							} else if d68.Loc == LocRegPair {
 								ctx.ProtectReg(d68.Reg)
@@ -56050,7 +56152,7 @@ func init_list() {
 								ctx.EmitStoreToStack(d73, int32(bbs[5].PhiBase)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 							}
-							if d68.Loc == LocReg {
+							if d68.Loc == LocReg || d68.Loc == LocFPReg {
 								ctx.UnprotectReg(d68.Reg)
 							} else if d68.Loc == LocRegPair {
 								ctx.UnprotectReg(d68.Reg)
@@ -56165,7 +56267,7 @@ func init_list() {
 					d75 = snap105
 					ctx.MarkLabel(lbl14)
 					ctx.SyncDesc(&d68)
-					if d68.Loc == LocReg {
+					if d68.Loc == LocReg || d68.Loc == LocFPReg {
 						ctx.ProtectReg(d68.Reg)
 					} else if d68.Loc == LocRegPair {
 						ctx.ProtectReg(d68.Reg)
@@ -56188,7 +56290,7 @@ func init_list() {
 						ctx.EmitStoreToStack(d107, int32(bbs[5].PhiBase)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 					}
-					if d68.Loc == LocReg {
+					if d68.Loc == LocReg || d68.Loc == LocFPReg {
 						ctx.UnprotectReg(d68.Reg)
 					} else if d68.Loc == LocRegPair {
 						ctx.UnprotectReg(d68.Reg)
@@ -56499,7 +56601,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d144)
 					if ps.General {
 						ctx.SyncDesc(&d144)
-						if d144.Loc == LocReg {
+						if d144.Loc == LocReg || d144.Loc == LocFPReg {
 							ctx.ProtectReg(d144.Reg)
 						} else if d144.Loc == LocRegPair {
 							ctx.ProtectReg(d144.Reg)
@@ -56522,7 +56624,7 @@ func init_list() {
 							ctx.EmitStoreToStack(d145, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d144.Loc == LocReg {
+						if d144.Loc == LocReg || d144.Loc == LocFPReg {
 							ctx.UnprotectReg(d144.Reg)
 						} else if d144.Loc == LocRegPair {
 							ctx.UnprotectReg(d144.Reg)
@@ -56740,14 +56842,14 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d149)
 					if ps.General {
 						ctx.SyncDesc(&d2)
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.ProtectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.ProtectReg(d2.Reg)
 							ctx.ProtectReg(d2.Reg2)
 						}
 						ctx.SyncDesc(&d70)
-						if d70.Loc == LocReg {
+						if d70.Loc == LocReg || d70.Loc == LocFPReg {
 							ctx.ProtectReg(d70.Reg)
 						} else if d70.Loc == LocRegPair {
 							ctx.ProtectReg(d70.Reg)
@@ -56777,13 +56879,13 @@ func init_list() {
 						ctx.EnsureDesc(&d151)
 						ctx.EmitStoreToStack(d151, int32(bbs[6].PhiBase)+int32(16))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[6].PhiBase)+int32(32))
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.UnprotectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.UnprotectReg(d2.Reg)
 							ctx.UnprotectReg(d2.Reg2)
 						}
-						if d70.Loc == LocReg {
+						if d70.Loc == LocReg || d70.Loc == LocFPReg {
 							ctx.UnprotectReg(d70.Reg)
 						} else if d70.Loc == LocRegPair {
 							ctx.UnprotectReg(d70.Reg)
@@ -57815,14 +57917,14 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d276)
 					if ps.General {
 						ctx.SyncDesc(&d3)
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.ProtectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.ProtectReg(d3.Reg)
 							ctx.ProtectReg(d3.Reg2)
 						}
 						ctx.SyncDesc(&d4)
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.ProtectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.ProtectReg(d4.Reg)
@@ -57852,13 +57954,13 @@ func init_list() {
 						ctx.EnsureDesc(&d278)
 						ctx.EmitStoreToStack(d278, int32(bbs[9].PhiBase)+int32(16))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[9].PhiBase)+int32(32))
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.UnprotectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.UnprotectReg(d3.Reg)
 							ctx.UnprotectReg(d3.Reg2)
 						}
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.UnprotectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.UnprotectReg(d4.Reg)
@@ -58542,21 +58644,21 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d6)
-							if d6.Loc == LocReg {
+							if d6.Loc == LocReg || d6.Loc == LocFPReg {
 								ctx.ProtectReg(d6.Reg)
 							} else if d6.Loc == LocRegPair {
 								ctx.ProtectReg(d6.Reg)
 								ctx.ProtectReg(d6.Reg2)
 							}
 							ctx.SyncDesc(&d7)
-							if d7.Loc == LocReg {
+							if d7.Loc == LocReg || d7.Loc == LocFPReg {
 								ctx.ProtectReg(d7.Reg)
 							} else if d7.Loc == LocRegPair {
 								ctx.ProtectReg(d7.Reg)
 								ctx.ProtectReg(d7.Reg2)
 							}
 							ctx.SyncDesc(&d159)
-							if d159.Loc == LocReg {
+							if d159.Loc == LocReg || d159.Loc == LocFPReg {
 								ctx.ProtectReg(d159.Reg)
 							} else if d159.Loc == LocRegPair {
 								ctx.ProtectReg(d159.Reg)
@@ -58591,19 +58693,19 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d292)
 							ctx.EmitStoreToStack(d292, int32(bbs[6].PhiBase)+int32(32))
-							if d6.Loc == LocReg {
+							if d6.Loc == LocReg || d6.Loc == LocFPReg {
 								ctx.UnprotectReg(d6.Reg)
 							} else if d6.Loc == LocRegPair {
 								ctx.UnprotectReg(d6.Reg)
 								ctx.UnprotectReg(d6.Reg2)
 							}
-							if d7.Loc == LocReg {
+							if d7.Loc == LocReg || d7.Loc == LocFPReg {
 								ctx.UnprotectReg(d7.Reg)
 							} else if d7.Loc == LocRegPair {
 								ctx.UnprotectReg(d7.Reg)
 								ctx.UnprotectReg(d7.Reg2)
 							}
-							if d159.Loc == LocReg {
+							if d159.Loc == LocReg || d159.Loc == LocFPReg {
 								ctx.UnprotectReg(d159.Reg)
 							} else if d159.Loc == LocRegPair {
 								ctx.UnprotectReg(d159.Reg)
@@ -58867,21 +58969,21 @@ func init_list() {
 					d299 = snap374
 					ctx.MarkLabel(lbl15)
 					ctx.SyncDesc(&d6)
-					if d6.Loc == LocReg {
+					if d6.Loc == LocReg || d6.Loc == LocFPReg {
 						ctx.ProtectReg(d6.Reg)
 					} else if d6.Loc == LocRegPair {
 						ctx.ProtectReg(d6.Reg)
 						ctx.ProtectReg(d6.Reg2)
 					}
 					ctx.SyncDesc(&d7)
-					if d7.Loc == LocReg {
+					if d7.Loc == LocReg || d7.Loc == LocFPReg {
 						ctx.ProtectReg(d7.Reg)
 					} else if d7.Loc == LocRegPair {
 						ctx.ProtectReg(d7.Reg)
 						ctx.ProtectReg(d7.Reg2)
 					}
 					ctx.SyncDesc(&d159)
-					if d159.Loc == LocReg {
+					if d159.Loc == LocReg || d159.Loc == LocFPReg {
 						ctx.ProtectReg(d159.Reg)
 					} else if d159.Loc == LocRegPair {
 						ctx.ProtectReg(d159.Reg)
@@ -58916,19 +59018,19 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d378)
 					ctx.EmitStoreToStack(d378, int32(bbs[6].PhiBase)+int32(32))
-					if d6.Loc == LocReg {
+					if d6.Loc == LocReg || d6.Loc == LocFPReg {
 						ctx.UnprotectReg(d6.Reg)
 					} else if d6.Loc == LocRegPair {
 						ctx.UnprotectReg(d6.Reg)
 						ctx.UnprotectReg(d6.Reg2)
 					}
-					if d7.Loc == LocReg {
+					if d7.Loc == LocReg || d7.Loc == LocFPReg {
 						ctx.UnprotectReg(d7.Reg)
 					} else if d7.Loc == LocRegPair {
 						ctx.UnprotectReg(d7.Reg)
 						ctx.UnprotectReg(d7.Reg2)
 					}
-					if d159.Loc == LocReg {
+					if d159.Loc == LocReg || d159.Loc == LocFPReg {
 						ctx.UnprotectReg(d159.Reg)
 					} else if d159.Loc == LocRegPair {
 						ctx.UnprotectReg(d159.Reg)
@@ -60716,14 +60818,14 @@ func init_list() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d286)
-						if d286.Loc == LocReg {
+						if d286.Loc == LocReg || d286.Loc == LocFPReg {
 							ctx.ProtectReg(d286.Reg)
 						} else if d286.Loc == LocRegPair {
 							ctx.ProtectReg(d286.Reg)
 							ctx.ProtectReg(d286.Reg2)
 						}
 						ctx.SyncDesc(&d466)
-						if d466.Loc == LocReg {
+						if d466.Loc == LocReg || d466.Loc == LocFPReg {
 							ctx.ProtectReg(d466.Reg)
 						} else if d466.Loc == LocRegPair {
 							ctx.ProtectReg(d466.Reg)
@@ -60753,13 +60855,13 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d644)
 						ctx.EmitStoreToStack(d644, int32(bbs[9].PhiBase)+int32(32))
-						if d286.Loc == LocReg {
+						if d286.Loc == LocReg || d286.Loc == LocFPReg {
 							ctx.UnprotectReg(d286.Reg)
 						} else if d286.Loc == LocRegPair {
 							ctx.UnprotectReg(d286.Reg)
 							ctx.UnprotectReg(d286.Reg2)
 						}
-						if d466.Loc == LocReg {
+						if d466.Loc == LocReg || d466.Loc == LocFPReg {
 							ctx.UnprotectReg(d466.Reg)
 						} else if d466.Loc == LocRegPair {
 							ctx.UnprotectReg(d466.Reg)
@@ -61199,7 +61301,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d651)
 					if ps.General {
 						ctx.SyncDesc(&d286)
-						if d286.Loc == LocReg {
+						if d286.Loc == LocReg || d286.Loc == LocFPReg {
 							ctx.ProtectReg(d286.Reg)
 						} else if d286.Loc == LocRegPair {
 							ctx.ProtectReg(d286.Reg)
@@ -61211,7 +61313,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d658)
 						ctx.EmitStoreToStack(d658, int32(bbs[9].PhiBase)+int32(32))
-						if d286.Loc == LocReg {
+						if d286.Loc == LocReg || d286.Loc == LocFPReg {
 							ctx.UnprotectReg(d286.Reg)
 						} else if d286.Loc == LocRegPair {
 							ctx.UnprotectReg(d286.Reg)
@@ -62247,7 +62349,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d21)
-							if d21.Loc == LocReg {
+							if d21.Loc == LocReg || d21.Loc == LocFPReg {
 								ctx.ProtectReg(d21.Reg)
 							} else if d21.Loc == LocRegPair {
 								ctx.ProtectReg(d21.Reg)
@@ -62259,7 +62361,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d100)
 							ctx.EmitStoreToStack(d100, int32(bbs[1].PhiBase)+int32(24))
-							if d21.Loc == LocReg {
+							if d21.Loc == LocReg || d21.Loc == LocFPReg {
 								ctx.UnprotectReg(d21.Reg)
 							} else if d21.Loc == LocRegPair {
 								ctx.UnprotectReg(d21.Reg)
@@ -62392,7 +62494,7 @@ func init_list() {
 					d102 = snap138
 					ctx.MarkLabel(lbl6)
 					ctx.SyncDesc(&d21)
-					if d21.Loc == LocReg {
+					if d21.Loc == LocReg || d21.Loc == LocFPReg {
 						ctx.ProtectReg(d21.Reg)
 					} else if d21.Loc == LocRegPair {
 						ctx.ProtectReg(d21.Reg)
@@ -62404,7 +62506,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d140)
 					ctx.EmitStoreToStack(d140, int32(bbs[1].PhiBase)+int32(24))
-					if d21.Loc == LocReg {
+					if d21.Loc == LocReg || d21.Loc == LocFPReg {
 						ctx.UnprotectReg(d21.Reg)
 					} else if d21.Loc == LocRegPair {
 						ctx.UnprotectReg(d21.Reg)
@@ -62949,7 +63051,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d188)
 					if ps.General {
 						ctx.SyncDesc(&d21)
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.ProtectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.ProtectReg(d21.Reg)
@@ -62961,7 +63063,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d190)
 						ctx.EmitStoreToStack(d190, int32(bbs[1].PhiBase)+int32(24))
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.UnprotectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.UnprotectReg(d21.Reg)
@@ -63810,7 +63912,7 @@ func init_list() {
 						if d81.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d18)
-								if d18.Loc == LocReg {
+								if d18.Loc == LocReg || d18.Loc == LocFPReg {
 									ctx.ProtectReg(d18.Reg)
 								} else if d18.Loc == LocRegPair {
 									ctx.ProtectReg(d18.Reg)
@@ -63822,7 +63924,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d82)
 								ctx.EmitStoreToStack(d82, int32(bbs[1].PhiBase)+int32(24))
-								if d18.Loc == LocReg {
+								if d18.Loc == LocReg || d18.Loc == LocFPReg {
 									ctx.UnprotectReg(d18.Reg)
 								} else if d18.Loc == LocRegPair {
 									ctx.UnprotectReg(d18.Reg)
@@ -63942,7 +64044,7 @@ func init_list() {
 					alloc116 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl6)
 					ctx.SyncDesc(&d18)
-					if d18.Loc == LocReg {
+					if d18.Loc == LocReg || d18.Loc == LocFPReg {
 						ctx.ProtectReg(d18.Reg)
 					} else if d18.Loc == LocRegPair {
 						ctx.ProtectReg(d18.Reg)
@@ -63954,7 +64056,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d117)
 					ctx.EmitStoreToStack(d117, int32(bbs[1].PhiBase)+int32(24))
-					if d18.Loc == LocReg {
+					if d18.Loc == LocReg || d18.Loc == LocFPReg {
 						ctx.UnprotectReg(d18.Reg)
 					} else if d18.Loc == LocRegPair {
 						ctx.UnprotectReg(d18.Reg)
@@ -64465,7 +64567,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d159)
 					if ps.General {
 						ctx.SyncDesc(&d18)
-						if d18.Loc == LocReg {
+						if d18.Loc == LocReg || d18.Loc == LocFPReg {
 							ctx.ProtectReg(d18.Reg)
 						} else if d18.Loc == LocRegPair {
 							ctx.ProtectReg(d18.Reg)
@@ -64477,7 +64579,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d161)
 						ctx.EmitStoreToStack(d161, int32(bbs[1].PhiBase)+int32(24))
-						if d18.Loc == LocReg {
+						if d18.Loc == LocReg || d18.Loc == LocFPReg {
 							ctx.UnprotectReg(d18.Reg)
 						} else if d18.Loc == LocRegPair {
 							ctx.UnprotectReg(d18.Reg)
@@ -64829,7 +64931,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d9)
 					if ps.General {
 						ctx.SyncDesc(&d8)
-						if d8.Loc == LocReg {
+						if d8.Loc == LocReg || d8.Loc == LocFPReg {
 							ctx.ProtectReg(d8.Reg)
 						} else if d8.Loc == LocRegPair {
 							ctx.ProtectReg(d8.Reg)
@@ -64853,7 +64955,7 @@ func init_list() {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[1].PhiBase)+int32(0))+8)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[1].PhiBase)+int32(16))
-						if d8.Loc == LocReg {
+						if d8.Loc == LocReg || d8.Loc == LocFPReg {
 							ctx.UnprotectReg(d8.Reg)
 						} else if d8.Loc == LocRegPair {
 							ctx.UnprotectReg(d8.Reg)
@@ -65872,7 +65974,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d138)
 					if ps.General {
 						ctx.SyncDesc(&d16)
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.ProtectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.ProtectReg(d16.Reg)
@@ -65884,7 +65986,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d139)
 						ctx.EmitStoreToStack(d139, int32(bbs[1].PhiBase)+int32(16))
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.UnprotectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.UnprotectReg(d16.Reg)
@@ -67100,7 +67202,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d301)
 					if ps.General {
 						ctx.SyncDesc(&d16)
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.ProtectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.ProtectReg(d16.Reg)
@@ -67112,7 +67214,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d302)
 						ctx.EmitStoreToStack(d302, int32(bbs[1].PhiBase)+int32(16))
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.UnprotectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.UnprotectReg(d16.Reg)
@@ -67394,7 +67496,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d308)
 					if ps.General {
 						ctx.SyncDesc(&d16)
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.ProtectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.ProtectReg(d16.Reg)
@@ -67406,7 +67508,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d309)
 						ctx.EmitStoreToStack(d309, int32(bbs[1].PhiBase)+int32(16))
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.UnprotectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.UnprotectReg(d16.Reg)
@@ -73008,7 +73110,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d133)
 					if ps.General {
 						ctx.SyncDesc(&d15)
-						if d15.Loc == LocReg {
+						if d15.Loc == LocReg || d15.Loc == LocFPReg {
 							ctx.ProtectReg(d15.Reg)
 						} else if d15.Loc == LocRegPair {
 							ctx.ProtectReg(d15.Reg)
@@ -73020,7 +73122,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d134)
 						ctx.EmitStoreToStack(d134, int32(bbs[1].PhiBase)+int32(16))
-						if d15.Loc == LocReg {
+						if d15.Loc == LocReg || d15.Loc == LocFPReg {
 							ctx.UnprotectReg(d15.Reg)
 						} else if d15.Loc == LocRegPair {
 							ctx.UnprotectReg(d15.Reg)
@@ -73226,7 +73328,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d15)
-							if d15.Loc == LocReg {
+							if d15.Loc == LocReg || d15.Loc == LocFPReg {
 								ctx.ProtectReg(d15.Reg)
 							} else if d15.Loc == LocRegPair {
 								ctx.ProtectReg(d15.Reg)
@@ -73238,7 +73340,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d141)
 							ctx.EmitStoreToStack(d141, int32(bbs[1].PhiBase)+int32(16))
-							if d15.Loc == LocReg {
+							if d15.Loc == LocReg || d15.Loc == LocFPReg {
 								ctx.UnprotectReg(d15.Reg)
 							} else if d15.Loc == LocRegPair {
 								ctx.UnprotectReg(d15.Reg)
@@ -73365,7 +73467,7 @@ func init_list() {
 					d143 = snap177
 					ctx.MarkLabel(lbl8)
 					ctx.SyncDesc(&d15)
-					if d15.Loc == LocReg {
+					if d15.Loc == LocReg || d15.Loc == LocFPReg {
 						ctx.ProtectReg(d15.Reg)
 					} else if d15.Loc == LocRegPair {
 						ctx.ProtectReg(d15.Reg)
@@ -73377,7 +73479,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d179)
 					ctx.EmitStoreToStack(d179, int32(bbs[1].PhiBase)+int32(16))
-					if d15.Loc == LocReg {
+					if d15.Loc == LocReg || d15.Loc == LocFPReg {
 						ctx.UnprotectReg(d15.Reg)
 					} else if d15.Loc == LocRegPair {
 						ctx.UnprotectReg(d15.Reg)
@@ -74602,7 +74704,7 @@ func init_list() {
 				ctx.FreeDesc(&d46)
 				ctx.ReclaimUntrackedRegs()
 				ctx.SyncDesc(&d30)
-				if d30.Loc == LocReg {
+				if d30.Loc == LocReg || d30.Loc == LocFPReg {
 					ctx.ProtectReg(d30.Reg)
 				} else if d30.Loc == LocRegPair {
 					ctx.ProtectReg(d30.Reg)
@@ -74614,7 +74716,7 @@ func init_list() {
 				}
 				ctx.EnsureDesc(&d48)
 				ctx.EmitStoreToStack(d48, int32(phiBase2)+int32(48))
-				if d30.Loc == LocReg {
+				if d30.Loc == LocReg || d30.Loc == LocFPReg {
 					ctx.UnprotectReg(d30.Reg)
 				} else if d30.Loc == LocRegPair {
 					ctx.UnprotectReg(d30.Reg)
@@ -74699,7 +74801,7 @@ func init_list() {
 					} else {
 						ctx.MarkLabel(lbl35)
 						ctx.SyncDesc(&d35)
-						if d35.Loc == LocReg {
+						if d35.Loc == LocReg || d35.Loc == LocFPReg {
 							ctx.ProtectReg(d35.Reg)
 						} else if d35.Loc == LocRegPair {
 							ctx.ProtectReg(d35.Reg)
@@ -74711,7 +74813,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d54)
 						ctx.EmitStoreToStack(d54, int32(phiBase2)+int32(64))
-						if d35.Loc == LocReg {
+						if d35.Loc == LocReg || d35.Loc == LocFPReg {
 							ctx.UnprotectReg(d35.Reg)
 						} else if d35.Loc == LocRegPair {
 							ctx.UnprotectReg(d35.Reg)
@@ -74727,7 +74829,7 @@ func init_list() {
 					ctx.EmitJmp(lbl21)
 					ctx.MarkLabel(lbl35)
 					ctx.SyncDesc(&d35)
-					if d35.Loc == LocReg {
+					if d35.Loc == LocReg || d35.Loc == LocFPReg {
 						ctx.ProtectReg(d35.Reg)
 					} else if d35.Loc == LocRegPair {
 						ctx.ProtectReg(d35.Reg)
@@ -74739,7 +74841,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d55)
 					ctx.EmitStoreToStack(d55, int32(phiBase2)+int32(64))
-					if d35.Loc == LocReg {
+					if d35.Loc == LocReg || d35.Loc == LocFPReg {
 						ctx.UnprotectReg(d35.Reg)
 					} else if d35.Loc == LocRegPair {
 						ctx.UnprotectReg(d35.Reg)
@@ -74931,7 +75033,7 @@ func init_list() {
 					} else {
 						ctx.MarkLabel(lbl39)
 						ctx.SyncDesc(&d42)
-						if d42.Loc == LocReg {
+						if d42.Loc == LocReg || d42.Loc == LocFPReg {
 							ctx.ProtectReg(d42.Reg)
 						} else if d42.Loc == LocRegPair {
 							ctx.ProtectReg(d42.Reg)
@@ -74943,7 +75045,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d66)
 						ctx.EmitStoreToStack(d66, int32(phiBase2)+int32(0))
-						if d42.Loc == LocReg {
+						if d42.Loc == LocReg || d42.Loc == LocFPReg {
 							ctx.UnprotectReg(d42.Reg)
 						} else if d42.Loc == LocRegPair {
 							ctx.UnprotectReg(d42.Reg)
@@ -74959,7 +75061,7 @@ func init_list() {
 					ctx.EmitJmp(lbl14)
 					ctx.MarkLabel(lbl39)
 					ctx.SyncDesc(&d42)
-					if d42.Loc == LocReg {
+					if d42.Loc == LocReg || d42.Loc == LocFPReg {
 						ctx.ProtectReg(d42.Reg)
 					} else if d42.Loc == LocRegPair {
 						ctx.ProtectReg(d42.Reg)
@@ -74971,7 +75073,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d67)
 					ctx.EmitStoreToStack(d67, int32(phiBase2)+int32(0))
-					if d42.Loc == LocReg {
+					if d42.Loc == LocReg || d42.Loc == LocFPReg {
 						ctx.UnprotectReg(d42.Reg)
 					} else if d42.Loc == LocRegPair {
 						ctx.UnprotectReg(d42.Reg)
@@ -75067,7 +75169,7 @@ func init_list() {
 					} else {
 						ctx.MarkLabel(lbl41)
 						ctx.SyncDesc(&d60)
-						if d60.Loc == LocReg {
+						if d60.Loc == LocReg || d60.Loc == LocFPReg {
 							ctx.ProtectReg(d60.Reg)
 						} else if d60.Loc == LocRegPair {
 							ctx.ProtectReg(d60.Reg)
@@ -75079,7 +75181,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d74)
 						ctx.EmitStoreToStack(d74, int32(phiBase2)+int32(16))
-						if d60.Loc == LocReg {
+						if d60.Loc == LocReg || d60.Loc == LocFPReg {
 							ctx.UnprotectReg(d60.Reg)
 						} else if d60.Loc == LocRegPair {
 							ctx.UnprotectReg(d60.Reg)
@@ -75095,7 +75197,7 @@ func init_list() {
 					ctx.EmitJmp(lbl13)
 					ctx.MarkLabel(lbl41)
 					ctx.SyncDesc(&d60)
-					if d60.Loc == LocReg {
+					if d60.Loc == LocReg || d60.Loc == LocFPReg {
 						ctx.ProtectReg(d60.Reg)
 					} else if d60.Loc == LocRegPair {
 						ctx.ProtectReg(d60.Reg)
@@ -75107,7 +75209,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d75)
 					ctx.EmitStoreToStack(d75, int32(phiBase2)+int32(16))
-					if d60.Loc == LocReg {
+					if d60.Loc == LocReg || d60.Loc == LocFPReg {
 						ctx.UnprotectReg(d60.Reg)
 					} else if d60.Loc == LocRegPair {
 						ctx.UnprotectReg(d60.Reg)
@@ -76077,7 +76179,7 @@ func init_list() {
 				ctx.FreeDesc(&d46)
 				ctx.ReclaimUntrackedRegs()
 				ctx.SyncDesc(&d30)
-				if d30.Loc == LocReg {
+				if d30.Loc == LocReg || d30.Loc == LocFPReg {
 					ctx.ProtectReg(d30.Reg)
 				} else if d30.Loc == LocRegPair {
 					ctx.ProtectReg(d30.Reg)
@@ -76089,7 +76191,7 @@ func init_list() {
 				}
 				ctx.EnsureDesc(&d48)
 				ctx.EmitStoreToStack(d48, int32(phiBase2)+int32(48))
-				if d30.Loc == LocReg {
+				if d30.Loc == LocReg || d30.Loc == LocFPReg {
 					ctx.UnprotectReg(d30.Reg)
 				} else if d30.Loc == LocRegPair {
 					ctx.UnprotectReg(d30.Reg)
@@ -76174,7 +76276,7 @@ func init_list() {
 					} else {
 						ctx.MarkLabel(lbl35)
 						ctx.SyncDesc(&d35)
-						if d35.Loc == LocReg {
+						if d35.Loc == LocReg || d35.Loc == LocFPReg {
 							ctx.ProtectReg(d35.Reg)
 						} else if d35.Loc == LocRegPair {
 							ctx.ProtectReg(d35.Reg)
@@ -76186,7 +76288,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d54)
 						ctx.EmitStoreToStack(d54, int32(phiBase2)+int32(64))
-						if d35.Loc == LocReg {
+						if d35.Loc == LocReg || d35.Loc == LocFPReg {
 							ctx.UnprotectReg(d35.Reg)
 						} else if d35.Loc == LocRegPair {
 							ctx.UnprotectReg(d35.Reg)
@@ -76202,7 +76304,7 @@ func init_list() {
 					ctx.EmitJmp(lbl21)
 					ctx.MarkLabel(lbl35)
 					ctx.SyncDesc(&d35)
-					if d35.Loc == LocReg {
+					if d35.Loc == LocReg || d35.Loc == LocFPReg {
 						ctx.ProtectReg(d35.Reg)
 					} else if d35.Loc == LocRegPair {
 						ctx.ProtectReg(d35.Reg)
@@ -76214,7 +76316,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d55)
 					ctx.EmitStoreToStack(d55, int32(phiBase2)+int32(64))
-					if d35.Loc == LocReg {
+					if d35.Loc == LocReg || d35.Loc == LocFPReg {
 						ctx.UnprotectReg(d35.Reg)
 					} else if d35.Loc == LocRegPair {
 						ctx.UnprotectReg(d35.Reg)
@@ -76406,7 +76508,7 @@ func init_list() {
 					} else {
 						ctx.MarkLabel(lbl39)
 						ctx.SyncDesc(&d42)
-						if d42.Loc == LocReg {
+						if d42.Loc == LocReg || d42.Loc == LocFPReg {
 							ctx.ProtectReg(d42.Reg)
 						} else if d42.Loc == LocRegPair {
 							ctx.ProtectReg(d42.Reg)
@@ -76418,7 +76520,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d66)
 						ctx.EmitStoreToStack(d66, int32(phiBase2)+int32(0))
-						if d42.Loc == LocReg {
+						if d42.Loc == LocReg || d42.Loc == LocFPReg {
 							ctx.UnprotectReg(d42.Reg)
 						} else if d42.Loc == LocRegPair {
 							ctx.UnprotectReg(d42.Reg)
@@ -76434,7 +76536,7 @@ func init_list() {
 					ctx.EmitJmp(lbl14)
 					ctx.MarkLabel(lbl39)
 					ctx.SyncDesc(&d42)
-					if d42.Loc == LocReg {
+					if d42.Loc == LocReg || d42.Loc == LocFPReg {
 						ctx.ProtectReg(d42.Reg)
 					} else if d42.Loc == LocRegPair {
 						ctx.ProtectReg(d42.Reg)
@@ -76446,7 +76548,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d67)
 					ctx.EmitStoreToStack(d67, int32(phiBase2)+int32(0))
-					if d42.Loc == LocReg {
+					if d42.Loc == LocReg || d42.Loc == LocFPReg {
 						ctx.UnprotectReg(d42.Reg)
 					} else if d42.Loc == LocRegPair {
 						ctx.UnprotectReg(d42.Reg)
@@ -76542,7 +76644,7 @@ func init_list() {
 					} else {
 						ctx.MarkLabel(lbl41)
 						ctx.SyncDesc(&d60)
-						if d60.Loc == LocReg {
+						if d60.Loc == LocReg || d60.Loc == LocFPReg {
 							ctx.ProtectReg(d60.Reg)
 						} else if d60.Loc == LocRegPair {
 							ctx.ProtectReg(d60.Reg)
@@ -76554,7 +76656,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d74)
 						ctx.EmitStoreToStack(d74, int32(phiBase2)+int32(16))
-						if d60.Loc == LocReg {
+						if d60.Loc == LocReg || d60.Loc == LocFPReg {
 							ctx.UnprotectReg(d60.Reg)
 						} else if d60.Loc == LocRegPair {
 							ctx.UnprotectReg(d60.Reg)
@@ -76570,7 +76672,7 @@ func init_list() {
 					ctx.EmitJmp(lbl13)
 					ctx.MarkLabel(lbl41)
 					ctx.SyncDesc(&d60)
-					if d60.Loc == LocReg {
+					if d60.Loc == LocReg || d60.Loc == LocFPReg {
 						ctx.ProtectReg(d60.Reg)
 					} else if d60.Loc == LocRegPair {
 						ctx.ProtectReg(d60.Reg)
@@ -76582,7 +76684,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d75)
 					ctx.EmitStoreToStack(d75, int32(phiBase2)+int32(16))
-					if d60.Loc == LocReg {
+					if d60.Loc == LocReg || d60.Loc == LocFPReg {
 						ctx.UnprotectReg(d60.Reg)
 					} else if d60.Loc == LocRegPair {
 						ctx.UnprotectReg(d60.Reg)
@@ -77912,7 +78014,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d133)
 					if ps.General {
 						ctx.SyncDesc(&d15)
-						if d15.Loc == LocReg {
+						if d15.Loc == LocReg || d15.Loc == LocFPReg {
 							ctx.ProtectReg(d15.Reg)
 						} else if d15.Loc == LocRegPair {
 							ctx.ProtectReg(d15.Reg)
@@ -77924,7 +78026,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d134)
 						ctx.EmitStoreToStack(d134, int32(bbs[1].PhiBase)+int32(16))
-						if d15.Loc == LocReg {
+						if d15.Loc == LocReg || d15.Loc == LocFPReg {
 							ctx.UnprotectReg(d15.Reg)
 						} else if d15.Loc == LocRegPair {
 							ctx.UnprotectReg(d15.Reg)
@@ -78092,7 +78194,7 @@ func init_list() {
 						if d139.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d15)
-								if d15.Loc == LocReg {
+								if d15.Loc == LocReg || d15.Loc == LocFPReg {
 									ctx.ProtectReg(d15.Reg)
 								} else if d15.Loc == LocRegPair {
 									ctx.ProtectReg(d15.Reg)
@@ -78104,7 +78206,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d140)
 								ctx.EmitStoreToStack(d140, int32(bbs[1].PhiBase)+int32(16))
-								if d15.Loc == LocReg {
+								if d15.Loc == LocReg || d15.Loc == LocFPReg {
 									ctx.UnprotectReg(d15.Reg)
 								} else if d15.Loc == LocRegPair {
 									ctx.UnprotectReg(d15.Reg)
@@ -78236,7 +78338,7 @@ func init_list() {
 					alloc178 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl8)
 					ctx.SyncDesc(&d15)
-					if d15.Loc == LocReg {
+					if d15.Loc == LocReg || d15.Loc == LocFPReg {
 						ctx.ProtectReg(d15.Reg)
 					} else if d15.Loc == LocRegPair {
 						ctx.ProtectReg(d15.Reg)
@@ -78248,7 +78350,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d179)
 					ctx.EmitStoreToStack(d179, int32(bbs[1].PhiBase)+int32(16))
-					if d15.Loc == LocReg {
+					if d15.Loc == LocReg || d15.Loc == LocFPReg {
 						ctx.UnprotectReg(d15.Reg)
 					} else if d15.Loc == LocRegPair {
 						ctx.UnprotectReg(d15.Reg)
@@ -79338,7 +79440,7 @@ func init_list() {
 						if d60.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d11)
-								if d11.Loc == LocReg {
+								if d11.Loc == LocReg || d11.Loc == LocFPReg {
 									ctx.ProtectReg(d11.Reg)
 								} else if d11.Loc == LocRegPair {
 									ctx.ProtectReg(d11.Reg)
@@ -79350,7 +79452,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d61)
 								ctx.EmitStoreToStack(d61, int32(bbs[1].PhiBase)+int32(0))
-								if d11.Loc == LocReg {
+								if d11.Loc == LocReg || d11.Loc == LocFPReg {
 									ctx.UnprotectReg(d11.Reg)
 								} else if d11.Loc == LocRegPair {
 									ctx.UnprotectReg(d11.Reg)
@@ -79452,7 +79554,7 @@ func init_list() {
 					alloc89 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl6)
 					ctx.SyncDesc(&d11)
-					if d11.Loc == LocReg {
+					if d11.Loc == LocReg || d11.Loc == LocFPReg {
 						ctx.ProtectReg(d11.Reg)
 					} else if d11.Loc == LocRegPair {
 						ctx.ProtectReg(d11.Reg)
@@ -79464,7 +79566,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d90)
 					ctx.EmitStoreToStack(d90, int32(bbs[1].PhiBase)+int32(0))
-					if d11.Loc == LocReg {
+					if d11.Loc == LocReg || d11.Loc == LocFPReg {
 						ctx.UnprotectReg(d11.Reg)
 					} else if d11.Loc == LocRegPair {
 						ctx.UnprotectReg(d11.Reg)
@@ -80785,7 +80887,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d21)
-							if d21.Loc == LocReg {
+							if d21.Loc == LocReg || d21.Loc == LocFPReg {
 								ctx.ProtectReg(d21.Reg)
 							} else if d21.Loc == LocRegPair {
 								ctx.ProtectReg(d21.Reg)
@@ -80797,7 +80899,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d90)
 							ctx.EmitStoreToStack(d90, int32(bbs[1].PhiBase)+int32(24))
-							if d21.Loc == LocReg {
+							if d21.Loc == LocReg || d21.Loc == LocFPReg {
 								ctx.UnprotectReg(d21.Reg)
 							} else if d21.Loc == LocRegPair {
 								ctx.UnprotectReg(d21.Reg)
@@ -80918,7 +81020,7 @@ func init_list() {
 					d92 = snap124
 					ctx.MarkLabel(lbl6)
 					ctx.SyncDesc(&d21)
-					if d21.Loc == LocReg {
+					if d21.Loc == LocReg || d21.Loc == LocFPReg {
 						ctx.ProtectReg(d21.Reg)
 					} else if d21.Loc == LocRegPair {
 						ctx.ProtectReg(d21.Reg)
@@ -80930,7 +81032,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d126)
 					ctx.EmitStoreToStack(d126, int32(bbs[1].PhiBase)+int32(24))
-					if d21.Loc == LocReg {
+					if d21.Loc == LocReg || d21.Loc == LocFPReg {
 						ctx.UnprotectReg(d21.Reg)
 					} else if d21.Loc == LocRegPair {
 						ctx.UnprotectReg(d21.Reg)
@@ -81462,7 +81564,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d180)
 					if ps.General {
 						ctx.SyncDesc(&d21)
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.ProtectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.ProtectReg(d21.Reg)
@@ -81474,7 +81576,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d182)
 						ctx.EmitStoreToStack(d182, int32(bbs[1].PhiBase)+int32(24))
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.UnprotectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.UnprotectReg(d21.Reg)
@@ -82285,7 +82387,7 @@ func init_list() {
 					ctx.FreeDesc(&d73)
 					if ps.General {
 						ctx.SyncDesc(&d17)
-						if d17.Loc == LocReg {
+						if d17.Loc == LocReg || d17.Loc == LocFPReg {
 							ctx.ProtectReg(d17.Reg)
 						} else if d17.Loc == LocRegPair {
 							ctx.ProtectReg(d17.Reg)
@@ -82297,7 +82399,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d83)
 						ctx.EmitStoreToStack(d83, int32(bbs[1].PhiBase)+int32(0))
-						if d17.Loc == LocReg {
+						if d17.Loc == LocReg || d17.Loc == LocFPReg {
 							ctx.UnprotectReg(d17.Reg)
 						} else if d17.Loc == LocRegPair {
 							ctx.UnprotectReg(d17.Reg)
@@ -83228,7 +83330,7 @@ func init_list() {
 					ctx.FreeDesc(&d73)
 					if ps.General {
 						ctx.SyncDesc(&d16)
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.ProtectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.ProtectReg(d16.Reg)
@@ -83240,7 +83342,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d82)
 						ctx.EmitStoreToStack(d82, int32(bbs[1].PhiBase)+int32(0))
-						if d16.Loc == LocReg {
+						if d16.Loc == LocReg || d16.Loc == LocFPReg {
 							ctx.UnprotectReg(d16.Reg)
 						} else if d16.Loc == LocRegPair {
 							ctx.UnprotectReg(d16.Reg)
@@ -83807,7 +83909,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d14)
-							if d14.Loc == LocReg {
+							if d14.Loc == LocReg || d14.Loc == LocFPReg {
 								ctx.ProtectReg(d14.Reg)
 							} else if d14.Loc == LocRegPair {
 								ctx.ProtectReg(d14.Reg)
@@ -83831,7 +83933,7 @@ func init_list() {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 							}
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[2].PhiBase)+int32(16))
-							if d14.Loc == LocReg {
+							if d14.Loc == LocReg || d14.Loc == LocFPReg {
 								ctx.UnprotectReg(d14.Reg)
 							} else if d14.Loc == LocRegPair {
 								ctx.UnprotectReg(d14.Reg)
@@ -83911,7 +84013,7 @@ func init_list() {
 					d22 = snap40
 					ctx.MarkLabel(lbl9)
 					ctx.SyncDesc(&d14)
-					if d14.Loc == LocReg {
+					if d14.Loc == LocReg || d14.Loc == LocFPReg {
 						ctx.ProtectReg(d14.Reg)
 					} else if d14.Loc == LocRegPair {
 						ctx.ProtectReg(d14.Reg)
@@ -83935,7 +84037,7 @@ func init_list() {
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 					}
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[2].PhiBase)+int32(16))
-					if d14.Loc == LocReg {
+					if d14.Loc == LocReg || d14.Loc == LocFPReg {
 						ctx.UnprotectReg(d14.Reg)
 					} else if d14.Loc == LocRegPair {
 						ctx.UnprotectReg(d14.Reg)
@@ -84154,7 +84256,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d69)
 					if ps.General {
 						ctx.SyncDesc(&d69)
-						if d69.Loc == LocReg {
+						if d69.Loc == LocReg || d69.Loc == LocFPReg {
 							ctx.ProtectReg(d69.Reg)
 						} else if d69.Loc == LocRegPair {
 							ctx.ProtectReg(d69.Reg)
@@ -84178,7 +84280,7 @@ func init_list() {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(16))
-						if d69.Loc == LocReg {
+						if d69.Loc == LocReg || d69.Loc == LocFPReg {
 							ctx.UnprotectReg(d69.Reg)
 						} else if d69.Loc == LocRegPair {
 							ctx.UnprotectReg(d69.Reg)
@@ -84366,14 +84468,14 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d76)
 					if ps.General {
 						ctx.SyncDesc(&d1)
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.ProtectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.ProtectReg(d1.Reg)
 							ctx.ProtectReg(d1.Reg2)
 						}
 						ctx.SyncDesc(&d2)
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.ProtectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.ProtectReg(d2.Reg)
@@ -84403,13 +84505,13 @@ func init_list() {
 						ctx.EnsureDesc(&d78)
 						ctx.EmitStoreToStack(d78, int32(bbs[3].PhiBase)+int32(16))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[3].PhiBase)+int32(32))
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.UnprotectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.UnprotectReg(d1.Reg)
 							ctx.UnprotectReg(d1.Reg2)
 						}
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.UnprotectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.UnprotectReg(d2.Reg)
@@ -86151,14 +86253,14 @@ func init_list() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d86)
-						if d86.Loc == LocReg {
+						if d86.Loc == LocReg || d86.Loc == LocFPReg {
 							ctx.ProtectReg(d86.Reg)
 						} else if d86.Loc == LocRegPair {
 							ctx.ProtectReg(d86.Reg)
 							ctx.ProtectReg(d86.Reg2)
 						}
 						ctx.SyncDesc(&d186)
-						if d186.Loc == LocReg {
+						if d186.Loc == LocReg || d186.Loc == LocFPReg {
 							ctx.ProtectReg(d186.Reg)
 						} else if d186.Loc == LocRegPair {
 							ctx.ProtectReg(d186.Reg)
@@ -86188,13 +86290,13 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d300)
 						ctx.EmitStoreToStack(d300, int32(bbs[3].PhiBase)+int32(32))
-						if d86.Loc == LocReg {
+						if d86.Loc == LocReg || d86.Loc == LocFPReg {
 							ctx.UnprotectReg(d86.Reg)
 						} else if d86.Loc == LocRegPair {
 							ctx.UnprotectReg(d86.Reg)
 							ctx.UnprotectReg(d86.Reg2)
 						}
-						if d186.Loc == LocReg {
+						if d186.Loc == LocReg || d186.Loc == LocFPReg {
 							ctx.UnprotectReg(d186.Reg)
 						} else if d186.Loc == LocRegPair {
 							ctx.UnprotectReg(d186.Reg)
@@ -86489,7 +86591,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d307)
 					if ps.General {
 						ctx.SyncDesc(&d86)
-						if d86.Loc == LocReg {
+						if d86.Loc == LocReg || d86.Loc == LocFPReg {
 							ctx.ProtectReg(d86.Reg)
 						} else if d86.Loc == LocRegPair {
 							ctx.ProtectReg(d86.Reg)
@@ -86501,7 +86603,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d314)
 						ctx.EmitStoreToStack(d314, int32(bbs[3].PhiBase)+int32(32))
-						if d86.Loc == LocReg {
+						if d86.Loc == LocReg || d86.Loc == LocFPReg {
 							ctx.UnprotectReg(d86.Reg)
 						} else if d86.Loc == LocRegPair {
 							ctx.UnprotectReg(d86.Reg)
@@ -86965,7 +87067,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d14)
-							if d14.Loc == LocReg {
+							if d14.Loc == LocReg || d14.Loc == LocFPReg {
 								ctx.ProtectReg(d14.Reg)
 							} else if d14.Loc == LocRegPair {
 								ctx.ProtectReg(d14.Reg)
@@ -86989,7 +87091,7 @@ func init_list() {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 							}
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[2].PhiBase)+int32(16))
-							if d14.Loc == LocReg {
+							if d14.Loc == LocReg || d14.Loc == LocFPReg {
 								ctx.UnprotectReg(d14.Reg)
 							} else if d14.Loc == LocRegPair {
 								ctx.UnprotectReg(d14.Reg)
@@ -87069,7 +87171,7 @@ func init_list() {
 					d22 = snap40
 					ctx.MarkLabel(lbl10)
 					ctx.SyncDesc(&d14)
-					if d14.Loc == LocReg {
+					if d14.Loc == LocReg || d14.Loc == LocFPReg {
 						ctx.ProtectReg(d14.Reg)
 					} else if d14.Loc == LocRegPair {
 						ctx.ProtectReg(d14.Reg)
@@ -87093,7 +87195,7 @@ func init_list() {
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 					}
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[2].PhiBase)+int32(16))
-					if d14.Loc == LocReg {
+					if d14.Loc == LocReg || d14.Loc == LocFPReg {
 						ctx.UnprotectReg(d14.Reg)
 					} else if d14.Loc == LocRegPair {
 						ctx.UnprotectReg(d14.Reg)
@@ -87312,7 +87414,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d69)
 					if ps.General {
 						ctx.SyncDesc(&d69)
-						if d69.Loc == LocReg {
+						if d69.Loc == LocReg || d69.Loc == LocFPReg {
 							ctx.ProtectReg(d69.Reg)
 						} else if d69.Loc == LocRegPair {
 							ctx.ProtectReg(d69.Reg)
@@ -87336,7 +87438,7 @@ func init_list() {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(16))
-						if d69.Loc == LocReg {
+						if d69.Loc == LocReg || d69.Loc == LocFPReg {
 							ctx.UnprotectReg(d69.Reg)
 						} else if d69.Loc == LocRegPair {
 							ctx.UnprotectReg(d69.Reg)
@@ -87524,14 +87626,14 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d76)
 					if ps.General {
 						ctx.SyncDesc(&d1)
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.ProtectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.ProtectReg(d1.Reg)
 							ctx.ProtectReg(d1.Reg2)
 						}
 						ctx.SyncDesc(&d2)
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.ProtectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.ProtectReg(d2.Reg)
@@ -87561,13 +87663,13 @@ func init_list() {
 						ctx.EnsureDesc(&d78)
 						ctx.EmitStoreToStack(d78, int32(bbs[3].PhiBase)+int32(16))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[3].PhiBase)+int32(32))
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.UnprotectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.UnprotectReg(d1.Reg)
 							ctx.UnprotectReg(d1.Reg2)
 						}
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.UnprotectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.UnprotectReg(d2.Reg)
@@ -88519,7 +88621,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d86)
-							if d86.Loc == LocReg {
+							if d86.Loc == LocReg || d86.Loc == LocFPReg {
 								ctx.ProtectReg(d86.Reg)
 							} else if d86.Loc == LocRegPair {
 								ctx.ProtectReg(d86.Reg)
@@ -88531,7 +88633,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d198)
 							ctx.EmitStoreToStack(d198, int32(bbs[3].PhiBase)+int32(32))
-							if d86.Loc == LocReg {
+							if d86.Loc == LocReg || d86.Loc == LocFPReg {
 								ctx.UnprotectReg(d86.Reg)
 							} else if d86.Loc == LocRegPair {
 								ctx.UnprotectReg(d86.Reg)
@@ -88715,7 +88817,7 @@ func init_list() {
 					d200 = snap253
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d86)
-					if d86.Loc == LocReg {
+					if d86.Loc == LocReg || d86.Loc == LocFPReg {
 						ctx.ProtectReg(d86.Reg)
 					} else if d86.Loc == LocRegPair {
 						ctx.ProtectReg(d86.Reg)
@@ -88727,7 +88829,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d255)
 					ctx.EmitStoreToStack(d255, int32(bbs[3].PhiBase)+int32(32))
-					if d86.Loc == LocReg {
+					if d86.Loc == LocReg || d86.Loc == LocFPReg {
 						ctx.UnprotectReg(d86.Reg)
 					} else if d86.Loc == LocRegPair {
 						ctx.UnprotectReg(d86.Reg)
@@ -90176,14 +90278,14 @@ func init_list() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d86)
-						if d86.Loc == LocReg {
+						if d86.Loc == LocReg || d86.Loc == LocFPReg {
 							ctx.ProtectReg(d86.Reg)
 						} else if d86.Loc == LocRegPair {
 							ctx.ProtectReg(d86.Reg)
 							ctx.ProtectReg(d86.Reg2)
 						}
 						ctx.SyncDesc(&d182)
-						if d182.Loc == LocReg {
+						if d182.Loc == LocReg || d182.Loc == LocFPReg {
 							ctx.ProtectReg(d182.Reg)
 						} else if d182.Loc == LocRegPair {
 							ctx.ProtectReg(d182.Reg)
@@ -90213,13 +90315,13 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d435)
 						ctx.EmitStoreToStack(d435, int32(bbs[3].PhiBase)+int32(32))
-						if d86.Loc == LocReg {
+						if d86.Loc == LocReg || d86.Loc == LocFPReg {
 							ctx.UnprotectReg(d86.Reg)
 						} else if d86.Loc == LocRegPair {
 							ctx.UnprotectReg(d86.Reg)
 							ctx.UnprotectReg(d86.Reg2)
 						}
-						if d182.Loc == LocReg {
+						if d182.Loc == LocReg || d182.Loc == LocFPReg {
 							ctx.UnprotectReg(d182.Reg)
 						} else if d182.Loc == LocRegPair {
 							ctx.UnprotectReg(d182.Reg)
@@ -90542,7 +90644,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d442)
 					if ps.General {
 						ctx.SyncDesc(&d86)
-						if d86.Loc == LocReg {
+						if d86.Loc == LocReg || d86.Loc == LocFPReg {
 							ctx.ProtectReg(d86.Reg)
 						} else if d86.Loc == LocRegPair {
 							ctx.ProtectReg(d86.Reg)
@@ -90554,7 +90656,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d449)
 						ctx.EmitStoreToStack(d449, int32(bbs[3].PhiBase)+int32(32))
-						if d86.Loc == LocReg {
+						if d86.Loc == LocReg || d86.Loc == LocFPReg {
 							ctx.UnprotectReg(d86.Reg)
 						} else if d86.Loc == LocRegPair {
 							ctx.UnprotectReg(d86.Reg)
@@ -91403,7 +91505,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d47)
-							if d47.Loc == LocReg {
+							if d47.Loc == LocReg || d47.Loc == LocFPReg {
 								ctx.ProtectReg(d47.Reg)
 							} else if d47.Loc == LocRegPair {
 								ctx.ProtectReg(d47.Reg)
@@ -91427,7 +91529,7 @@ func init_list() {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[4].PhiBase)+int32(0))+8)
 							}
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(16))
-							if d47.Loc == LocReg {
+							if d47.Loc == LocReg || d47.Loc == LocFPReg {
 								ctx.UnprotectReg(d47.Reg)
 							} else if d47.Loc == LocRegPair {
 								ctx.UnprotectReg(d47.Reg)
@@ -91525,7 +91627,7 @@ func init_list() {
 					d55 = snap79
 					ctx.MarkLabel(lbl16)
 					ctx.SyncDesc(&d47)
-					if d47.Loc == LocReg {
+					if d47.Loc == LocReg || d47.Loc == LocFPReg {
 						ctx.ProtectReg(d47.Reg)
 					} else if d47.Loc == LocRegPair {
 						ctx.ProtectReg(d47.Reg)
@@ -91549,7 +91651,7 @@ func init_list() {
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[4].PhiBase)+int32(0))+8)
 					}
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[4].PhiBase)+int32(16))
-					if d47.Loc == LocReg {
+					if d47.Loc == LocReg || d47.Loc == LocFPReg {
 						ctx.UnprotectReg(d47.Reg)
 					} else if d47.Loc == LocRegPair {
 						ctx.UnprotectReg(d47.Reg)
@@ -91819,7 +91921,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d114)
 					if ps.General {
 						ctx.SyncDesc(&d114)
-						if d114.Loc == LocReg {
+						if d114.Loc == LocReg || d114.Loc == LocFPReg {
 							ctx.ProtectReg(d114.Reg)
 						} else if d114.Loc == LocRegPair {
 							ctx.ProtectReg(d114.Reg)
@@ -91843,7 +91945,7 @@ func init_list() {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[4].PhiBase)+int32(0))+8)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[4].PhiBase)+int32(16))
-						if d114.Loc == LocReg {
+						if d114.Loc == LocReg || d114.Loc == LocFPReg {
 							ctx.UnprotectReg(d114.Reg)
 						} else if d114.Loc == LocRegPair {
 							ctx.UnprotectReg(d114.Reg)
@@ -92058,14 +92160,14 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d121)
 					if ps.General {
 						ctx.SyncDesc(&d1)
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.ProtectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.ProtectReg(d1.Reg)
 							ctx.ProtectReg(d1.Reg2)
 						}
 						ctx.SyncDesc(&d2)
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.ProtectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.ProtectReg(d2.Reg)
@@ -92095,13 +92197,13 @@ func init_list() {
 						ctx.EnsureDesc(&d123)
 						ctx.EmitStoreToStack(d123, int32(bbs[5].PhiBase)+int32(16))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[5].PhiBase)+int32(32))
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.UnprotectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.UnprotectReg(d1.Reg)
 							ctx.UnprotectReg(d1.Reg2)
 						}
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.UnprotectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.UnprotectReg(d2.Reg)
@@ -93761,14 +93863,14 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d350)
 					if ps.General {
 						ctx.SyncDesc(&d3)
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.ProtectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.ProtectReg(d3.Reg)
 							ctx.ProtectReg(d3.Reg2)
 						}
 						ctx.SyncDesc(&d4)
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.ProtectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.ProtectReg(d4.Reg)
@@ -93798,13 +93900,13 @@ func init_list() {
 						ctx.EnsureDesc(&d352)
 						ctx.EmitStoreToStack(d352, int32(bbs[10].PhiBase)+int32(16))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[10].PhiBase)+int32(32))
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.UnprotectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.UnprotectReg(d3.Reg)
 							ctx.UnprotectReg(d3.Reg2)
 						}
-						if d4.Loc == LocReg {
+						if d4.Loc == LocReg || d4.Loc == LocFPReg {
 							ctx.UnprotectReg(d4.Reg)
 						} else if d4.Loc == LocRegPair {
 							ctx.UnprotectReg(d4.Reg)
@@ -94082,14 +94184,14 @@ func init_list() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d131)
-						if d131.Loc == LocReg {
+						if d131.Loc == LocReg || d131.Loc == LocFPReg {
 							ctx.ProtectReg(d131.Reg)
 						} else if d131.Loc == LocRegPair {
 							ctx.ProtectReg(d131.Reg)
 							ctx.ProtectReg(d131.Reg2)
 						}
 						ctx.SyncDesc(&d239)
-						if d239.Loc == LocReg {
+						if d239.Loc == LocReg || d239.Loc == LocFPReg {
 							ctx.ProtectReg(d239.Reg)
 						} else if d239.Loc == LocRegPair {
 							ctx.ProtectReg(d239.Reg)
@@ -94119,13 +94221,13 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d358)
 						ctx.EmitStoreToStack(d358, int32(bbs[5].PhiBase)+int32(32))
-						if d131.Loc == LocReg {
+						if d131.Loc == LocReg || d131.Loc == LocFPReg {
 							ctx.UnprotectReg(d131.Reg)
 						} else if d131.Loc == LocRegPair {
 							ctx.UnprotectReg(d131.Reg)
 							ctx.UnprotectReg(d131.Reg2)
 						}
-						if d239.Loc == LocReg {
+						if d239.Loc == LocReg || d239.Loc == LocFPReg {
 							ctx.UnprotectReg(d239.Reg)
 						} else if d239.Loc == LocRegPair {
 							ctx.UnprotectReg(d239.Reg)
@@ -94455,7 +94557,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d365)
 					if ps.General {
 						ctx.SyncDesc(&d131)
-						if d131.Loc == LocReg {
+						if d131.Loc == LocReg || d131.Loc == LocFPReg {
 							ctx.ProtectReg(d131.Reg)
 						} else if d131.Loc == LocRegPair {
 							ctx.ProtectReg(d131.Reg)
@@ -94467,7 +94569,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d372)
 						ctx.EmitStoreToStack(d372, int32(bbs[5].PhiBase)+int32(32))
-						if d131.Loc == LocReg {
+						if d131.Loc == LocReg || d131.Loc == LocFPReg {
 							ctx.UnprotectReg(d131.Reg)
 						} else if d131.Loc == LocRegPair {
 							ctx.UnprotectReg(d131.Reg)
@@ -97213,14 +97315,14 @@ func init_list() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d378)
-						if d378.Loc == LocReg {
+						if d378.Loc == LocReg || d378.Loc == LocFPReg {
 							ctx.ProtectReg(d378.Reg)
 						} else if d378.Loc == LocRegPair {
 							ctx.ProtectReg(d378.Reg)
 							ctx.ProtectReg(d378.Reg2)
 						}
 						ctx.SyncDesc(&d544)
-						if d544.Loc == LocReg {
+						if d544.Loc == LocReg || d544.Loc == LocFPReg {
 							ctx.ProtectReg(d544.Reg)
 						} else if d544.Loc == LocRegPair {
 							ctx.ProtectReg(d544.Reg)
@@ -97250,13 +97352,13 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d714)
 						ctx.EmitStoreToStack(d714, int32(bbs[10].PhiBase)+int32(32))
-						if d378.Loc == LocReg {
+						if d378.Loc == LocReg || d378.Loc == LocFPReg {
 							ctx.UnprotectReg(d378.Reg)
 						} else if d378.Loc == LocRegPair {
 							ctx.UnprotectReg(d378.Reg)
 							ctx.UnprotectReg(d378.Reg2)
 						}
-						if d544.Loc == LocReg {
+						if d544.Loc == LocReg || d544.Loc == LocFPReg {
 							ctx.UnprotectReg(d544.Reg)
 						} else if d544.Loc == LocRegPair {
 							ctx.UnprotectReg(d544.Reg)
@@ -97679,7 +97781,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d721)
 					if ps.General {
 						ctx.SyncDesc(&d378)
-						if d378.Loc == LocReg {
+						if d378.Loc == LocReg || d378.Loc == LocFPReg {
 							ctx.ProtectReg(d378.Reg)
 						} else if d378.Loc == LocRegPair {
 							ctx.ProtectReg(d378.Reg)
@@ -97691,7 +97793,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d728)
 						ctx.EmitStoreToStack(d728, int32(bbs[10].PhiBase)+int32(32))
-						if d378.Loc == LocReg {
+						if d378.Loc == LocReg || d378.Loc == LocFPReg {
 							ctx.UnprotectReg(d378.Reg)
 						} else if d378.Loc == LocRegPair {
 							ctx.UnprotectReg(d378.Reg)
@@ -98223,7 +98325,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d17)
-							if d17.Loc == LocReg {
+							if d17.Loc == LocReg || d17.Loc == LocFPReg {
 								ctx.ProtectReg(d17.Reg)
 							} else if d17.Loc == LocRegPair {
 								ctx.ProtectReg(d17.Reg)
@@ -98247,7 +98349,7 @@ func init_list() {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 							}
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[2].PhiBase)+int32(16))
-							if d17.Loc == LocReg {
+							if d17.Loc == LocReg || d17.Loc == LocFPReg {
 								ctx.UnprotectReg(d17.Reg)
 							} else if d17.Loc == LocRegPair {
 								ctx.UnprotectReg(d17.Reg)
@@ -98333,7 +98435,7 @@ func init_list() {
 					d25 = snap45
 					ctx.MarkLabel(lbl10)
 					ctx.SyncDesc(&d17)
-					if d17.Loc == LocReg {
+					if d17.Loc == LocReg || d17.Loc == LocFPReg {
 						ctx.ProtectReg(d17.Reg)
 					} else if d17.Loc == LocRegPair {
 						ctx.ProtectReg(d17.Reg)
@@ -98357,7 +98459,7 @@ func init_list() {
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 					}
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[2].PhiBase)+int32(16))
-					if d17.Loc == LocReg {
+					if d17.Loc == LocReg || d17.Loc == LocFPReg {
 						ctx.UnprotectReg(d17.Reg)
 					} else if d17.Loc == LocRegPair {
 						ctx.UnprotectReg(d17.Reg)
@@ -98592,7 +98694,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d76)
 					if ps.General {
 						ctx.SyncDesc(&d76)
-						if d76.Loc == LocReg {
+						if d76.Loc == LocReg || d76.Loc == LocFPReg {
 							ctx.ProtectReg(d76.Reg)
 						} else if d76.Loc == LocRegPair {
 							ctx.ProtectReg(d76.Reg)
@@ -98616,7 +98718,7 @@ func init_list() {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(16))
-						if d76.Loc == LocReg {
+						if d76.Loc == LocReg || d76.Loc == LocFPReg {
 							ctx.UnprotectReg(d76.Reg)
 						} else if d76.Loc == LocRegPair {
 							ctx.UnprotectReg(d76.Reg)
@@ -98812,14 +98914,14 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d83)
 					if ps.General {
 						ctx.SyncDesc(&d1)
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.ProtectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.ProtectReg(d1.Reg)
 							ctx.ProtectReg(d1.Reg2)
 						}
 						ctx.SyncDesc(&d2)
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.ProtectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.ProtectReg(d2.Reg)
@@ -98849,13 +98951,13 @@ func init_list() {
 						ctx.EnsureDesc(&d85)
 						ctx.EmitStoreToStack(d85, int32(bbs[3].PhiBase)+int32(16))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[3].PhiBase)+int32(32))
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.UnprotectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.UnprotectReg(d1.Reg)
 							ctx.UnprotectReg(d1.Reg2)
 						}
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.UnprotectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.UnprotectReg(d2.Reg)
@@ -99876,7 +99978,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d93)
-							if d93.Loc == LocReg {
+							if d93.Loc == LocReg || d93.Loc == LocFPReg {
 								ctx.ProtectReg(d93.Reg)
 							} else if d93.Loc == LocRegPair {
 								ctx.ProtectReg(d93.Reg)
@@ -99888,7 +99990,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d219)
 							ctx.EmitStoreToStack(d219, int32(bbs[3].PhiBase)+int32(32))
-							if d93.Loc == LocReg {
+							if d93.Loc == LocReg || d93.Loc == LocFPReg {
 								ctx.UnprotectReg(d93.Reg)
 							} else if d93.Loc == LocRegPair {
 								ctx.UnprotectReg(d93.Reg)
@@ -100090,7 +100192,7 @@ func init_list() {
 					d221 = snap280
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d93)
-					if d93.Loc == LocReg {
+					if d93.Loc == LocReg || d93.Loc == LocFPReg {
 						ctx.ProtectReg(d93.Reg)
 					} else if d93.Loc == LocRegPair {
 						ctx.ProtectReg(d93.Reg)
@@ -100102,7 +100204,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d282)
 					ctx.EmitStoreToStack(d282, int32(bbs[3].PhiBase)+int32(32))
-					if d93.Loc == LocReg {
+					if d93.Loc == LocReg || d93.Loc == LocFPReg {
 						ctx.UnprotectReg(d93.Reg)
 					} else if d93.Loc == LocRegPair {
 						ctx.UnprotectReg(d93.Reg)
@@ -101689,14 +101791,14 @@ func init_list() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d93)
-						if d93.Loc == LocReg {
+						if d93.Loc == LocReg || d93.Loc == LocFPReg {
 							ctx.ProtectReg(d93.Reg)
 						} else if d93.Loc == LocRegPair {
 							ctx.ProtectReg(d93.Reg)
 							ctx.ProtectReg(d93.Reg2)
 						}
 						ctx.SyncDesc(&d197)
-						if d197.Loc == LocReg {
+						if d197.Loc == LocReg || d197.Loc == LocFPReg {
 							ctx.ProtectReg(d197.Reg)
 						} else if d197.Loc == LocRegPair {
 							ctx.ProtectReg(d197.Reg)
@@ -101726,13 +101828,13 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d480)
 						ctx.EmitStoreToStack(d480, int32(bbs[3].PhiBase)+int32(32))
-						if d93.Loc == LocReg {
+						if d93.Loc == LocReg || d93.Loc == LocFPReg {
 							ctx.UnprotectReg(d93.Reg)
 						} else if d93.Loc == LocRegPair {
 							ctx.UnprotectReg(d93.Reg)
 							ctx.UnprotectReg(d93.Reg2)
 						}
-						if d197.Loc == LocReg {
+						if d197.Loc == LocReg || d197.Loc == LocFPReg {
 							ctx.UnprotectReg(d197.Reg)
 						} else if d197.Loc == LocRegPair {
 							ctx.UnprotectReg(d197.Reg)
@@ -102079,7 +102181,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d487)
 					if ps.General {
 						ctx.SyncDesc(&d93)
-						if d93.Loc == LocReg {
+						if d93.Loc == LocReg || d93.Loc == LocFPReg {
 							ctx.ProtectReg(d93.Reg)
 						} else if d93.Loc == LocRegPair {
 							ctx.ProtectReg(d93.Reg)
@@ -102091,7 +102193,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d494)
 						ctx.EmitStoreToStack(d494, int32(bbs[3].PhiBase)+int32(32))
-						if d93.Loc == LocReg {
+						if d93.Loc == LocReg || d93.Loc == LocFPReg {
 							ctx.UnprotectReg(d93.Reg)
 						} else if d93.Loc == LocRegPair {
 							ctx.UnprotectReg(d93.Reg)
@@ -102605,7 +102707,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d17)
-							if d17.Loc == LocReg {
+							if d17.Loc == LocReg || d17.Loc == LocFPReg {
 								ctx.ProtectReg(d17.Reg)
 							} else if d17.Loc == LocRegPair {
 								ctx.ProtectReg(d17.Reg)
@@ -102629,7 +102731,7 @@ func init_list() {
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 							}
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[2].PhiBase)+int32(16))
-							if d17.Loc == LocReg {
+							if d17.Loc == LocReg || d17.Loc == LocFPReg {
 								ctx.UnprotectReg(d17.Reg)
 							} else if d17.Loc == LocRegPair {
 								ctx.UnprotectReg(d17.Reg)
@@ -102715,7 +102817,7 @@ func init_list() {
 					d25 = snap45
 					ctx.MarkLabel(lbl10)
 					ctx.SyncDesc(&d17)
-					if d17.Loc == LocReg {
+					if d17.Loc == LocReg || d17.Loc == LocFPReg {
 						ctx.ProtectReg(d17.Reg)
 					} else if d17.Loc == LocRegPair {
 						ctx.ProtectReg(d17.Reg)
@@ -102739,7 +102841,7 @@ func init_list() {
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 					}
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(bbs[2].PhiBase)+int32(16))
-					if d17.Loc == LocReg {
+					if d17.Loc == LocReg || d17.Loc == LocFPReg {
 						ctx.UnprotectReg(d17.Reg)
 					} else if d17.Loc == LocRegPair {
 						ctx.UnprotectReg(d17.Reg)
@@ -102974,7 +103076,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d76)
 					if ps.General {
 						ctx.SyncDesc(&d76)
-						if d76.Loc == LocReg {
+						if d76.Loc == LocReg || d76.Loc == LocFPReg {
 							ctx.ProtectReg(d76.Reg)
 						} else if d76.Loc == LocRegPair {
 							ctx.ProtectReg(d76.Reg)
@@ -102998,7 +103100,7 @@ func init_list() {
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(1)}, int32(bbs[2].PhiBase)+int32(16))
-						if d76.Loc == LocReg {
+						if d76.Loc == LocReg || d76.Loc == LocFPReg {
 							ctx.UnprotectReg(d76.Reg)
 						} else if d76.Loc == LocRegPair {
 							ctx.UnprotectReg(d76.Reg)
@@ -103194,14 +103296,14 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d83)
 					if ps.General {
 						ctx.SyncDesc(&d1)
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.ProtectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.ProtectReg(d1.Reg)
 							ctx.ProtectReg(d1.Reg2)
 						}
 						ctx.SyncDesc(&d2)
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.ProtectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.ProtectReg(d2.Reg)
@@ -103231,13 +103333,13 @@ func init_list() {
 						ctx.EnsureDesc(&d85)
 						ctx.EmitStoreToStack(d85, int32(bbs[3].PhiBase)+int32(16))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[3].PhiBase)+int32(32))
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.UnprotectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.UnprotectReg(d1.Reg)
 							ctx.UnprotectReg(d1.Reg2)
 						}
-						if d2.Loc == LocReg {
+						if d2.Loc == LocReg || d2.Loc == LocFPReg {
 							ctx.UnprotectReg(d2.Reg)
 						} else if d2.Loc == LocRegPair {
 							ctx.UnprotectReg(d2.Reg)
@@ -104223,7 +104325,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d93)
-							if d93.Loc == LocReg {
+							if d93.Loc == LocReg || d93.Loc == LocFPReg {
 								ctx.ProtectReg(d93.Reg)
 							} else if d93.Loc == LocRegPair {
 								ctx.ProtectReg(d93.Reg)
@@ -104235,7 +104337,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d209)
 							ctx.EmitStoreToStack(d209, int32(bbs[3].PhiBase)+int32(32))
-							if d93.Loc == LocReg {
+							if d93.Loc == LocReg || d93.Loc == LocFPReg {
 								ctx.UnprotectReg(d93.Reg)
 							} else if d93.Loc == LocRegPair {
 								ctx.UnprotectReg(d93.Reg)
@@ -104425,7 +104527,7 @@ func init_list() {
 					d211 = snap266
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d93)
-					if d93.Loc == LocReg {
+					if d93.Loc == LocReg || d93.Loc == LocFPReg {
 						ctx.ProtectReg(d93.Reg)
 					} else if d93.Loc == LocRegPair {
 						ctx.ProtectReg(d93.Reg)
@@ -104437,7 +104539,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d268)
 					ctx.EmitStoreToStack(d268, int32(bbs[3].PhiBase)+int32(32))
-					if d93.Loc == LocReg {
+					if d93.Loc == LocReg || d93.Loc == LocFPReg {
 						ctx.UnprotectReg(d93.Reg)
 					} else if d93.Loc == LocRegPair {
 						ctx.UnprotectReg(d93.Reg)
@@ -106011,14 +106113,14 @@ func init_list() {
 					ctx.ReclaimUntrackedRegs()
 					if ps.General {
 						ctx.SyncDesc(&d93)
-						if d93.Loc == LocReg {
+						if d93.Loc == LocReg || d93.Loc == LocFPReg {
 							ctx.ProtectReg(d93.Reg)
 						} else if d93.Loc == LocRegPair {
 							ctx.ProtectReg(d93.Reg)
 							ctx.ProtectReg(d93.Reg2)
 						}
 						ctx.SyncDesc(&d332)
-						if d332.Loc == LocReg {
+						if d332.Loc == LocReg || d332.Loc == LocFPReg {
 							ctx.ProtectReg(d332.Reg)
 						} else if d332.Loc == LocRegPair {
 							ctx.ProtectReg(d332.Reg)
@@ -106048,13 +106150,13 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d472)
 						ctx.EmitStoreToStack(d472, int32(bbs[3].PhiBase)+int32(32))
-						if d93.Loc == LocReg {
+						if d93.Loc == LocReg || d93.Loc == LocFPReg {
 							ctx.UnprotectReg(d93.Reg)
 						} else if d93.Loc == LocRegPair {
 							ctx.UnprotectReg(d93.Reg)
 							ctx.UnprotectReg(d93.Reg2)
 						}
-						if d332.Loc == LocReg {
+						if d332.Loc == LocReg || d332.Loc == LocFPReg {
 							ctx.UnprotectReg(d332.Reg)
 						} else if d332.Loc == LocRegPair {
 							ctx.UnprotectReg(d332.Reg)
@@ -106401,7 +106503,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d479)
 					if ps.General {
 						ctx.SyncDesc(&d93)
-						if d93.Loc == LocReg {
+						if d93.Loc == LocReg || d93.Loc == LocFPReg {
 							ctx.ProtectReg(d93.Reg)
 						} else if d93.Loc == LocRegPair {
 							ctx.ProtectReg(d93.Reg)
@@ -106413,7 +106515,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d486)
 						ctx.EmitStoreToStack(d486, int32(bbs[3].PhiBase)+int32(32))
-						if d93.Loc == LocReg {
+						if d93.Loc == LocReg || d93.Loc == LocFPReg {
 							ctx.UnprotectReg(d93.Reg)
 						} else if d93.Loc == LocRegPair {
 							ctx.UnprotectReg(d93.Reg)
@@ -107408,7 +107510,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d21)
-							if d21.Loc == LocReg {
+							if d21.Loc == LocReg || d21.Loc == LocFPReg {
 								ctx.ProtectReg(d21.Reg)
 							} else if d21.Loc == LocRegPair {
 								ctx.ProtectReg(d21.Reg)
@@ -107420,7 +107522,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d90)
 							ctx.EmitStoreToStack(d90, int32(bbs[1].PhiBase)+int32(24))
-							if d21.Loc == LocReg {
+							if d21.Loc == LocReg || d21.Loc == LocFPReg {
 								ctx.UnprotectReg(d21.Reg)
 							} else if d21.Loc == LocRegPair {
 								ctx.UnprotectReg(d21.Reg)
@@ -107541,7 +107643,7 @@ func init_list() {
 					d92 = snap124
 					ctx.MarkLabel(lbl7)
 					ctx.SyncDesc(&d21)
-					if d21.Loc == LocReg {
+					if d21.Loc == LocReg || d21.Loc == LocFPReg {
 						ctx.ProtectReg(d21.Reg)
 					} else if d21.Loc == LocRegPair {
 						ctx.ProtectReg(d21.Reg)
@@ -107553,7 +107655,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d126)
 					ctx.EmitStoreToStack(d126, int32(bbs[1].PhiBase)+int32(24))
-					if d21.Loc == LocReg {
+					if d21.Loc == LocReg || d21.Loc == LocFPReg {
 						ctx.UnprotectReg(d21.Reg)
 					} else if d21.Loc == LocRegPair {
 						ctx.UnprotectReg(d21.Reg)
@@ -108054,7 +108156,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d170)
 					if ps.General {
 						ctx.SyncDesc(&d21)
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.ProtectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.ProtectReg(d21.Reg)
@@ -108066,7 +108168,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d172)
 						ctx.EmitStoreToStack(d172, int32(bbs[1].PhiBase)+int32(24))
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.UnprotectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.UnprotectReg(d21.Reg)
@@ -108367,7 +108469,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d21)
-							if d21.Loc == LocReg {
+							if d21.Loc == LocReg || d21.Loc == LocFPReg {
 								ctx.ProtectReg(d21.Reg)
 							} else if d21.Loc == LocRegPair {
 								ctx.ProtectReg(d21.Reg)
@@ -108379,7 +108481,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d189)
 							ctx.EmitStoreToStack(d189, int32(bbs[1].PhiBase)+int32(24))
-							if d21.Loc == LocReg {
+							if d21.Loc == LocReg || d21.Loc == LocFPReg {
 								ctx.UnprotectReg(d21.Reg)
 							} else if d21.Loc == LocRegPair {
 								ctx.UnprotectReg(d21.Reg)
@@ -108554,7 +108656,7 @@ func init_list() {
 					d191 = snap241
 					ctx.MarkLabel(lbl8)
 					ctx.SyncDesc(&d21)
-					if d21.Loc == LocReg {
+					if d21.Loc == LocReg || d21.Loc == LocFPReg {
 						ctx.ProtectReg(d21.Reg)
 					} else if d21.Loc == LocRegPair {
 						ctx.ProtectReg(d21.Reg)
@@ -108566,7 +108668,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d243)
 					ctx.EmitStoreToStack(d243, int32(bbs[1].PhiBase)+int32(24))
-					if d21.Loc == LocReg {
+					if d21.Loc == LocReg || d21.Loc == LocFPReg {
 						ctx.UnprotectReg(d21.Reg)
 					} else if d21.Loc == LocRegPair {
 						ctx.UnprotectReg(d21.Reg)
@@ -109642,7 +109744,7 @@ func init_list() {
 					ctx.FreeDesc(&d72)
 					if ps.General {
 						ctx.SyncDesc(&d19)
-						if d19.Loc == LocReg {
+						if d19.Loc == LocReg || d19.Loc == LocFPReg {
 							ctx.ProtectReg(d19.Reg)
 						} else if d19.Loc == LocRegPair {
 							ctx.ProtectReg(d19.Reg)
@@ -109654,7 +109756,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d82)
 						ctx.EmitStoreToStack(d82, int32(bbs[1].PhiBase)+int32(0))
-						if d19.Loc == LocReg {
+						if d19.Loc == LocReg || d19.Loc == LocFPReg {
 							ctx.UnprotectReg(d19.Reg)
 						} else if d19.Loc == LocRegPair {
 							ctx.UnprotectReg(d19.Reg)
@@ -110771,7 +110873,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d96)
 					if ps.General {
 						ctx.SyncDesc(&d23)
-						if d23.Loc == LocReg {
+						if d23.Loc == LocReg || d23.Loc == LocFPReg {
 							ctx.ProtectReg(d23.Reg)
 						} else if d23.Loc == LocRegPair {
 							ctx.ProtectReg(d23.Reg)
@@ -110783,7 +110885,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d98)
 						ctx.EmitStoreToStack(d98, int32(bbs[1].PhiBase)+int32(24))
-						if d23.Loc == LocReg {
+						if d23.Loc == LocReg || d23.Loc == LocFPReg {
 							ctx.UnprotectReg(d23.Reg)
 						} else if d23.Loc == LocRegPair {
 							ctx.UnprotectReg(d23.Reg)
@@ -111734,7 +111836,7 @@ func init_list() {
 					ctx.FreeDesc(&d49)
 					if ps.General {
 						ctx.SyncDesc(&d11)
-						if d11.Loc == LocReg {
+						if d11.Loc == LocReg || d11.Loc == LocFPReg {
 							ctx.ProtectReg(d11.Reg)
 						} else if d11.Loc == LocRegPair {
 							ctx.ProtectReg(d11.Reg)
@@ -111746,7 +111848,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d59)
 						ctx.EmitStoreToStack(d59, int32(bbs[1].PhiBase)+int32(0))
-						if d11.Loc == LocReg {
+						if d11.Loc == LocReg || d11.Loc == LocFPReg {
 							ctx.UnprotectReg(d11.Reg)
 						} else if d11.Loc == LocRegPair {
 							ctx.UnprotectReg(d11.Reg)
@@ -112488,7 +112590,7 @@ func init_list() {
 					ctx.FreeDesc(&d50)
 					if ps.General {
 						ctx.SyncDesc(&d11)
-						if d11.Loc == LocReg {
+						if d11.Loc == LocReg || d11.Loc == LocFPReg {
 							ctx.ProtectReg(d11.Reg)
 						} else if d11.Loc == LocRegPair {
 							ctx.ProtectReg(d11.Reg)
@@ -112500,7 +112602,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d60)
 						ctx.EmitStoreToStack(d60, int32(bbs[1].PhiBase)+int32(0))
-						if d11.Loc == LocReg {
+						if d11.Loc == LocReg || d11.Loc == LocFPReg {
 							ctx.UnprotectReg(d11.Reg)
 						} else if d11.Loc == LocRegPair {
 							ctx.UnprotectReg(d11.Reg)
@@ -113435,7 +113537,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d14)
-							if d14.Loc == LocReg {
+							if d14.Loc == LocReg || d14.Loc == LocFPReg {
 								ctx.ProtectReg(d14.Reg)
 							} else if d14.Loc == LocRegPair {
 								ctx.ProtectReg(d14.Reg)
@@ -113447,7 +113549,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d73)
 							ctx.EmitStoreToStack(d73, int32(bbs[1].PhiBase)+int32(16))
-							if d14.Loc == LocReg {
+							if d14.Loc == LocReg || d14.Loc == LocFPReg {
 								ctx.UnprotectReg(d14.Reg)
 							} else if d14.Loc == LocRegPair {
 								ctx.UnprotectReg(d14.Reg)
@@ -113553,7 +113655,7 @@ func init_list() {
 					d75 = snap102
 					ctx.MarkLabel(lbl6)
 					ctx.SyncDesc(&d14)
-					if d14.Loc == LocReg {
+					if d14.Loc == LocReg || d14.Loc == LocFPReg {
 						ctx.ProtectReg(d14.Reg)
 					} else if d14.Loc == LocRegPair {
 						ctx.ProtectReg(d14.Reg)
@@ -113565,7 +113667,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d104)
 					ctx.EmitStoreToStack(d104, int32(bbs[1].PhiBase)+int32(16))
-					if d14.Loc == LocReg {
+					if d14.Loc == LocReg || d14.Loc == LocFPReg {
 						ctx.UnprotectReg(d14.Reg)
 					} else if d14.Loc == LocRegPair {
 						ctx.UnprotectReg(d14.Reg)
@@ -114090,7 +114192,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d146)
 					if ps.General {
 						ctx.SyncDesc(&d14)
-						if d14.Loc == LocReg {
+						if d14.Loc == LocReg || d14.Loc == LocFPReg {
 							ctx.ProtectReg(d14.Reg)
 						} else if d14.Loc == LocRegPair {
 							ctx.ProtectReg(d14.Reg)
@@ -114102,7 +114204,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d147)
 						ctx.EmitStoreToStack(d147, int32(bbs[1].PhiBase)+int32(16))
-						if d14.Loc == LocReg {
+						if d14.Loc == LocReg || d14.Loc == LocFPReg {
 							ctx.UnprotectReg(d14.Reg)
 						} else if d14.Loc == LocRegPair {
 							ctx.UnprotectReg(d14.Reg)
@@ -115405,7 +115507,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d6)
 					if ps.General {
 						ctx.SyncDesc(&d5)
-						if d5.Loc == LocReg {
+						if d5.Loc == LocReg || d5.Loc == LocFPReg {
 							ctx.ProtectReg(d5.Reg)
 						} else if d5.Loc == LocRegPair {
 							ctx.ProtectReg(d5.Reg)
@@ -115427,7 +115529,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d7.Reg3, RegRSP, int32(bbs[1].PhiBase)+int32(0)+16)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[1].PhiBase)+int32(24))
-						if d5.Loc == LocReg {
+						if d5.Loc == LocReg || d5.Loc == LocFPReg {
 							ctx.UnprotectReg(d5.Reg)
 						} else if d5.Loc == LocRegPair {
 							ctx.UnprotectReg(d5.Reg)
@@ -116585,7 +116687,7 @@ func init_list() {
 						if d127.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d13)
-								if d13.Loc == LocReg {
+								if d13.Loc == LocReg || d13.Loc == LocFPReg {
 									ctx.ProtectReg(d13.Reg)
 								} else if d13.Loc == LocRegPair {
 									ctx.ProtectReg(d13.Reg)
@@ -116597,7 +116699,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d128)
 								ctx.EmitStoreToStack(d128, int32(bbs[1].PhiBase)+int32(24))
-								if d13.Loc == LocReg {
+								if d13.Loc == LocReg || d13.Loc == LocFPReg {
 									ctx.UnprotectReg(d13.Reg)
 								} else if d13.Loc == LocRegPair {
 									ctx.UnprotectReg(d13.Reg)
@@ -116643,7 +116745,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d64)
-							if d64.Loc == LocReg {
+							if d64.Loc == LocReg || d64.Loc == LocFPReg {
 								ctx.ProtectReg(d64.Reg)
 							} else if d64.Loc == LocRegPair {
 								ctx.ProtectReg(d64.Reg)
@@ -116655,7 +116757,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d131)
 							ctx.EmitStoreToStack(d131, int32(bbs[4].PhiBase)+int32(0))
-							if d64.Loc == LocReg {
+							if d64.Loc == LocReg || d64.Loc == LocFPReg {
 								ctx.UnprotectReg(d64.Reg)
 							} else if d64.Loc == LocRegPair {
 								ctx.UnprotectReg(d64.Reg)
@@ -116746,7 +116848,7 @@ func init_list() {
 					alloc167 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl10)
 					ctx.SyncDesc(&d13)
-					if d13.Loc == LocReg {
+					if d13.Loc == LocReg || d13.Loc == LocFPReg {
 						ctx.ProtectReg(d13.Reg)
 					} else if d13.Loc == LocRegPair {
 						ctx.ProtectReg(d13.Reg)
@@ -116758,7 +116860,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d168)
 					ctx.EmitStoreToStack(d168, int32(bbs[1].PhiBase)+int32(24))
-					if d13.Loc == LocReg {
+					if d13.Loc == LocReg || d13.Loc == LocFPReg {
 						ctx.UnprotectReg(d13.Reg)
 					} else if d13.Loc == LocRegPair {
 						ctx.UnprotectReg(d13.Reg)
@@ -116801,7 +116903,7 @@ func init_list() {
 					d133 = snap166
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d64)
-					if d64.Loc == LocReg {
+					if d64.Loc == LocReg || d64.Loc == LocFPReg {
 						ctx.ProtectReg(d64.Reg)
 					} else if d64.Loc == LocRegPair {
 						ctx.ProtectReg(d64.Reg)
@@ -116813,7 +116915,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d169)
 					ctx.EmitStoreToStack(d169, int32(bbs[4].PhiBase)+int32(0))
-					if d64.Loc == LocReg {
+					if d64.Loc == LocReg || d64.Loc == LocFPReg {
 						ctx.UnprotectReg(d64.Reg)
 					} else if d64.Loc == LocRegPair {
 						ctx.UnprotectReg(d64.Reg)
@@ -117185,7 +117287,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d216)
 					if ps.General {
 						ctx.SyncDesc(&d13)
-						if d13.Loc == LocReg {
+						if d13.Loc == LocReg || d13.Loc == LocFPReg {
 							ctx.ProtectReg(d13.Reg)
 						} else if d13.Loc == LocRegPair {
 							ctx.ProtectReg(d13.Reg)
@@ -117197,7 +117299,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d218)
 						ctx.EmitStoreToStack(d218, int32(bbs[1].PhiBase)+int32(24))
-						if d13.Loc == LocReg {
+						if d13.Loc == LocReg || d13.Loc == LocFPReg {
 							ctx.UnprotectReg(d13.Reg)
 						} else if d13.Loc == LocRegPair {
 							ctx.UnprotectReg(d13.Reg)
@@ -118454,7 +118556,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d76)
 					if ps.General {
 						ctx.SyncDesc(&d75)
-						if d75.Loc == LocReg {
+						if d75.Loc == LocReg || d75.Loc == LocFPReg {
 							ctx.ProtectReg(d75.Reg)
 						} else if d75.Loc == LocRegPair {
 							ctx.ProtectReg(d75.Reg)
@@ -118476,7 +118578,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d77.Reg3, RegRSP, int32(bbs[3].PhiBase)+int32(0)+16)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[3].PhiBase)+int32(24))
-						if d75.Loc == LocReg {
+						if d75.Loc == LocReg || d75.Loc == LocFPReg {
 							ctx.UnprotectReg(d75.Reg)
 						} else if d75.Loc == LocRegPair {
 							ctx.UnprotectReg(d75.Reg)
@@ -118763,7 +118865,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d93)
 					if ps.General {
 						ctx.SyncDesc(&d92)
-						if d92.Loc == LocReg {
+						if d92.Loc == LocReg || d92.Loc == LocFPReg {
 							ctx.ProtectReg(d92.Reg)
 						} else if d92.Loc == LocRegPair {
 							ctx.ProtectReg(d92.Reg)
@@ -118785,7 +118887,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d94.Reg3, RegRSP, int32(bbs[13].PhiBase)+int32(0)+16)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[13].PhiBase)+int32(24))
-						if d92.Loc == LocReg {
+						if d92.Loc == LocReg || d92.Loc == LocFPReg {
 							ctx.UnprotectReg(d92.Reg)
 						} else if d92.Loc == LocRegPair {
 							ctx.UnprotectReg(d92.Reg)
@@ -119879,7 +119981,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d222)
 					if ps.General {
 						ctx.SyncDesc(&d1)
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.ProtectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.ProtectReg(d1.Reg)
@@ -119901,7 +120003,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d223.Reg3, RegRSP, int32(bbs[6].PhiBase)+int32(0)+16)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[6].PhiBase)+int32(24))
-						if d1.Loc == LocReg {
+						if d1.Loc == LocReg || d1.Loc == LocFPReg {
 							ctx.UnprotectReg(d1.Reg)
 						} else if d1.Loc == LocRegPair {
 							ctx.UnprotectReg(d1.Reg)
@@ -120604,14 +120706,14 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d3)
-							if d3.Loc == LocReg {
+							if d3.Loc == LocReg || d3.Loc == LocFPReg {
 								ctx.ProtectReg(d3.Reg)
 							} else if d3.Loc == LocRegPair {
 								ctx.ProtectReg(d3.Reg)
 								ctx.ProtectReg(d3.Reg2)
 							}
 							ctx.SyncDesc(&d100)
-							if d100.Loc == LocReg {
+							if d100.Loc == LocReg || d100.Loc == LocFPReg {
 								ctx.ProtectReg(d100.Reg)
 							} else if d100.Loc == LocRegPair {
 								ctx.ProtectReg(d100.Reg)
@@ -120638,13 +120740,13 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d235)
 							ctx.EmitStoreToStack(d235, int32(bbs[3].PhiBase)+int32(24))
-							if d3.Loc == LocReg {
+							if d3.Loc == LocReg || d3.Loc == LocFPReg {
 								ctx.UnprotectReg(d3.Reg)
 							} else if d3.Loc == LocRegPair {
 								ctx.UnprotectReg(d3.Reg)
 								ctx.UnprotectReg(d3.Reg2)
 							}
-							if d100.Loc == LocReg {
+							if d100.Loc == LocReg || d100.Loc == LocFPReg {
 								ctx.UnprotectReg(d100.Reg)
 							} else if d100.Loc == LocRegPair {
 								ctx.UnprotectReg(d100.Reg)
@@ -120899,14 +121001,14 @@ func init_list() {
 					d240 = snap313
 					ctx.MarkLabel(lbl32)
 					ctx.SyncDesc(&d3)
-					if d3.Loc == LocReg {
+					if d3.Loc == LocReg || d3.Loc == LocFPReg {
 						ctx.ProtectReg(d3.Reg)
 					} else if d3.Loc == LocRegPair {
 						ctx.ProtectReg(d3.Reg)
 						ctx.ProtectReg(d3.Reg2)
 					}
 					ctx.SyncDesc(&d100)
-					if d100.Loc == LocReg {
+					if d100.Loc == LocReg || d100.Loc == LocFPReg {
 						ctx.ProtectReg(d100.Reg)
 					} else if d100.Loc == LocRegPair {
 						ctx.ProtectReg(d100.Reg)
@@ -120933,13 +121035,13 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d316)
 					ctx.EmitStoreToStack(d316, int32(bbs[3].PhiBase)+int32(24))
-					if d3.Loc == LocReg {
+					if d3.Loc == LocReg || d3.Loc == LocFPReg {
 						ctx.UnprotectReg(d3.Reg)
 					} else if d3.Loc == LocRegPair {
 						ctx.UnprotectReg(d3.Reg)
 						ctx.UnprotectReg(d3.Reg2)
 					}
-					if d100.Loc == LocReg {
+					if d100.Loc == LocReg || d100.Loc == LocFPReg {
 						ctx.UnprotectReg(d100.Reg)
 					} else if d100.Loc == LocRegPair {
 						ctx.UnprotectReg(d100.Reg)
@@ -123339,7 +123441,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d405)
-							if d405.Loc == LocReg {
+							if d405.Loc == LocReg || d405.Loc == LocFPReg {
 								ctx.ProtectReg(d405.Reg)
 							} else if d405.Loc == LocRegPair {
 								ctx.ProtectReg(d405.Reg)
@@ -123351,7 +123453,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d597)
 							ctx.EmitStoreToStack(d597, int32(bbs[8].PhiBase)+int32(0))
-							if d405.Loc == LocReg {
+							if d405.Loc == LocReg || d405.Loc == LocFPReg {
 								ctx.UnprotectReg(d405.Reg)
 							} else if d405.Loc == LocRegPair {
 								ctx.UnprotectReg(d405.Reg)
@@ -123658,7 +123760,7 @@ func init_list() {
 					d599 = snap693
 					ctx.MarkLabel(lbl34)
 					ctx.SyncDesc(&d405)
-					if d405.Loc == LocReg {
+					if d405.Loc == LocReg || d405.Loc == LocFPReg {
 						ctx.ProtectReg(d405.Reg)
 					} else if d405.Loc == LocRegPair {
 						ctx.ProtectReg(d405.Reg)
@@ -123670,7 +123772,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d695)
 					ctx.EmitStoreToStack(d695, int32(bbs[8].PhiBase)+int32(0))
-					if d405.Loc == LocReg {
+					if d405.Loc == LocReg || d405.Loc == LocFPReg {
 						ctx.UnprotectReg(d405.Reg)
 					} else if d405.Loc == LocRegPair {
 						ctx.UnprotectReg(d405.Reg)
@@ -124517,7 +124619,7 @@ func init_list() {
 						if d797.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d230)
-								if d230.Loc == LocReg {
+								if d230.Loc == LocReg || d230.Loc == LocFPReg {
 									ctx.ProtectReg(d230.Reg)
 								} else if d230.Loc == LocRegPair {
 									ctx.ProtectReg(d230.Reg)
@@ -124529,7 +124631,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d798)
 								ctx.EmitStoreToStack(d798, int32(bbs[6].PhiBase)+int32(24))
-								if d230.Loc == LocReg {
+								if d230.Loc == LocReg || d230.Loc == LocFPReg {
 									ctx.UnprotectReg(d230.Reg)
 								} else if d230.Loc == LocRegPair {
 									ctx.UnprotectReg(d230.Reg)
@@ -124865,7 +124967,7 @@ func init_list() {
 					alloc904 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl35)
 					ctx.SyncDesc(&d230)
-					if d230.Loc == LocReg {
+					if d230.Loc == LocReg || d230.Loc == LocFPReg {
 						ctx.ProtectReg(d230.Reg)
 					} else if d230.Loc == LocRegPair {
 						ctx.ProtectReg(d230.Reg)
@@ -124877,7 +124979,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d905)
 					ctx.EmitStoreToStack(d905, int32(bbs[6].PhiBase)+int32(24))
-					if d230.Loc == LocReg {
+					if d230.Loc == LocReg || d230.Loc == LocFPReg {
 						ctx.UnprotectReg(d230.Reg)
 					} else if d230.Loc == LocRegPair {
 						ctx.UnprotectReg(d230.Reg)
@@ -126358,7 +126460,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d1019)
 					if ps.General {
 						ctx.SyncDesc(&d230)
-						if d230.Loc == LocReg {
+						if d230.Loc == LocReg || d230.Loc == LocFPReg {
 							ctx.ProtectReg(d230.Reg)
 						} else if d230.Loc == LocRegPair {
 							ctx.ProtectReg(d230.Reg)
@@ -126370,7 +126472,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d1021)
 						ctx.EmitStoreToStack(d1021, int32(bbs[6].PhiBase)+int32(24))
-						if d230.Loc == LocReg {
+						if d230.Loc == LocReg || d230.Loc == LocFPReg {
 							ctx.UnprotectReg(d230.Reg)
 						} else if d230.Loc == LocRegPair {
 							ctx.UnprotectReg(d230.Reg)
@@ -128997,7 +129099,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d1276)
 					if ps.General {
 						ctx.SyncDesc(&d7)
-						if d7.Loc == LocReg {
+						if d7.Loc == LocReg || d7.Loc == LocFPReg {
 							ctx.ProtectReg(d7.Reg)
 						} else if d7.Loc == LocRegPair {
 							ctx.ProtectReg(d7.Reg)
@@ -129019,7 +129121,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d1277.Reg3, RegRSP, int32(bbs[21].PhiBase)+int32(0)+16)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[21].PhiBase)+int32(24))
-						if d7.Loc == LocReg {
+						if d7.Loc == LocReg || d7.Loc == LocFPReg {
 							ctx.UnprotectReg(d7.Reg)
 						} else if d7.Loc == LocRegPair {
 							ctx.UnprotectReg(d7.Reg)
@@ -131471,7 +131573,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d1282)
-							if d1282.Loc == LocReg {
+							if d1282.Loc == LocReg || d1282.Loc == LocFPReg {
 								ctx.ProtectReg(d1282.Reg)
 							} else if d1282.Loc == LocRegPair {
 								ctx.ProtectReg(d1282.Reg)
@@ -131483,7 +131585,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d1562)
 							ctx.EmitStoreToStack(d1562, int32(bbs[16].PhiBase)+int32(0))
-							if d1282.Loc == LocReg {
+							if d1282.Loc == LocReg || d1282.Loc == LocFPReg {
 								ctx.UnprotectReg(d1282.Reg)
 							} else if d1282.Loc == LocRegPair {
 								ctx.UnprotectReg(d1282.Reg)
@@ -131922,7 +132024,7 @@ func init_list() {
 					d1564 = snap1702
 					ctx.MarkLabel(lbl37)
 					ctx.SyncDesc(&d1282)
-					if d1282.Loc == LocReg {
+					if d1282.Loc == LocReg || d1282.Loc == LocFPReg {
 						ctx.ProtectReg(d1282.Reg)
 					} else if d1282.Loc == LocRegPair {
 						ctx.ProtectReg(d1282.Reg)
@@ -131934,7 +132036,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d1704)
 					ctx.EmitStoreToStack(d1704, int32(bbs[16].PhiBase)+int32(0))
-					if d1282.Loc == LocReg {
+					if d1282.Loc == LocReg || d1282.Loc == LocFPReg {
 						ctx.UnprotectReg(d1282.Reg)
 					} else if d1282.Loc == LocRegPair {
 						ctx.UnprotectReg(d1282.Reg)
@@ -133133,7 +133235,7 @@ func init_list() {
 						if d1850.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d1026)
-								if d1026.Loc == LocReg {
+								if d1026.Loc == LocReg || d1026.Loc == LocFPReg {
 									ctx.ProtectReg(d1026.Reg)
 								} else if d1026.Loc == LocRegPair {
 									ctx.ProtectReg(d1026.Reg)
@@ -133145,7 +133247,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d1851)
 								ctx.EmitStoreToStack(d1851, int32(bbs[13].PhiBase)+int32(24))
-								if d1026.Loc == LocReg {
+								if d1026.Loc == LocReg || d1026.Loc == LocFPReg {
 									ctx.UnprotectReg(d1026.Reg)
 								} else if d1026.Loc == LocRegPair {
 									ctx.UnprotectReg(d1026.Reg)
@@ -133613,7 +133715,7 @@ func init_list() {
 					alloc2001 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl38)
 					ctx.SyncDesc(&d1026)
-					if d1026.Loc == LocReg {
+					if d1026.Loc == LocReg || d1026.Loc == LocFPReg {
 						ctx.ProtectReg(d1026.Reg)
 					} else if d1026.Loc == LocRegPair {
 						ctx.ProtectReg(d1026.Reg)
@@ -133625,7 +133727,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d2002)
 					ctx.EmitStoreToStack(d2002, int32(bbs[13].PhiBase)+int32(24))
-					if d1026.Loc == LocReg {
+					if d1026.Loc == LocReg || d1026.Loc == LocFPReg {
 						ctx.UnprotectReg(d1026.Reg)
 					} else if d1026.Loc == LocRegPair {
 						ctx.UnprotectReg(d1026.Reg)
@@ -135678,7 +135780,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d2160)
 					if ps.General {
 						ctx.SyncDesc(&d1026)
-						if d1026.Loc == LocReg {
+						if d1026.Loc == LocReg || d1026.Loc == LocFPReg {
 							ctx.ProtectReg(d1026.Reg)
 						} else if d1026.Loc == LocRegPair {
 							ctx.ProtectReg(d1026.Reg)
@@ -135690,7 +135792,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d2162)
 						ctx.EmitStoreToStack(d2162, int32(bbs[13].PhiBase)+int32(24))
-						if d1026.Loc == LocReg {
+						if d1026.Loc == LocReg || d1026.Loc == LocFPReg {
 							ctx.UnprotectReg(d1026.Reg)
 						} else if d1026.Loc == LocRegPair {
 							ctx.UnprotectReg(d1026.Reg)
@@ -138518,7 +138620,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d2503)
 					if ps.General {
 						ctx.SyncDesc(&d11)
-						if d11.Loc == LocReg {
+						if d11.Loc == LocReg || d11.Loc == LocFPReg {
 							ctx.ProtectReg(d11.Reg)
 						} else if d11.Loc == LocRegPair {
 							ctx.ProtectReg(d11.Reg)
@@ -138540,7 +138642,7 @@ func init_list() {
 							ctx.EmitStoreRegMem(d2504.Reg3, RegRSP, int32(bbs[24].PhiBase)+int32(0)+16)
 						}
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[24].PhiBase)+int32(24))
-						if d11.Loc == LocReg {
+						if d11.Loc == LocReg || d11.Loc == LocFPReg {
 							ctx.UnprotectReg(d11.Reg)
 						} else if d11.Loc == LocRegPair {
 							ctx.UnprotectReg(d11.Reg)
@@ -140091,14 +140193,14 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d13)
-							if d13.Loc == LocReg {
+							if d13.Loc == LocReg || d13.Loc == LocFPReg {
 								ctx.ProtectReg(d13.Reg)
 							} else if d13.Loc == LocRegPair {
 								ctx.ProtectReg(d13.Reg)
 								ctx.ProtectReg(d13.Reg2)
 							}
 							ctx.SyncDesc(&d2167)
-							if d2167.Loc == LocReg {
+							if d2167.Loc == LocReg || d2167.Loc == LocFPReg {
 								ctx.ProtectReg(d2167.Reg)
 							} else if d2167.Loc == LocRegPair {
 								ctx.ProtectReg(d2167.Reg)
@@ -140125,13 +140227,13 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d2516)
 							ctx.EmitStoreToStack(d2516, int32(bbs[21].PhiBase)+int32(24))
-							if d13.Loc == LocReg {
+							if d13.Loc == LocReg || d13.Loc == LocFPReg {
 								ctx.UnprotectReg(d13.Reg)
 							} else if d13.Loc == LocRegPair {
 								ctx.UnprotectReg(d13.Reg)
 								ctx.UnprotectReg(d13.Reg2)
 							}
-							if d2167.Loc == LocReg {
+							if d2167.Loc == LocReg || d2167.Loc == LocFPReg {
 								ctx.UnprotectReg(d2167.Reg)
 							} else if d2167.Loc == LocRegPair {
 								ctx.UnprotectReg(d2167.Reg)
@@ -140704,14 +140806,14 @@ func init_list() {
 					d2521 = snap2700
 					ctx.MarkLabel(lbl41)
 					ctx.SyncDesc(&d13)
-					if d13.Loc == LocReg {
+					if d13.Loc == LocReg || d13.Loc == LocFPReg {
 						ctx.ProtectReg(d13.Reg)
 					} else if d13.Loc == LocRegPair {
 						ctx.ProtectReg(d13.Reg)
 						ctx.ProtectReg(d13.Reg2)
 					}
 					ctx.SyncDesc(&d2167)
-					if d2167.Loc == LocReg {
+					if d2167.Loc == LocReg || d2167.Loc == LocFPReg {
 						ctx.ProtectReg(d2167.Reg)
 					} else if d2167.Loc == LocRegPair {
 						ctx.ProtectReg(d2167.Reg)
@@ -140738,13 +140840,13 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d2703)
 					ctx.EmitStoreToStack(d2703, int32(bbs[21].PhiBase)+int32(24))
-					if d13.Loc == LocReg {
+					if d13.Loc == LocReg || d13.Loc == LocFPReg {
 						ctx.UnprotectReg(d13.Reg)
 					} else if d13.Loc == LocRegPair {
 						ctx.UnprotectReg(d13.Reg)
 						ctx.UnprotectReg(d13.Reg2)
 					}
-					if d2167.Loc == LocReg {
+					if d2167.Loc == LocReg || d2167.Loc == LocFPReg {
 						ctx.UnprotectReg(d2167.Reg)
 					} else if d2167.Loc == LocRegPair {
 						ctx.UnprotectReg(d2167.Reg)
@@ -145794,7 +145896,7 @@ func init_list() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d2898)
-							if d2898.Loc == LocReg {
+							if d2898.Loc == LocReg || d2898.Loc == LocFPReg {
 								ctx.ProtectReg(d2898.Reg)
 							} else if d2898.Loc == LocRegPair {
 								ctx.ProtectReg(d2898.Reg)
@@ -145806,7 +145908,7 @@ func init_list() {
 							}
 							ctx.EnsureDesc(&d3302)
 							ctx.EmitStoreToStack(d3302, int32(bbs[26].PhiBase)+int32(0))
-							if d2898.Loc == LocReg {
+							if d2898.Loc == LocReg || d2898.Loc == LocFPReg {
 								ctx.UnprotectReg(d2898.Reg)
 							} else if d2898.Loc == LocRegPair {
 								ctx.UnprotectReg(d2898.Reg)
@@ -146431,7 +146533,7 @@ func init_list() {
 					d3304 = snap3504
 					ctx.MarkLabel(lbl43)
 					ctx.SyncDesc(&d2898)
-					if d2898.Loc == LocReg {
+					if d2898.Loc == LocReg || d2898.Loc == LocFPReg {
 						ctx.ProtectReg(d2898.Reg)
 					} else if d2898.Loc == LocRegPair {
 						ctx.ProtectReg(d2898.Reg)
@@ -146443,7 +146545,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d3506)
 					ctx.EmitStoreToStack(d3506, int32(bbs[26].PhiBase)+int32(0))
-					if d2898.Loc == LocReg {
+					if d2898.Loc == LocReg || d2898.Loc == LocFPReg {
 						ctx.UnprotectReg(d2898.Reg)
 					} else if d2898.Loc == LocRegPair {
 						ctx.UnprotectReg(d2898.Reg)
@@ -148138,7 +148240,7 @@ func init_list() {
 						if d3714.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d2511)
-								if d2511.Loc == LocReg {
+								if d2511.Loc == LocReg || d2511.Loc == LocFPReg {
 									ctx.ProtectReg(d2511.Reg)
 								} else if d2511.Loc == LocRegPair {
 									ctx.ProtectReg(d2511.Reg)
@@ -148150,7 +148252,7 @@ func init_list() {
 								}
 								ctx.EnsureDesc(&d3715)
 								ctx.EmitStoreToStack(d3715, int32(bbs[24].PhiBase)+int32(24))
-								if d2511.Loc == LocReg {
+								if d2511.Loc == LocReg || d2511.Loc == LocFPReg {
 									ctx.UnprotectReg(d2511.Reg)
 								} else if d2511.Loc == LocRegPair {
 									ctx.UnprotectReg(d2511.Reg)
@@ -148804,7 +148906,7 @@ func init_list() {
 					alloc3927 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl44)
 					ctx.SyncDesc(&d2511)
-					if d2511.Loc == LocReg {
+					if d2511.Loc == LocReg || d2511.Loc == LocFPReg {
 						ctx.ProtectReg(d2511.Reg)
 					} else if d2511.Loc == LocRegPair {
 						ctx.ProtectReg(d2511.Reg)
@@ -148816,7 +148918,7 @@ func init_list() {
 					}
 					ctx.EnsureDesc(&d3928)
 					ctx.EmitStoreToStack(d3928, int32(bbs[24].PhiBase)+int32(24))
-					if d2511.Loc == LocReg {
+					if d2511.Loc == LocReg || d2511.Loc == LocFPReg {
 						ctx.UnprotectReg(d2511.Reg)
 					} else if d2511.Loc == LocRegPair {
 						ctx.UnprotectReg(d2511.Reg)
@@ -151675,7 +151777,7 @@ func init_list() {
 					ctx.StabilizeDescForControlFlow(&d4148)
 					if ps.General {
 						ctx.SyncDesc(&d2511)
-						if d2511.Loc == LocReg {
+						if d2511.Loc == LocReg || d2511.Loc == LocFPReg {
 							ctx.ProtectReg(d2511.Reg)
 						} else if d2511.Loc == LocRegPair {
 							ctx.ProtectReg(d2511.Reg)
@@ -151687,7 +151789,7 @@ func init_list() {
 						}
 						ctx.EnsureDesc(&d4150)
 						ctx.EmitStoreToStack(d4150, int32(bbs[24].PhiBase)+int32(24))
-						if d2511.Loc == LocReg {
+						if d2511.Loc == LocReg || d2511.Loc == LocFPReg {
 							ctx.UnprotectReg(d2511.Reg)
 						} else if d2511.Loc == LocRegPair {
 							ctx.UnprotectReg(d2511.Reg)

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -891,7 +891,7 @@ func init_list_assoc_extra() {
 					ctx.FreeDesc(&d85)
 					if ps.General {
 						ctx.SyncDesc(&d21)
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.ProtectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.ProtectReg(d21.Reg)
@@ -903,7 +903,7 @@ func init_list_assoc_extra() {
 						}
 						ctx.EnsureDesc(&d86)
 						ctx.EmitStoreToStack(d86, int32(bbs[1].PhiBase)+int32(0))
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.UnprotectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.UnprotectReg(d21.Reg)
@@ -2021,7 +2021,7 @@ func init_list_assoc_extra() {
 					ctx.FreeDesc(&d88)
 					if ps.General {
 						ctx.SyncDesc(&d21)
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.ProtectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.ProtectReg(d21.Reg)
@@ -2033,7 +2033,7 @@ func init_list_assoc_extra() {
 						}
 						ctx.EnsureDesc(&d96)
 						ctx.EmitStoreToStack(d96, int32(bbs[1].PhiBase)+int32(0))
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.UnprotectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.UnprotectReg(d21.Reg)
@@ -3173,7 +3173,7 @@ func init_list_assoc_extra() {
 					ctx.FreeDesc(&d89)
 					if ps.General {
 						ctx.SyncDesc(&d21)
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.ProtectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.ProtectReg(d21.Reg)
@@ -3185,7 +3185,7 @@ func init_list_assoc_extra() {
 						}
 						ctx.EnsureDesc(&d97)
 						ctx.EmitStoreToStack(d97, int32(bbs[1].PhiBase)+int32(0))
-						if d21.Loc == LocReg {
+						if d21.Loc == LocReg || d21.Loc == LocFPReg {
 							ctx.UnprotectReg(d21.Reg)
 						} else if d21.Loc == LocRegPair {
 							ctx.UnprotectReg(d21.Reg)
@@ -4288,7 +4288,7 @@ func init_list_assoc_extra() {
 					ctx.FreeDesc(&d70)
 					if ps.General {
 						ctx.SyncDesc(&d18)
-						if d18.Loc == LocReg {
+						if d18.Loc == LocReg || d18.Loc == LocFPReg {
 							ctx.ProtectReg(d18.Reg)
 						} else if d18.Loc == LocRegPair {
 							ctx.ProtectReg(d18.Reg)
@@ -4300,7 +4300,7 @@ func init_list_assoc_extra() {
 						}
 						ctx.EnsureDesc(&d78)
 						ctx.EmitStoreToStack(d78, int32(bbs[1].PhiBase)+int32(0))
-						if d18.Loc == LocReg {
+						if d18.Loc == LocReg || d18.Loc == LocFPReg {
 							ctx.UnprotectReg(d18.Reg)
 						} else if d18.Loc == LocRegPair {
 							ctx.UnprotectReg(d18.Reg)
@@ -5306,7 +5306,7 @@ func init_list_assoc_extra() {
 					ctx.FreeDesc(&d71)
 					if ps.General {
 						ctx.SyncDesc(&d18)
-						if d18.Loc == LocReg {
+						if d18.Loc == LocReg || d18.Loc == LocFPReg {
 							ctx.ProtectReg(d18.Reg)
 						} else if d18.Loc == LocRegPair {
 							ctx.ProtectReg(d18.Reg)
@@ -5318,7 +5318,7 @@ func init_list_assoc_extra() {
 						}
 						ctx.EnsureDesc(&d79)
 						ctx.EmitStoreToStack(d79, int32(bbs[1].PhiBase)+int32(0))
-						if d18.Loc == LocReg {
+						if d18.Loc == LocReg || d18.Loc == LocFPReg {
 							ctx.UnprotectReg(d18.Reg)
 						} else if d18.Loc == LocRegPair {
 							ctx.UnprotectReg(d18.Reg)

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -869,7 +869,7 @@ func init_processlist() {
 					ctx.FreeDesc(&d30)
 					if ps.General {
 						ctx.SyncDesc(&d31)
-						if d31.Loc == LocReg {
+						if d31.Loc == LocReg || d31.Loc == LocFPReg {
 							ctx.ProtectReg(d31.Reg)
 						} else if d31.Loc == LocRegPair {
 							ctx.ProtectReg(d31.Reg)
@@ -881,7 +881,7 @@ func init_processlist() {
 						}
 						ctx.EnsureDesc(&d33)
 						ctx.EmitStoreToStack(d33, int32(bbs[2].PhiBase)+int32(0))
-						if d31.Loc == LocReg {
+						if d31.Loc == LocReg || d31.Loc == LocFPReg {
 							ctx.UnprotectReg(d31.Reg)
 						} else if d31.Loc == LocRegPair {
 							ctx.UnprotectReg(d31.Reg)
@@ -1587,7 +1587,7 @@ func init_processlist() {
 						if d105.Imm.Bool() {
 							if ps.General {
 								ctx.SyncDesc(&d104)
-								if d104.Loc == LocReg {
+								if d104.Loc == LocReg || d104.Loc == LocFPReg {
 									ctx.ProtectReg(d104.Reg)
 								} else if d104.Loc == LocRegPair {
 									ctx.ProtectReg(d104.Reg)
@@ -1610,7 +1610,7 @@ func init_processlist() {
 									ctx.EmitStoreToStack(d106, int32(bbs[7].PhiBase)+int32(0))
 									ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[7].PhiBase)+int32(0))+8)
 								}
-								if d104.Loc == LocReg {
+								if d104.Loc == LocReg || d104.Loc == LocFPReg {
 									ctx.UnprotectReg(d104.Reg)
 								} else if d104.Loc == LocRegPair {
 									ctx.UnprotectReg(d104.Reg)
@@ -1727,7 +1727,7 @@ func init_processlist() {
 					alloc139 := ctx.SnapshotAllocState()
 					ctx.MarkLabel(lbl11)
 					ctx.SyncDesc(&d104)
-					if d104.Loc == LocReg {
+					if d104.Loc == LocReg || d104.Loc == LocFPReg {
 						ctx.ProtectReg(d104.Reg)
 					} else if d104.Loc == LocRegPair {
 						ctx.ProtectReg(d104.Reg)
@@ -1750,7 +1750,7 @@ func init_processlist() {
 						ctx.EmitStoreToStack(d140, int32(bbs[7].PhiBase)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[7].PhiBase)+int32(0))+8)
 					}
-					if d104.Loc == LocReg {
+					if d104.Loc == LocReg || d104.Loc == LocFPReg {
 						ctx.UnprotectReg(d104.Reg)
 					} else if d104.Loc == LocRegPair {
 						ctx.UnprotectReg(d104.Reg)
@@ -2281,7 +2281,7 @@ func init_processlist() {
 					ctx.StabilizeDescForControlFlow(&d182)
 					if ps.General {
 						ctx.SyncDesc(&d182)
-						if d182.Loc == LocReg {
+						if d182.Loc == LocReg || d182.Loc == LocFPReg {
 							ctx.ProtectReg(d182.Reg)
 						} else if d182.Loc == LocRegPair {
 							ctx.ProtectReg(d182.Reg)
@@ -2304,7 +2304,7 @@ func init_processlist() {
 							ctx.EmitStoreToStack(d183, int32(bbs[7].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[7].PhiBase)+int32(0))+8)
 						}
-						if d182.Loc == LocReg {
+						if d182.Loc == LocReg || d182.Loc == LocFPReg {
 							ctx.UnprotectReg(d182.Reg)
 						} else if d182.Loc == LocRegPair {
 							ctx.UnprotectReg(d182.Reg)
@@ -2715,7 +2715,7 @@ func init_processlist() {
 					ctx.FreeDesc(&d207)
 					if ps.General {
 						ctx.SyncDesc(&d45)
-						if d45.Loc == LocReg {
+						if d45.Loc == LocReg || d45.Loc == LocFPReg {
 							ctx.ProtectReg(d45.Reg)
 						} else if d45.Loc == LocRegPair {
 							ctx.ProtectReg(d45.Reg)
@@ -2727,7 +2727,7 @@ func init_processlist() {
 						}
 						ctx.EnsureDesc(&d210)
 						ctx.EmitStoreToStack(d210, int32(bbs[3].PhiBase)+int32(0))
-						if d45.Loc == LocReg {
+						if d45.Loc == LocReg || d45.Loc == LocFPReg {
 							ctx.UnprotectReg(d45.Reg)
 						} else if d45.Loc == LocRegPair {
 							ctx.UnprotectReg(d45.Reg)
@@ -3136,7 +3136,7 @@ func init_processlist() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d104)
-							if d104.Loc == LocReg {
+							if d104.Loc == LocReg || d104.Loc == LocFPReg {
 								ctx.ProtectReg(d104.Reg)
 							} else if d104.Loc == LocRegPair {
 								ctx.ProtectReg(d104.Reg)
@@ -3159,7 +3159,7 @@ func init_processlist() {
 								ctx.EmitStoreToStack(d217, int32(bbs[7].PhiBase)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[7].PhiBase)+int32(0))+8)
 							}
-							if d104.Loc == LocReg {
+							if d104.Loc == LocReg || d104.Loc == LocFPReg {
 								ctx.UnprotectReg(d104.Reg)
 							} else if d104.Loc == LocRegPair {
 								ctx.UnprotectReg(d104.Reg)
@@ -3391,7 +3391,7 @@ func init_processlist() {
 					d219 = snap288
 					ctx.MarkLabel(lbl12)
 					ctx.SyncDesc(&d104)
-					if d104.Loc == LocReg {
+					if d104.Loc == LocReg || d104.Loc == LocFPReg {
 						ctx.ProtectReg(d104.Reg)
 					} else if d104.Loc == LocRegPair {
 						ctx.ProtectReg(d104.Reg)
@@ -3414,7 +3414,7 @@ func init_processlist() {
 						ctx.EmitStoreToStack(d290, int32(bbs[7].PhiBase)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[7].PhiBase)+int32(0))+8)
 					}
-					if d104.Loc == LocReg {
+					if d104.Loc == LocReg || d104.Loc == LocFPReg {
 						ctx.UnprotectReg(d104.Reg)
 					} else if d104.Loc == LocRegPair {
 						ctx.UnprotectReg(d104.Reg)

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -1260,29 +1260,31 @@ func init() {
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d5 := ctx.EmitGetTagDesc(&d1, JITValueDesc{Loc: LocAny})
+				d5 := d1
+				d5.ID = 0
+				d6 := ctx.EmitGetTagDesc(&d5, JITValueDesc{Loc: LocAny})
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d5)
-				var d6 JITValueDesc
-				if d5.Loc == LocImm {
-					d6 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d5.Imm.Int()) != uint64(0xa))}
+				ctx.EnsureDesc(&d6)
+				var d7 JITValueDesc
+				if d6.Loc == LocImm {
+					d7 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d6.Imm.Int()) != uint64(0xa))}
 				} else {
 					r0 := ctx.AllocReg()
-					ctx.EmitCmpRegImm32(d5.Reg, 10)
-					d6 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondNotEqual}
-					ctx.BindReg(r0, &d6)
+					ctx.EmitCmpRegImm32(d6.Reg, 10)
+					d7 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r0, Condition: CondNotEqual}
+					ctx.BindReg(r0, &d7)
 				}
-				ctx.FreeDesc(&d5)
+				ctx.FreeDesc(&d6)
 				ctx.ReclaimUntrackedRegs()
-				d7 := d6
-				ctx.EnsureDesc(&d7)
-				if d7.Loc != LocImm && d7.Loc != LocFlags {
+				d8 := d7
+				ctx.EnsureDesc(&d8)
+				if d8.Loc != LocImm && d8.Loc != LocFlags {
 					panic("jit: fused If condition is neither LocImm nor LocFlags")
 				}
 				lbl23 := ctx.ReserveLabel()
 				lbl24 := ctx.ReserveLabel()
-				if d7.Loc == LocImm {
-					if d7.Imm.Bool() {
+				if d8.Loc == LocImm {
+					if d8.Imm.Bool() {
 						ctx.MarkLabel(lbl23)
 						ctx.EmitJmp(lbl2)
 					} else {
@@ -1290,9 +1292,9 @@ func init() {
 						ctx.EmitJmp(lbl3)
 					}
 				} else {
-					ctx.EmitJump(d7.Condition, lbl23)
+					ctx.EmitJump(d8.Condition, lbl23)
 					ctx.EmitJmp(lbl24)
-					ctx.FreeDesc(&d6)
+					ctx.FreeDesc(&d7)
 					ctx.MarkLabel(lbl23)
 					ctx.EmitJmp(lbl2)
 					ctx.MarkLabel(lbl24)
@@ -1305,63 +1307,63 @@ func init() {
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d8 := ctx.EmitGoCallScalar(GoFuncAddr(func() *Proc { return new(Proc) }), nil, 1)
-				ctx.BindReg(d8.Reg, &d8)
-				ctx.StabilizeDescForControlFlow(&d8)
+				d9 := ctx.EmitGoCallScalar(GoFuncAddr(func() *Proc { return new(Proc) }), nil, 1)
+				ctx.BindReg(d9.Reg, &d9)
+				ctx.StabilizeDescForControlFlow(&d9)
 				ctx.ReclaimUntrackedRegs()
 				d1 = JITPrepareScmerGoArg(ctx, d1)
 				ctx.SyncDesc(&d1)
-				d9 := ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d1}, 1)
-				d9.NoHeapPointer = false
-				ctx.BindReg(d9.Reg, &d9)
+				d10 := ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d1}, 1)
+				d10.NoHeapPointer = false
+				ctx.BindReg(d10.Reg, &d10)
 				ctx.ReclaimUntrackedRegs()
-				d10 := args[0]
-				d10.ID = 0
-				ctx.FreeDesc(&d9)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d10)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(dst *Proc, value Proc) { *dst = value }), []JITValueDesc{d8, d10})
+				d11 := args[0]
+				d11.ID = 0
 				ctx.FreeDesc(&d10)
 				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				var d11 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 0
-					r1 := ctx.AllocReg()
-					ctx.EmitMovRegMem64(r1, fieldAddr)
-					d11 = JITValueDesc{Loc: LocReg, Reg: r1}
-					ctx.BindReg(r1, &d11)
-				} else {
-					off := int32(0)
-					baseReg := d8.Reg
-					r2 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMem(r2, baseReg, off)
-					d11 = JITValueDesc{Loc: LocReg, Reg: r2}
-					ctx.BindReg(r2, &d11)
-				}
-				ctx.ReclaimUntrackedRegs()
 				ctx.EnsureDesc(&d11)
-				var d12 JITValueDesc
-				if d11.Loc == LocImm {
-					d12 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d11.Imm.Int()) != uint64(0x0))}
-				} else {
-					r3 := ctx.AllocReg()
-					ctx.EmitCmpRegImm32(d11.Reg, 0)
-					d12 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r3, Condition: CondNotEqual}
-					ctx.BindReg(r3, &d12)
-				}
+				ctx.EmitGoCallVoid(GoFuncAddr(func(dst *Proc, value Proc) { *dst = value }), []JITValueDesc{d9, d11})
 				ctx.FreeDesc(&d11)
 				ctx.ReclaimUntrackedRegs()
-				d13 := d12
-				ctx.EnsureDesc(&d13)
-				if d13.Loc != LocImm && d13.Loc != LocFlags {
+				ctx.ReclaimUntrackedRegs()
+				var d12 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 0
+					r1 := ctx.AllocReg()
+					ctx.EmitMovRegMem64(r1, fieldAddr)
+					d12 = JITValueDesc{Loc: LocReg, Reg: r1}
+					ctx.BindReg(r1, &d12)
+				} else {
+					off := int32(0)
+					baseReg := d9.Reg
+					r2 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMem(r2, baseReg, off)
+					d12 = JITValueDesc{Loc: LocReg, Reg: r2}
+					ctx.BindReg(r2, &d12)
+				}
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d12)
+				var d13 JITValueDesc
+				if d12.Loc == LocImm {
+					d13 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d12.Imm.Int()) != uint64(0x0))}
+				} else {
+					r3 := ctx.AllocReg()
+					ctx.EmitCmpRegImm32(d12.Reg, 0)
+					d13 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r3, Condition: CondNotEqual}
+					ctx.BindReg(r3, &d13)
+				}
+				ctx.FreeDesc(&d12)
+				ctx.ReclaimUntrackedRegs()
+				d14 := d13
+				ctx.EnsureDesc(&d14)
+				if d14.Loc != LocImm && d14.Loc != LocFlags {
 					panic("jit: fused If condition is neither LocImm nor LocFlags")
 				}
 				lbl25 := ctx.ReserveLabel()
 				lbl26 := ctx.ReserveLabel()
-				if d13.Loc == LocImm {
-					if d13.Imm.Bool() {
+				if d14.Loc == LocImm {
+					if d14.Imm.Bool() {
 						ctx.MarkLabel(lbl25)
 						ctx.EmitJmp(lbl6)
 					} else {
@@ -1370,9 +1372,9 @@ func init() {
 						ctx.EmitJmp(lbl5)
 					}
 				} else {
-					ctx.EmitJump(d13.Condition, lbl25)
+					ctx.EmitJump(d14.Condition, lbl25)
 					ctx.EmitJmp(lbl26)
-					ctx.FreeDesc(&d12)
+					ctx.FreeDesc(&d13)
 					ctx.MarkLabel(lbl25)
 					ctx.EmitJmp(lbl6)
 					ctx.MarkLabel(lbl26)
@@ -1386,18 +1388,18 @@ func init() {
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d14 := JITValueDesc{Loc: LocStack, Type: JITTypeUnknown, StackOff: int32(phiBase2) + int32(0)}
-				ctx.StabilizeDescForControlFlow(&d14)
+				d15 := JITValueDesc{Loc: LocStack, Type: JITTypeUnknown, StackOff: int32(phiBase2) + int32(0)}
+				ctx.StabilizeDescForControlFlow(&d15)
 				ctx.ReclaimUntrackedRegs()
-				d15 := d14
-				ctx.EnsureDesc(&d15)
-				if d15.Loc != LocImm && d15.Loc != LocReg {
+				d16 := d15
+				ctx.EnsureDesc(&d16)
+				if d16.Loc != LocImm && d16.Loc != LocReg {
 					panic("jit: If condition is neither LocImm nor LocReg")
 				}
 				lbl27 := ctx.ReserveLabel()
 				lbl28 := ctx.ReserveLabel()
-				if d15.Loc == LocImm {
-					if d15.Imm.Bool() {
+				if d16.Loc == LocImm {
+					if d16.Imm.Bool() {
 						ctx.MarkLabel(lbl27)
 						ctx.EmitJmp(lbl7)
 					} else {
@@ -1405,7 +1407,7 @@ func init() {
 						ctx.EmitJmp(lbl8)
 					}
 				} else {
-					ctx.EmitCmpRegImm32(d15.Reg, 0)
+					ctx.EmitCmpRegImm32(d16.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl27)
 					ctx.EmitJmp(lbl28)
 					ctx.MarkLabel(lbl27)
@@ -1416,54 +1418,54 @@ func init() {
 				bbpos_1_7 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl8)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d16 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 40
+				var d17 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 40
 					r4 := ctx.AllocReg()
 					ctx.EmitMovRegMem64(r4, fieldAddr)
-					d16 = JITValueDesc{Loc: LocReg, Reg: r4}
-					ctx.BindReg(r4, &d16)
+					d17 = JITValueDesc{Loc: LocReg, Reg: r4}
+					ctx.BindReg(r4, &d17)
 				} else {
 					off := int32(40)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r5 := ctx.AllocRegExcept(baseReg)
 					ctx.EmitMovRegMem(r5, baseReg, off)
-					d16 = JITValueDesc{Loc: LocReg, Reg: r5}
-					ctx.BindReg(r5, &d16)
+					d17 = JITValueDesc{Loc: LocReg, Reg: r5}
+					ctx.BindReg(r5, &d17)
 				}
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d16)
-				var d17 JITValueDesc
-				if d16.Loc == LocImm {
-					d17 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d16.Imm.IsNil() == true)}
+				ctx.EnsureDesc(&d17)
+				var d18 JITValueDesc
+				if d17.Loc == LocImm {
+					d18 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d17.Imm.IsNil() == true)}
 				} else {
-					ctx.EnsureDesc(&d16)
-					if d16.Loc != LocReg && d16.Loc != LocRegPair && d16.Loc != LocRegTriple {
+					ctx.EnsureDesc(&d17)
+					if d17.Loc != LocReg && d17.Loc != LocRegPair && d17.Loc != LocRegTriple {
 						panic("jit: nil comparison requires a register value")
 					}
-					r6 := ctx.AllocReg()
-					ctx.EmitCmpRegImm32(d16.Reg, 0)
+					r6 := ctx.AllocRegExcept(d17.Reg)
+					ctx.EmitCmpRegImm32(d17.Reg, 0)
 					ctx.EmitSetcc(r6, CondEqual)
-					d17 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r6}
-					ctx.BindReg(r6, &d17)
+					d18 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r6}
+					ctx.BindReg(r6, &d18)
 				}
-				ctx.FreeDesc(&d16)
+				ctx.FreeDesc(&d17)
 				ctx.ReclaimUntrackedRegs()
-				d18 := d17
-				ctx.EnsureDesc(&d18)
-				if d18.Loc != LocImm && d18.Loc != LocReg {
+				d19 := d18
+				ctx.EnsureDesc(&d19)
+				if d19.Loc != LocImm && d19.Loc != LocReg {
 					panic("jit: If condition is neither LocImm nor LocReg")
 				}
 				lbl29 := ctx.ReserveLabel()
 				lbl30 := ctx.ReserveLabel()
-				if d18.Loc == LocImm {
-					if d18.Imm.Bool() {
+				if d19.Loc == LocImm {
+					if d19.Imm.Bool() {
 						ctx.MarkLabel(lbl29)
 						ctx.EmitJmp(lbl9)
 					} else {
@@ -1471,7 +1473,7 @@ func init() {
 						ctx.EmitJmp(lbl11)
 					}
 				} else {
-					ctx.EmitCmpRegImm32(d18.Reg, 0)
+					ctx.EmitCmpRegImm32(d19.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl29)
 					ctx.EmitJmp(lbl30)
 					ctx.MarkLabel(lbl29)
@@ -1479,71 +1481,71 @@ func init() {
 					ctx.MarkLabel(lbl30)
 					ctx.EmitJmp(lbl11)
 				}
-				ctx.FreeDesc(&d17)
+				ctx.FreeDesc(&d18)
 				bbpos_1_10 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl11)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d19 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 40
+				var d20 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 40
 					r7 := ctx.AllocReg()
 					ctx.EmitMovRegMem64(r7, fieldAddr)
-					d19 = JITValueDesc{Loc: LocReg, Reg: r7}
-					ctx.BindReg(r7, &d19)
+					d20 = JITValueDesc{Loc: LocReg, Reg: r7}
+					ctx.BindReg(r7, &d20)
 				} else {
 					off := int32(40)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r8 := ctx.AllocRegExcept(baseReg)
 					ctx.EmitMovRegMem(r8, baseReg, off)
-					d19 = JITValueDesc{Loc: LocReg, Reg: r8}
-					ctx.BindReg(r8, &d19)
+					d20 = JITValueDesc{Loc: LocReg, Reg: r8}
+					ctx.BindReg(r8, &d20)
 				}
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d19)
-				d21 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(unsafe.Pointer(&Globalenv)))), NoHeapPointer: true, Rooted: true}
-				ctx.EnsureDescsTogether(&d19, &d21)
-				var d20 JITValueDesc
-				if d19.Loc == LocImm && d21.Loc == LocImm {
-					d20 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d19.Imm.Int() == d21.Imm.Int())}
-				} else if d21.Loc == LocImm {
+				ctx.EnsureDesc(&d20)
+				d22 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(unsafe.Pointer(&Globalenv)))), NoHeapPointer: true, Rooted: true}
+				ctx.EnsureDescsTogether(&d20, &d22)
+				var d21 JITValueDesc
+				if d20.Loc == LocImm && d22.Loc == LocImm {
+					d21 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d20.Imm.Int() == d22.Imm.Int())}
+				} else if d22.Loc == LocImm {
 					r9 := ctx.AllocReg()
-					if d21.Imm.Int() >= -2147483648 && d21.Imm.Int() <= 2147483647 {
-						ctx.EmitCmpRegImm32(d19.Reg, int32(d21.Imm.Int()))
+					if d22.Imm.Int() >= -2147483648 && d22.Imm.Int() <= 2147483647 {
+						ctx.EmitCmpRegImm32(d20.Reg, int32(d22.Imm.Int()))
 					} else {
-						ctx.EmitMovRegImm64(RegR11, uint64(d21.Imm.Int()))
-						ctx.EmitCmpInt64(d19.Reg, RegR11)
+						ctx.EmitMovRegImm64(RegR11, uint64(d22.Imm.Int()))
+						ctx.EmitCmpInt64(d20.Reg, RegR11)
 					}
-					d20 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r9, Condition: CondEqual}
-					ctx.BindReg(r9, &d20)
-				} else if d19.Loc == LocImm {
+					d21 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r9, Condition: CondEqual}
+					ctx.BindReg(r9, &d21)
+				} else if d20.Loc == LocImm {
 					r10 := ctx.AllocReg()
-					ctx.EmitMovRegImm64(RegR11, uint64(d19.Imm.Int()))
-					ctx.EmitCmpInt64(RegR11, d21.Reg)
-					d20 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r10, Condition: CondEqual}
-					ctx.BindReg(r10, &d20)
+					ctx.EmitMovRegImm64(RegR11, uint64(d20.Imm.Int()))
+					ctx.EmitCmpInt64(RegR11, d22.Reg)
+					d21 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r10, Condition: CondEqual}
+					ctx.BindReg(r10, &d21)
 				} else {
 					r11 := ctx.AllocReg()
-					ctx.EmitCmpInt64(d19.Reg, d21.Reg)
-					d20 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r11, Condition: CondEqual}
-					ctx.BindReg(r11, &d20)
+					ctx.EmitCmpInt64(d20.Reg, d22.Reg)
+					d21 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r11, Condition: CondEqual}
+					ctx.BindReg(r11, &d21)
 				}
-				ctx.FreeDesc(&d19)
+				ctx.FreeDesc(&d20)
 				ctx.ReclaimUntrackedRegs()
-				d22 := d20
-				ctx.EnsureDesc(&d22)
-				if d22.Loc != LocImm && d22.Loc != LocFlags {
+				d23 := d21
+				ctx.EnsureDesc(&d23)
+				if d23.Loc != LocImm && d23.Loc != LocFlags {
 					panic("jit: fused If condition is neither LocImm nor LocFlags")
 				}
 				lbl31 := ctx.ReserveLabel()
 				lbl32 := ctx.ReserveLabel()
-				if d22.Loc == LocImm {
-					if d22.Imm.Bool() {
+				if d23.Loc == LocImm {
+					if d23.Imm.Bool() {
 						ctx.MarkLabel(lbl31)
 						ctx.EmitJmp(lbl9)
 					} else {
@@ -1551,9 +1553,9 @@ func init() {
 						ctx.EmitJmp(lbl10)
 					}
 				} else {
-					ctx.EmitJump(d22.Condition, lbl31)
+					ctx.EmitJump(d23.Condition, lbl31)
 					ctx.EmitJmp(lbl32)
-					ctx.FreeDesc(&d20)
+					ctx.FreeDesc(&d21)
 					ctx.MarkLabel(lbl31)
 					ctx.EmitJmp(lbl9)
 					ctx.MarkLabel(lbl32)
@@ -1562,80 +1564,80 @@ func init() {
 				bbpos_1_9 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl10)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d23 := ctx.EmitGoCallScalar(GoFuncAddr(func() *Env { return new(Env) }), nil, 1)
-				ctx.BindReg(d23.Reg, &d23)
-				ctx.StabilizeDescForControlFlow(&d23)
+				d24 := ctx.EmitGoCallScalar(GoFuncAddr(func() *Env { return new(Env) }), nil, 1)
+				ctx.BindReg(d24.Reg, &d24)
+				ctx.StabilizeDescForControlFlow(&d24)
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d24 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 40
+				var d25 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 40
 					r12 := ctx.AllocReg()
 					ctx.EmitMovRegMem64(r12, fieldAddr)
-					d24 = JITValueDesc{Loc: LocReg, Reg: r12}
-					ctx.BindReg(r12, &d24)
+					d25 = JITValueDesc{Loc: LocReg, Reg: r12}
+					ctx.BindReg(r12, &d25)
 				} else {
 					off := int32(40)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r13 := ctx.AllocRegExcept(baseReg)
 					ctx.EmitMovRegMem(r13, baseReg, off)
-					d24 = JITValueDesc{Loc: LocReg, Reg: r13}
-					ctx.BindReg(r13, &d24)
+					d25 = JITValueDesc{Loc: LocReg, Reg: r13}
+					ctx.BindReg(r13, &d25)
 				}
 				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d25)
 				ctx.EnsureDesc(&d24)
-				ctx.EnsureDesc(&d23)
-				ctx.EnsureDesc(&d24)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Env, value *Env) { base.Outer = value }), []JITValueDesc{d23, d24})
-				ctx.FreeDesc(&d24)
+				ctx.EnsureDesc(&d25)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Env, value *Env) { base.Outer = value }), []JITValueDesc{d24, d25})
+				ctx.FreeDesc(&d25)
 				ctx.ReclaimUntrackedRegs()
-				d25 := ctx.EmitGoCallScalar(GoFuncAddr(func(size int) map[Symbol]struct{} { return make(map[Symbol]struct{}, size) }), []JITValueDesc{JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0), NoHeapPointer: true}}, 1)
-				ctx.StabilizeDescForControlFlow(&d25)
+				d26 := ctx.EmitGoCallScalar(GoFuncAddr(func(size int) map[Symbol]struct{} { return make(map[Symbol]struct{}, size) }), []JITValueDesc{JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0), NoHeapPointer: true}}, 1)
+				ctx.StabilizeDescForControlFlow(&d26)
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d26 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 8
+				var d27 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 8
 					r14 := ctx.AllocReg()
 					r15 := ctx.AllocRegExcept(r14)
 					ctx.EmitMovRegMem64(r14, fieldAddr)
 					ctx.EmitMovRegMem64(r15, fieldAddr+8)
-					d26 = JITValueDesc{Loc: LocRegPair, Reg: r14, Reg2: r15}
-					ctx.BindReg(r14, &d26)
-					ctx.BindReg(r15, &d26)
+					d27 = JITValueDesc{Loc: LocRegPair, Reg: r14, Reg2: r15}
+					ctx.BindReg(r14, &d27)
+					ctx.BindReg(r15, &d27)
 				} else {
 					off := int32(8)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r16 := ctx.AllocRegExcept(baseReg)
 					r17 := ctx.AllocRegExcept(baseReg, r16)
 					ctx.EmitMovRegMem(r16, baseReg, off)
 					ctx.EmitMovRegMem(r17, baseReg, off+8)
-					d26 = JITValueDesc{Loc: LocRegPair, Reg: r16, Reg2: r17}
-					ctx.BindReg(r16, &d26)
-					ctx.BindReg(r17, &d26)
+					d27 = JITValueDesc{Loc: LocRegPair, Reg: r16, Reg2: r17}
+					ctx.BindReg(r16, &d27)
+					ctx.BindReg(r17, &d27)
 				}
 				ctx.ReclaimUntrackedRegs()
-				d28 := d26
-				d28.ID = 0
-				d27 := ctx.EmitTagEqualsBorrowed(&d28, tagSlice, JITValueDesc{Loc: LocAny})
-				ctx.FreeDesc(&d26)
-				ctx.ReclaimUntrackedRegs()
 				d29 := d27
-				ctx.EnsureDesc(&d29)
-				if d29.Loc != LocImm && d29.Loc != LocReg {
+				d29.ID = 0
+				d28 := ctx.EmitTagEqualsBorrowed(&d29, tagSlice, JITValueDesc{Loc: LocAny})
+				ctx.FreeDesc(&d27)
+				ctx.ReclaimUntrackedRegs()
+				d30 := d28
+				ctx.EnsureDesc(&d30)
+				if d30.Loc != LocImm && d30.Loc != LocReg {
 					panic("jit: If condition is neither LocImm nor LocReg")
 				}
 				lbl33 := ctx.ReserveLabel()
 				lbl34 := ctx.ReserveLabel()
-				if d29.Loc == LocImm {
-					if d29.Imm.Bool() {
+				if d30.Loc == LocImm {
+					if d30.Imm.Bool() {
 						ctx.MarkLabel(lbl33)
 						ctx.EmitJmp(lbl14)
 					} else {
@@ -1643,7 +1645,7 @@ func init() {
 						ctx.EmitJmp(lbl16)
 					}
 				} else {
-					ctx.EmitCmpRegImm32(d29.Reg, 0)
+					ctx.EmitCmpRegImm32(d30.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl33)
 					ctx.EmitJmp(lbl34)
 					ctx.MarkLabel(lbl33)
@@ -1651,56 +1653,56 @@ func init() {
 					ctx.MarkLabel(lbl34)
 					ctx.EmitJmp(lbl16)
 				}
-				ctx.FreeDesc(&d27)
+				ctx.FreeDesc(&d28)
 				bbpos_1_15 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl16)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d30 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 8
+				var d31 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 8
 					r18 := ctx.AllocReg()
 					r19 := ctx.AllocRegExcept(r18)
 					ctx.EmitMovRegMem64(r18, fieldAddr)
 					ctx.EmitMovRegMem64(r19, fieldAddr+8)
-					d30 = JITValueDesc{Loc: LocRegPair, Reg: r18, Reg2: r19}
-					ctx.BindReg(r18, &d30)
-					ctx.BindReg(r19, &d30)
+					d31 = JITValueDesc{Loc: LocRegPair, Reg: r18, Reg2: r19}
+					ctx.BindReg(r18, &d31)
+					ctx.BindReg(r19, &d31)
 				} else {
 					off := int32(8)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r20 := ctx.AllocRegExcept(baseReg)
 					r21 := ctx.AllocRegExcept(baseReg, r20)
 					ctx.EmitMovRegMem(r20, baseReg, off)
 					ctx.EmitMovRegMem(r21, baseReg, off+8)
-					d30 = JITValueDesc{Loc: LocRegPair, Reg: r20, Reg2: r21}
-					ctx.BindReg(r20, &d30)
-					ctx.BindReg(r21, &d30)
+					d31 = JITValueDesc{Loc: LocRegPair, Reg: r20, Reg2: r21}
+					ctx.BindReg(r20, &d31)
+					ctx.BindReg(r21, &d31)
 				}
 				ctx.ReclaimUntrackedRegs()
-				d30 = JITPrepareScmerGoArg(ctx, d30)
-				ctx.SyncDesc(&d30)
-				d31 := ctx.EmitGoCallScalar(GoFuncAddr((Scmer).IsSymbol), []JITValueDesc{d30}, 1)
-				d31.NoHeapPointer = true
-				ctx.EmitAndRegImm32(d31.Reg, 1)
-				d31.Type = tagBool
-				ctx.BindReg(d31.Reg, &d31)
-				ctx.FreeDesc(&d30)
+				d31 = JITPrepareScmerGoArg(ctx, d31)
+				ctx.SyncDesc(&d31)
+				d32 := ctx.EmitGoCallScalar(GoFuncAddr((Scmer).IsSymbol), []JITValueDesc{d31}, 1)
+				d32.NoHeapPointer = true
+				ctx.EmitAndRegImm32(d32.Reg, 1)
+				d32.Type = tagBool
+				ctx.BindReg(d32.Reg, &d32)
+				ctx.FreeDesc(&d31)
 				ctx.ReclaimUntrackedRegs()
-				d32 := d31
-				ctx.EnsureDesc(&d32)
-				if d32.Loc != LocImm && d32.Loc != LocReg {
+				d33 := d32
+				ctx.EnsureDesc(&d33)
+				if d33.Loc != LocImm && d33.Loc != LocReg {
 					panic("jit: If condition is neither LocImm nor LocReg")
 				}
 				lbl35 := ctx.ReserveLabel()
 				lbl36 := ctx.ReserveLabel()
-				if d32.Loc == LocImm {
-					if d32.Imm.Bool() {
+				if d33.Loc == LocImm {
+					if d33.Imm.Bool() {
 						ctx.MarkLabel(lbl35)
 						ctx.EmitJmp(lbl20)
 					} else {
@@ -1708,7 +1710,7 @@ func init() {
 						ctx.EmitJmp(lbl15)
 					}
 				} else {
-					ctx.EmitCmpRegImm32(d32.Reg, 0)
+					ctx.EmitCmpRegImm32(d33.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl35)
 					ctx.EmitJmp(lbl36)
 					ctx.MarkLabel(lbl35)
@@ -1716,156 +1718,156 @@ func init() {
 					ctx.MarkLabel(lbl36)
 					ctx.EmitJmp(lbl15)
 				}
-				ctx.FreeDesc(&d31)
+				ctx.FreeDesc(&d32)
 				bbpos_1_14 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl15)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d33 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 24
+				var d34 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 24
 					r22 := ctx.AllocReg()
 					r23 := ctx.AllocRegExcept(r22)
 					ctx.EmitMovRegMem64(r22, fieldAddr)
 					ctx.EmitMovRegMem64(r23, fieldAddr+8)
-					d33 = JITValueDesc{Loc: LocRegPair, Reg: r22, Reg2: r23}
-					ctx.BindReg(r22, &d33)
-					ctx.BindReg(r23, &d33)
+					d34 = JITValueDesc{Loc: LocRegPair, Reg: r22, Reg2: r23}
+					ctx.BindReg(r22, &d34)
+					ctx.BindReg(r23, &d34)
 				} else {
 					off := int32(24)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r24 := ctx.AllocRegExcept(baseReg)
 					r25 := ctx.AllocRegExcept(baseReg, r24)
 					ctx.EmitMovRegMem(r24, baseReg, off)
 					ctx.EmitMovRegMem(r25, baseReg, off+8)
-					d33 = JITValueDesc{Loc: LocRegPair, Reg: r24, Reg2: r25}
-					ctx.BindReg(r24, &d33)
-					ctx.BindReg(r25, &d33)
+					d34 = JITValueDesc{Loc: LocRegPair, Reg: r24, Reg2: r25}
+					ctx.BindReg(r24, &d34)
+					ctx.BindReg(r25, &d34)
 				}
 				ctx.ReclaimUntrackedRegs()
-				d33 = JITPrepareScmerGoArg(ctx, d33)
-				if d25.Loc == LocRegPair || d25.Loc == LocStackPair || d25.Loc == LocRegTriple || d25.Loc == LocStackTriple {
+				d34 = JITPrepareScmerGoArg(ctx, d34)
+				if d26.Loc == LocRegPair || d26.Loc == LocStackPair || d26.Loc == LocRegTriple || d26.Loc == LocStackTriple {
 					panic("jit: generic call arg expects 1-word value")
 				}
-				ctx.SyncDesc(&d33)
-				ctx.SyncDesc(&d25)
-				ctx.EmitGoCallVoid(GoFuncAddr(collectProcedureBindings), []JITValueDesc{d33, d25})
-				ctx.FreeDesc(&d33)
+				ctx.SyncDesc(&d34)
+				ctx.SyncDesc(&d26)
+				ctx.EmitGoCallVoid(GoFuncAddr(collectProcedureBindings), []JITValueDesc{d34, d26})
+				ctx.FreeDesc(&d34)
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d34 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 24
+				var d35 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 24
 					r26 := ctx.AllocReg()
 					r27 := ctx.AllocRegExcept(r26)
 					ctx.EmitMovRegMem64(r26, fieldAddr)
 					ctx.EmitMovRegMem64(r27, fieldAddr+8)
-					d34 = JITValueDesc{Loc: LocRegPair, Reg: r26, Reg2: r27}
-					ctx.BindReg(r26, &d34)
-					ctx.BindReg(r27, &d34)
+					d35 = JITValueDesc{Loc: LocRegPair, Reg: r26, Reg2: r27}
+					ctx.BindReg(r26, &d35)
+					ctx.BindReg(r27, &d35)
 				} else {
 					off := int32(24)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r28 := ctx.AllocRegExcept(baseReg)
 					r29 := ctx.AllocRegExcept(baseReg, r28)
 					ctx.EmitMovRegMem(r28, baseReg, off)
 					ctx.EmitMovRegMem(r29, baseReg, off+8)
-					d34 = JITValueDesc{Loc: LocRegPair, Reg: r28, Reg2: r29}
-					ctx.BindReg(r28, &d34)
-					ctx.BindReg(r29, &d34)
+					d35 = JITValueDesc{Loc: LocRegPair, Reg: r28, Reg2: r29}
+					ctx.BindReg(r28, &d35)
+					ctx.BindReg(r29, &d35)
 				}
 				ctx.ReclaimUntrackedRegs()
-				d34 = JITPrepareScmerGoArg(ctx, d34)
-				if d23.Loc == LocRegPair || d23.Loc == LocStackPair || d23.Loc == LocRegTriple || d23.Loc == LocStackTriple {
+				d35 = JITPrepareScmerGoArg(ctx, d35)
+				if d24.Loc == LocRegPair || d24.Loc == LocStackPair || d24.Loc == LocRegTriple || d24.Loc == LocStackTriple {
 					panic("jit: generic call arg expects 1-word value")
 				}
-				if d25.Loc == LocRegPair || d25.Loc == LocStackPair || d25.Loc == LocRegTriple || d25.Loc == LocStackTriple {
+				if d26.Loc == LocRegPair || d26.Loc == LocStackPair || d26.Loc == LocRegTriple || d26.Loc == LocStackTriple {
 					panic("jit: generic call arg expects 1-word value")
 				}
-				ctx.SyncDesc(&d34)
-				ctx.SyncDesc(&d23)
-				ctx.SyncDesc(&d25)
-				d35 := ctx.EmitGoCallScalar(GoFuncAddr(closeProcedureCaptures), []JITValueDesc{d34, d23, d25}, 2)
-				d35.NoHeapPointer = false
-				ctx.BindReg(d35.Reg, &d35)
-				ctx.BindReg(d35.Reg2, &d35)
-				ctx.FreeDesc(&d34)
-				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d35)
-				ctx.EnsureDesc(&d8)
-				ctx.EnsureDesc(&d35)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value Scmer) { base.Body = value }), []JITValueDesc{d8, d35})
+				ctx.SyncDesc(&d35)
+				ctx.SyncDesc(&d24)
+				ctx.SyncDesc(&d26)
+				d36 := ctx.EmitGoCallScalar(GoFuncAddr(closeProcedureCaptures), []JITValueDesc{d35, d24, d26}, 2)
+				d36.NoHeapPointer = false
+				ctx.BindReg(d36.Reg, &d36)
+				ctx.BindReg(d36.Reg2, &d36)
 				ctx.FreeDesc(&d35)
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d36 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(unsafe.Pointer(&Globalenv)))), NoHeapPointer: true, Rooted: true}
-				ctx.EnsureDesc(&d8)
 				ctx.EnsureDesc(&d36)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value *Env) { base.En = value }), []JITValueDesc{d8, d36})
+				ctx.EnsureDesc(&d9)
+				ctx.EnsureDesc(&d36)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value Scmer) { base.Body = value }), []JITValueDesc{d9, d36})
+				ctx.FreeDesc(&d36)
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d37 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-				ctx.EnsureDesc(&d8)
+				d37 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(unsafe.Pointer(&Globalenv)))), NoHeapPointer: true, Rooted: true}
+				ctx.EnsureDesc(&d9)
 				ctx.EnsureDesc(&d37)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value uintptr) { base.JITCode = value }), []JITValueDesc{d8, d37})
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value *Env) { base.En = value }), []JITValueDesc{d9, d37})
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d38 := JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
-				ctx.EnsureDesc(&d8)
+				d38 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+				ctx.EnsureDesc(&d9)
 				ctx.EnsureDesc(&d38)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value *JITEntryPoint) { base.Compiled = value }), []JITValueDesc{d8, d38})
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value uintptr) { base.JITCode = value }), []JITValueDesc{d9, d38})
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d39 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 56
+				d39 := JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+				ctx.EnsureDesc(&d9)
+				ctx.EnsureDesc(&d39)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value *JITEntryPoint) { base.Compiled = value }), []JITValueDesc{d9, d39})
+				ctx.ReclaimUntrackedRegs()
+				ctx.ReclaimUntrackedRegs()
+				var d40 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 56
 					r30 := ctx.AllocReg()
 					ctx.EmitMovRegMem64(r30, fieldAddr)
-					d39 = JITValueDesc{Loc: LocReg, Reg: r30}
-					ctx.BindReg(r30, &d39)
+					d40 = JITValueDesc{Loc: LocReg, Reg: r30}
+					ctx.BindReg(r30, &d40)
 				} else {
 					off := int32(56)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r31 := ctx.AllocRegExcept(baseReg)
 					ctx.EmitMovRegMem(r31, baseReg, off)
-					d39 = JITValueDesc{Loc: LocReg, Reg: r31}
-					ctx.BindReg(r31, &d39)
+					d40 = JITValueDesc{Loc: LocReg, Reg: r31}
+					ctx.BindReg(r31, &d40)
 				}
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d39)
-				var d40 JITValueDesc
-				if d39.Loc == LocImm {
-					d40 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d39.Imm.IsNil() != true)}
+				ctx.EnsureDesc(&d40)
+				var d41 JITValueDesc
+				if d40.Loc == LocImm {
+					d41 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d40.Imm.IsNil() != true)}
 				} else {
-					ctx.EnsureDesc(&d39)
-					if d39.Loc != LocReg && d39.Loc != LocRegPair && d39.Loc != LocRegTriple {
+					ctx.EnsureDesc(&d40)
+					if d40.Loc != LocReg && d40.Loc != LocRegPair && d40.Loc != LocRegTriple {
 						panic("jit: nil comparison requires a register value")
 					}
-					r32 := ctx.AllocReg()
-					ctx.EmitCmpRegImm32(d39.Reg, 0)
+					r32 := ctx.AllocRegExcept(d40.Reg)
+					ctx.EmitCmpRegImm32(d40.Reg, 0)
 					ctx.EmitSetcc(r32, CondNotEqual)
-					d40 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r32}
-					ctx.BindReg(r32, &d40)
+					d41 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r32}
+					ctx.BindReg(r32, &d41)
 				}
-				ctx.FreeDesc(&d39)
+				ctx.FreeDesc(&d40)
 				ctx.ReclaimUntrackedRegs()
-				d41 := d40
-				ctx.EnsureDesc(&d41)
-				if d41.Loc != LocImm && d41.Loc != LocReg {
+				d42 := d41
+				ctx.EnsureDesc(&d42)
+				if d42.Loc != LocImm && d42.Loc != LocReg {
 					panic("jit: If condition is neither LocImm nor LocReg")
 				}
 				lbl37 := ctx.ReserveLabel()
 				lbl38 := ctx.ReserveLabel()
-				if d41.Loc == LocImm {
-					if d41.Imm.Bool() {
+				if d42.Loc == LocImm {
+					if d42.Imm.Bool() {
 						ctx.MarkLabel(lbl37)
 						ctx.EmitJmp(lbl21)
 					} else {
@@ -1873,7 +1875,7 @@ func init() {
 						ctx.EmitJmp(lbl22)
 					}
 				} else {
-					ctx.EmitCmpRegImm32(d41.Reg, 0)
+					ctx.EmitCmpRegImm32(d42.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl37)
 					ctx.EmitJmp(lbl38)
 					ctx.MarkLabel(lbl37)
@@ -1881,18 +1883,18 @@ func init() {
 					ctx.MarkLabel(lbl38)
 					ctx.EmitJmp(lbl22)
 				}
-				ctx.FreeDesc(&d40)
+				ctx.FreeDesc(&d41)
 				bbpos_1_21 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl22)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d8)
-				d42 := d8
-				_ = d42
+				ctx.EnsureDesc(&d9)
+				d43 := d9
+				_ = d43
 				bbpos_2_0 := int32(-1)
 				_ = bbpos_2_0
 				lbl39 := ctx.ReserveLabel()
@@ -1902,93 +1904,93 @@ func init() {
 				ctx.ResolveFixups()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d43 := ctx.EmitGoCallScalar(GoFuncAddr(func() *Proc { return new(Proc) }), nil, 1)
-				ctx.BindReg(d43.Reg, &d43)
+				d44 := ctx.EmitGoCallScalar(GoFuncAddr(func() *Proc { return new(Proc) }), nil, 1)
+				ctx.BindReg(d44.Reg, &d44)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d42)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(dst, src *Proc) { *dst = *src }), []JITValueDesc{d43, d42})
+				ctx.EnsureDesc(&d43)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(dst, src *Proc) { *dst = *src }), []JITValueDesc{d44, d43})
 				ctx.ReclaimUntrackedRegs()
-				if d43.Loc == LocRegPair || d43.Loc == LocStackPair || d43.Loc == LocRegTriple || d43.Loc == LocStackTriple {
+				if d44.Loc == LocRegPair || d44.Loc == LocStackPair || d44.Loc == LocRegTriple || d44.Loc == LocStackTriple {
 					panic("jit: generic call arg expects 1-word value")
 				}
-				ctx.SyncDesc(&d43)
-				d44 := ctx.EmitGoCallScalar(GoFuncAddr(NewProc), []JITValueDesc{d43}, 2)
-				d44.NoHeapPointer = false
-				ctx.BindReg(d44.Reg, &d44)
-				ctx.BindReg(d44.Reg2, &d44)
+				ctx.SyncDesc(&d44)
+				d45 := ctx.EmitGoCallScalar(GoFuncAddr(NewProc), []JITValueDesc{d44}, 2)
+				d45.NoHeapPointer = false
+				ctx.BindReg(d45.Reg, &d45)
+				ctx.BindReg(d45.Reg2, &d45)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d44)
+				ctx.EnsureDesc(&d45)
 				ctx.ReclaimUntrackedRegs()
 				r33 := ctx.AllocReg()
 				r34 := ctx.AllocRegExcept(r33)
-				d45 := JITValueDesc{Loc: LocRegPair, Reg: r33, Reg2: r34}
-				ctx.BindReg(r33, &d45)
-				ctx.BindReg(r34, &d45)
-				ctx.EmitMovPairToResult(&d44, &d45)
+				d46 := JITValueDesc{Loc: LocRegPair, Reg: r33, Reg2: r34}
+				ctx.BindReg(r33, &d46)
+				ctx.BindReg(r34, &d46)
+				ctx.EmitMovPairToResult(&d45, &d46)
 				ctx.EmitJmp(lbl0)
 				bbpos_1_1 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl2)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d46 := JITValueDesc{Loc: LocRegPair, Reg: r33, Reg2: r34}
-				ctx.BindReg(r33, &d46)
-				ctx.BindReg(r34, &d46)
-				ctx.EmitMovPairToResult(&d1, &d46)
+				d47 := JITValueDesc{Loc: LocRegPair, Reg: r33, Reg2: r34}
+				ctx.BindReg(r33, &d47)
+				ctx.BindReg(r34, &d47)
+				ctx.EmitMovPairToResult(&d1, &d47)
 				ctx.EmitJmp(lbl0)
 				bbpos_1_5 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl6)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d47 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 48
+				var d48 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 48
 					r35 := ctx.AllocReg()
 					ctx.EmitMovRegMem64(r35, fieldAddr)
-					d47 = JITValueDesc{Loc: LocReg, Reg: r35}
-					ctx.BindReg(r35, &d47)
+					d48 = JITValueDesc{Loc: LocReg, Reg: r35}
+					ctx.BindReg(r35, &d48)
 				} else {
 					off := int32(48)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r36 := ctx.AllocRegExcept(baseReg)
 					ctx.EmitMovRegMem(r36, baseReg, off)
-					d47 = JITValueDesc{Loc: LocReg, Reg: r36}
-					ctx.BindReg(r36, &d47)
+					d48 = JITValueDesc{Loc: LocReg, Reg: r36}
+					ctx.BindReg(r36, &d48)
 				}
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d47)
-				var d48 JITValueDesc
-				if d47.Loc == LocImm {
-					d48 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d47.Imm.IsNil() != true)}
+				ctx.EnsureDesc(&d48)
+				var d49 JITValueDesc
+				if d48.Loc == LocImm {
+					d49 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d48.Imm.IsNil() != true)}
 				} else {
-					ctx.EnsureDesc(&d47)
-					if d47.Loc != LocReg && d47.Loc != LocRegPair && d47.Loc != LocRegTriple {
+					ctx.EnsureDesc(&d48)
+					if d48.Loc != LocReg && d48.Loc != LocRegPair && d48.Loc != LocRegTriple {
 						panic("jit: nil comparison requires a register value")
 					}
-					r37 := ctx.AllocReg()
-					ctx.EmitCmpRegImm32(d47.Reg, 0)
+					r37 := ctx.AllocRegExcept(d48.Reg)
+					ctx.EmitCmpRegImm32(d48.Reg, 0)
 					ctx.EmitSetcc(r37, CondNotEqual)
-					d48 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r37}
-					ctx.BindReg(r37, &d48)
+					d49 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r37}
+					ctx.BindReg(r37, &d49)
 				}
-				ctx.FreeDesc(&d47)
+				ctx.FreeDesc(&d48)
 				ctx.ReclaimUntrackedRegs()
-				d49 := d48
-				ctx.EnsureDesc(&d49)
-				if d49.Loc != LocImm && d49.Loc != LocReg {
+				d50 := d49
+				ctx.EnsureDesc(&d50)
+				if d50.Loc != LocImm && d50.Loc != LocReg {
 					panic("jit: If condition is neither LocImm nor LocReg")
 				}
 				lbl40 := ctx.ReserveLabel()
 				lbl41 := ctx.ReserveLabel()
-				if d49.Loc == LocImm {
-					if d49.Imm.Bool() {
+				if d50.Loc == LocImm {
+					if d50.Imm.Bool() {
 						ctx.MarkLabel(lbl40)
 						ctx.EmitJmp(lbl4)
 					} else {
@@ -1997,7 +1999,7 @@ func init() {
 						ctx.EmitJmp(lbl5)
 					}
 				} else {
-					ctx.EmitCmpRegImm32(d49.Reg, 0)
+					ctx.EmitCmpRegImm32(d50.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl40)
 					ctx.EmitJmp(lbl41)
 					ctx.MarkLabel(lbl40)
@@ -2006,143 +2008,143 @@ func init() {
 					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewInt(0)}, int32(phiBase2)+int32(0))
 					ctx.EmitJmp(lbl5)
 				}
-				ctx.FreeDesc(&d48)
+				ctx.FreeDesc(&d49)
 				bbpos_1_6 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl7)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				d1 = JITPrepareScmerGoArg(ctx, d1)
 				ctx.SyncDesc(&d1)
-				d50 := ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d1}, 1)
-				d50.NoHeapPointer = false
-				ctx.BindReg(d50.Reg, &d50)
-				ctx.ReclaimUntrackedRegs()
-				if d50.Loc == LocRegPair || d50.Loc == LocStackPair || d50.Loc == LocRegTriple || d50.Loc == LocStackTriple {
-					panic("jit: generic call arg expects 1-word value")
-				}
-				ctx.SyncDesc(&d50)
-				d51 := ctx.EmitGoCallScalar(GoFuncAddr(jitProcCaptures), []JITValueDesc{d50}, 3)
+				d51 := ctx.EmitGoCallScalar(GoFuncAddr((Scmer).Proc), []JITValueDesc{d1}, 1)
 				d51.NoHeapPointer = false
 				ctx.BindReg(d51.Reg, &d51)
-				ctx.BindReg(d51.Reg2, &d51)
-				ctx.BindReg(d51.Reg3, &d51)
-				ctx.FreeDesc(&d50)
 				ctx.ReclaimUntrackedRegs()
-				callResults52 := JITEmitGoCallResults(ctx, GoFuncAddr(JITCloneScmerSlice), []JITValueDesc{d51}, []uint8{3}, []uint8{1})
-				d53 := callResults52[0]
+				if d51.Loc == LocRegPair || d51.Loc == LocStackPair || d51.Loc == LocRegTriple || d51.Loc == LocStackTriple {
+					panic("jit: generic call arg expects 1-word value")
+				}
+				ctx.SyncDesc(&d51)
+				d52 := ctx.EmitGoCallScalar(GoFuncAddr(jitProcCaptures), []JITValueDesc{d51}, 3)
+				d52.NoHeapPointer = false
+				ctx.BindReg(d52.Reg, &d52)
+				ctx.BindReg(d52.Reg2, &d52)
+				ctx.BindReg(d52.Reg3, &d52)
+				ctx.FreeDesc(&d51)
+				ctx.ReclaimUntrackedRegs()
+				callResults53 := JITEmitGoCallResults(ctx, GoFuncAddr(JITCloneScmerSlice), []JITValueDesc{d52}, []uint8{3}, []uint8{1})
+				d54 := callResults53[0]
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d54 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 24
+				var d55 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 24
 					r38 := ctx.AllocReg()
 					r39 := ctx.AllocRegExcept(r38)
 					ctx.EmitMovRegMem64(r38, fieldAddr)
 					ctx.EmitMovRegMem64(r39, fieldAddr+8)
-					d54 = JITValueDesc{Loc: LocRegPair, Reg: r38, Reg2: r39}
-					ctx.BindReg(r38, &d54)
-					ctx.BindReg(r39, &d54)
+					d55 = JITValueDesc{Loc: LocRegPair, Reg: r38, Reg2: r39}
+					ctx.BindReg(r38, &d55)
+					ctx.BindReg(r39, &d55)
 				} else {
 					off := int32(24)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r40 := ctx.AllocRegExcept(baseReg)
 					r41 := ctx.AllocRegExcept(baseReg, r40)
 					ctx.EmitMovRegMem(r40, baseReg, off)
 					ctx.EmitMovRegMem(r41, baseReg, off+8)
-					d54 = JITValueDesc{Loc: LocRegPair, Reg: r40, Reg2: r41}
-					ctx.BindReg(r40, &d54)
-					ctx.BindReg(r41, &d54)
-				}
-				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				var d55 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 48
-					r42 := ctx.AllocReg()
-					ctx.EmitMovRegMem64(r42, fieldAddr)
-					d55 = JITValueDesc{Loc: LocReg, Reg: r42}
-					ctx.BindReg(r42, &d55)
-				} else {
-					off := int32(48)
-					baseReg := d8.Reg
-					r43 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMem(r43, baseReg, off)
-					d55 = JITValueDesc{Loc: LocReg, Reg: r43}
-					ctx.BindReg(r43, &d55)
+					d55 = JITValueDesc{Loc: LocRegPair, Reg: r40, Reg2: r41}
+					ctx.BindReg(r40, &d55)
+					ctx.BindReg(r41, &d55)
 				}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				var d56 JITValueDesc
-				ctx.EnsureDesc(&d55)
-				if d55.Loc == LocImm {
-					fieldAddr := uintptr(d55.Imm.Int()) + 280
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 48
+					r42 := ctx.AllocReg()
+					ctx.EmitMovRegMem64(r42, fieldAddr)
+					d56 = JITValueDesc{Loc: LocReg, Reg: r42}
+					ctx.BindReg(r42, &d56)
+				} else {
+					off := int32(48)
+					baseReg := d9.Reg
+					r43 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMem(r43, baseReg, off)
+					d56 = JITValueDesc{Loc: LocReg, Reg: r43}
+					ctx.BindReg(r43, &d56)
+				}
+				ctx.ReclaimUntrackedRegs()
+				ctx.ReclaimUntrackedRegs()
+				var d57 JITValueDesc
+				ctx.EnsureDesc(&d56)
+				if d56.Loc == LocImm {
+					fieldAddr := uintptr(d56.Imm.Int()) + 280
 					r44 := ctx.AllocReg()
 					ctx.EmitMovRegMem64(r44, fieldAddr)
-					d56 = JITValueDesc{Loc: LocReg, Reg: r44}
-					ctx.BindReg(r44, &d56)
+					d57 = JITValueDesc{Loc: LocReg, Reg: r44}
+					ctx.BindReg(r44, &d57)
 				} else {
 					off := int32(280)
-					baseReg := d55.Reg
+					baseReg := d56.Reg
 					r45 := ctx.AllocRegExcept(baseReg)
 					ctx.EmitMovRegMem(r45, baseReg, off)
-					d56 = JITValueDesc{Loc: LocReg, Reg: r45}
-					ctx.BindReg(r45, &d56)
+					d57 = JITValueDesc{Loc: LocReg, Reg: r45}
+					ctx.BindReg(r45, &d57)
 				}
-				ctx.FreeDesc(&d55)
+				ctx.FreeDesc(&d56)
 				ctx.ReclaimUntrackedRegs()
-				d54 = JITPrepareScmerGoArg(ctx, d54)
-				if d56.Loc == LocRegPair || d56.Loc == LocStackPair || d56.Loc == LocRegTriple || d56.Loc == LocStackTriple {
-					panic("jit: generic call arg expects 1-word value")
-				}
-				d53 = JITPrepareGoSliceArg(ctx, d53)
-				if d53.Loc != LocRegTriple && d53.Loc != LocStackTriple {
-					panic("jit: generic call arg expects 3-word Go slice (closeJITProcedureCaptures arg2)")
-				}
-				d57 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+				d55 = JITPrepareScmerGoArg(ctx, d55)
 				if d57.Loc == LocRegPair || d57.Loc == LocStackPair || d57.Loc == LocRegTriple || d57.Loc == LocStackTriple {
 					panic("jit: generic call arg expects 1-word value")
 				}
-				ctx.SyncDesc(&d54)
-				ctx.SyncDesc(&d56)
-				ctx.SyncDesc(&d53)
+				d54 = JITPrepareGoSliceArg(ctx, d54)
+				if d54.Loc != LocRegTriple && d54.Loc != LocStackTriple {
+					panic("jit: generic call arg expects 3-word Go slice (closeJITProcedureCaptures arg2)")
+				}
+				d58 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+				if d58.Loc == LocRegPair || d58.Loc == LocStackPair || d58.Loc == LocRegTriple || d58.Loc == LocStackTriple {
+					panic("jit: generic call arg expects 1-word value")
+				}
+				ctx.SyncDesc(&d55)
 				ctx.SyncDesc(&d57)
-				d58 := ctx.EmitGoCallScalar(GoFuncAddr(closeJITProcedureCaptures), []JITValueDesc{d54, d56, d53, d57}, 2)
-				d58.NoHeapPointer = false
-				ctx.BindReg(d58.Reg, &d58)
-				ctx.BindReg(d58.Reg2, &d58)
-				ctx.FreeDesc(&d57)
-				ctx.FreeDesc(&d54)
-				ctx.FreeDesc(&d56)
-				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d58)
-				ctx.EnsureDesc(&d8)
-				ctx.EnsureDesc(&d58)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value Scmer) { base.Body = value }), []JITValueDesc{d8, d58})
+				ctx.SyncDesc(&d54)
+				ctx.SyncDesc(&d58)
+				d59 := ctx.EmitGoCallScalar(GoFuncAddr(closeJITProcedureCaptures), []JITValueDesc{d55, d57, d54, d58}, 2)
+				d59.NoHeapPointer = false
+				ctx.BindReg(d59.Reg, &d59)
+				ctx.BindReg(d59.Reg2, &d59)
 				ctx.FreeDesc(&d58)
+				ctx.FreeDesc(&d55)
+				ctx.FreeDesc(&d57)
+				ctx.ReclaimUntrackedRegs()
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d59)
+				ctx.EnsureDesc(&d9)
+				ctx.EnsureDesc(&d59)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value Scmer) { base.Body = value }), []JITValueDesc{d9, d59})
+				ctx.FreeDesc(&d59)
 				ctx.ReclaimUntrackedRegs()
 				ctx.EmitJmp(lbl8)
 				bbpos_1_8 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl9)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d59 := d14
-				ctx.EnsureDesc(&d59)
-				if d59.Loc != LocImm && d59.Loc != LocReg {
+				d60 := d15
+				ctx.EnsureDesc(&d60)
+				if d60.Loc != LocImm && d60.Loc != LocReg {
 					panic("jit: If condition is neither LocImm nor LocReg")
 				}
 				lbl42 := ctx.ReserveLabel()
 				lbl43 := ctx.ReserveLabel()
-				if d59.Loc == LocImm {
-					if d59.Imm.Bool() {
+				if d60.Loc == LocImm {
+					if d60.Imm.Bool() {
 						ctx.MarkLabel(lbl42)
 						ctx.EmitJmp(lbl13)
 					} else {
@@ -2150,7 +2152,7 @@ func init() {
 						ctx.EmitJmp(lbl12)
 					}
 				} else {
-					ctx.EmitCmpRegImm32(d59.Reg, 0)
+					ctx.EmitCmpRegImm32(d60.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl42)
 					ctx.EmitJmp(lbl43)
 					ctx.MarkLabel(lbl42)
@@ -2161,136 +2163,136 @@ func init() {
 				bbpos_1_11 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl12)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d60 := JITValueDesc{Loc: LocRegPair, Reg: r33, Reg2: r34}
-				ctx.BindReg(r33, &d60)
-				ctx.BindReg(r34, &d60)
-				ctx.EmitMovPairToResult(&d1, &d60)
+				d61 := JITValueDesc{Loc: LocRegPair, Reg: r33, Reg2: r34}
+				ctx.BindReg(r33, &d61)
+				ctx.BindReg(r34, &d61)
+				ctx.EmitMovPairToResult(&d1, &d61)
 				ctx.EmitJmp(lbl0)
 				bbpos_1_13 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl14)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d61 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 8
+				var d62 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 8
 					r46 := ctx.AllocReg()
 					r47 := ctx.AllocRegExcept(r46)
 					ctx.EmitMovRegMem64(r46, fieldAddr)
 					ctx.EmitMovRegMem64(r47, fieldAddr+8)
-					d61 = JITValueDesc{Loc: LocRegPair, Reg: r46, Reg2: r47}
-					ctx.BindReg(r46, &d61)
-					ctx.BindReg(r47, &d61)
+					d62 = JITValueDesc{Loc: LocRegPair, Reg: r46, Reg2: r47}
+					ctx.BindReg(r46, &d62)
+					ctx.BindReg(r47, &d62)
 				} else {
 					off := int32(8)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r48 := ctx.AllocRegExcept(baseReg)
 					r49 := ctx.AllocRegExcept(baseReg, r48)
 					ctx.EmitMovRegMem(r48, baseReg, off)
 					ctx.EmitMovRegMem(r49, baseReg, off+8)
-					d61 = JITValueDesc{Loc: LocRegPair, Reg: r48, Reg2: r49}
-					ctx.BindReg(r48, &d61)
-					ctx.BindReg(r49, &d61)
+					d62 = JITValueDesc{Loc: LocRegPair, Reg: r48, Reg2: r49}
+					ctx.BindReg(r48, &d62)
+					ctx.BindReg(r49, &d62)
 				}
 				ctx.ReclaimUntrackedRegs()
-				d62 := jitKnownSliceHeader(ctx, &d61)
-				ctx.StabilizeDescForControlFlow(&d62)
-				ctx.FreeDesc(&d61)
+				d63 := jitKnownSliceHeader(ctx, &d62)
+				ctx.StabilizeDescForControlFlow(&d63)
+				ctx.FreeDesc(&d62)
 				ctx.ReclaimUntrackedRegs()
-				var d63 JITValueDesc
-				if d62.SliceSizeKnown {
-					d63 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d62.KnownSliceLen))}
-				} else if d62.Loc == LocImm {
-					d63 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d62.StackOff))}
-				} else if d62.Loc == LocStackTriple {
-					d63 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d62.StackOff + 8, NoHeapPointer: true}
+				var d64 JITValueDesc
+				if d63.SliceSizeKnown {
+					d64 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d63.KnownSliceLen))}
+				} else if d63.Loc == LocImm {
+					d64 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d63.StackOff))}
+				} else if d63.Loc == LocStackTriple {
+					d64 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d63.StackOff + 8, NoHeapPointer: true}
 				} else {
-					ctx.EnsureDesc(&d62)
-					if d62.Loc == LocRegPair || d62.Loc == LocRegTriple {
-						d63 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d62.Reg2, ID: 0}
-					} else if d62.Loc == LocReg {
-						d63 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d62.Reg, ID: 0}
+					ctx.EnsureDesc(&d63)
+					if d63.Loc == LocRegPair || d63.Loc == LocRegTriple {
+						d64 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d63.Reg2, ID: 0}
+					} else if d63.Loc == LocReg {
+						d64 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d63.Reg, ID: 0}
 					} else {
 						panic("len on unsupported descriptor location")
 					}
 				}
-				ctx.StabilizeDescForControlFlow(&d63)
+				ctx.StabilizeDescForControlFlow(&d64)
 				ctx.ReclaimUntrackedRegs()
 				ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(phiBase2)+int32(16))
 				bbpos_1_16 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl17)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
 				d4 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d64 := JITValueDesc{Loc: LocStack, Type: JITTypeUnknown, StackOff: int32(phiBase2) + int32(16)}
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d64)
-				ctx.EnsureDesc(&d64)
-				var d65 JITValueDesc
-				if d64.Loc == LocImm {
-					d65 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d64.Imm.Int() + 1)}
-				} else {
-					scratch := ctx.AllocRegExcept(d64.Reg)
-					ctx.EmitMovRegReg(scratch, d64.Reg)
-					ctx.EmitAddRegImm32(scratch, int32(1))
-					d65 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-					ctx.BindReg(scratch, &d65)
-				}
-				if d65.Loc == LocReg && d64.Loc == LocReg && d65.Reg == d64.Reg {
-					ctx.TransferReg(d64.Reg)
-					d64.Loc = LocNone
-				}
-				ctx.StabilizeDescForControlFlow(&d65)
-				ctx.FreeDesc(&d64)
+				d65 := JITValueDesc{Loc: LocStack, Type: JITTypeUnknown, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.EnsureDesc(&d65)
-				ctx.EnsureDesc(&d63)
-				ctx.EnsureDescsTogether(&d65, &d63)
+				ctx.EnsureDesc(&d65)
 				var d66 JITValueDesc
-				if d65.Loc == LocImm && d63.Loc == LocImm {
-					d66 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d65.Imm.Int() < d63.Imm.Int())}
-				} else if d63.Loc == LocImm {
-					r50 := ctx.AllocRegExcept(d65.Reg)
-					if d63.Imm.Int() >= -2147483648 && d63.Imm.Int() <= 2147483647 {
-						ctx.EmitCmpRegImm32(d65.Reg, int32(d63.Imm.Int()))
-					} else {
-						ctx.EmitMovRegImm64(RegR11, uint64(d63.Imm.Int()))
-						ctx.EmitCmpInt64(d65.Reg, RegR11)
-					}
-					d66 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r50, Condition: CondSignedLess}
-					ctx.BindReg(r50, &d66)
-				} else if d65.Loc == LocImm {
-					r51 := ctx.AllocReg()
-					ctx.EmitMovRegImm64(RegR11, uint64(d65.Imm.Int()))
-					ctx.EmitCmpInt64(RegR11, d63.Reg)
-					d66 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r51, Condition: CondSignedLess}
-					ctx.BindReg(r51, &d66)
+				if d65.Loc == LocImm {
+					d66 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d65.Imm.Int() + 1)}
 				} else {
-					r52 := ctx.AllocRegExcept(d65.Reg)
-					ctx.EmitCmpInt64(d65.Reg, d63.Reg)
-					d66 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r52, Condition: CondSignedLess}
-					ctx.BindReg(r52, &d66)
+					scratch := ctx.AllocRegExcept(d65.Reg)
+					ctx.EmitMovRegReg(scratch, d65.Reg)
+					ctx.EmitAddRegImm32(scratch, int32(1))
+					d66 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+					ctx.BindReg(scratch, &d66)
+				}
+				if d66.Loc == LocReg && d65.Loc == LocReg && d66.Reg == d65.Reg {
+					ctx.TransferReg(d65.Reg)
+					d65.Loc = LocNone
+				}
+				ctx.StabilizeDescForControlFlow(&d66)
+				ctx.FreeDesc(&d65)
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d66)
+				ctx.EnsureDesc(&d64)
+				ctx.EnsureDescsTogether(&d66, &d64)
+				var d67 JITValueDesc
+				if d66.Loc == LocImm && d64.Loc == LocImm {
+					d67 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d66.Imm.Int() < d64.Imm.Int())}
+				} else if d64.Loc == LocImm {
+					r50 := ctx.AllocRegExcept(d66.Reg)
+					if d64.Imm.Int() >= -2147483648 && d64.Imm.Int() <= 2147483647 {
+						ctx.EmitCmpRegImm32(d66.Reg, int32(d64.Imm.Int()))
+					} else {
+						ctx.EmitMovRegImm64(RegR11, uint64(d64.Imm.Int()))
+						ctx.EmitCmpInt64(d66.Reg, RegR11)
+					}
+					d67 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r50, Condition: CondSignedLess}
+					ctx.BindReg(r50, &d67)
+				} else if d66.Loc == LocImm {
+					r51 := ctx.AllocReg()
+					ctx.EmitMovRegImm64(RegR11, uint64(d66.Imm.Int()))
+					ctx.EmitCmpInt64(RegR11, d64.Reg)
+					d67 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r51, Condition: CondSignedLess}
+					ctx.BindReg(r51, &d67)
+				} else {
+					r52 := ctx.AllocRegExcept(d66.Reg)
+					ctx.EmitCmpInt64(d66.Reg, d64.Reg)
+					d67 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r52, Condition: CondSignedLess}
+					ctx.BindReg(r52, &d67)
 				}
 				ctx.ReclaimUntrackedRegs()
-				d67 := d66
-				ctx.EnsureDesc(&d67)
-				if d67.Loc != LocImm && d67.Loc != LocFlags {
+				d68 := d67
+				ctx.EnsureDesc(&d68)
+				if d68.Loc != LocImm && d68.Loc != LocFlags {
 					panic("jit: fused If condition is neither LocImm nor LocFlags")
 				}
 				lbl44 := ctx.ReserveLabel()
 				lbl45 := ctx.ReserveLabel()
-				if d67.Loc == LocImm {
-					if d67.Imm.Bool() {
+				if d68.Loc == LocImm {
+					if d68.Imm.Bool() {
 						ctx.MarkLabel(lbl44)
 						ctx.EmitJmp(lbl18)
 					} else {
@@ -2298,9 +2300,9 @@ func init() {
 						ctx.EmitJmp(lbl15)
 					}
 				} else {
-					ctx.EmitJump(d67.Condition, lbl44)
+					ctx.EmitJump(d68.Condition, lbl44)
 					ctx.EmitJmp(lbl45)
-					ctx.FreeDesc(&d66)
+					ctx.FreeDesc(&d67)
 					ctx.MarkLabel(lbl44)
 					ctx.EmitJmp(lbl18)
 					ctx.MarkLabel(lbl45)
@@ -2309,37 +2311,37 @@ func init() {
 				bbpos_1_19 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl20)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
-				d64 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d65 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d68 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 8
+				var d69 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 8
 					r53 := ctx.AllocReg()
 					r54 := ctx.AllocRegExcept(r53)
 					ctx.EmitMovRegMem64(r53, fieldAddr)
 					ctx.EmitMovRegMem64(r54, fieldAddr+8)
-					d68 = JITValueDesc{Loc: LocRegPair, Reg: r53, Reg2: r54}
-					ctx.BindReg(r53, &d68)
-					ctx.BindReg(r54, &d68)
+					d69 = JITValueDesc{Loc: LocRegPair, Reg: r53, Reg2: r54}
+					ctx.BindReg(r53, &d69)
+					ctx.BindReg(r54, &d69)
 				} else {
 					off := int32(8)
-					baseReg := d8.Reg
+					baseReg := d9.Reg
 					r55 := ctx.AllocRegExcept(baseReg)
 					r56 := ctx.AllocRegExcept(baseReg, r55)
 					ctx.EmitMovRegMem(r55, baseReg, off)
 					ctx.EmitMovRegMem(r56, baseReg, off+8)
-					d68 = JITValueDesc{Loc: LocRegPair, Reg: r55, Reg2: r56}
-					ctx.BindReg(r55, &d68)
-					ctx.BindReg(r56, &d68)
+					d69 = JITValueDesc{Loc: LocRegPair, Reg: r55, Reg2: r56}
+					ctx.BindReg(r55, &d69)
+					ctx.BindReg(r56, &d69)
 				}
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d68)
-				inlineResultOff69 := ctx.AllocStack(int32(16))
-				d70 := JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: inlineResultOff69}
+				ctx.EnsureDesc(&d69)
+				inlineResultOff70 := ctx.AllocStack(int32(16))
+				d71 := JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: inlineResultOff70}
 				lbl46 := ctx.ReserveLabel()
 				bbpos_3_0 := int32(-1)
 				_ = bbpos_3_0
@@ -2358,29 +2360,31 @@ func init() {
 				ctx.ResolveFixups()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d71 := ctx.EmitGetTagDesc(&d68, JITValueDesc{Loc: LocAny})
+				d72 := d69
+				d72.ID = 0
+				d73 := ctx.EmitGetTagDesc(&d72, JITValueDesc{Loc: LocAny})
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d71)
-				var d72 JITValueDesc
-				if d71.Loc == LocImm {
-					d72 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d71.Imm.Int()) != uint64(0x2))}
+				ctx.EnsureDesc(&d73)
+				var d74 JITValueDesc
+				if d73.Loc == LocImm {
+					d74 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d73.Imm.Int()) != uint64(0x2))}
 				} else {
 					r57 := ctx.AllocReg()
-					ctx.EmitCmpRegImm32(d71.Reg, 2)
-					d72 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r57, Condition: CondNotEqual}
-					ctx.BindReg(r57, &d72)
+					ctx.EmitCmpRegImm32(d73.Reg, 2)
+					d74 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r57, Condition: CondNotEqual}
+					ctx.BindReg(r57, &d74)
 				}
-				ctx.FreeDesc(&d71)
+				ctx.FreeDesc(&d73)
 				ctx.ReclaimUntrackedRegs()
-				d73 := d72
-				ctx.EnsureDesc(&d73)
-				if d73.Loc != LocImm && d73.Loc != LocFlags {
+				d75 := d74
+				ctx.EnsureDesc(&d75)
+				if d75.Loc != LocImm && d75.Loc != LocFlags {
 					panic("jit: fused If condition is neither LocImm nor LocFlags")
 				}
 				lbl50 := ctx.ReserveLabel()
 				lbl51 := ctx.ReserveLabel()
-				if d73.Loc == LocImm {
-					if d73.Imm.Bool() {
+				if d75.Loc == LocImm {
+					if d75.Imm.Bool() {
 						ctx.MarkLabel(lbl50)
 						ctx.EmitJmp(lbl48)
 					} else {
@@ -2388,9 +2392,9 @@ func init() {
 						ctx.EmitJmp(lbl49)
 					}
 				} else {
-					ctx.EmitJump(d73.Condition, lbl50)
+					ctx.EmitJump(d75.Condition, lbl50)
 					ctx.EmitJmp(lbl51)
-					ctx.FreeDesc(&d72)
+					ctx.FreeDesc(&d74)
 					ctx.MarkLabel(lbl50)
 					ctx.EmitJmp(lbl48)
 					ctx.MarkLabel(lbl51)
@@ -2401,28 +2405,28 @@ func init() {
 				ctx.ResolveFixups()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d75 := d68
-				ctx.SyncDesc(&d75)
-				if d75.Loc == LocMem {
-					tmpScalar := JITValueDesc{Loc: LocReg, Type: d75.Type, Reg: ctx.AllocReg()}
+				d77 := d69
+				ctx.SyncDesc(&d77)
+				if d77.Loc == LocMem {
+					tmpScalar := JITValueDesc{Loc: LocReg, Type: d77.Type, Reg: ctx.AllocReg()}
 					scratch := ctx.AllocRegExcept(tmpScalar.Reg)
-					ctx.EmitMovRegImm64(scratch, uint64(d75.MemPtr))
+					ctx.EmitMovRegImm64(scratch, uint64(d77.MemPtr))
 					ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
 					ctx.FreeReg(scratch)
 					ctx.BindReg(tmpScalar.Reg, &tmpScalar)
-					d75 = tmpScalar
+					d77 = tmpScalar
 				}
-				d75 = JITPrepareScmerGoArg(ctx, d75)
-				if d75.Loc != LocRegPair && d75.Loc != LocStackPair && d75.Loc != LocInputPair {
+				d77 = JITPrepareScmerGoArg(ctx, d77)
+				if d77.Loc != LocRegPair && d77.Loc != LocStackPair && d77.Loc != LocInputPair {
 					panic("jit: Scmer.String receiver not materialized as pair")
 				}
-				d74 := ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d75}, 2)
-				ctx.FreeDesc(&d68)
+				d76 := ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d77}, 2)
+				ctx.FreeDesc(&d69)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d74)
+				ctx.EnsureDesc(&d76)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d74)
-				ctx.EmitCopyDescWords(&d70, &d74, 2)
+				ctx.EnsureDesc(&d76)
+				ctx.EmitCopyDescWords(&d71, &d76, 2)
 				ctx.EmitJmp(lbl46)
 				bbpos_3_1 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl48)
@@ -2430,247 +2434,247 @@ func init() {
 				ctx.ReclaimUntrackedRegs()
 				ctx.EmitGoPanic("jit: invalid arguments for inlined Go helper")
 				ctx.MarkLabel(lbl46)
-				ctx.FreeDesc(&d68)
+				ctx.FreeDesc(&d69)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d25)
-				ctx.EnsureDesc(&d70)
-				d76 := JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
-				ctx.EmitGoCallVoid(GoFuncAddr(func(m map[Symbol]struct{}, key Symbol, value struct{}) { m[key] = value }), []JITValueDesc{d25, d70, d76})
+				ctx.EnsureDesc(&d26)
+				ctx.EnsureDesc(&d71)
+				d78 := JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+				ctx.EmitGoCallVoid(GoFuncAddr(func(m map[Symbol]struct{}, key Symbol, value struct{}) { m[key] = value }), []JITValueDesc{d26, d71, d78})
 				ctx.ReclaimUntrackedRegs()
 				ctx.EmitJmp(lbl15)
 				bbpos_1_20 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl21)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
-				d64 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d65 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d77 := ctx.EmitGoCallScalar(GoFuncAddr(func() *ProcOptimizerMeta { return new(ProcOptimizerMeta) }), nil, 1)
-				ctx.BindReg(d77.Reg, &d77)
-				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				var d78 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 56
-					r58 := ctx.AllocReg()
-					ctx.EmitMovRegMem64(r58, fieldAddr)
-					d78 = JITValueDesc{Loc: LocReg, Reg: r58}
-					ctx.BindReg(r58, &d78)
-				} else {
-					off := int32(56)
-					baseReg := d8.Reg
-					r59 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMem(r59, baseReg, off)
-					d78 = JITValueDesc{Loc: LocReg, Reg: r59}
-					ctx.BindReg(r59, &d78)
-				}
-				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				var d79 JITValueDesc
-				ctx.EnsureDesc(&d78)
-				if d78.Loc == LocImm {
-					fieldAddr := uintptr(d78.Imm.Int()) + 0
-					r60 := ctx.AllocReg()
-					ctx.EmitMovRegMem64(r60, fieldAddr)
-					d79 = JITValueDesc{Loc: LocReg, Reg: r60}
-					ctx.BindReg(r60, &d79)
-				} else {
-					off := int32(0)
-					baseReg := d78.Reg
-					r61 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMem(r61, baseReg, off)
-					d79 = JITValueDesc{Loc: LocReg, Reg: r61}
-					ctx.BindReg(r61, &d79)
-				}
-				ctx.FreeDesc(&d78)
+				d79 := ctx.EmitGoCallScalar(GoFuncAddr(func() *ProcOptimizerMeta { return new(ProcOptimizerMeta) }), nil, 1)
+				ctx.BindReg(d79.Reg, &d79)
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				var d80 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 56
-					r62 := ctx.AllocReg()
-					ctx.EmitMovRegMem64(r62, fieldAddr)
-					d80 = JITValueDesc{Loc: LocReg, Reg: r62}
-					ctx.BindReg(r62, &d80)
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 56
+					r58 := ctx.AllocReg()
+					ctx.EmitMovRegMem64(r58, fieldAddr)
+					d80 = JITValueDesc{Loc: LocReg, Reg: r58}
+					ctx.BindReg(r58, &d80)
 				} else {
 					off := int32(56)
-					baseReg := d8.Reg
-					r63 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMem(r63, baseReg, off)
-					d80 = JITValueDesc{Loc: LocReg, Reg: r63}
-					ctx.BindReg(r63, &d80)
+					baseReg := d9.Reg
+					r59 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMem(r59, baseReg, off)
+					d80 = JITValueDesc{Loc: LocReg, Reg: r59}
+					ctx.BindReg(r59, &d80)
 				}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				var d81 JITValueDesc
 				ctx.EnsureDesc(&d80)
 				if d80.Loc == LocImm {
-					fieldAddr := uintptr(d80.Imm.Int()) + 24
-					r64 := ctx.AllocReg()
-					ctx.EmitMovRegMem8(r64, fieldAddr)
-					d81 = JITValueDesc{Loc: LocReg, Reg: r64}
-					ctx.BindReg(r64, &d81)
+					fieldAddr := uintptr(d80.Imm.Int()) + 0
+					r60 := ctx.AllocReg()
+					ctx.EmitMovRegMem64(r60, fieldAddr)
+					d81 = JITValueDesc{Loc: LocReg, Reg: r60}
+					ctx.BindReg(r60, &d81)
 				} else {
-					off := int32(24)
+					off := int32(0)
 					baseReg := d80.Reg
-					r65 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMemB(r65, baseReg, off)
-					d81 = JITValueDesc{Loc: LocReg, Reg: r65}
-					ctx.BindReg(r65, &d81)
+					r61 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMem(r61, baseReg, off)
+					d81 = JITValueDesc{Loc: LocReg, Reg: r61}
+					ctx.BindReg(r61, &d81)
 				}
 				ctx.FreeDesc(&d80)
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				var d82 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 56
-					r66 := ctx.AllocReg()
-					ctx.EmitMovRegMem64(r66, fieldAddr)
-					d82 = JITValueDesc{Loc: LocReg, Reg: r66}
-					ctx.BindReg(r66, &d82)
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 56
+					r62 := ctx.AllocReg()
+					ctx.EmitMovRegMem64(r62, fieldAddr)
+					d82 = JITValueDesc{Loc: LocReg, Reg: r62}
+					ctx.BindReg(r62, &d82)
 				} else {
 					off := int32(56)
-					baseReg := d8.Reg
-					r67 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMem(r67, baseReg, off)
-					d82 = JITValueDesc{Loc: LocReg, Reg: r67}
-					ctx.BindReg(r67, &d82)
+					baseReg := d9.Reg
+					r63 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMem(r63, baseReg, off)
+					d82 = JITValueDesc{Loc: LocReg, Reg: r63}
+					ctx.BindReg(r63, &d82)
 				}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				var d83 JITValueDesc
 				ctx.EnsureDesc(&d82)
 				if d82.Loc == LocImm {
-					fieldAddr := uintptr(d82.Imm.Int()) + 25
-					r68 := ctx.AllocReg()
-					ctx.EmitMovRegMem8(r68, fieldAddr)
-					d83 = JITValueDesc{Loc: LocReg, Reg: r68}
-					ctx.BindReg(r68, &d83)
+					fieldAddr := uintptr(d82.Imm.Int()) + 24
+					r64 := ctx.AllocReg()
+					ctx.EmitMovRegMem8(r64, fieldAddr)
+					d83 = JITValueDesc{Loc: LocReg, Reg: r64}
+					ctx.BindReg(r64, &d83)
 				} else {
-					off := int32(25)
+					off := int32(24)
 					baseReg := d82.Reg
-					r69 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMemB(r69, baseReg, off)
-					d83 = JITValueDesc{Loc: LocReg, Reg: r69}
-					ctx.BindReg(r69, &d83)
+					r65 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMemB(r65, baseReg, off)
+					d83 = JITValueDesc{Loc: LocReg, Reg: r65}
+					ctx.BindReg(r65, &d83)
 				}
 				ctx.FreeDesc(&d82)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d79)
-				ctx.EnsureDesc(&d77)
-				ctx.EnsureDesc(&d79)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *ProcOptimizerMeta, value TypeInfo) { base.Return = value }), []JITValueDesc{d77, d79})
-				ctx.FreeDesc(&d79)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d81)
-				ctx.EnsureDesc(&d77)
-				ctx.EnsureDesc(&d81)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *ProcOptimizerMeta, value bool) { base.HasReturn = value }), []JITValueDesc{d77, d81})
-				ctx.FreeDesc(&d81)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d83)
-				ctx.EnsureDesc(&d77)
-				ctx.EnsureDesc(&d83)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *ProcOptimizerMeta, value procSequenceKind) { base.Sequence = value }), []JITValueDesc{d77, d83})
-				ctx.FreeDesc(&d83)
-				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d77)
-				ctx.EnsureDesc(&d8)
-				ctx.EnsureDesc(&d77)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value *ProcOptimizerMeta) { base.OptimizerMeta = value }), []JITValueDesc{d8, d77})
-				ctx.ReclaimUntrackedRegs()
-				ctx.EmitJmp(lbl22)
-				bbpos_1_3 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-				ctx.MarkLabel(lbl4)
-				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
-				d64 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				var d84 JITValueDesc
-				ctx.EnsureDesc(&d8)
-				if d8.Loc == LocImm {
-					fieldAddr := uintptr(d8.Imm.Int()) + 48
-					r70 := ctx.AllocReg()
-					ctx.EmitMovRegMem64(r70, fieldAddr)
-					d84 = JITValueDesc{Loc: LocReg, Reg: r70}
-					ctx.BindReg(r70, &d84)
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 56
+					r66 := ctx.AllocReg()
+					ctx.EmitMovRegMem64(r66, fieldAddr)
+					d84 = JITValueDesc{Loc: LocReg, Reg: r66}
+					ctx.BindReg(r66, &d84)
 				} else {
-					off := int32(48)
-					baseReg := d8.Reg
-					r71 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMem(r71, baseReg, off)
-					d84 = JITValueDesc{Loc: LocReg, Reg: r71}
-					ctx.BindReg(r71, &d84)
+					off := int32(56)
+					baseReg := d9.Reg
+					r67 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMem(r67, baseReg, off)
+					d84 = JITValueDesc{Loc: LocReg, Reg: r67}
+					ctx.BindReg(r67, &d84)
 				}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				var d85 JITValueDesc
 				ctx.EnsureDesc(&d84)
 				if d84.Loc == LocImm {
-					fieldAddr := uintptr(d84.Imm.Int()) + 288
-					r72 := ctx.AllocReg()
-					ctx.EmitMovRegMem64(r72, fieldAddr)
-					d85 = JITValueDesc{Loc: LocReg, Reg: r72}
-					ctx.BindReg(r72, &d85)
+					fieldAddr := uintptr(d84.Imm.Int()) + 25
+					r68 := ctx.AllocReg()
+					ctx.EmitMovRegMem8(r68, fieldAddr)
+					d85 = JITValueDesc{Loc: LocReg, Reg: r68}
+					ctx.BindReg(r68, &d85)
 				} else {
-					off := int32(288)
+					off := int32(25)
 					baseReg := d84.Reg
-					r73 := ctx.AllocRegExcept(baseReg)
-					ctx.EmitMovRegMem(r73, baseReg, off)
-					d85 = JITValueDesc{Loc: LocReg, Reg: r73}
-					ctx.BindReg(r73, &d85)
+					r69 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMemB(r69, baseReg, off)
+					d85 = JITValueDesc{Loc: LocReg, Reg: r69}
+					ctx.BindReg(r69, &d85)
 				}
 				ctx.FreeDesc(&d84)
 				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d81)
+				ctx.EnsureDesc(&d79)
+				ctx.EnsureDesc(&d81)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *ProcOptimizerMeta, value TypeInfo) { base.Return = value }), []JITValueDesc{d79, d81})
+				ctx.FreeDesc(&d81)
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d83)
+				ctx.EnsureDesc(&d79)
+				ctx.EnsureDesc(&d83)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *ProcOptimizerMeta, value bool) { base.HasReturn = value }), []JITValueDesc{d79, d83})
+				ctx.FreeDesc(&d83)
+				ctx.ReclaimUntrackedRegs()
 				ctx.EnsureDesc(&d85)
-				var d86 JITValueDesc
-				if d85.Loc == LocImm {
-					d86 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d85.Imm.Int() != 0)}
-				} else {
-					ctx.EmitCmpRegImm32(d85.Reg, 0)
-					r74 := ctx.AllocReg()
-					ctx.EmitSetcc(r74, CondNotEqual)
-					d86 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r74}
-					ctx.BindReg(r74, &d86)
-				}
-				ctx.EnsureDesc(&d86)
-				ctx.EmitStoreToStack(d86, int32(phiBase2)+int32(0))
-				ctx.StabilizeDescForControlFlow(&d86)
+				ctx.EnsureDesc(&d79)
+				ctx.EnsureDesc(&d85)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *ProcOptimizerMeta, value procSequenceKind) { base.Sequence = value }), []JITValueDesc{d79, d85})
 				ctx.FreeDesc(&d85)
+				ctx.ReclaimUntrackedRegs()
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d79)
+				ctx.EnsureDesc(&d9)
+				ctx.EnsureDesc(&d79)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value *ProcOptimizerMeta) { base.OptimizerMeta = value }), []JITValueDesc{d9, d79})
+				ctx.ReclaimUntrackedRegs()
+				ctx.EmitJmp(lbl22)
+				bbpos_1_3 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+				ctx.MarkLabel(lbl4)
+				ctx.ResolveFixups()
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d65 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
+				ctx.ReclaimUntrackedRegs()
+				ctx.ReclaimUntrackedRegs()
+				ctx.ReclaimUntrackedRegs()
+				var d86 JITValueDesc
+				ctx.EnsureDesc(&d9)
+				if d9.Loc == LocImm {
+					fieldAddr := uintptr(d9.Imm.Int()) + 48
+					r70 := ctx.AllocReg()
+					ctx.EmitMovRegMem64(r70, fieldAddr)
+					d86 = JITValueDesc{Loc: LocReg, Reg: r70}
+					ctx.BindReg(r70, &d86)
+				} else {
+					off := int32(48)
+					baseReg := d9.Reg
+					r71 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMem(r71, baseReg, off)
+					d86 = JITValueDesc{Loc: LocReg, Reg: r71}
+					ctx.BindReg(r71, &d86)
+				}
+				ctx.ReclaimUntrackedRegs()
+				ctx.ReclaimUntrackedRegs()
+				var d87 JITValueDesc
+				ctx.EnsureDesc(&d86)
+				if d86.Loc == LocImm {
+					fieldAddr := uintptr(d86.Imm.Int()) + 288
+					r72 := ctx.AllocReg()
+					ctx.EmitMovRegMem64(r72, fieldAddr)
+					d87 = JITValueDesc{Loc: LocReg, Reg: r72}
+					ctx.BindReg(r72, &d87)
+				} else {
+					off := int32(288)
+					baseReg := d86.Reg
+					r73 := ctx.AllocRegExcept(baseReg)
+					ctx.EmitMovRegMem(r73, baseReg, off)
+					d87 = JITValueDesc{Loc: LocReg, Reg: r73}
+					ctx.BindReg(r73, &d87)
+				}
+				ctx.FreeDesc(&d86)
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d87)
+				var d88 JITValueDesc
+				if d87.Loc == LocImm {
+					d88 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d87.Imm.Int() != 0)}
+				} else {
+					ctx.EmitCmpRegImm32(d87.Reg, 0)
+					r74 := ctx.AllocRegExcept(d87.Reg)
+					ctx.EmitSetcc(r74, CondNotEqual)
+					d88 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r74}
+					ctx.BindReg(r74, &d88)
+				}
+				ctx.EnsureDesc(&d88)
+				ctx.EmitStoreToStack(d88, int32(phiBase2)+int32(0))
+				ctx.StabilizeDescForControlFlow(&d88)
+				ctx.FreeDesc(&d87)
 				ctx.ReclaimUntrackedRegs()
 				ctx.EmitJmp(lbl5)
 				bbpos_1_12 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl13)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
-				d64 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d65 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d87 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-				ctx.EnsureDesc(&d8)
-				ctx.EnsureDesc(&d87)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value uintptr) { base.JITCode = value }), []JITValueDesc{d8, d87})
+				d89 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+				ctx.EnsureDesc(&d9)
+				ctx.EnsureDesc(&d89)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value uintptr) { base.JITCode = value }), []JITValueDesc{d9, d89})
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d88 := JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
-				ctx.EnsureDesc(&d8)
-				ctx.EnsureDesc(&d88)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value *JITEntryPoint) { base.Compiled = value }), []JITValueDesc{d8, d88})
+				d90 := JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+				ctx.EnsureDesc(&d9)
+				ctx.EnsureDesc(&d90)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(base *Proc, value *JITEntryPoint) { base.Compiled = value }), []JITValueDesc{d9, d90})
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d8)
-				d89 := d8
-				_ = d89
+				ctx.EnsureDesc(&d9)
+				d91 := d9
+				_ = d91
 				bbpos_4_0 := int32(-1)
 				_ = bbpos_4_0
 				lbl52 := ctx.ReserveLabel()
@@ -2680,128 +2684,128 @@ func init() {
 				ctx.ResolveFixups()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d90 := ctx.EmitGoCallScalar(GoFuncAddr(func() *Proc { return new(Proc) }), nil, 1)
-				ctx.BindReg(d90.Reg, &d90)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d89)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(dst, src *Proc) { *dst = *src }), []JITValueDesc{d90, d89})
-				ctx.ReclaimUntrackedRegs()
-				if d90.Loc == LocRegPair || d90.Loc == LocStackPair || d90.Loc == LocRegTriple || d90.Loc == LocStackTriple {
-					panic("jit: generic call arg expects 1-word value")
-				}
-				ctx.SyncDesc(&d90)
-				d91 := ctx.EmitGoCallScalar(GoFuncAddr(NewProc), []JITValueDesc{d90}, 2)
-				d91.NoHeapPointer = false
-				ctx.BindReg(d91.Reg, &d91)
-				ctx.BindReg(d91.Reg2, &d91)
+				d92 := ctx.EmitGoCallScalar(GoFuncAddr(func() *Proc { return new(Proc) }), nil, 1)
+				ctx.BindReg(d92.Reg, &d92)
 				ctx.ReclaimUntrackedRegs()
 				ctx.EnsureDesc(&d91)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(dst, src *Proc) { *dst = *src }), []JITValueDesc{d92, d91})
 				ctx.ReclaimUntrackedRegs()
-				d92 := JITValueDesc{Loc: LocRegPair, Reg: r33, Reg2: r34}
-				ctx.BindReg(r33, &d92)
-				ctx.BindReg(r34, &d92)
-				ctx.EmitMovPairToResult(&d91, &d92)
+				if d92.Loc == LocRegPair || d92.Loc == LocStackPair || d92.Loc == LocRegTriple || d92.Loc == LocStackTriple {
+					panic("jit: generic call arg expects 1-word value")
+				}
+				ctx.SyncDesc(&d92)
+				d93 := ctx.EmitGoCallScalar(GoFuncAddr(NewProc), []JITValueDesc{d92}, 2)
+				d93.NoHeapPointer = false
+				ctx.BindReg(d93.Reg, &d93)
+				ctx.BindReg(d93.Reg2, &d93)
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d93)
+				ctx.ReclaimUntrackedRegs()
+				d94 := JITValueDesc{Loc: LocRegPair, Reg: r33, Reg2: r34}
+				ctx.BindReg(r33, &d94)
+				ctx.BindReg(r34, &d94)
+				ctx.EmitMovPairToResult(&d93, &d94)
 				ctx.EmitJmp(lbl0)
 				bbpos_1_17 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl18)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
-				d64 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d65 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d65)
+				ctx.EnsureDesc(&d66)
 				ctx.ReclaimUntrackedRegs()
-				d94 := ctx.EmitSliceElementAddress(&d62, &d65, 16)
-				ctx.EnsureDesc(&d94)
-				r75 := ctx.AllocRegExcept(d94.Reg)
-				ctx.EmitMovRegMem(r75, d94.Reg, 8)
-				ctx.EmitMovRegMem(d94.Reg, d94.Reg, 0)
-				d93 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d94.Reg, Reg2: r75}
-				ctx.BindReg(d94.Reg, &d93)
-				ctx.BindReg(r75, &d93)
-				ctx.StabilizeDescForControlFlow(&d93)
-				ctx.ReclaimUntrackedRegs()
-				d93 = JITPrepareScmerGoArg(ctx, d93)
-				ctx.SyncDesc(&d93)
-				d95 := ctx.EmitGoCallScalar(GoFuncAddr((Scmer).IsSymbol), []JITValueDesc{d93}, 1)
-				d95.NoHeapPointer = true
-				ctx.EmitAndRegImm32(d95.Reg, 1)
-				d95.Type = tagBool
-				ctx.BindReg(d95.Reg, &d95)
-				ctx.ReclaimUntrackedRegs()
-				d96 := d95
+				d96 := ctx.EmitSliceElementAddress(&d63, &d66, 16)
 				ctx.EnsureDesc(&d96)
-				if d96.Loc != LocImm && d96.Loc != LocReg {
+				r75 := ctx.AllocRegExcept(d96.Reg)
+				ctx.EmitMovRegMem(r75, d96.Reg, 8)
+				ctx.EmitMovRegMem(d96.Reg, d96.Reg, 0)
+				d95 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d96.Reg, Reg2: r75}
+				ctx.BindReg(d96.Reg, &d95)
+				ctx.BindReg(r75, &d95)
+				ctx.StabilizeDescForControlFlow(&d95)
+				ctx.ReclaimUntrackedRegs()
+				d95 = JITPrepareScmerGoArg(ctx, d95)
+				ctx.SyncDesc(&d95)
+				d97 := ctx.EmitGoCallScalar(GoFuncAddr((Scmer).IsSymbol), []JITValueDesc{d95}, 1)
+				d97.NoHeapPointer = true
+				ctx.EmitAndRegImm32(d97.Reg, 1)
+				d97.Type = tagBool
+				ctx.BindReg(d97.Reg, &d97)
+				ctx.ReclaimUntrackedRegs()
+				d98 := d97
+				ctx.EnsureDesc(&d98)
+				if d98.Loc != LocImm && d98.Loc != LocReg {
 					panic("jit: If condition is neither LocImm nor LocReg")
 				}
 				lbl53 := ctx.ReserveLabel()
 				lbl54 := ctx.ReserveLabel()
-				if d96.Loc == LocImm {
-					if d96.Imm.Bool() {
+				if d98.Loc == LocImm {
+					if d98.Imm.Bool() {
 						ctx.MarkLabel(lbl53)
 						ctx.EmitJmp(lbl19)
 					} else {
 						ctx.MarkLabel(lbl54)
-						ctx.SyncDesc(&d65)
-						if d65.Loc == LocReg {
-							ctx.ProtectReg(d65.Reg)
-						} else if d65.Loc == LocRegPair {
-							ctx.ProtectReg(d65.Reg)
-							ctx.ProtectReg(d65.Reg2)
+						ctx.SyncDesc(&d66)
+						if d66.Loc == LocReg || d66.Loc == LocFPReg {
+							ctx.ProtectReg(d66.Reg)
+						} else if d66.Loc == LocRegPair {
+							ctx.ProtectReg(d66.Reg)
+							ctx.ProtectReg(d66.Reg2)
 						}
-						d97 := d65
-						if d97.Loc == LocNone {
+						d99 := d66
+						if d99.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.EnsureDesc(&d97)
-						ctx.EmitStoreToStack(d97, int32(phiBase2)+int32(16))
-						if d65.Loc == LocReg {
-							ctx.UnprotectReg(d65.Reg)
-						} else if d65.Loc == LocRegPair {
-							ctx.UnprotectReg(d65.Reg)
-							ctx.UnprotectReg(d65.Reg2)
+						ctx.EnsureDesc(&d99)
+						ctx.EmitStoreToStack(d99, int32(phiBase2)+int32(16))
+						if d66.Loc == LocReg || d66.Loc == LocFPReg {
+							ctx.UnprotectReg(d66.Reg)
+						} else if d66.Loc == LocRegPair {
+							ctx.UnprotectReg(d66.Reg)
+							ctx.UnprotectReg(d66.Reg2)
 						}
 						ctx.EmitJmp(lbl17)
 					}
 				} else {
-					ctx.EmitCmpRegImm32(d96.Reg, 0)
+					ctx.EmitCmpRegImm32(d98.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl53)
 					ctx.EmitJmp(lbl54)
 					ctx.MarkLabel(lbl53)
 					ctx.EmitJmp(lbl19)
 					ctx.MarkLabel(lbl54)
-					ctx.SyncDesc(&d65)
-					if d65.Loc == LocReg {
-						ctx.ProtectReg(d65.Reg)
-					} else if d65.Loc == LocRegPair {
-						ctx.ProtectReg(d65.Reg)
-						ctx.ProtectReg(d65.Reg2)
+					ctx.SyncDesc(&d66)
+					if d66.Loc == LocReg || d66.Loc == LocFPReg {
+						ctx.ProtectReg(d66.Reg)
+					} else if d66.Loc == LocRegPair {
+						ctx.ProtectReg(d66.Reg)
+						ctx.ProtectReg(d66.Reg2)
 					}
-					d98 := d65
-					if d98.Loc == LocNone {
+					d100 := d66
+					if d100.Loc == LocNone {
 						panic("jit: phi source has no location")
 					}
-					ctx.EnsureDesc(&d98)
-					ctx.EmitStoreToStack(d98, int32(phiBase2)+int32(16))
-					if d65.Loc == LocReg {
-						ctx.UnprotectReg(d65.Reg)
-					} else if d65.Loc == LocRegPair {
-						ctx.UnprotectReg(d65.Reg)
-						ctx.UnprotectReg(d65.Reg2)
+					ctx.EnsureDesc(&d100)
+					ctx.EmitStoreToStack(d100, int32(phiBase2)+int32(16))
+					if d66.Loc == LocReg || d66.Loc == LocFPReg {
+						ctx.UnprotectReg(d66.Reg)
+					} else if d66.Loc == LocRegPair {
+						ctx.UnprotectReg(d66.Reg)
+						ctx.UnprotectReg(d66.Reg2)
 					}
 					ctx.EmitJmp(lbl17)
 				}
-				ctx.FreeDesc(&d95)
+				ctx.FreeDesc(&d97)
 				bbpos_1_18 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl19)
 				ctx.ResolveFixups()
-				d14 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
-				d64 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
+				d15 = JITValueDesc{Loc: LocStack, Type: tagBool, StackOff: int32(phiBase2) + int32(0)}
+				d65 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase2) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d93)
-				inlineResultOff99 := ctx.AllocStack(int32(16))
-				d100 := JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: inlineResultOff99}
+				ctx.EnsureDesc(&d95)
+				inlineResultOff101 := ctx.AllocStack(int32(16))
+				d102 := JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: inlineResultOff101}
 				lbl55 := ctx.ReserveLabel()
 				bbpos_5_0 := int32(-1)
 				_ = bbpos_5_0
@@ -2820,29 +2824,31 @@ func init() {
 				ctx.ResolveFixups()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d101 := ctx.EmitGetTagDesc(&d93, JITValueDesc{Loc: LocAny})
+				d103 := d95
+				d103.ID = 0
+				d104 := ctx.EmitGetTagDesc(&d103, JITValueDesc{Loc: LocAny})
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d101)
-				var d102 JITValueDesc
-				if d101.Loc == LocImm {
-					d102 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d101.Imm.Int()) != uint64(0x2))}
+				ctx.EnsureDesc(&d104)
+				var d105 JITValueDesc
+				if d104.Loc == LocImm {
+					d105 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d104.Imm.Int()) != uint64(0x2))}
 				} else {
 					r76 := ctx.AllocReg()
-					ctx.EmitCmpRegImm32(d101.Reg, 2)
-					d102 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r76, Condition: CondNotEqual}
-					ctx.BindReg(r76, &d102)
+					ctx.EmitCmpRegImm32(d104.Reg, 2)
+					d105 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r76, Condition: CondNotEqual}
+					ctx.BindReg(r76, &d105)
 				}
-				ctx.FreeDesc(&d101)
+				ctx.FreeDesc(&d104)
 				ctx.ReclaimUntrackedRegs()
-				d103 := d102
-				ctx.EnsureDesc(&d103)
-				if d103.Loc != LocImm && d103.Loc != LocFlags {
+				d106 := d105
+				ctx.EnsureDesc(&d106)
+				if d106.Loc != LocImm && d106.Loc != LocFlags {
 					panic("jit: fused If condition is neither LocImm nor LocFlags")
 				}
 				lbl59 := ctx.ReserveLabel()
 				lbl60 := ctx.ReserveLabel()
-				if d103.Loc == LocImm {
-					if d103.Imm.Bool() {
+				if d106.Loc == LocImm {
+					if d106.Imm.Bool() {
 						ctx.MarkLabel(lbl59)
 						ctx.EmitJmp(lbl57)
 					} else {
@@ -2850,9 +2856,9 @@ func init() {
 						ctx.EmitJmp(lbl58)
 					}
 				} else {
-					ctx.EmitJump(d103.Condition, lbl59)
+					ctx.EmitJump(d106.Condition, lbl59)
 					ctx.EmitJmp(lbl60)
-					ctx.FreeDesc(&d102)
+					ctx.FreeDesc(&d105)
 					ctx.MarkLabel(lbl59)
 					ctx.EmitJmp(lbl57)
 					ctx.MarkLabel(lbl60)
@@ -2863,28 +2869,28 @@ func init() {
 				ctx.ResolveFixups()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d105 := d93
-				ctx.SyncDesc(&d105)
-				if d105.Loc == LocMem {
-					tmpScalar := JITValueDesc{Loc: LocReg, Type: d105.Type, Reg: ctx.AllocReg()}
+				d108 := d95
+				ctx.SyncDesc(&d108)
+				if d108.Loc == LocMem {
+					tmpScalar := JITValueDesc{Loc: LocReg, Type: d108.Type, Reg: ctx.AllocReg()}
 					scratch := ctx.AllocRegExcept(tmpScalar.Reg)
-					ctx.EmitMovRegImm64(scratch, uint64(d105.MemPtr))
+					ctx.EmitMovRegImm64(scratch, uint64(d108.MemPtr))
 					ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
 					ctx.FreeReg(scratch)
 					ctx.BindReg(tmpScalar.Reg, &tmpScalar)
-					d105 = tmpScalar
+					d108 = tmpScalar
 				}
-				d105 = JITPrepareScmerGoArg(ctx, d105)
-				if d105.Loc != LocRegPair && d105.Loc != LocStackPair && d105.Loc != LocInputPair {
+				d108 = JITPrepareScmerGoArg(ctx, d108)
+				if d108.Loc != LocRegPair && d108.Loc != LocStackPair && d108.Loc != LocInputPair {
 					panic("jit: Scmer.String receiver not materialized as pair")
 				}
-				d104 := ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d105}, 2)
-				ctx.FreeDesc(&d93)
+				d107 := ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d108}, 2)
+				ctx.FreeDesc(&d95)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d104)
+				ctx.EnsureDesc(&d107)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d104)
-				ctx.EmitCopyDescWords(&d100, &d104, 2)
+				ctx.EnsureDesc(&d107)
+				ctx.EmitCopyDescWords(&d102, &d107, 2)
 				ctx.EmitJmp(lbl55)
 				bbpos_5_1 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl57)
@@ -2893,41 +2899,41 @@ func init() {
 				ctx.EmitGoPanic("jit: invalid arguments for inlined Go helper")
 				ctx.MarkLabel(lbl55)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d25)
-				ctx.EnsureDesc(&d100)
-				d106 := JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
-				ctx.EmitGoCallVoid(GoFuncAddr(func(m map[Symbol]struct{}, key Symbol, value struct{}) { m[key] = value }), []JITValueDesc{d25, d100, d106})
+				ctx.EnsureDesc(&d26)
+				ctx.EnsureDesc(&d102)
+				d109 := JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+				ctx.EmitGoCallVoid(GoFuncAddr(func(m map[Symbol]struct{}, key Symbol, value struct{}) { m[key] = value }), []JITValueDesc{d26, d102, d109})
 				ctx.ReclaimUntrackedRegs()
-				ctx.SyncDesc(&d65)
-				if d65.Loc == LocReg {
-					ctx.ProtectReg(d65.Reg)
-				} else if d65.Loc == LocRegPair {
-					ctx.ProtectReg(d65.Reg)
-					ctx.ProtectReg(d65.Reg2)
+				ctx.SyncDesc(&d66)
+				if d66.Loc == LocReg || d66.Loc == LocFPReg {
+					ctx.ProtectReg(d66.Reg)
+				} else if d66.Loc == LocRegPair {
+					ctx.ProtectReg(d66.Reg)
+					ctx.ProtectReg(d66.Reg2)
 				}
-				d107 := d65
-				if d107.Loc == LocNone {
+				d110 := d66
+				if d110.Loc == LocNone {
 					panic("jit: phi source has no location")
 				}
-				ctx.EnsureDesc(&d107)
-				ctx.EmitStoreToStack(d107, int32(phiBase2)+int32(16))
-				if d65.Loc == LocReg {
-					ctx.UnprotectReg(d65.Reg)
-				} else if d65.Loc == LocRegPair {
-					ctx.UnprotectReg(d65.Reg)
-					ctx.UnprotectReg(d65.Reg2)
+				ctx.EnsureDesc(&d110)
+				ctx.EmitStoreToStack(d110, int32(phiBase2)+int32(16))
+				if d66.Loc == LocReg || d66.Loc == LocFPReg {
+					ctx.UnprotectReg(d66.Reg)
+				} else if d66.Loc == LocRegPair {
+					ctx.UnprotectReg(d66.Reg)
+					ctx.UnprotectReg(d66.Reg2)
 				}
 				ctx.EmitJmp(lbl17)
 				ctx.MarkLabel(lbl0)
-				d108 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: r33, Reg2: r34}
-				ctx.BindReg(r33, &d108)
-				ctx.BindReg(r34, &d108)
-				ctx.BindReg(r33, &d108)
-				ctx.BindReg(r34, &d108)
+				d111 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: r33, Reg2: r34}
+				ctx.BindReg(r33, &d111)
+				ctx.BindReg(r34, &d111)
+				ctx.BindReg(r33, &d111)
+				ctx.BindReg(r34, &d111)
 				ctx.FreeDesc(&d0)
-				if d108.Loc == LocImm {
+				if d111.Loc == LocImm {
 					if result.Loc == LocAny {
-						return d108
+						return d111
 					}
 				}
 				if result.Loc == LocAny {
@@ -2935,20 +2941,20 @@ func init() {
 					ctx.BindReg(result.Reg, &result)
 					ctx.BindReg(result.Reg2, &result)
 				}
-				ctx.SyncDesc(&d108)
-				if d108.Loc == LocRegPair || d108.Loc == LocStackPair || d108.Loc == LocInputPair {
-					ctx.EmitMovPairToResult(&d108, &result)
-					result.Type = d108.Type
+				ctx.SyncDesc(&d111)
+				if d111.Loc == LocRegPair || d111.Loc == LocStackPair || d111.Loc == LocInputPair {
+					ctx.EmitMovPairToResult(&d111, &result)
+					result.Type = d111.Type
 				} else {
-					switch d108.Type {
+					switch d111.Type {
 					case tagBool:
-						ctx.EmitMakeBool(result, d108)
+						ctx.EmitMakeBool(result, d111)
 						result.Type = tagBool
 					case tagInt:
-						ctx.EmitMakeInt(result, d108)
+						ctx.EmitMakeInt(result, d111)
 						result.Type = tagInt
 					case tagFloat:
-						ctx.EmitMakeFloat(result, d108)
+						ctx.EmitMakeFloat(result, d111)
 						result.Type = tagFloat
 					case tagNil:
 						ctx.EmitMakeNil(result)
@@ -3314,7 +3320,7 @@ func init() {
 					ctx.FreeDesc(&d25)
 					if ps.General {
 						ctx.SyncDesc(&d26)
-						if d26.Loc == LocReg {
+						if d26.Loc == LocReg || d26.Loc == LocFPReg {
 							ctx.ProtectReg(d26.Reg)
 						} else if d26.Loc == LocRegPair {
 							ctx.ProtectReg(d26.Reg)
@@ -3326,7 +3332,7 @@ func init() {
 						}
 						ctx.EnsureDesc(&d27)
 						ctx.EmitStoreToStack(d27, int32(bbs[2].PhiBase)+int32(0))
-						if d26.Loc == LocReg {
+						if d26.Loc == LocReg || d26.Loc == LocFPReg {
 							ctx.UnprotectReg(d26.Reg)
 						} else if d26.Loc == LocRegPair {
 							ctx.UnprotectReg(d26.Reg)
@@ -4326,7 +4332,7 @@ func init() {
 					_ = d64
 					if ps.General {
 						ctx.SyncDesc(&d24)
-						if d24.Loc == LocReg {
+						if d24.Loc == LocReg || d24.Loc == LocFPReg {
 							ctx.ProtectReg(d24.Reg)
 						} else if d24.Loc == LocRegPair {
 							ctx.ProtectReg(d24.Reg)
@@ -4338,7 +4344,7 @@ func init() {
 						}
 						ctx.EnsureDesc(&d65)
 						ctx.EmitStoreToStack(d65, int32(bbs[3].PhiBase)+int32(0))
-						if d24.Loc == LocReg {
+						if d24.Loc == LocReg || d24.Loc == LocFPReg {
 							ctx.UnprotectReg(d24.Reg)
 						} else if d24.Loc == LocRegPair {
 							ctx.UnprotectReg(d24.Reg)
@@ -4854,30 +4860,32 @@ func init() {
 					ctx.BindReg(r4, &d13)
 				}
 				ctx.ReclaimUntrackedRegs()
-				d14 := ctx.EmitGetTagDesc(&d13, JITValueDesc{Loc: LocAny})
+				d14 := d13
+				d14.ID = 0
+				d15 := ctx.EmitGetTagDesc(&d14, JITValueDesc{Loc: LocAny})
 				ctx.FreeDesc(&d13)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d14)
-				var d15 JITValueDesc
-				if d14.Loc == LocImm {
-					d15 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d14.Imm.Int()) == uint64(0x6))}
+				ctx.EnsureDesc(&d15)
+				var d16 JITValueDesc
+				if d15.Loc == LocImm {
+					d16 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d15.Imm.Int()) == uint64(0x6))}
 				} else {
 					r5 := ctx.AllocReg()
-					ctx.EmitCmpRegImm32(d14.Reg, 6)
-					d15 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r5, Condition: CondEqual}
-					ctx.BindReg(r5, &d15)
+					ctx.EmitCmpRegImm32(d15.Reg, 6)
+					d16 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r5, Condition: CondEqual}
+					ctx.BindReg(r5, &d16)
 				}
-				ctx.FreeDesc(&d14)
+				ctx.FreeDesc(&d15)
 				ctx.ReclaimUntrackedRegs()
-				d16 := d15
-				ctx.EnsureDesc(&d16)
-				if d16.Loc != LocImm && d16.Loc != LocFlags {
+				d17 := d16
+				ctx.EnsureDesc(&d17)
+				if d17.Loc != LocImm && d17.Loc != LocFlags {
 					panic("jit: fused If condition is neither LocImm nor LocFlags")
 				}
 				lbl19 := ctx.ReserveLabel()
 				lbl20 := ctx.ReserveLabel()
-				if d16.Loc == LocImm {
-					if d16.Imm.Bool() {
+				if d17.Loc == LocImm {
+					if d17.Imm.Bool() {
 						ctx.MarkLabel(lbl19)
 						ctx.EmitJmp(lbl6)
 					} else {
@@ -4885,9 +4893,9 @@ func init() {
 						ctx.EmitJmp(lbl7)
 					}
 				} else {
-					ctx.EmitJump(d16.Condition, lbl19)
+					ctx.EmitJump(d17.Condition, lbl19)
 					ctx.EmitJmp(lbl20)
-					ctx.FreeDesc(&d15)
+					ctx.FreeDesc(&d16)
 					ctx.MarkLabel(lbl19)
 					ctx.EmitJmp(lbl6)
 					ctx.MarkLabel(lbl20)
@@ -4915,7 +4923,7 @@ func init() {
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				var d17 JITValueDesc
+				var d18 JITValueDesc
 				ctx.EnsureDesc(&d10)
 				if d10.Loc == LocImm {
 					fieldAddr := uintptr(d10.Imm.Int()) + 8
@@ -4923,9 +4931,9 @@ func init() {
 					r7 := ctx.AllocRegExcept(r6)
 					ctx.EmitMovRegMem64(r6, fieldAddr)
 					ctx.EmitMovRegMem64(r7, fieldAddr+8)
-					d17 = JITValueDesc{Loc: LocRegPair, Reg: r6, Reg2: r7}
-					ctx.BindReg(r6, &d17)
-					ctx.BindReg(r7, &d17)
+					d18 = JITValueDesc{Loc: LocRegPair, Reg: r6, Reg2: r7}
+					ctx.BindReg(r6, &d18)
+					ctx.BindReg(r7, &d18)
 				} else {
 					off := int32(8)
 					baseReg := d10.Reg
@@ -4933,62 +4941,62 @@ func init() {
 					r9 := ctx.AllocRegExcept(baseReg, r8)
 					ctx.EmitMovRegMem(r8, baseReg, off)
 					ctx.EmitMovRegMem(r9, baseReg, off+8)
-					d17 = JITValueDesc{Loc: LocRegPair, Reg: r8, Reg2: r9}
-					ctx.BindReg(r8, &d17)
-					ctx.BindReg(r9, &d17)
+					d18 = JITValueDesc{Loc: LocRegPair, Reg: r8, Reg2: r9}
+					ctx.BindReg(r8, &d18)
+					ctx.BindReg(r9, &d18)
 				}
 				ctx.ReclaimUntrackedRegs()
-				d18 := jitKnownSliceHeader(ctx, &d17)
-				ctx.StabilizeDescForControlFlow(&d18)
-				ctx.FreeDesc(&d17)
+				d19 := jitKnownSliceHeader(ctx, &d18)
+				ctx.StabilizeDescForControlFlow(&d19)
+				ctx.FreeDesc(&d18)
 				ctx.ReclaimUntrackedRegs()
-				var d19 JITValueDesc
-				if d18.SliceSizeKnown {
-					d19 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d18.KnownSliceLen))}
-				} else if d18.Loc == LocImm {
-					d19 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d18.StackOff))}
-				} else if d18.Loc == LocStackTriple {
-					d19 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d18.StackOff + 8, NoHeapPointer: true}
+				var d20 JITValueDesc
+				if d19.SliceSizeKnown {
+					d20 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.KnownSliceLen))}
+				} else if d19.Loc == LocImm {
+					d20 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.StackOff))}
+				} else if d19.Loc == LocStackTriple {
+					d20 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d19.StackOff + 8, NoHeapPointer: true}
 				} else {
-					ctx.EnsureDesc(&d18)
-					if d18.Loc == LocRegPair || d18.Loc == LocRegTriple {
-						d19 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d18.Reg2, ID: 0}
-					} else if d18.Loc == LocReg {
-						d19 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d18.Reg, ID: 0}
+					ctx.EnsureDesc(&d19)
+					if d19.Loc == LocRegPair || d19.Loc == LocRegTriple {
+						d20 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg2, ID: 0}
+					} else if d19.Loc == LocReg {
+						d20 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg, ID: 0}
 					} else {
 						panic("len on unsupported descriptor location")
 					}
 				}
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d19)
-				ctx.EnsureDesc(&d19)
+				ctx.EnsureDesc(&d20)
+				ctx.EnsureDesc(&d20)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d19)
-				ctx.EnsureDesc(&d19)
-				callResults20 := JITEmitGoCallResults(ctx, GoFuncAddr(jitMakeScmerSlice), []JITValueDesc{d19, d19}, []uint8{3}, []uint8{1})
-				d21 := callResults20[0]
-				d21.Type = tagSlice
-				ctx.StabilizeDescForControlFlow(&d21)
-				ctx.FreeDesc(&d19)
-				ctx.ReclaimUntrackedRegs()
-				var d22 JITValueDesc
-				if d18.SliceSizeKnown {
-					d22 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d18.KnownSliceLen))}
-				} else if d18.Loc == LocImm {
-					d22 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d18.StackOff))}
-				} else if d18.Loc == LocStackTriple {
-					d22 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d18.StackOff + 8, NoHeapPointer: true}
-				} else {
-					ctx.EnsureDesc(&d18)
-					if d18.Loc == LocRegPair || d18.Loc == LocRegTriple {
-						d22 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d18.Reg2, ID: 0}
-					} else if d18.Loc == LocReg {
-						d22 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d18.Reg, ID: 0}
-					} else {
-						panic("len on unsupported descriptor location")
-					}
-				}
+				ctx.EnsureDesc(&d20)
+				ctx.EnsureDesc(&d20)
+				callResults21 := JITEmitGoCallResults(ctx, GoFuncAddr(jitMakeScmerSlice), []JITValueDesc{d20, d20}, []uint8{3}, []uint8{1})
+				d22 := callResults21[0]
+				d22.Type = tagSlice
 				ctx.StabilizeDescForControlFlow(&d22)
+				ctx.FreeDesc(&d20)
+				ctx.ReclaimUntrackedRegs()
+				var d23 JITValueDesc
+				if d19.SliceSizeKnown {
+					d23 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.KnownSliceLen))}
+				} else if d19.Loc == LocImm {
+					d23 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d19.StackOff))}
+				} else if d19.Loc == LocStackTriple {
+					d23 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d19.StackOff + 8, NoHeapPointer: true}
+				} else {
+					ctx.EnsureDesc(&d19)
+					if d19.Loc == LocRegPair || d19.Loc == LocRegTriple {
+						d23 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg2, ID: 0}
+					} else if d19.Loc == LocReg {
+						d23 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d19.Reg, ID: 0}
+					} else {
+						panic("len on unsupported descriptor location")
+					}
+				}
+				ctx.StabilizeDescForControlFlow(&d23)
 				ctx.ReclaimUntrackedRegs()
 				ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(phiBase5)+int32(0))
 				bbpos_1_7 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
@@ -4998,65 +5006,65 @@ func init() {
 				d7 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d23 := JITValueDesc{Loc: LocStack, Type: JITTypeUnknown, StackOff: int32(phiBase5) + int32(0)}
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d23)
-				ctx.EnsureDesc(&d23)
-				var d24 JITValueDesc
-				if d23.Loc == LocImm {
-					d24 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d23.Imm.Int() + 1)}
-				} else {
-					scratch := ctx.AllocRegExcept(d23.Reg)
-					ctx.EmitMovRegReg(scratch, d23.Reg)
-					ctx.EmitAddRegImm32(scratch, int32(1))
-					d24 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-					ctx.BindReg(scratch, &d24)
-				}
-				if d24.Loc == LocReg && d23.Loc == LocReg && d24.Reg == d23.Reg {
-					ctx.TransferReg(d23.Reg)
-					d23.Loc = LocNone
-				}
-				ctx.StabilizeDescForControlFlow(&d24)
-				ctx.FreeDesc(&d23)
+				d24 := JITValueDesc{Loc: LocStack, Type: JITTypeUnknown, StackOff: int32(phiBase5) + int32(0)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.EnsureDesc(&d24)
-				ctx.EnsureDesc(&d22)
-				ctx.EnsureDescsTogether(&d24, &d22)
+				ctx.EnsureDesc(&d24)
 				var d25 JITValueDesc
-				if d24.Loc == LocImm && d22.Loc == LocImm {
-					d25 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d24.Imm.Int() < d22.Imm.Int())}
-				} else if d22.Loc == LocImm {
-					r10 := ctx.AllocRegExcept(d24.Reg)
-					if d22.Imm.Int() >= -2147483648 && d22.Imm.Int() <= 2147483647 {
-						ctx.EmitCmpRegImm32(d24.Reg, int32(d22.Imm.Int()))
-					} else {
-						ctx.EmitMovRegImm64(RegR11, uint64(d22.Imm.Int()))
-						ctx.EmitCmpInt64(d24.Reg, RegR11)
-					}
-					d25 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r10, Condition: CondSignedLess}
-					ctx.BindReg(r10, &d25)
-				} else if d24.Loc == LocImm {
-					r11 := ctx.AllocReg()
-					ctx.EmitMovRegImm64(RegR11, uint64(d24.Imm.Int()))
-					ctx.EmitCmpInt64(RegR11, d22.Reg)
-					d25 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r11, Condition: CondSignedLess}
-					ctx.BindReg(r11, &d25)
+				if d24.Loc == LocImm {
+					d25 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d24.Imm.Int() + 1)}
 				} else {
-					r12 := ctx.AllocRegExcept(d24.Reg)
-					ctx.EmitCmpInt64(d24.Reg, d22.Reg)
-					d25 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r12, Condition: CondSignedLess}
-					ctx.BindReg(r12, &d25)
+					scratch := ctx.AllocRegExcept(d24.Reg)
+					ctx.EmitMovRegReg(scratch, d24.Reg)
+					ctx.EmitAddRegImm32(scratch, int32(1))
+					d25 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+					ctx.BindReg(scratch, &d25)
+				}
+				if d25.Loc == LocReg && d24.Loc == LocReg && d25.Reg == d24.Reg {
+					ctx.TransferReg(d24.Reg)
+					d24.Loc = LocNone
+				}
+				ctx.StabilizeDescForControlFlow(&d25)
+				ctx.FreeDesc(&d24)
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d25)
+				ctx.EnsureDesc(&d23)
+				ctx.EnsureDescsTogether(&d25, &d23)
+				var d26 JITValueDesc
+				if d25.Loc == LocImm && d23.Loc == LocImm {
+					d26 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d25.Imm.Int() < d23.Imm.Int())}
+				} else if d23.Loc == LocImm {
+					r10 := ctx.AllocRegExcept(d25.Reg)
+					if d23.Imm.Int() >= -2147483648 && d23.Imm.Int() <= 2147483647 {
+						ctx.EmitCmpRegImm32(d25.Reg, int32(d23.Imm.Int()))
+					} else {
+						ctx.EmitMovRegImm64(RegR11, uint64(d23.Imm.Int()))
+						ctx.EmitCmpInt64(d25.Reg, RegR11)
+					}
+					d26 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r10, Condition: CondSignedLess}
+					ctx.BindReg(r10, &d26)
+				} else if d25.Loc == LocImm {
+					r11 := ctx.AllocReg()
+					ctx.EmitMovRegImm64(RegR11, uint64(d25.Imm.Int()))
+					ctx.EmitCmpInt64(RegR11, d23.Reg)
+					d26 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r11, Condition: CondSignedLess}
+					ctx.BindReg(r11, &d26)
+				} else {
+					r12 := ctx.AllocRegExcept(d25.Reg)
+					ctx.EmitCmpInt64(d25.Reg, d23.Reg)
+					d26 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r12, Condition: CondSignedLess}
+					ctx.BindReg(r12, &d26)
 				}
 				ctx.ReclaimUntrackedRegs()
-				d26 := d25
-				ctx.EnsureDesc(&d26)
-				if d26.Loc != LocImm && d26.Loc != LocFlags {
+				d27 := d26
+				ctx.EnsureDesc(&d27)
+				if d27.Loc != LocImm && d27.Loc != LocFlags {
 					panic("jit: fused If condition is neither LocImm nor LocFlags")
 				}
 				lbl21 := ctx.ReserveLabel()
 				lbl22 := ctx.ReserveLabel()
-				if d26.Loc == LocImm {
-					if d26.Imm.Bool() {
+				if d27.Loc == LocImm {
+					if d27.Imm.Bool() {
 						ctx.MarkLabel(lbl21)
 						ctx.EmitJmp(lbl9)
 					} else {
@@ -5064,9 +5072,9 @@ func init() {
 						ctx.EmitJmp(lbl10)
 					}
 				} else {
-					ctx.EmitJump(d26.Condition, lbl21)
+					ctx.EmitJump(d27.Condition, lbl21)
 					ctx.EmitJmp(lbl22)
-					ctx.FreeDesc(&d25)
+					ctx.FreeDesc(&d26)
 					ctx.MarkLabel(lbl21)
 					ctx.EmitJmp(lbl9)
 					ctx.MarkLabel(lbl22)
@@ -5075,16 +5083,16 @@ func init() {
 				bbpos_1_9 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl10)
 				ctx.ResolveFixups()
-				d23 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
+				d24 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
 				d7 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
 				ctx.EnsureDesc(&d3)
-				ctx.EnsureDesc(&d21)
-				d27 := d3
-				_ = d27
-				d28 := d21
+				ctx.EnsureDesc(&d22)
+				d28 := d3
 				_ = d28
+				d29 := d22
+				_ = d29
 				bbpos_2_0 := int32(-1)
 				_ = bbpos_2_0
 				lbl23 := ctx.ReserveLabel()
@@ -5094,234 +5102,234 @@ func init() {
 				ctx.ResolveFixups()
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d27 = JITPrepareScmerGoArg(ctx, d27)
-				d28 = JITPrepareGoSliceArg(ctx, d28)
-				if d28.Loc != LocRegTriple && d28.Loc != LocStackTriple {
+				d28 = JITPrepareScmerGoArg(ctx, d28)
+				d29 = JITPrepareGoSliceArg(ctx, d29)
+				if d29.Loc != LocRegTriple && d29.Loc != LocStackTriple {
 					panic("jit: generic call arg expects 3-word Go slice (ApplyEx arg1)")
 				}
-				d29 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(unsafe.Pointer(&Globalenv)))), NoHeapPointer: true, Rooted: true}
-				if d29.Loc == LocRegPair || d29.Loc == LocStackPair || d29.Loc == LocRegTriple || d29.Loc == LocStackTriple {
+				d30 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(unsafe.Pointer(&Globalenv)))), NoHeapPointer: true, Rooted: true}
+				if d30.Loc == LocRegPair || d30.Loc == LocStackPair || d30.Loc == LocRegTriple || d30.Loc == LocStackTriple {
 					panic("jit: generic call arg expects 1-word value")
 				}
-				ctx.SyncDesc(&d27)
 				ctx.SyncDesc(&d28)
 				ctx.SyncDesc(&d29)
-				d30 := ctx.EmitGoCallScalar(GoFuncAddr(ApplyEx), []JITValueDesc{d27, d28, d29}, 2)
-				d30.NoHeapPointer = false
-				ctx.BindReg(d30.Reg, &d30)
-				ctx.BindReg(d30.Reg2, &d30)
+				ctx.SyncDesc(&d30)
+				d31 := ctx.EmitGoCallScalar(GoFuncAddr(ApplyEx), []JITValueDesc{d28, d29, d30}, 2)
+				d31.NoHeapPointer = false
+				ctx.BindReg(d31.Reg, &d31)
+				ctx.BindReg(d31.Reg2, &d31)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d30)
+				ctx.EnsureDesc(&d31)
 				ctx.ReclaimUntrackedRegs()
 				r13 := ctx.AllocReg()
 				r14 := ctx.AllocRegExcept(r13)
-				d31 := JITValueDesc{Loc: LocRegPair, Reg: r13, Reg2: r14}
-				ctx.BindReg(r13, &d31)
-				ctx.BindReg(r14, &d31)
-				ctx.EmitMovPairToResult(&d30, &d31)
+				d32 := JITValueDesc{Loc: LocRegPair, Reg: r13, Reg2: r14}
+				ctx.BindReg(r13, &d32)
+				ctx.BindReg(r14, &d32)
+				ctx.EmitMovPairToResult(&d31, &d32)
 				ctx.EmitJmp(lbl0)
 				bbpos_1_8 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl9)
 				ctx.ResolveFixups()
-				d23 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
+				d24 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
 				d7 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d24)
+				ctx.EnsureDesc(&d25)
 				ctx.ReclaimUntrackedRegs()
-				d33 := ctx.EmitSliceElementAddress(&d18, &d24, 16)
-				ctx.EnsureDesc(&d33)
-				r15 := ctx.AllocRegExcept(d33.Reg)
-				ctx.EmitMovRegMem(r15, d33.Reg, 8)
-				ctx.EmitMovRegMem(d33.Reg, d33.Reg, 0)
-				d32 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d33.Reg, Reg2: r15}
-				ctx.BindReg(d33.Reg, &d32)
-				ctx.BindReg(r15, &d32)
+				d34 := ctx.EmitSliceElementAddress(&d19, &d25, 16)
+				ctx.EnsureDesc(&d34)
+				r15 := ctx.AllocRegExcept(d34.Reg)
+				ctx.EmitMovRegMem(r15, d34.Reg, 8)
+				ctx.EmitMovRegMem(d34.Reg, d34.Reg, 0)
+				d33 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d34.Reg, Reg2: r15}
+				ctx.BindReg(d34.Reg, &d33)
+				ctx.BindReg(r15, &d33)
 				ctx.ReclaimUntrackedRegs()
-				d32 = JITPrepareScmerGoArg(ctx, d32)
-				ctx.SyncDesc(&d32)
-				d34 := ctx.EmitGoCallScalar(GoFuncAddr(mustSymbol), []JITValueDesc{d32}, 2)
-				d34.NoHeapPointer = false
-				ctx.BindReg(d34.Reg, &d34)
-				ctx.BindReg(d34.Reg2, &d34)
-				ctx.StabilizeDescForControlFlow(&d34)
-				ctx.FreeDesc(&d32)
+				d33 = JITPrepareScmerGoArg(ctx, d33)
+				ctx.SyncDesc(&d33)
+				d35 := ctx.EmitGoCallScalar(GoFuncAddr(mustSymbol), []JITValueDesc{d33}, 2)
+				d35.NoHeapPointer = false
+				ctx.BindReg(d35.Reg, &d35)
+				ctx.BindReg(d35.Reg2, &d35)
+				ctx.StabilizeDescForControlFlow(&d35)
+				ctx.FreeDesc(&d33)
 				ctx.ReclaimUntrackedRegs()
 				ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(phiBase5)+int32(16))
 				bbpos_1_10 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl11)
 				ctx.ResolveFixups()
-				d23 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
+				d24 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
 				d7 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				d35 := JITValueDesc{Loc: LocStack, Type: JITTypeUnknown, StackOff: int32(phiBase5) + int32(16)}
-				ctx.StabilizeDescForControlFlow(&d35)
+				d36 := JITValueDesc{Loc: LocStack, Type: JITTypeUnknown, StackOff: int32(phiBase5) + int32(16)}
+				ctx.StabilizeDescForControlFlow(&d36)
 				ctx.ReclaimUntrackedRegs()
-				var d36 JITValueDesc
+				var d37 JITValueDesc
 				if d4.SliceSizeKnown {
-					d36 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d4.KnownSliceLen))}
+					d37 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d4.KnownSliceLen))}
 				} else if d4.Loc == LocImm {
-					d36 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d4.StackOff))}
+					d37 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d4.StackOff))}
 				} else if d4.Loc == LocStackTriple {
-					d36 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d4.StackOff + 8, NoHeapPointer: true}
+					d37 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d4.StackOff + 8, NoHeapPointer: true}
 				} else {
 					ctx.EnsureDesc(&d4)
 					if d4.Loc == LocRegPair || d4.Loc == LocRegTriple {
-						d36 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d4.Reg2, ID: 0}
+						d37 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d4.Reg2, ID: 0}
 					} else if d4.Loc == LocReg {
-						d36 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d4.Reg, ID: 0}
+						d37 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d4.Reg, ID: 0}
 					} else {
 						panic("len on unsupported descriptor location")
 					}
 				}
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d35)
 				ctx.EnsureDesc(&d36)
-				ctx.EnsureDescsTogether(&d35, &d36)
-				var d37 JITValueDesc
-				if d35.Loc == LocImm && d36.Loc == LocImm {
-					d37 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d35.Imm.Int() < d36.Imm.Int())}
-				} else if d36.Loc == LocImm {
-					r16 := ctx.AllocRegExcept(d35.Reg)
-					if d36.Imm.Int() >= -2147483648 && d36.Imm.Int() <= 2147483647 {
-						ctx.EmitCmpRegImm32(d35.Reg, int32(d36.Imm.Int()))
+				ctx.EnsureDesc(&d37)
+				ctx.EnsureDescsTogether(&d36, &d37)
+				var d38 JITValueDesc
+				if d36.Loc == LocImm && d37.Loc == LocImm {
+					d38 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d36.Imm.Int() < d37.Imm.Int())}
+				} else if d37.Loc == LocImm {
+					r16 := ctx.AllocRegExcept(d36.Reg)
+					if d37.Imm.Int() >= -2147483648 && d37.Imm.Int() <= 2147483647 {
+						ctx.EmitCmpRegImm32(d36.Reg, int32(d37.Imm.Int()))
 					} else {
-						ctx.EmitMovRegImm64(RegR11, uint64(d36.Imm.Int()))
-						ctx.EmitCmpInt64(d35.Reg, RegR11)
+						ctx.EmitMovRegImm64(RegR11, uint64(d37.Imm.Int()))
+						ctx.EmitCmpInt64(d36.Reg, RegR11)
 					}
-					d37 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r16, Condition: CondSignedLess}
-					ctx.BindReg(r16, &d37)
-				} else if d35.Loc == LocImm {
+					d38 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r16, Condition: CondSignedLess}
+					ctx.BindReg(r16, &d38)
+				} else if d36.Loc == LocImm {
 					r17 := ctx.AllocReg()
-					ctx.EmitMovRegImm64(RegR11, uint64(d35.Imm.Int()))
-					ctx.EmitCmpInt64(RegR11, d36.Reg)
-					d37 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r17, Condition: CondSignedLess}
-					ctx.BindReg(r17, &d37)
+					ctx.EmitMovRegImm64(RegR11, uint64(d36.Imm.Int()))
+					ctx.EmitCmpInt64(RegR11, d37.Reg)
+					d38 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r17, Condition: CondSignedLess}
+					ctx.BindReg(r17, &d38)
 				} else {
-					r18 := ctx.AllocRegExcept(d35.Reg)
-					ctx.EmitCmpInt64(d35.Reg, d36.Reg)
-					d37 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r18, Condition: CondSignedLess}
-					ctx.BindReg(r18, &d37)
+					r18 := ctx.AllocRegExcept(d36.Reg)
+					ctx.EmitCmpInt64(d36.Reg, d37.Reg)
+					d38 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r18, Condition: CondSignedLess}
+					ctx.BindReg(r18, &d38)
 				}
-				ctx.FreeDesc(&d36)
+				ctx.FreeDesc(&d37)
 				ctx.ReclaimUntrackedRegs()
-				d38 := d37
-				ctx.EnsureDesc(&d38)
-				if d38.Loc != LocImm && d38.Loc != LocFlags {
+				d39 := d38
+				ctx.EnsureDesc(&d39)
+				if d39.Loc != LocImm && d39.Loc != LocFlags {
 					panic("jit: fused If condition is neither LocImm nor LocFlags")
 				}
 				lbl24 := ctx.ReserveLabel()
 				lbl25 := ctx.ReserveLabel()
-				if d38.Loc == LocImm {
-					if d38.Imm.Bool() {
+				if d39.Loc == LocImm {
+					if d39.Imm.Bool() {
 						ctx.MarkLabel(lbl24)
 						ctx.EmitJmp(lbl12)
 					} else {
 						ctx.MarkLabel(lbl25)
-						ctx.SyncDesc(&d24)
-						if d24.Loc == LocReg {
-							ctx.ProtectReg(d24.Reg)
-						} else if d24.Loc == LocRegPair {
-							ctx.ProtectReg(d24.Reg)
-							ctx.ProtectReg(d24.Reg2)
+						ctx.SyncDesc(&d25)
+						if d25.Loc == LocReg || d25.Loc == LocFPReg {
+							ctx.ProtectReg(d25.Reg)
+						} else if d25.Loc == LocRegPair {
+							ctx.ProtectReg(d25.Reg)
+							ctx.ProtectReg(d25.Reg2)
 						}
-						d39 := d24
-						if d39.Loc == LocNone {
+						d40 := d25
+						if d40.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.EnsureDesc(&d39)
-						ctx.EmitStoreToStack(d39, int32(phiBase5)+int32(0))
-						if d24.Loc == LocReg {
-							ctx.UnprotectReg(d24.Reg)
-						} else if d24.Loc == LocRegPair {
-							ctx.UnprotectReg(d24.Reg)
-							ctx.UnprotectReg(d24.Reg2)
+						ctx.EnsureDesc(&d40)
+						ctx.EmitStoreToStack(d40, int32(phiBase5)+int32(0))
+						if d25.Loc == LocReg || d25.Loc == LocFPReg {
+							ctx.UnprotectReg(d25.Reg)
+						} else if d25.Loc == LocRegPair {
+							ctx.UnprotectReg(d25.Reg)
+							ctx.UnprotectReg(d25.Reg2)
 						}
 						ctx.EmitJmp(lbl8)
 					}
 				} else {
-					ctx.EmitJump(d38.Condition, lbl24)
+					ctx.EmitJump(d39.Condition, lbl24)
 					ctx.EmitJmp(lbl25)
-					ctx.FreeDesc(&d37)
+					ctx.FreeDesc(&d38)
 					ctx.MarkLabel(lbl24)
 					ctx.EmitJmp(lbl12)
 					ctx.MarkLabel(lbl25)
-					ctx.SyncDesc(&d24)
-					if d24.Loc == LocReg {
-						ctx.ProtectReg(d24.Reg)
-					} else if d24.Loc == LocRegPair {
-						ctx.ProtectReg(d24.Reg)
-						ctx.ProtectReg(d24.Reg2)
+					ctx.SyncDesc(&d25)
+					if d25.Loc == LocReg || d25.Loc == LocFPReg {
+						ctx.ProtectReg(d25.Reg)
+					} else if d25.Loc == LocRegPair {
+						ctx.ProtectReg(d25.Reg)
+						ctx.ProtectReg(d25.Reg2)
 					}
-					d40 := d24
-					if d40.Loc == LocNone {
+					d41 := d25
+					if d41.Loc == LocNone {
 						panic("jit: phi source has no location")
 					}
-					ctx.EnsureDesc(&d40)
-					ctx.EmitStoreToStack(d40, int32(phiBase5)+int32(0))
-					if d24.Loc == LocReg {
-						ctx.UnprotectReg(d24.Reg)
-					} else if d24.Loc == LocRegPair {
-						ctx.UnprotectReg(d24.Reg)
-						ctx.UnprotectReg(d24.Reg2)
+					ctx.EnsureDesc(&d41)
+					ctx.EmitStoreToStack(d41, int32(phiBase5)+int32(0))
+					if d25.Loc == LocReg || d25.Loc == LocFPReg {
+						ctx.UnprotectReg(d25.Reg)
+					} else if d25.Loc == LocRegPair {
+						ctx.UnprotectReg(d25.Reg)
+						ctx.UnprotectReg(d25.Reg2)
 					}
 					ctx.EmitJmp(lbl8)
 				}
 				bbpos_1_11 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl12)
 				ctx.ResolveFixups()
-				d23 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
-				d35 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
+				d24 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
+				d36 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d35)
+				ctx.EnsureDesc(&d36)
 				ctx.ReclaimUntrackedRegs()
-				d42 := ctx.EmitSliceElementAddress(&d4, &d35, 16)
-				ctx.EnsureDesc(&d42)
-				r19 := ctx.AllocRegExcept(d42.Reg)
-				ctx.EmitMovRegMem(r19, d42.Reg, 8)
-				ctx.EmitMovRegMem(d42.Reg, d42.Reg, 0)
-				d41 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d42.Reg, Reg2: r19}
-				ctx.BindReg(d42.Reg, &d41)
-				ctx.BindReg(r19, &d41)
+				d43 := ctx.EmitSliceElementAddress(&d4, &d36, 16)
+				ctx.EnsureDesc(&d43)
+				r19 := ctx.AllocRegExcept(d43.Reg)
+				ctx.EmitMovRegMem(r19, d43.Reg, 8)
+				ctx.EmitMovRegMem(d43.Reg, d43.Reg, 0)
+				d42 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d43.Reg, Reg2: r19}
+				ctx.BindReg(d43.Reg, &d42)
+				ctx.BindReg(r19, &d42)
 				ctx.ReclaimUntrackedRegs()
-				d44 := d41
-				ctx.SyncDesc(&d44)
-				if d44.Loc == LocMem {
-					tmpScalar := JITValueDesc{Loc: LocReg, Type: d44.Type, Reg: ctx.AllocReg()}
+				d45 := d42
+				ctx.SyncDesc(&d45)
+				if d45.Loc == LocMem {
+					tmpScalar := JITValueDesc{Loc: LocReg, Type: d45.Type, Reg: ctx.AllocReg()}
 					scratch := ctx.AllocRegExcept(tmpScalar.Reg)
-					ctx.EmitMovRegImm64(scratch, uint64(d44.MemPtr))
+					ctx.EmitMovRegImm64(scratch, uint64(d45.MemPtr))
 					ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
 					ctx.FreeReg(scratch)
 					ctx.BindReg(tmpScalar.Reg, &tmpScalar)
-					d44 = tmpScalar
+					d45 = tmpScalar
 				}
-				d44 = JITPrepareScmerGoArg(ctx, d44)
-				if d44.Loc != LocRegPair && d44.Loc != LocStackPair && d44.Loc != LocInputPair {
+				d45 = JITPrepareScmerGoArg(ctx, d45)
+				if d45.Loc != LocRegPair && d45.Loc != LocStackPair && d45.Loc != LocInputPair {
 					panic("jit: Scmer.String receiver not materialized as pair")
 				}
-				d43 := ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d44}, 2)
-				ctx.FreeDesc(&d41)
+				d44 := ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d45}, 2)
+				ctx.FreeDesc(&d42)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d34)
+				ctx.EnsureDesc(&d35)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d43)
-				ctx.EnsureDesc(&d34)
-				d45 := ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d43, d34}, 1)
-				ctx.EmitAndRegImm32(d45.Reg, 1)
-				d45.Type = tagBool
-				ctx.BindReg(d45.Reg, &d45)
+				ctx.EnsureDesc(&d44)
+				ctx.EnsureDesc(&d35)
+				d46 := ctx.EmitGoCallScalar(GoFuncAddr(JITStringEqual), []JITValueDesc{d44, d35}, 1)
+				ctx.EmitAndRegImm32(d46.Reg, 1)
+				d46.Type = tagBool
+				ctx.BindReg(d46.Reg, &d46)
 				ctx.ReclaimUntrackedRegs()
-				d46 := d45
-				ctx.EnsureDesc(&d46)
-				if d46.Loc != LocImm && d46.Loc != LocReg {
+				d47 := d46
+				ctx.EnsureDesc(&d47)
+				if d47.Loc != LocImm && d47.Loc != LocReg {
 					panic("jit: If condition is neither LocImm nor LocReg")
 				}
 				lbl26 := ctx.ReserveLabel()
 				lbl27 := ctx.ReserveLabel()
-				if d46.Loc == LocImm {
-					if d46.Imm.Bool() {
+				if d47.Loc == LocImm {
+					if d47.Imm.Bool() {
 						ctx.MarkLabel(lbl26)
 						ctx.EmitJmp(lbl13)
 					} else {
@@ -5329,7 +5337,7 @@ func init() {
 						ctx.EmitJmp(lbl14)
 					}
 				} else {
-					ctx.EmitCmpRegImm32(d46.Reg, 0)
+					ctx.EmitCmpRegImm32(d47.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl26)
 					ctx.EmitJmp(lbl27)
 					ctx.MarkLabel(lbl26)
@@ -5337,98 +5345,98 @@ func init() {
 					ctx.MarkLabel(lbl27)
 					ctx.EmitJmp(lbl14)
 				}
-				ctx.FreeDesc(&d45)
+				ctx.FreeDesc(&d46)
 				bbpos_1_13 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl14)
 				ctx.ResolveFixups()
-				d23 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
-				d35 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
+				d24 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
+				d36 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d35)
-				ctx.EnsureDesc(&d35)
-				var d47 JITValueDesc
-				if d35.Loc == LocImm {
-					d47 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d35.Imm.Int() + 2)}
+				ctx.EnsureDesc(&d36)
+				ctx.EnsureDesc(&d36)
+				var d48 JITValueDesc
+				if d36.Loc == LocImm {
+					d48 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d36.Imm.Int() + 2)}
 				} else {
-					scratch := ctx.AllocRegExcept(d35.Reg)
-					ctx.EmitMovRegReg(scratch, d35.Reg)
+					scratch := ctx.AllocRegExcept(d36.Reg)
+					ctx.EmitMovRegReg(scratch, d36.Reg)
 					ctx.EmitAddRegImm32(scratch, int32(2))
-					d47 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-					ctx.BindReg(scratch, &d47)
+					d48 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+					ctx.BindReg(scratch, &d48)
 				}
-				if d47.Loc == LocReg && d35.Loc == LocReg && d47.Reg == d35.Reg {
-					ctx.TransferReg(d35.Reg)
-					d35.Loc = LocNone
+				if d48.Loc == LocReg && d36.Loc == LocReg && d48.Reg == d36.Reg {
+					ctx.TransferReg(d36.Reg)
+					d36.Loc = LocNone
 				}
-				ctx.EnsureDesc(&d47)
-				ctx.EmitStoreToStack(d47, int32(phiBase5)+int32(16))
-				ctx.StabilizeDescForControlFlow(&d47)
+				ctx.EnsureDesc(&d48)
+				ctx.EmitStoreToStack(d48, int32(phiBase5)+int32(16))
+				ctx.StabilizeDescForControlFlow(&d48)
 				ctx.ReclaimUntrackedRegs()
 				ctx.EmitJmp(lbl11)
 				bbpos_1_12 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 				ctx.MarkLabel(lbl13)
 				ctx.ResolveFixups()
-				d23 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
-				d35 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
+				d24 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(0)}
+				d36 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase5) + int32(16)}
 				ctx.ReclaimUntrackedRegs()
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d35)
-				ctx.EnsureDesc(&d35)
-				var d48 JITValueDesc
-				if d35.Loc == LocImm {
-					d48 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d35.Imm.Int() + 1)}
+				ctx.EnsureDesc(&d36)
+				ctx.EnsureDesc(&d36)
+				var d49 JITValueDesc
+				if d36.Loc == LocImm {
+					d49 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d36.Imm.Int() + 1)}
 				} else {
-					scratch := ctx.AllocRegExcept(d35.Reg)
-					ctx.EmitMovRegReg(scratch, d35.Reg)
+					scratch := ctx.AllocRegExcept(d36.Reg)
+					ctx.EmitMovRegReg(scratch, d36.Reg)
 					ctx.EmitAddRegImm32(scratch, int32(1))
-					d48 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-					ctx.BindReg(scratch, &d48)
+					d49 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+					ctx.BindReg(scratch, &d49)
 				}
-				if d48.Loc == LocReg && d35.Loc == LocReg && d48.Reg == d35.Reg {
-					ctx.TransferReg(d35.Reg)
-					d35.Loc = LocNone
+				if d49.Loc == LocReg && d36.Loc == LocReg && d49.Reg == d36.Reg {
+					ctx.TransferReg(d36.Reg)
+					d36.Loc = LocNone
 				}
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d48)
+				ctx.EnsureDesc(&d49)
 				ctx.ReclaimUntrackedRegs()
-				d50 := ctx.EmitSliceElementAddress(&d4, &d48, 16)
-				ctx.EnsureDesc(&d50)
-				r20 := ctx.AllocRegExcept(d50.Reg)
-				ctx.EmitMovRegMem(r20, d50.Reg, 8)
-				ctx.EmitMovRegMem(d50.Reg, d50.Reg, 0)
-				d49 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d50.Reg, Reg2: r20}
-				ctx.BindReg(d50.Reg, &d49)
-				ctx.BindReg(r20, &d49)
-				ctx.FreeDesc(&d48)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d24)
-				ctx.ReclaimUntrackedRegs()
-				ctx.SyncDesc(&d49)
-				d51 := d21
-				d51.ID = 0
-				d52 := d24
-				d52.ID = 0
-				if !ctx.TryEmitStoreScmerSliceElement(&d51, &d52, &d49, int32(16)) {
-					ctx.StabilizeDescAcrossNestedCall(&d24)
-					d52 = d24
-					d52.ID = 0
-					ctx.EmitStoreScmerSliceElement(&d51, &d52, &d49, int32(16))
-				}
-				ctx.FreeDesc(&d52)
+				d51 := ctx.EmitSliceElementAddress(&d4, &d49, 16)
+				ctx.EnsureDesc(&d51)
+				r20 := ctx.AllocRegExcept(d51.Reg)
+				ctx.EmitMovRegMem(r20, d51.Reg, 8)
+				ctx.EmitMovRegMem(d51.Reg, d51.Reg, 0)
+				d50 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: d51.Reg, Reg2: r20}
+				ctx.BindReg(d51.Reg, &d50)
+				ctx.BindReg(r20, &d50)
 				ctx.FreeDesc(&d49)
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d25)
+				ctx.ReclaimUntrackedRegs()
+				ctx.SyncDesc(&d50)
+				d52 := d22
+				d52.ID = 0
+				d53 := d25
+				d53.ID = 0
+				if !ctx.TryEmitStoreScmerSliceElement(&d52, &d53, &d50, int32(16)) {
+					ctx.StabilizeDescAcrossNestedCall(&d25)
+					d53 = d25
+					d53.ID = 0
+					ctx.EmitStoreScmerSliceElement(&d52, &d53, &d50, int32(16))
+				}
+				ctx.FreeDesc(&d53)
+				ctx.FreeDesc(&d50)
 				ctx.ReclaimUntrackedRegs()
 				ctx.EmitJmp(lbl14)
 				ctx.MarkLabel(lbl0)
-				d53 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: r13, Reg2: r14}
-				ctx.BindReg(r13, &d53)
-				ctx.BindReg(r14, &d53)
-				ctx.BindReg(r13, &d53)
-				ctx.BindReg(r14, &d53)
+				d54 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: r13, Reg2: r14}
+				ctx.BindReg(r13, &d54)
+				ctx.BindReg(r14, &d54)
+				ctx.BindReg(r13, &d54)
+				ctx.BindReg(r14, &d54)
 				ctx.FreeDesc(&d0)
-				if d53.Loc == LocImm {
+				if d54.Loc == LocImm {
 					if result.Loc == LocAny {
-						return d53
+						return d54
 					}
 				}
 				if result.Loc == LocAny {
@@ -5436,20 +5444,20 @@ func init() {
 					ctx.BindReg(result.Reg, &result)
 					ctx.BindReg(result.Reg2, &result)
 				}
-				ctx.SyncDesc(&d53)
-				if d53.Loc == LocRegPair || d53.Loc == LocStackPair || d53.Loc == LocInputPair {
-					ctx.EmitMovPairToResult(&d53, &result)
-					result.Type = d53.Type
+				ctx.SyncDesc(&d54)
+				if d54.Loc == LocRegPair || d54.Loc == LocStackPair || d54.Loc == LocInputPair {
+					ctx.EmitMovPairToResult(&d54, &result)
+					result.Type = d54.Type
 				} else {
-					switch d53.Type {
+					switch d54.Type {
 					case tagBool:
-						ctx.EmitMakeBool(result, d53)
+						ctx.EmitMakeBool(result, d54)
 						result.Type = tagBool
 					case tagInt:
-						ctx.EmitMakeInt(result, d53)
+						ctx.EmitMakeInt(result, d54)
 						result.Type = tagInt
 					case tagFloat:
-						ctx.EmitMakeFloat(result, d53)
+						ctx.EmitMakeFloat(result, d54)
 						result.Type = tagFloat
 					case tagNil:
 						ctx.EmitMakeNil(result)
@@ -6638,7 +6646,7 @@ func init() {
 					ctx.StabilizeDescForControlFlow(&d121)
 					if ps.General {
 						ctx.SyncDesc(&d121)
-						if d121.Loc == LocReg {
+						if d121.Loc == LocReg || d121.Loc == LocFPReg {
 							ctx.ProtectReg(d121.Reg)
 						} else if d121.Loc == LocRegPair {
 							ctx.ProtectReg(d121.Reg)
@@ -6659,7 +6667,7 @@ func init() {
 							ctx.EmitStoreRegMem(d122.Reg2, RegRSP, int32(bbs[3].PhiBase)+int32(0)+8)
 							ctx.EmitStoreRegMem(d122.Reg3, RegRSP, int32(bbs[3].PhiBase)+int32(0)+16)
 						}
-						if d121.Loc == LocReg {
+						if d121.Loc == LocReg || d121.Loc == LocFPReg {
 							ctx.UnprotectReg(d121.Reg)
 						} else if d121.Loc == LocRegPair {
 							ctx.UnprotectReg(d121.Reg)
@@ -7097,7 +7105,7 @@ func init() {
 					ctx.FreeDesc(&d7)
 					if ps.General {
 						ctx.SyncDesc(&d3)
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.ProtectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.ProtectReg(d3.Reg)
@@ -7118,7 +7126,7 @@ func init() {
 							ctx.EmitStoreRegMem(d10.Reg2, RegRSP, int32(bbs[3].PhiBase)+int32(0)+8)
 							ctx.EmitStoreRegMem(d10.Reg3, RegRSP, int32(bbs[3].PhiBase)+int32(0)+16)
 						}
-						if d3.Loc == LocReg {
+						if d3.Loc == LocReg || d3.Loc == LocFPReg {
 							ctx.UnprotectReg(d3.Reg)
 						} else if d3.Loc == LocRegPair {
 							ctx.UnprotectReg(d3.Reg)
@@ -7920,7 +7928,7 @@ func init() {
 					ctx.StabilizeDescForControlFlow(&d114)
 					if ps.General {
 						ctx.SyncDesc(&d114)
-						if d114.Loc == LocReg {
+						if d114.Loc == LocReg || d114.Loc == LocFPReg {
 							ctx.ProtectReg(d114.Reg)
 						} else if d114.Loc == LocRegPair {
 							ctx.ProtectReg(d114.Reg)
@@ -7941,7 +7949,7 @@ func init() {
 							ctx.EmitStoreRegMem(d115.Reg2, RegRSP, int32(bbs[3].PhiBase)+int32(0)+8)
 							ctx.EmitStoreRegMem(d115.Reg3, RegRSP, int32(bbs[3].PhiBase)+int32(0)+16)
 						}
-						if d114.Loc == LocReg {
+						if d114.Loc == LocReg || d114.Loc == LocFPReg {
 							ctx.UnprotectReg(d114.Reg)
 						} else if d114.Loc == LocRegPair {
 							ctx.UnprotectReg(d114.Reg)
@@ -8096,7 +8104,7 @@ func init() {
 					ctx.StabilizeDescForControlFlow(&d118)
 					if ps.General {
 						ctx.SyncDesc(&d118)
-						if d118.Loc == LocReg {
+						if d118.Loc == LocReg || d118.Loc == LocFPReg {
 							ctx.ProtectReg(d118.Reg)
 						} else if d118.Loc == LocRegPair {
 							ctx.ProtectReg(d118.Reg)
@@ -8117,7 +8125,7 @@ func init() {
 							ctx.EmitStoreRegMem(d119.Reg2, RegRSP, int32(bbs[3].PhiBase)+int32(0)+8)
 							ctx.EmitStoreRegMem(d119.Reg3, RegRSP, int32(bbs[3].PhiBase)+int32(0)+16)
 						}
-						if d118.Loc == LocReg {
+						if d118.Loc == LocReg || d118.Loc == LocFPReg {
 							ctx.UnprotectReg(d118.Reg)
 						} else if d118.Loc == LocRegPair {
 							ctx.UnprotectReg(d118.Reg)
@@ -13216,7 +13224,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d24)
 					if ps.General {
 						ctx.SyncDesc(&d25)
-						if d25.Loc == LocReg {
+						if d25.Loc == LocReg || d25.Loc == LocFPReg {
 							ctx.ProtectReg(d25.Reg)
 						} else if d25.Loc == LocRegPair {
 							ctx.ProtectReg(d25.Reg)
@@ -13239,7 +13247,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d27, int32(bbs[2].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 						}
-						if d25.Loc == LocReg {
+						if d25.Loc == LocReg || d25.Loc == LocFPReg {
 							ctx.UnprotectReg(d25.Reg)
 						} else if d25.Loc == LocRegPair {
 							ctx.UnprotectReg(d25.Reg)
@@ -13770,7 +13778,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl43)
 							ctx.SyncDesc(&d51)
-							if d51.Loc == LocReg {
+							if d51.Loc == LocReg || d51.Loc == LocFPReg {
 								ctx.ProtectReg(d51.Reg)
 							} else if d51.Loc == LocRegPair {
 								ctx.ProtectReg(d51.Reg)
@@ -13793,7 +13801,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d62, int32(phiBase39)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase39)+int32(0))+8)
 							}
-							if d51.Loc == LocReg {
+							if d51.Loc == LocReg || d51.Loc == LocFPReg {
 								ctx.UnprotectReg(d51.Reg)
 							} else if d51.Loc == LocRegPair {
 								ctx.UnprotectReg(d51.Reg)
@@ -13809,7 +13817,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl10)
 						ctx.MarkLabel(lbl43)
 						ctx.SyncDesc(&d51)
-						if d51.Loc == LocReg {
+						if d51.Loc == LocReg || d51.Loc == LocFPReg {
 							ctx.ProtectReg(d51.Reg)
 						} else if d51.Loc == LocRegPair {
 							ctx.ProtectReg(d51.Reg)
@@ -13832,7 +13840,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d63, int32(phiBase39)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase39)+int32(0))+8)
 						}
-						if d51.Loc == LocReg {
+						if d51.Loc == LocReg || d51.Loc == LocFPReg {
 							ctx.UnprotectReg(d51.Reg)
 						} else if d51.Loc == LocRegPair {
 							ctx.UnprotectReg(d51.Reg)
@@ -13966,7 +13974,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d71)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d71)
-					if d71.Loc == LocReg {
+					if d71.Loc == LocReg || d71.Loc == LocFPReg {
 						ctx.ProtectReg(d71.Reg)
 					} else if d71.Loc == LocRegPair {
 						ctx.ProtectReg(d71.Reg)
@@ -13989,7 +13997,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d72, int32(phiBase39)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase39)+int32(0))+8)
 					}
-					if d71.Loc == LocReg {
+					if d71.Loc == LocReg || d71.Loc == LocFPReg {
 						ctx.UnprotectReg(d71.Reg)
 					} else if d71.Loc == LocRegPair {
 						ctx.UnprotectReg(d71.Reg)
@@ -14151,7 +14159,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d85)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d85)
-					if d85.Loc == LocReg {
+					if d85.Loc == LocReg || d85.Loc == LocFPReg {
 						ctx.ProtectReg(d85.Reg)
 					} else if d85.Loc == LocRegPair {
 						ctx.ProtectReg(d85.Reg)
@@ -14172,7 +14180,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d86.Reg2, RegRSP, int32(phiBase39)+int32(16)+8)
 						ctx.EmitStoreRegMem(d86.Reg3, RegRSP, int32(phiBase39)+int32(16)+16)
 					}
-					if d85.Loc == LocReg {
+					if d85.Loc == LocReg || d85.Loc == LocFPReg {
 						ctx.UnprotectReg(d85.Reg)
 					} else if d85.Loc == LocRegPair {
 						ctx.UnprotectReg(d85.Reg)
@@ -14648,7 +14656,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl91)
 							ctx.SyncDesc(&d110)
-							if d110.Loc == LocReg {
+							if d110.Loc == LocReg || d110.Loc == LocFPReg {
 								ctx.ProtectReg(d110.Reg)
 							} else if d110.Loc == LocRegPair {
 								ctx.ProtectReg(d110.Reg)
@@ -14671,7 +14679,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d121, int32(phiBase98)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase98)+int32(0))+8)
 							}
-							if d110.Loc == LocReg {
+							if d110.Loc == LocReg || d110.Loc == LocFPReg {
 								ctx.UnprotectReg(d110.Reg)
 							} else if d110.Loc == LocRegPair {
 								ctx.UnprotectReg(d110.Reg)
@@ -14687,7 +14695,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl58)
 						ctx.MarkLabel(lbl91)
 						ctx.SyncDesc(&d110)
-						if d110.Loc == LocReg {
+						if d110.Loc == LocReg || d110.Loc == LocFPReg {
 							ctx.ProtectReg(d110.Reg)
 						} else if d110.Loc == LocRegPair {
 							ctx.ProtectReg(d110.Reg)
@@ -14710,7 +14718,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d122, int32(phiBase98)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase98)+int32(0))+8)
 						}
-						if d110.Loc == LocReg {
+						if d110.Loc == LocReg || d110.Loc == LocFPReg {
 							ctx.UnprotectReg(d110.Reg)
 						} else if d110.Loc == LocRegPair {
 							ctx.UnprotectReg(d110.Reg)
@@ -14844,7 +14852,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d130)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d130)
-					if d130.Loc == LocReg {
+					if d130.Loc == LocReg || d130.Loc == LocFPReg {
 						ctx.ProtectReg(d130.Reg)
 					} else if d130.Loc == LocRegPair {
 						ctx.ProtectReg(d130.Reg)
@@ -14867,7 +14875,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d131, int32(phiBase98)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase98)+int32(0))+8)
 					}
-					if d130.Loc == LocReg {
+					if d130.Loc == LocReg || d130.Loc == LocFPReg {
 						ctx.UnprotectReg(d130.Reg)
 					} else if d130.Loc == LocRegPair {
 						ctx.UnprotectReg(d130.Reg)
@@ -15029,7 +15037,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d144)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d144)
-					if d144.Loc == LocReg {
+					if d144.Loc == LocReg || d144.Loc == LocFPReg {
 						ctx.ProtectReg(d144.Reg)
 					} else if d144.Loc == LocRegPair {
 						ctx.ProtectReg(d144.Reg)
@@ -15050,7 +15058,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d145.Reg2, RegRSP, int32(phiBase98)+int32(16)+8)
 						ctx.EmitStoreRegMem(d145.Reg3, RegRSP, int32(phiBase98)+int32(16)+16)
 					}
-					if d144.Loc == LocReg {
+					if d144.Loc == LocReg || d144.Loc == LocFPReg {
 						ctx.UnprotectReg(d144.Reg)
 					} else if d144.Loc == LocRegPair {
 						ctx.UnprotectReg(d144.Reg)
@@ -15526,7 +15534,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl139)
 							ctx.SyncDesc(&d169)
-							if d169.Loc == LocReg {
+							if d169.Loc == LocReg || d169.Loc == LocFPReg {
 								ctx.ProtectReg(d169.Reg)
 							} else if d169.Loc == LocRegPair {
 								ctx.ProtectReg(d169.Reg)
@@ -15549,7 +15557,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d180, int32(phiBase157)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase157)+int32(0))+8)
 							}
-							if d169.Loc == LocReg {
+							if d169.Loc == LocReg || d169.Loc == LocFPReg {
 								ctx.UnprotectReg(d169.Reg)
 							} else if d169.Loc == LocRegPair {
 								ctx.UnprotectReg(d169.Reg)
@@ -15565,7 +15573,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl106)
 						ctx.MarkLabel(lbl139)
 						ctx.SyncDesc(&d169)
-						if d169.Loc == LocReg {
+						if d169.Loc == LocReg || d169.Loc == LocFPReg {
 							ctx.ProtectReg(d169.Reg)
 						} else if d169.Loc == LocRegPair {
 							ctx.ProtectReg(d169.Reg)
@@ -15588,7 +15596,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d181, int32(phiBase157)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase157)+int32(0))+8)
 						}
-						if d169.Loc == LocReg {
+						if d169.Loc == LocReg || d169.Loc == LocFPReg {
 							ctx.UnprotectReg(d169.Reg)
 						} else if d169.Loc == LocRegPair {
 							ctx.UnprotectReg(d169.Reg)
@@ -15722,7 +15730,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d189)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d189)
-					if d189.Loc == LocReg {
+					if d189.Loc == LocReg || d189.Loc == LocFPReg {
 						ctx.ProtectReg(d189.Reg)
 					} else if d189.Loc == LocRegPair {
 						ctx.ProtectReg(d189.Reg)
@@ -15745,7 +15753,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d190, int32(phiBase157)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase157)+int32(0))+8)
 					}
-					if d189.Loc == LocReg {
+					if d189.Loc == LocReg || d189.Loc == LocFPReg {
 						ctx.UnprotectReg(d189.Reg)
 					} else if d189.Loc == LocRegPair {
 						ctx.UnprotectReg(d189.Reg)
@@ -15907,7 +15915,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d203)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d203)
-					if d203.Loc == LocReg {
+					if d203.Loc == LocReg || d203.Loc == LocFPReg {
 						ctx.ProtectReg(d203.Reg)
 					} else if d203.Loc == LocRegPair {
 						ctx.ProtectReg(d203.Reg)
@@ -15928,7 +15936,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d204.Reg2, RegRSP, int32(phiBase157)+int32(16)+8)
 						ctx.EmitStoreRegMem(d204.Reg3, RegRSP, int32(phiBase157)+int32(16)+16)
 					}
-					if d203.Loc == LocReg {
+					if d203.Loc == LocReg || d203.Loc == LocFPReg {
 						ctx.UnprotectReg(d203.Reg)
 					} else if d203.Loc == LocRegPair {
 						ctx.UnprotectReg(d203.Reg)
@@ -16404,7 +16412,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl187)
 							ctx.SyncDesc(&d228)
-							if d228.Loc == LocReg {
+							if d228.Loc == LocReg || d228.Loc == LocFPReg {
 								ctx.ProtectReg(d228.Reg)
 							} else if d228.Loc == LocRegPair {
 								ctx.ProtectReg(d228.Reg)
@@ -16427,7 +16435,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d239, int32(phiBase216)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase216)+int32(0))+8)
 							}
-							if d228.Loc == LocReg {
+							if d228.Loc == LocReg || d228.Loc == LocFPReg {
 								ctx.UnprotectReg(d228.Reg)
 							} else if d228.Loc == LocRegPair {
 								ctx.UnprotectReg(d228.Reg)
@@ -16443,7 +16451,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl154)
 						ctx.MarkLabel(lbl187)
 						ctx.SyncDesc(&d228)
-						if d228.Loc == LocReg {
+						if d228.Loc == LocReg || d228.Loc == LocFPReg {
 							ctx.ProtectReg(d228.Reg)
 						} else if d228.Loc == LocRegPair {
 							ctx.ProtectReg(d228.Reg)
@@ -16466,7 +16474,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d240, int32(phiBase216)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase216)+int32(0))+8)
 						}
-						if d228.Loc == LocReg {
+						if d228.Loc == LocReg || d228.Loc == LocFPReg {
 							ctx.UnprotectReg(d228.Reg)
 						} else if d228.Loc == LocRegPair {
 							ctx.UnprotectReg(d228.Reg)
@@ -16600,7 +16608,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d248)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d248)
-					if d248.Loc == LocReg {
+					if d248.Loc == LocReg || d248.Loc == LocFPReg {
 						ctx.ProtectReg(d248.Reg)
 					} else if d248.Loc == LocRegPair {
 						ctx.ProtectReg(d248.Reg)
@@ -16623,7 +16631,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d249, int32(phiBase216)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase216)+int32(0))+8)
 					}
-					if d248.Loc == LocReg {
+					if d248.Loc == LocReg || d248.Loc == LocFPReg {
 						ctx.UnprotectReg(d248.Reg)
 					} else if d248.Loc == LocRegPair {
 						ctx.UnprotectReg(d248.Reg)
@@ -16785,7 +16793,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d262)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d262)
-					if d262.Loc == LocReg {
+					if d262.Loc == LocReg || d262.Loc == LocFPReg {
 						ctx.ProtectReg(d262.Reg)
 					} else if d262.Loc == LocRegPair {
 						ctx.ProtectReg(d262.Reg)
@@ -16806,7 +16814,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d263.Reg2, RegRSP, int32(phiBase216)+int32(16)+8)
 						ctx.EmitStoreRegMem(d263.Reg3, RegRSP, int32(phiBase216)+int32(16)+16)
 					}
-					if d262.Loc == LocReg {
+					if d262.Loc == LocReg || d262.Loc == LocFPReg {
 						ctx.UnprotectReg(d262.Reg)
 					} else if d262.Loc == LocRegPair {
 						ctx.UnprotectReg(d262.Reg)
@@ -17282,7 +17290,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl235)
 							ctx.SyncDesc(&d287)
-							if d287.Loc == LocReg {
+							if d287.Loc == LocReg || d287.Loc == LocFPReg {
 								ctx.ProtectReg(d287.Reg)
 							} else if d287.Loc == LocRegPair {
 								ctx.ProtectReg(d287.Reg)
@@ -17305,7 +17313,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d298, int32(phiBase275)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase275)+int32(0))+8)
 							}
-							if d287.Loc == LocReg {
+							if d287.Loc == LocReg || d287.Loc == LocFPReg {
 								ctx.UnprotectReg(d287.Reg)
 							} else if d287.Loc == LocRegPair {
 								ctx.UnprotectReg(d287.Reg)
@@ -17321,7 +17329,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl202)
 						ctx.MarkLabel(lbl235)
 						ctx.SyncDesc(&d287)
-						if d287.Loc == LocReg {
+						if d287.Loc == LocReg || d287.Loc == LocFPReg {
 							ctx.ProtectReg(d287.Reg)
 						} else if d287.Loc == LocRegPair {
 							ctx.ProtectReg(d287.Reg)
@@ -17344,7 +17352,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d299, int32(phiBase275)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase275)+int32(0))+8)
 						}
-						if d287.Loc == LocReg {
+						if d287.Loc == LocReg || d287.Loc == LocFPReg {
 							ctx.UnprotectReg(d287.Reg)
 						} else if d287.Loc == LocRegPair {
 							ctx.UnprotectReg(d287.Reg)
@@ -17478,7 +17486,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d307)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d307)
-					if d307.Loc == LocReg {
+					if d307.Loc == LocReg || d307.Loc == LocFPReg {
 						ctx.ProtectReg(d307.Reg)
 					} else if d307.Loc == LocRegPair {
 						ctx.ProtectReg(d307.Reg)
@@ -17501,7 +17509,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d308, int32(phiBase275)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase275)+int32(0))+8)
 					}
-					if d307.Loc == LocReg {
+					if d307.Loc == LocReg || d307.Loc == LocFPReg {
 						ctx.UnprotectReg(d307.Reg)
 					} else if d307.Loc == LocRegPair {
 						ctx.UnprotectReg(d307.Reg)
@@ -17663,7 +17671,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d321)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d321)
-					if d321.Loc == LocReg {
+					if d321.Loc == LocReg || d321.Loc == LocFPReg {
 						ctx.ProtectReg(d321.Reg)
 					} else if d321.Loc == LocRegPair {
 						ctx.ProtectReg(d321.Reg)
@@ -17684,7 +17692,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d322.Reg2, RegRSP, int32(phiBase275)+int32(16)+8)
 						ctx.EmitStoreRegMem(d322.Reg3, RegRSP, int32(phiBase275)+int32(16)+16)
 					}
-					if d321.Loc == LocReg {
+					if d321.Loc == LocReg || d321.Loc == LocFPReg {
 						ctx.UnprotectReg(d321.Reg)
 					} else if d321.Loc == LocRegPair {
 						ctx.UnprotectReg(d321.Reg)
@@ -18160,7 +18168,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl283)
 							ctx.SyncDesc(&d346)
-							if d346.Loc == LocReg {
+							if d346.Loc == LocReg || d346.Loc == LocFPReg {
 								ctx.ProtectReg(d346.Reg)
 							} else if d346.Loc == LocRegPair {
 								ctx.ProtectReg(d346.Reg)
@@ -18183,7 +18191,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d357, int32(phiBase334)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase334)+int32(0))+8)
 							}
-							if d346.Loc == LocReg {
+							if d346.Loc == LocReg || d346.Loc == LocFPReg {
 								ctx.UnprotectReg(d346.Reg)
 							} else if d346.Loc == LocRegPair {
 								ctx.UnprotectReg(d346.Reg)
@@ -18199,7 +18207,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl250)
 						ctx.MarkLabel(lbl283)
 						ctx.SyncDesc(&d346)
-						if d346.Loc == LocReg {
+						if d346.Loc == LocReg || d346.Loc == LocFPReg {
 							ctx.ProtectReg(d346.Reg)
 						} else if d346.Loc == LocRegPair {
 							ctx.ProtectReg(d346.Reg)
@@ -18222,7 +18230,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d358, int32(phiBase334)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase334)+int32(0))+8)
 						}
-						if d346.Loc == LocReg {
+						if d346.Loc == LocReg || d346.Loc == LocFPReg {
 							ctx.UnprotectReg(d346.Reg)
 						} else if d346.Loc == LocRegPair {
 							ctx.UnprotectReg(d346.Reg)
@@ -18356,7 +18364,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d366)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d366)
-					if d366.Loc == LocReg {
+					if d366.Loc == LocReg || d366.Loc == LocFPReg {
 						ctx.ProtectReg(d366.Reg)
 					} else if d366.Loc == LocRegPair {
 						ctx.ProtectReg(d366.Reg)
@@ -18379,7 +18387,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d367, int32(phiBase334)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase334)+int32(0))+8)
 					}
-					if d366.Loc == LocReg {
+					if d366.Loc == LocReg || d366.Loc == LocFPReg {
 						ctx.UnprotectReg(d366.Reg)
 					} else if d366.Loc == LocRegPair {
 						ctx.UnprotectReg(d366.Reg)
@@ -18541,7 +18549,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d380)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d380)
-					if d380.Loc == LocReg {
+					if d380.Loc == LocReg || d380.Loc == LocFPReg {
 						ctx.ProtectReg(d380.Reg)
 					} else if d380.Loc == LocRegPair {
 						ctx.ProtectReg(d380.Reg)
@@ -18562,7 +18570,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d381.Reg2, RegRSP, int32(phiBase334)+int32(16)+8)
 						ctx.EmitStoreRegMem(d381.Reg3, RegRSP, int32(phiBase334)+int32(16)+16)
 					}
-					if d380.Loc == LocReg {
+					if d380.Loc == LocReg || d380.Loc == LocFPReg {
 						ctx.UnprotectReg(d380.Reg)
 					} else if d380.Loc == LocRegPair {
 						ctx.UnprotectReg(d380.Reg)
@@ -19038,7 +19046,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl331)
 							ctx.SyncDesc(&d405)
-							if d405.Loc == LocReg {
+							if d405.Loc == LocReg || d405.Loc == LocFPReg {
 								ctx.ProtectReg(d405.Reg)
 							} else if d405.Loc == LocRegPair {
 								ctx.ProtectReg(d405.Reg)
@@ -19061,7 +19069,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d416, int32(phiBase393)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase393)+int32(0))+8)
 							}
-							if d405.Loc == LocReg {
+							if d405.Loc == LocReg || d405.Loc == LocFPReg {
 								ctx.UnprotectReg(d405.Reg)
 							} else if d405.Loc == LocRegPair {
 								ctx.UnprotectReg(d405.Reg)
@@ -19077,7 +19085,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl298)
 						ctx.MarkLabel(lbl331)
 						ctx.SyncDesc(&d405)
-						if d405.Loc == LocReg {
+						if d405.Loc == LocReg || d405.Loc == LocFPReg {
 							ctx.ProtectReg(d405.Reg)
 						} else if d405.Loc == LocRegPair {
 							ctx.ProtectReg(d405.Reg)
@@ -19100,7 +19108,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d417, int32(phiBase393)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase393)+int32(0))+8)
 						}
-						if d405.Loc == LocReg {
+						if d405.Loc == LocReg || d405.Loc == LocFPReg {
 							ctx.UnprotectReg(d405.Reg)
 						} else if d405.Loc == LocRegPair {
 							ctx.UnprotectReg(d405.Reg)
@@ -19234,7 +19242,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d425)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d425)
-					if d425.Loc == LocReg {
+					if d425.Loc == LocReg || d425.Loc == LocFPReg {
 						ctx.ProtectReg(d425.Reg)
 					} else if d425.Loc == LocRegPair {
 						ctx.ProtectReg(d425.Reg)
@@ -19257,7 +19265,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d426, int32(phiBase393)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase393)+int32(0))+8)
 					}
-					if d425.Loc == LocReg {
+					if d425.Loc == LocReg || d425.Loc == LocFPReg {
 						ctx.UnprotectReg(d425.Reg)
 					} else if d425.Loc == LocRegPair {
 						ctx.UnprotectReg(d425.Reg)
@@ -19419,7 +19427,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d439)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d439)
-					if d439.Loc == LocReg {
+					if d439.Loc == LocReg || d439.Loc == LocFPReg {
 						ctx.ProtectReg(d439.Reg)
 					} else if d439.Loc == LocRegPair {
 						ctx.ProtectReg(d439.Reg)
@@ -19440,7 +19448,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d440.Reg2, RegRSP, int32(phiBase393)+int32(16)+8)
 						ctx.EmitStoreRegMem(d440.Reg3, RegRSP, int32(phiBase393)+int32(16)+16)
 					}
-					if d439.Loc == LocReg {
+					if d439.Loc == LocReg || d439.Loc == LocFPReg {
 						ctx.UnprotectReg(d439.Reg)
 					} else if d439.Loc == LocRegPair {
 						ctx.UnprotectReg(d439.Reg)
@@ -19916,7 +19924,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl379)
 							ctx.SyncDesc(&d464)
-							if d464.Loc == LocReg {
+							if d464.Loc == LocReg || d464.Loc == LocFPReg {
 								ctx.ProtectReg(d464.Reg)
 							} else if d464.Loc == LocRegPair {
 								ctx.ProtectReg(d464.Reg)
@@ -19939,7 +19947,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d475, int32(phiBase452)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase452)+int32(0))+8)
 							}
-							if d464.Loc == LocReg {
+							if d464.Loc == LocReg || d464.Loc == LocFPReg {
 								ctx.UnprotectReg(d464.Reg)
 							} else if d464.Loc == LocRegPair {
 								ctx.UnprotectReg(d464.Reg)
@@ -19955,7 +19963,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl346)
 						ctx.MarkLabel(lbl379)
 						ctx.SyncDesc(&d464)
-						if d464.Loc == LocReg {
+						if d464.Loc == LocReg || d464.Loc == LocFPReg {
 							ctx.ProtectReg(d464.Reg)
 						} else if d464.Loc == LocRegPair {
 							ctx.ProtectReg(d464.Reg)
@@ -19978,7 +19986,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d476, int32(phiBase452)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase452)+int32(0))+8)
 						}
-						if d464.Loc == LocReg {
+						if d464.Loc == LocReg || d464.Loc == LocFPReg {
 							ctx.UnprotectReg(d464.Reg)
 						} else if d464.Loc == LocRegPair {
 							ctx.UnprotectReg(d464.Reg)
@@ -20112,7 +20120,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d484)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d484)
-					if d484.Loc == LocReg {
+					if d484.Loc == LocReg || d484.Loc == LocFPReg {
 						ctx.ProtectReg(d484.Reg)
 					} else if d484.Loc == LocRegPair {
 						ctx.ProtectReg(d484.Reg)
@@ -20135,7 +20143,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d485, int32(phiBase452)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase452)+int32(0))+8)
 					}
-					if d484.Loc == LocReg {
+					if d484.Loc == LocReg || d484.Loc == LocFPReg {
 						ctx.UnprotectReg(d484.Reg)
 					} else if d484.Loc == LocRegPair {
 						ctx.UnprotectReg(d484.Reg)
@@ -20297,7 +20305,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d498)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d498)
-					if d498.Loc == LocReg {
+					if d498.Loc == LocReg || d498.Loc == LocFPReg {
 						ctx.ProtectReg(d498.Reg)
 					} else if d498.Loc == LocRegPair {
 						ctx.ProtectReg(d498.Reg)
@@ -20318,7 +20326,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d499.Reg2, RegRSP, int32(phiBase452)+int32(16)+8)
 						ctx.EmitStoreRegMem(d499.Reg3, RegRSP, int32(phiBase452)+int32(16)+16)
 					}
-					if d498.Loc == LocReg {
+					if d498.Loc == LocReg || d498.Loc == LocFPReg {
 						ctx.UnprotectReg(d498.Reg)
 					} else if d498.Loc == LocRegPair {
 						ctx.UnprotectReg(d498.Reg)
@@ -20794,7 +20802,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl427)
 							ctx.SyncDesc(&d523)
-							if d523.Loc == LocReg {
+							if d523.Loc == LocReg || d523.Loc == LocFPReg {
 								ctx.ProtectReg(d523.Reg)
 							} else if d523.Loc == LocRegPair {
 								ctx.ProtectReg(d523.Reg)
@@ -20817,7 +20825,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d534, int32(phiBase511)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase511)+int32(0))+8)
 							}
-							if d523.Loc == LocReg {
+							if d523.Loc == LocReg || d523.Loc == LocFPReg {
 								ctx.UnprotectReg(d523.Reg)
 							} else if d523.Loc == LocRegPair {
 								ctx.UnprotectReg(d523.Reg)
@@ -20833,7 +20841,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl394)
 						ctx.MarkLabel(lbl427)
 						ctx.SyncDesc(&d523)
-						if d523.Loc == LocReg {
+						if d523.Loc == LocReg || d523.Loc == LocFPReg {
 							ctx.ProtectReg(d523.Reg)
 						} else if d523.Loc == LocRegPair {
 							ctx.ProtectReg(d523.Reg)
@@ -20856,7 +20864,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d535, int32(phiBase511)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase511)+int32(0))+8)
 						}
-						if d523.Loc == LocReg {
+						if d523.Loc == LocReg || d523.Loc == LocFPReg {
 							ctx.UnprotectReg(d523.Reg)
 						} else if d523.Loc == LocRegPair {
 							ctx.UnprotectReg(d523.Reg)
@@ -20990,7 +20998,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d543)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d543)
-					if d543.Loc == LocReg {
+					if d543.Loc == LocReg || d543.Loc == LocFPReg {
 						ctx.ProtectReg(d543.Reg)
 					} else if d543.Loc == LocRegPair {
 						ctx.ProtectReg(d543.Reg)
@@ -21013,7 +21021,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d544, int32(phiBase511)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase511)+int32(0))+8)
 					}
-					if d543.Loc == LocReg {
+					if d543.Loc == LocReg || d543.Loc == LocFPReg {
 						ctx.UnprotectReg(d543.Reg)
 					} else if d543.Loc == LocRegPair {
 						ctx.UnprotectReg(d543.Reg)
@@ -21175,7 +21183,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d557)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d557)
-					if d557.Loc == LocReg {
+					if d557.Loc == LocReg || d557.Loc == LocFPReg {
 						ctx.ProtectReg(d557.Reg)
 					} else if d557.Loc == LocRegPair {
 						ctx.ProtectReg(d557.Reg)
@@ -21196,7 +21204,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d558.Reg2, RegRSP, int32(phiBase511)+int32(16)+8)
 						ctx.EmitStoreRegMem(d558.Reg3, RegRSP, int32(phiBase511)+int32(16)+16)
 					}
-					if d557.Loc == LocReg {
+					if d557.Loc == LocReg || d557.Loc == LocFPReg {
 						ctx.UnprotectReg(d557.Reg)
 					} else if d557.Loc == LocRegPair {
 						ctx.UnprotectReg(d557.Reg)
@@ -21672,7 +21680,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl475)
 							ctx.SyncDesc(&d582)
-							if d582.Loc == LocReg {
+							if d582.Loc == LocReg || d582.Loc == LocFPReg {
 								ctx.ProtectReg(d582.Reg)
 							} else if d582.Loc == LocRegPair {
 								ctx.ProtectReg(d582.Reg)
@@ -21695,7 +21703,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d593, int32(phiBase570)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase570)+int32(0))+8)
 							}
-							if d582.Loc == LocReg {
+							if d582.Loc == LocReg || d582.Loc == LocFPReg {
 								ctx.UnprotectReg(d582.Reg)
 							} else if d582.Loc == LocRegPair {
 								ctx.UnprotectReg(d582.Reg)
@@ -21711,7 +21719,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl442)
 						ctx.MarkLabel(lbl475)
 						ctx.SyncDesc(&d582)
-						if d582.Loc == LocReg {
+						if d582.Loc == LocReg || d582.Loc == LocFPReg {
 							ctx.ProtectReg(d582.Reg)
 						} else if d582.Loc == LocRegPair {
 							ctx.ProtectReg(d582.Reg)
@@ -21734,7 +21742,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d594, int32(phiBase570)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase570)+int32(0))+8)
 						}
-						if d582.Loc == LocReg {
+						if d582.Loc == LocReg || d582.Loc == LocFPReg {
 							ctx.UnprotectReg(d582.Reg)
 						} else if d582.Loc == LocRegPair {
 							ctx.UnprotectReg(d582.Reg)
@@ -21868,7 +21876,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d602)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d602)
-					if d602.Loc == LocReg {
+					if d602.Loc == LocReg || d602.Loc == LocFPReg {
 						ctx.ProtectReg(d602.Reg)
 					} else if d602.Loc == LocRegPair {
 						ctx.ProtectReg(d602.Reg)
@@ -21891,7 +21899,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d603, int32(phiBase570)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase570)+int32(0))+8)
 					}
-					if d602.Loc == LocReg {
+					if d602.Loc == LocReg || d602.Loc == LocFPReg {
 						ctx.UnprotectReg(d602.Reg)
 					} else if d602.Loc == LocRegPair {
 						ctx.UnprotectReg(d602.Reg)
@@ -22053,7 +22061,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d616)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d616)
-					if d616.Loc == LocReg {
+					if d616.Loc == LocReg || d616.Loc == LocFPReg {
 						ctx.ProtectReg(d616.Reg)
 					} else if d616.Loc == LocRegPair {
 						ctx.ProtectReg(d616.Reg)
@@ -22074,7 +22082,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d617.Reg2, RegRSP, int32(phiBase570)+int32(16)+8)
 						ctx.EmitStoreRegMem(d617.Reg3, RegRSP, int32(phiBase570)+int32(16)+16)
 					}
-					if d616.Loc == LocReg {
+					if d616.Loc == LocReg || d616.Loc == LocFPReg {
 						ctx.UnprotectReg(d616.Reg)
 					} else if d616.Loc == LocRegPair {
 						ctx.UnprotectReg(d616.Reg)
@@ -22550,7 +22558,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl523)
 							ctx.SyncDesc(&d641)
-							if d641.Loc == LocReg {
+							if d641.Loc == LocReg || d641.Loc == LocFPReg {
 								ctx.ProtectReg(d641.Reg)
 							} else if d641.Loc == LocRegPair {
 								ctx.ProtectReg(d641.Reg)
@@ -22573,7 +22581,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d652, int32(phiBase629)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase629)+int32(0))+8)
 							}
-							if d641.Loc == LocReg {
+							if d641.Loc == LocReg || d641.Loc == LocFPReg {
 								ctx.UnprotectReg(d641.Reg)
 							} else if d641.Loc == LocRegPair {
 								ctx.UnprotectReg(d641.Reg)
@@ -22589,7 +22597,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl490)
 						ctx.MarkLabel(lbl523)
 						ctx.SyncDesc(&d641)
-						if d641.Loc == LocReg {
+						if d641.Loc == LocReg || d641.Loc == LocFPReg {
 							ctx.ProtectReg(d641.Reg)
 						} else if d641.Loc == LocRegPair {
 							ctx.ProtectReg(d641.Reg)
@@ -22612,7 +22620,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d653, int32(phiBase629)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase629)+int32(0))+8)
 						}
-						if d641.Loc == LocReg {
+						if d641.Loc == LocReg || d641.Loc == LocFPReg {
 							ctx.UnprotectReg(d641.Reg)
 						} else if d641.Loc == LocRegPair {
 							ctx.UnprotectReg(d641.Reg)
@@ -22746,7 +22754,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d661)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d661)
-					if d661.Loc == LocReg {
+					if d661.Loc == LocReg || d661.Loc == LocFPReg {
 						ctx.ProtectReg(d661.Reg)
 					} else if d661.Loc == LocRegPair {
 						ctx.ProtectReg(d661.Reg)
@@ -22769,7 +22777,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d662, int32(phiBase629)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase629)+int32(0))+8)
 					}
-					if d661.Loc == LocReg {
+					if d661.Loc == LocReg || d661.Loc == LocFPReg {
 						ctx.UnprotectReg(d661.Reg)
 					} else if d661.Loc == LocRegPair {
 						ctx.UnprotectReg(d661.Reg)
@@ -22931,7 +22939,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d675)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d675)
-					if d675.Loc == LocReg {
+					if d675.Loc == LocReg || d675.Loc == LocFPReg {
 						ctx.ProtectReg(d675.Reg)
 					} else if d675.Loc == LocRegPair {
 						ctx.ProtectReg(d675.Reg)
@@ -22952,7 +22960,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d676.Reg2, RegRSP, int32(phiBase629)+int32(16)+8)
 						ctx.EmitStoreRegMem(d676.Reg3, RegRSP, int32(phiBase629)+int32(16)+16)
 					}
-					if d675.Loc == LocReg {
+					if d675.Loc == LocReg || d675.Loc == LocFPReg {
 						ctx.UnprotectReg(d675.Reg)
 					} else if d675.Loc == LocRegPair {
 						ctx.UnprotectReg(d675.Reg)
@@ -23428,7 +23436,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl571)
 							ctx.SyncDesc(&d700)
-							if d700.Loc == LocReg {
+							if d700.Loc == LocReg || d700.Loc == LocFPReg {
 								ctx.ProtectReg(d700.Reg)
 							} else if d700.Loc == LocRegPair {
 								ctx.ProtectReg(d700.Reg)
@@ -23451,7 +23459,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d711, int32(phiBase688)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase688)+int32(0))+8)
 							}
-							if d700.Loc == LocReg {
+							if d700.Loc == LocReg || d700.Loc == LocFPReg {
 								ctx.UnprotectReg(d700.Reg)
 							} else if d700.Loc == LocRegPair {
 								ctx.UnprotectReg(d700.Reg)
@@ -23467,7 +23475,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl538)
 						ctx.MarkLabel(lbl571)
 						ctx.SyncDesc(&d700)
-						if d700.Loc == LocReg {
+						if d700.Loc == LocReg || d700.Loc == LocFPReg {
 							ctx.ProtectReg(d700.Reg)
 						} else if d700.Loc == LocRegPair {
 							ctx.ProtectReg(d700.Reg)
@@ -23490,7 +23498,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d712, int32(phiBase688)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase688)+int32(0))+8)
 						}
-						if d700.Loc == LocReg {
+						if d700.Loc == LocReg || d700.Loc == LocFPReg {
 							ctx.UnprotectReg(d700.Reg)
 						} else if d700.Loc == LocRegPair {
 							ctx.UnprotectReg(d700.Reg)
@@ -23624,7 +23632,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d720)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d720)
-					if d720.Loc == LocReg {
+					if d720.Loc == LocReg || d720.Loc == LocFPReg {
 						ctx.ProtectReg(d720.Reg)
 					} else if d720.Loc == LocRegPair {
 						ctx.ProtectReg(d720.Reg)
@@ -23647,7 +23655,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d721, int32(phiBase688)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase688)+int32(0))+8)
 					}
-					if d720.Loc == LocReg {
+					if d720.Loc == LocReg || d720.Loc == LocFPReg {
 						ctx.UnprotectReg(d720.Reg)
 					} else if d720.Loc == LocRegPair {
 						ctx.UnprotectReg(d720.Reg)
@@ -23809,7 +23817,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d734)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d734)
-					if d734.Loc == LocReg {
+					if d734.Loc == LocReg || d734.Loc == LocFPReg {
 						ctx.ProtectReg(d734.Reg)
 					} else if d734.Loc == LocRegPair {
 						ctx.ProtectReg(d734.Reg)
@@ -23830,7 +23838,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d735.Reg2, RegRSP, int32(phiBase688)+int32(16)+8)
 						ctx.EmitStoreRegMem(d735.Reg3, RegRSP, int32(phiBase688)+int32(16)+16)
 					}
-					if d734.Loc == LocReg {
+					if d734.Loc == LocReg || d734.Loc == LocFPReg {
 						ctx.UnprotectReg(d734.Reg)
 					} else if d734.Loc == LocRegPair {
 						ctx.UnprotectReg(d734.Reg)
@@ -24306,7 +24314,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl619)
 							ctx.SyncDesc(&d759)
-							if d759.Loc == LocReg {
+							if d759.Loc == LocReg || d759.Loc == LocFPReg {
 								ctx.ProtectReg(d759.Reg)
 							} else if d759.Loc == LocRegPair {
 								ctx.ProtectReg(d759.Reg)
@@ -24329,7 +24337,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d770, int32(phiBase747)+int32(0))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase747)+int32(0))+8)
 							}
-							if d759.Loc == LocReg {
+							if d759.Loc == LocReg || d759.Loc == LocFPReg {
 								ctx.UnprotectReg(d759.Reg)
 							} else if d759.Loc == LocRegPair {
 								ctx.UnprotectReg(d759.Reg)
@@ -24345,7 +24353,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl586)
 						ctx.MarkLabel(lbl619)
 						ctx.SyncDesc(&d759)
-						if d759.Loc == LocReg {
+						if d759.Loc == LocReg || d759.Loc == LocFPReg {
 							ctx.ProtectReg(d759.Reg)
 						} else if d759.Loc == LocRegPair {
 							ctx.ProtectReg(d759.Reg)
@@ -24368,7 +24376,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d771, int32(phiBase747)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase747)+int32(0))+8)
 						}
-						if d759.Loc == LocReg {
+						if d759.Loc == LocReg || d759.Loc == LocFPReg {
 							ctx.UnprotectReg(d759.Reg)
 						} else if d759.Loc == LocRegPair {
 							ctx.UnprotectReg(d759.Reg)
@@ -24502,7 +24510,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d779)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d779)
-					if d779.Loc == LocReg {
+					if d779.Loc == LocReg || d779.Loc == LocFPReg {
 						ctx.ProtectReg(d779.Reg)
 					} else if d779.Loc == LocRegPair {
 						ctx.ProtectReg(d779.Reg)
@@ -24525,7 +24533,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d780, int32(phiBase747)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase747)+int32(0))+8)
 					}
-					if d779.Loc == LocReg {
+					if d779.Loc == LocReg || d779.Loc == LocFPReg {
 						ctx.UnprotectReg(d779.Reg)
 					} else if d779.Loc == LocRegPair {
 						ctx.UnprotectReg(d779.Reg)
@@ -24687,7 +24695,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d793)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d793)
-					if d793.Loc == LocReg {
+					if d793.Loc == LocReg || d793.Loc == LocFPReg {
 						ctx.ProtectReg(d793.Reg)
 					} else if d793.Loc == LocRegPair {
 						ctx.ProtectReg(d793.Reg)
@@ -24708,7 +24716,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d794.Reg2, RegRSP, int32(phiBase747)+int32(16)+8)
 						ctx.EmitStoreRegMem(d794.Reg3, RegRSP, int32(phiBase747)+int32(16)+16)
 					}
-					if d793.Loc == LocReg {
+					if d793.Loc == LocReg || d793.Loc == LocFPReg {
 						ctx.UnprotectReg(d793.Reg)
 					} else if d793.Loc == LocRegPair {
 						ctx.UnprotectReg(d793.Reg)
@@ -25077,7 +25085,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl635)
 							ctx.SyncDesc(&d824)
-							if d824.Loc == LocReg {
+							if d824.Loc == LocReg || d824.Loc == LocFPReg {
 								ctx.ProtectReg(d824.Reg)
 							} else if d824.Loc == LocRegPair {
 								ctx.ProtectReg(d824.Reg)
@@ -25100,7 +25108,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d828, int32(phiBase747)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase747)+int32(40))+8)
 							}
-							if d824.Loc == LocReg {
+							if d824.Loc == LocReg || d824.Loc == LocFPReg {
 								ctx.UnprotectReg(d824.Reg)
 							} else if d824.Loc == LocRegPair {
 								ctx.UnprotectReg(d824.Reg)
@@ -25116,7 +25124,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl601)
 						ctx.MarkLabel(lbl635)
 						ctx.SyncDesc(&d824)
-						if d824.Loc == LocReg {
+						if d824.Loc == LocReg || d824.Loc == LocFPReg {
 							ctx.ProtectReg(d824.Reg)
 						} else if d824.Loc == LocRegPair {
 							ctx.ProtectReg(d824.Reg)
@@ -25139,7 +25147,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d829, int32(phiBase747)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase747)+int32(40))+8)
 						}
-						if d824.Loc == LocReg {
+						if d824.Loc == LocReg || d824.Loc == LocFPReg {
 							ctx.UnprotectReg(d824.Reg)
 						} else if d824.Loc == LocRegPair {
 							ctx.UnprotectReg(d824.Reg)
@@ -25531,7 +25539,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d859)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d859)
-					if d859.Loc == LocReg {
+					if d859.Loc == LocReg || d859.Loc == LocFPReg {
 						ctx.ProtectReg(d859.Reg)
 					} else if d859.Loc == LocRegPair {
 						ctx.ProtectReg(d859.Reg)
@@ -25554,7 +25562,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d860, int32(phiBase747)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase747)+int32(40))+8)
 					}
-					if d859.Loc == LocReg {
+					if d859.Loc == LocReg || d859.Loc == LocFPReg {
 						ctx.UnprotectReg(d859.Reg)
 					} else if d859.Loc == LocRegPair {
 						ctx.UnprotectReg(d859.Reg)
@@ -25787,7 +25795,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d879)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d877)
-					if d877.Loc == LocReg {
+					if d877.Loc == LocReg || d877.Loc == LocFPReg {
 						ctx.ProtectReg(d877.Reg)
 					} else if d877.Loc == LocRegPair {
 						ctx.ProtectReg(d877.Reg)
@@ -25808,7 +25816,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d880.Reg2, RegRSP, int32(phiBase747)+int32(56)+8)
 						ctx.EmitStoreRegMem(d880.Reg3, RegRSP, int32(phiBase747)+int32(56)+16)
 					}
-					if d877.Loc == LocReg {
+					if d877.Loc == LocReg || d877.Loc == LocFPReg {
 						ctx.UnprotectReg(d877.Reg)
 					} else if d877.Loc == LocRegPair {
 						ctx.UnprotectReg(d877.Reg)
@@ -26510,7 +26518,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl655)
 							ctx.SyncDesc(&d940)
-							if d940.Loc == LocReg {
+							if d940.Loc == LocReg || d940.Loc == LocFPReg {
 								ctx.ProtectReg(d940.Reg)
 							} else if d940.Loc == LocRegPair {
 								ctx.ProtectReg(d940.Reg)
@@ -26533,7 +26541,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d944, int32(phiBase688)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase688)+int32(40))+8)
 							}
-							if d940.Loc == LocReg {
+							if d940.Loc == LocReg || d940.Loc == LocFPReg {
 								ctx.UnprotectReg(d940.Reg)
 							} else if d940.Loc == LocRegPair {
 								ctx.UnprotectReg(d940.Reg)
@@ -26549,7 +26557,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl553)
 						ctx.MarkLabel(lbl655)
 						ctx.SyncDesc(&d940)
-						if d940.Loc == LocReg {
+						if d940.Loc == LocReg || d940.Loc == LocFPReg {
 							ctx.ProtectReg(d940.Reg)
 						} else if d940.Loc == LocRegPair {
 							ctx.ProtectReg(d940.Reg)
@@ -26572,7 +26580,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d945, int32(phiBase688)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase688)+int32(40))+8)
 						}
-						if d940.Loc == LocReg {
+						if d940.Loc == LocReg || d940.Loc == LocFPReg {
 							ctx.UnprotectReg(d940.Reg)
 						} else if d940.Loc == LocRegPair {
 							ctx.UnprotectReg(d940.Reg)
@@ -26964,7 +26972,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d975)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d975)
-					if d975.Loc == LocReg {
+					if d975.Loc == LocReg || d975.Loc == LocFPReg {
 						ctx.ProtectReg(d975.Reg)
 					} else if d975.Loc == LocRegPair {
 						ctx.ProtectReg(d975.Reg)
@@ -26987,7 +26995,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d976, int32(phiBase688)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase688)+int32(40))+8)
 					}
-					if d975.Loc == LocReg {
+					if d975.Loc == LocReg || d975.Loc == LocFPReg {
 						ctx.UnprotectReg(d975.Reg)
 					} else if d975.Loc == LocRegPair {
 						ctx.UnprotectReg(d975.Reg)
@@ -27220,7 +27228,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d995)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d993)
-					if d993.Loc == LocReg {
+					if d993.Loc == LocReg || d993.Loc == LocFPReg {
 						ctx.ProtectReg(d993.Reg)
 					} else if d993.Loc == LocRegPair {
 						ctx.ProtectReg(d993.Reg)
@@ -27241,7 +27249,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d996.Reg2, RegRSP, int32(phiBase688)+int32(56)+8)
 						ctx.EmitStoreRegMem(d996.Reg3, RegRSP, int32(phiBase688)+int32(56)+16)
 					}
-					if d993.Loc == LocReg {
+					if d993.Loc == LocReg || d993.Loc == LocFPReg {
 						ctx.UnprotectReg(d993.Reg)
 					} else if d993.Loc == LocRegPair {
 						ctx.UnprotectReg(d993.Reg)
@@ -27943,7 +27951,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl675)
 							ctx.SyncDesc(&d1056)
-							if d1056.Loc == LocReg {
+							if d1056.Loc == LocReg || d1056.Loc == LocFPReg {
 								ctx.ProtectReg(d1056.Reg)
 							} else if d1056.Loc == LocRegPair {
 								ctx.ProtectReg(d1056.Reg)
@@ -27966,7 +27974,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d1060, int32(phiBase629)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase629)+int32(40))+8)
 							}
-							if d1056.Loc == LocReg {
+							if d1056.Loc == LocReg || d1056.Loc == LocFPReg {
 								ctx.UnprotectReg(d1056.Reg)
 							} else if d1056.Loc == LocRegPair {
 								ctx.UnprotectReg(d1056.Reg)
@@ -27982,7 +27990,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl505)
 						ctx.MarkLabel(lbl675)
 						ctx.SyncDesc(&d1056)
-						if d1056.Loc == LocReg {
+						if d1056.Loc == LocReg || d1056.Loc == LocFPReg {
 							ctx.ProtectReg(d1056.Reg)
 						} else if d1056.Loc == LocRegPair {
 							ctx.ProtectReg(d1056.Reg)
@@ -28005,7 +28013,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d1061, int32(phiBase629)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase629)+int32(40))+8)
 						}
-						if d1056.Loc == LocReg {
+						if d1056.Loc == LocReg || d1056.Loc == LocFPReg {
 							ctx.UnprotectReg(d1056.Reg)
 						} else if d1056.Loc == LocRegPair {
 							ctx.UnprotectReg(d1056.Reg)
@@ -28397,7 +28405,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d1091)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1091)
-					if d1091.Loc == LocReg {
+					if d1091.Loc == LocReg || d1091.Loc == LocFPReg {
 						ctx.ProtectReg(d1091.Reg)
 					} else if d1091.Loc == LocRegPair {
 						ctx.ProtectReg(d1091.Reg)
@@ -28420,7 +28428,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d1092, int32(phiBase629)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase629)+int32(40))+8)
 					}
-					if d1091.Loc == LocReg {
+					if d1091.Loc == LocReg || d1091.Loc == LocFPReg {
 						ctx.UnprotectReg(d1091.Reg)
 					} else if d1091.Loc == LocRegPair {
 						ctx.UnprotectReg(d1091.Reg)
@@ -28653,7 +28661,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d1111)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1109)
-					if d1109.Loc == LocReg {
+					if d1109.Loc == LocReg || d1109.Loc == LocFPReg {
 						ctx.ProtectReg(d1109.Reg)
 					} else if d1109.Loc == LocRegPair {
 						ctx.ProtectReg(d1109.Reg)
@@ -28674,7 +28682,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d1112.Reg2, RegRSP, int32(phiBase629)+int32(56)+8)
 						ctx.EmitStoreRegMem(d1112.Reg3, RegRSP, int32(phiBase629)+int32(56)+16)
 					}
-					if d1109.Loc == LocReg {
+					if d1109.Loc == LocReg || d1109.Loc == LocFPReg {
 						ctx.UnprotectReg(d1109.Reg)
 					} else if d1109.Loc == LocRegPair {
 						ctx.UnprotectReg(d1109.Reg)
@@ -29376,7 +29384,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl695)
 							ctx.SyncDesc(&d1172)
-							if d1172.Loc == LocReg {
+							if d1172.Loc == LocReg || d1172.Loc == LocFPReg {
 								ctx.ProtectReg(d1172.Reg)
 							} else if d1172.Loc == LocRegPair {
 								ctx.ProtectReg(d1172.Reg)
@@ -29399,7 +29407,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d1176, int32(phiBase570)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase570)+int32(40))+8)
 							}
-							if d1172.Loc == LocReg {
+							if d1172.Loc == LocReg || d1172.Loc == LocFPReg {
 								ctx.UnprotectReg(d1172.Reg)
 							} else if d1172.Loc == LocRegPair {
 								ctx.UnprotectReg(d1172.Reg)
@@ -29415,7 +29423,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl457)
 						ctx.MarkLabel(lbl695)
 						ctx.SyncDesc(&d1172)
-						if d1172.Loc == LocReg {
+						if d1172.Loc == LocReg || d1172.Loc == LocFPReg {
 							ctx.ProtectReg(d1172.Reg)
 						} else if d1172.Loc == LocRegPair {
 							ctx.ProtectReg(d1172.Reg)
@@ -29438,7 +29446,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d1177, int32(phiBase570)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase570)+int32(40))+8)
 						}
-						if d1172.Loc == LocReg {
+						if d1172.Loc == LocReg || d1172.Loc == LocFPReg {
 							ctx.UnprotectReg(d1172.Reg)
 						} else if d1172.Loc == LocRegPair {
 							ctx.UnprotectReg(d1172.Reg)
@@ -29830,7 +29838,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d1207)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1207)
-					if d1207.Loc == LocReg {
+					if d1207.Loc == LocReg || d1207.Loc == LocFPReg {
 						ctx.ProtectReg(d1207.Reg)
 					} else if d1207.Loc == LocRegPair {
 						ctx.ProtectReg(d1207.Reg)
@@ -29853,7 +29861,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d1208, int32(phiBase570)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase570)+int32(40))+8)
 					}
-					if d1207.Loc == LocReg {
+					if d1207.Loc == LocReg || d1207.Loc == LocFPReg {
 						ctx.UnprotectReg(d1207.Reg)
 					} else if d1207.Loc == LocRegPair {
 						ctx.UnprotectReg(d1207.Reg)
@@ -30086,7 +30094,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d1227)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1225)
-					if d1225.Loc == LocReg {
+					if d1225.Loc == LocReg || d1225.Loc == LocFPReg {
 						ctx.ProtectReg(d1225.Reg)
 					} else if d1225.Loc == LocRegPair {
 						ctx.ProtectReg(d1225.Reg)
@@ -30107,7 +30115,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d1228.Reg2, RegRSP, int32(phiBase570)+int32(56)+8)
 						ctx.EmitStoreRegMem(d1228.Reg3, RegRSP, int32(phiBase570)+int32(56)+16)
 					}
-					if d1225.Loc == LocReg {
+					if d1225.Loc == LocReg || d1225.Loc == LocFPReg {
 						ctx.UnprotectReg(d1225.Reg)
 					} else if d1225.Loc == LocRegPair {
 						ctx.UnprotectReg(d1225.Reg)
@@ -30809,7 +30817,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl715)
 							ctx.SyncDesc(&d1288)
-							if d1288.Loc == LocReg {
+							if d1288.Loc == LocReg || d1288.Loc == LocFPReg {
 								ctx.ProtectReg(d1288.Reg)
 							} else if d1288.Loc == LocRegPair {
 								ctx.ProtectReg(d1288.Reg)
@@ -30832,7 +30840,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d1292, int32(phiBase511)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase511)+int32(40))+8)
 							}
-							if d1288.Loc == LocReg {
+							if d1288.Loc == LocReg || d1288.Loc == LocFPReg {
 								ctx.UnprotectReg(d1288.Reg)
 							} else if d1288.Loc == LocRegPair {
 								ctx.UnprotectReg(d1288.Reg)
@@ -30848,7 +30856,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl409)
 						ctx.MarkLabel(lbl715)
 						ctx.SyncDesc(&d1288)
-						if d1288.Loc == LocReg {
+						if d1288.Loc == LocReg || d1288.Loc == LocFPReg {
 							ctx.ProtectReg(d1288.Reg)
 						} else if d1288.Loc == LocRegPair {
 							ctx.ProtectReg(d1288.Reg)
@@ -30871,7 +30879,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d1293, int32(phiBase511)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase511)+int32(40))+8)
 						}
-						if d1288.Loc == LocReg {
+						if d1288.Loc == LocReg || d1288.Loc == LocFPReg {
 							ctx.UnprotectReg(d1288.Reg)
 						} else if d1288.Loc == LocRegPair {
 							ctx.UnprotectReg(d1288.Reg)
@@ -31263,7 +31271,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d1323)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1323)
-					if d1323.Loc == LocReg {
+					if d1323.Loc == LocReg || d1323.Loc == LocFPReg {
 						ctx.ProtectReg(d1323.Reg)
 					} else if d1323.Loc == LocRegPair {
 						ctx.ProtectReg(d1323.Reg)
@@ -31286,7 +31294,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d1324, int32(phiBase511)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase511)+int32(40))+8)
 					}
-					if d1323.Loc == LocReg {
+					if d1323.Loc == LocReg || d1323.Loc == LocFPReg {
 						ctx.UnprotectReg(d1323.Reg)
 					} else if d1323.Loc == LocRegPair {
 						ctx.UnprotectReg(d1323.Reg)
@@ -31519,7 +31527,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d1343)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1341)
-					if d1341.Loc == LocReg {
+					if d1341.Loc == LocReg || d1341.Loc == LocFPReg {
 						ctx.ProtectReg(d1341.Reg)
 					} else if d1341.Loc == LocRegPair {
 						ctx.ProtectReg(d1341.Reg)
@@ -31540,7 +31548,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d1344.Reg2, RegRSP, int32(phiBase511)+int32(56)+8)
 						ctx.EmitStoreRegMem(d1344.Reg3, RegRSP, int32(phiBase511)+int32(56)+16)
 					}
-					if d1341.Loc == LocReg {
+					if d1341.Loc == LocReg || d1341.Loc == LocFPReg {
 						ctx.UnprotectReg(d1341.Reg)
 					} else if d1341.Loc == LocRegPair {
 						ctx.UnprotectReg(d1341.Reg)
@@ -32242,7 +32250,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl735)
 							ctx.SyncDesc(&d1404)
-							if d1404.Loc == LocReg {
+							if d1404.Loc == LocReg || d1404.Loc == LocFPReg {
 								ctx.ProtectReg(d1404.Reg)
 							} else if d1404.Loc == LocRegPair {
 								ctx.ProtectReg(d1404.Reg)
@@ -32265,7 +32273,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d1408, int32(phiBase452)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase452)+int32(40))+8)
 							}
-							if d1404.Loc == LocReg {
+							if d1404.Loc == LocReg || d1404.Loc == LocFPReg {
 								ctx.UnprotectReg(d1404.Reg)
 							} else if d1404.Loc == LocRegPair {
 								ctx.UnprotectReg(d1404.Reg)
@@ -32281,7 +32289,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl361)
 						ctx.MarkLabel(lbl735)
 						ctx.SyncDesc(&d1404)
-						if d1404.Loc == LocReg {
+						if d1404.Loc == LocReg || d1404.Loc == LocFPReg {
 							ctx.ProtectReg(d1404.Reg)
 						} else if d1404.Loc == LocRegPair {
 							ctx.ProtectReg(d1404.Reg)
@@ -32304,7 +32312,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d1409, int32(phiBase452)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase452)+int32(40))+8)
 						}
-						if d1404.Loc == LocReg {
+						if d1404.Loc == LocReg || d1404.Loc == LocFPReg {
 							ctx.UnprotectReg(d1404.Reg)
 						} else if d1404.Loc == LocRegPair {
 							ctx.UnprotectReg(d1404.Reg)
@@ -32696,7 +32704,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d1439)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1439)
-					if d1439.Loc == LocReg {
+					if d1439.Loc == LocReg || d1439.Loc == LocFPReg {
 						ctx.ProtectReg(d1439.Reg)
 					} else if d1439.Loc == LocRegPair {
 						ctx.ProtectReg(d1439.Reg)
@@ -32719,7 +32727,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d1440, int32(phiBase452)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase452)+int32(40))+8)
 					}
-					if d1439.Loc == LocReg {
+					if d1439.Loc == LocReg || d1439.Loc == LocFPReg {
 						ctx.UnprotectReg(d1439.Reg)
 					} else if d1439.Loc == LocRegPair {
 						ctx.UnprotectReg(d1439.Reg)
@@ -32952,7 +32960,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d1459)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1457)
-					if d1457.Loc == LocReg {
+					if d1457.Loc == LocReg || d1457.Loc == LocFPReg {
 						ctx.ProtectReg(d1457.Reg)
 					} else if d1457.Loc == LocRegPair {
 						ctx.ProtectReg(d1457.Reg)
@@ -32973,7 +32981,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d1460.Reg2, RegRSP, int32(phiBase452)+int32(56)+8)
 						ctx.EmitStoreRegMem(d1460.Reg3, RegRSP, int32(phiBase452)+int32(56)+16)
 					}
-					if d1457.Loc == LocReg {
+					if d1457.Loc == LocReg || d1457.Loc == LocFPReg {
 						ctx.UnprotectReg(d1457.Reg)
 					} else if d1457.Loc == LocRegPair {
 						ctx.UnprotectReg(d1457.Reg)
@@ -33675,7 +33683,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl755)
 							ctx.SyncDesc(&d1520)
-							if d1520.Loc == LocReg {
+							if d1520.Loc == LocReg || d1520.Loc == LocFPReg {
 								ctx.ProtectReg(d1520.Reg)
 							} else if d1520.Loc == LocRegPair {
 								ctx.ProtectReg(d1520.Reg)
@@ -33698,7 +33706,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d1524, int32(phiBase393)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase393)+int32(40))+8)
 							}
-							if d1520.Loc == LocReg {
+							if d1520.Loc == LocReg || d1520.Loc == LocFPReg {
 								ctx.UnprotectReg(d1520.Reg)
 							} else if d1520.Loc == LocRegPair {
 								ctx.UnprotectReg(d1520.Reg)
@@ -33714,7 +33722,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl313)
 						ctx.MarkLabel(lbl755)
 						ctx.SyncDesc(&d1520)
-						if d1520.Loc == LocReg {
+						if d1520.Loc == LocReg || d1520.Loc == LocFPReg {
 							ctx.ProtectReg(d1520.Reg)
 						} else if d1520.Loc == LocRegPair {
 							ctx.ProtectReg(d1520.Reg)
@@ -33737,7 +33745,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d1525, int32(phiBase393)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase393)+int32(40))+8)
 						}
-						if d1520.Loc == LocReg {
+						if d1520.Loc == LocReg || d1520.Loc == LocFPReg {
 							ctx.UnprotectReg(d1520.Reg)
 						} else if d1520.Loc == LocRegPair {
 							ctx.UnprotectReg(d1520.Reg)
@@ -34129,7 +34137,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d1555)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1555)
-					if d1555.Loc == LocReg {
+					if d1555.Loc == LocReg || d1555.Loc == LocFPReg {
 						ctx.ProtectReg(d1555.Reg)
 					} else if d1555.Loc == LocRegPair {
 						ctx.ProtectReg(d1555.Reg)
@@ -34152,7 +34160,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d1556, int32(phiBase393)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase393)+int32(40))+8)
 					}
-					if d1555.Loc == LocReg {
+					if d1555.Loc == LocReg || d1555.Loc == LocFPReg {
 						ctx.UnprotectReg(d1555.Reg)
 					} else if d1555.Loc == LocRegPair {
 						ctx.UnprotectReg(d1555.Reg)
@@ -34385,7 +34393,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d1575)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1573)
-					if d1573.Loc == LocReg {
+					if d1573.Loc == LocReg || d1573.Loc == LocFPReg {
 						ctx.ProtectReg(d1573.Reg)
 					} else if d1573.Loc == LocRegPair {
 						ctx.ProtectReg(d1573.Reg)
@@ -34406,7 +34414,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d1576.Reg2, RegRSP, int32(phiBase393)+int32(56)+8)
 						ctx.EmitStoreRegMem(d1576.Reg3, RegRSP, int32(phiBase393)+int32(56)+16)
 					}
-					if d1573.Loc == LocReg {
+					if d1573.Loc == LocReg || d1573.Loc == LocFPReg {
 						ctx.UnprotectReg(d1573.Reg)
 					} else if d1573.Loc == LocRegPair {
 						ctx.UnprotectReg(d1573.Reg)
@@ -35108,7 +35116,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl775)
 							ctx.SyncDesc(&d1636)
-							if d1636.Loc == LocReg {
+							if d1636.Loc == LocReg || d1636.Loc == LocFPReg {
 								ctx.ProtectReg(d1636.Reg)
 							} else if d1636.Loc == LocRegPair {
 								ctx.ProtectReg(d1636.Reg)
@@ -35131,7 +35139,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d1640, int32(phiBase334)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase334)+int32(40))+8)
 							}
-							if d1636.Loc == LocReg {
+							if d1636.Loc == LocReg || d1636.Loc == LocFPReg {
 								ctx.UnprotectReg(d1636.Reg)
 							} else if d1636.Loc == LocRegPair {
 								ctx.UnprotectReg(d1636.Reg)
@@ -35147,7 +35155,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl265)
 						ctx.MarkLabel(lbl775)
 						ctx.SyncDesc(&d1636)
-						if d1636.Loc == LocReg {
+						if d1636.Loc == LocReg || d1636.Loc == LocFPReg {
 							ctx.ProtectReg(d1636.Reg)
 						} else if d1636.Loc == LocRegPair {
 							ctx.ProtectReg(d1636.Reg)
@@ -35170,7 +35178,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d1641, int32(phiBase334)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase334)+int32(40))+8)
 						}
-						if d1636.Loc == LocReg {
+						if d1636.Loc == LocReg || d1636.Loc == LocFPReg {
 							ctx.UnprotectReg(d1636.Reg)
 						} else if d1636.Loc == LocRegPair {
 							ctx.UnprotectReg(d1636.Reg)
@@ -35562,7 +35570,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d1671)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1671)
-					if d1671.Loc == LocReg {
+					if d1671.Loc == LocReg || d1671.Loc == LocFPReg {
 						ctx.ProtectReg(d1671.Reg)
 					} else if d1671.Loc == LocRegPair {
 						ctx.ProtectReg(d1671.Reg)
@@ -35585,7 +35593,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d1672, int32(phiBase334)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase334)+int32(40))+8)
 					}
-					if d1671.Loc == LocReg {
+					if d1671.Loc == LocReg || d1671.Loc == LocFPReg {
 						ctx.UnprotectReg(d1671.Reg)
 					} else if d1671.Loc == LocRegPair {
 						ctx.UnprotectReg(d1671.Reg)
@@ -35818,7 +35826,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d1691)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1689)
-					if d1689.Loc == LocReg {
+					if d1689.Loc == LocReg || d1689.Loc == LocFPReg {
 						ctx.ProtectReg(d1689.Reg)
 					} else if d1689.Loc == LocRegPair {
 						ctx.ProtectReg(d1689.Reg)
@@ -35839,7 +35847,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d1692.Reg2, RegRSP, int32(phiBase334)+int32(56)+8)
 						ctx.EmitStoreRegMem(d1692.Reg3, RegRSP, int32(phiBase334)+int32(56)+16)
 					}
-					if d1689.Loc == LocReg {
+					if d1689.Loc == LocReg || d1689.Loc == LocFPReg {
 						ctx.UnprotectReg(d1689.Reg)
 					} else if d1689.Loc == LocRegPair {
 						ctx.UnprotectReg(d1689.Reg)
@@ -36541,7 +36549,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl795)
 							ctx.SyncDesc(&d1752)
-							if d1752.Loc == LocReg {
+							if d1752.Loc == LocReg || d1752.Loc == LocFPReg {
 								ctx.ProtectReg(d1752.Reg)
 							} else if d1752.Loc == LocRegPair {
 								ctx.ProtectReg(d1752.Reg)
@@ -36564,7 +36572,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d1756, int32(phiBase275)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase275)+int32(40))+8)
 							}
-							if d1752.Loc == LocReg {
+							if d1752.Loc == LocReg || d1752.Loc == LocFPReg {
 								ctx.UnprotectReg(d1752.Reg)
 							} else if d1752.Loc == LocRegPair {
 								ctx.UnprotectReg(d1752.Reg)
@@ -36580,7 +36588,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl217)
 						ctx.MarkLabel(lbl795)
 						ctx.SyncDesc(&d1752)
-						if d1752.Loc == LocReg {
+						if d1752.Loc == LocReg || d1752.Loc == LocFPReg {
 							ctx.ProtectReg(d1752.Reg)
 						} else if d1752.Loc == LocRegPair {
 							ctx.ProtectReg(d1752.Reg)
@@ -36603,7 +36611,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d1757, int32(phiBase275)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase275)+int32(40))+8)
 						}
-						if d1752.Loc == LocReg {
+						if d1752.Loc == LocReg || d1752.Loc == LocFPReg {
 							ctx.UnprotectReg(d1752.Reg)
 						} else if d1752.Loc == LocRegPair {
 							ctx.UnprotectReg(d1752.Reg)
@@ -36995,7 +37003,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d1787)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1787)
-					if d1787.Loc == LocReg {
+					if d1787.Loc == LocReg || d1787.Loc == LocFPReg {
 						ctx.ProtectReg(d1787.Reg)
 					} else if d1787.Loc == LocRegPair {
 						ctx.ProtectReg(d1787.Reg)
@@ -37018,7 +37026,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d1788, int32(phiBase275)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase275)+int32(40))+8)
 					}
-					if d1787.Loc == LocReg {
+					if d1787.Loc == LocReg || d1787.Loc == LocFPReg {
 						ctx.UnprotectReg(d1787.Reg)
 					} else if d1787.Loc == LocRegPair {
 						ctx.UnprotectReg(d1787.Reg)
@@ -37251,7 +37259,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d1807)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1805)
-					if d1805.Loc == LocReg {
+					if d1805.Loc == LocReg || d1805.Loc == LocFPReg {
 						ctx.ProtectReg(d1805.Reg)
 					} else if d1805.Loc == LocRegPair {
 						ctx.ProtectReg(d1805.Reg)
@@ -37272,7 +37280,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d1808.Reg2, RegRSP, int32(phiBase275)+int32(56)+8)
 						ctx.EmitStoreRegMem(d1808.Reg3, RegRSP, int32(phiBase275)+int32(56)+16)
 					}
-					if d1805.Loc == LocReg {
+					if d1805.Loc == LocReg || d1805.Loc == LocFPReg {
 						ctx.UnprotectReg(d1805.Reg)
 					} else if d1805.Loc == LocRegPair {
 						ctx.UnprotectReg(d1805.Reg)
@@ -37974,7 +37982,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl815)
 							ctx.SyncDesc(&d1868)
-							if d1868.Loc == LocReg {
+							if d1868.Loc == LocReg || d1868.Loc == LocFPReg {
 								ctx.ProtectReg(d1868.Reg)
 							} else if d1868.Loc == LocRegPair {
 								ctx.ProtectReg(d1868.Reg)
@@ -37997,7 +38005,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d1872, int32(phiBase216)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase216)+int32(40))+8)
 							}
-							if d1868.Loc == LocReg {
+							if d1868.Loc == LocReg || d1868.Loc == LocFPReg {
 								ctx.UnprotectReg(d1868.Reg)
 							} else if d1868.Loc == LocRegPair {
 								ctx.UnprotectReg(d1868.Reg)
@@ -38013,7 +38021,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl169)
 						ctx.MarkLabel(lbl815)
 						ctx.SyncDesc(&d1868)
-						if d1868.Loc == LocReg {
+						if d1868.Loc == LocReg || d1868.Loc == LocFPReg {
 							ctx.ProtectReg(d1868.Reg)
 						} else if d1868.Loc == LocRegPair {
 							ctx.ProtectReg(d1868.Reg)
@@ -38036,7 +38044,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d1873, int32(phiBase216)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase216)+int32(40))+8)
 						}
-						if d1868.Loc == LocReg {
+						if d1868.Loc == LocReg || d1868.Loc == LocFPReg {
 							ctx.UnprotectReg(d1868.Reg)
 						} else if d1868.Loc == LocRegPair {
 							ctx.UnprotectReg(d1868.Reg)
@@ -38428,7 +38436,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d1903)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1903)
-					if d1903.Loc == LocReg {
+					if d1903.Loc == LocReg || d1903.Loc == LocFPReg {
 						ctx.ProtectReg(d1903.Reg)
 					} else if d1903.Loc == LocRegPair {
 						ctx.ProtectReg(d1903.Reg)
@@ -38451,7 +38459,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d1904, int32(phiBase216)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase216)+int32(40))+8)
 					}
-					if d1903.Loc == LocReg {
+					if d1903.Loc == LocReg || d1903.Loc == LocFPReg {
 						ctx.UnprotectReg(d1903.Reg)
 					} else if d1903.Loc == LocRegPair {
 						ctx.UnprotectReg(d1903.Reg)
@@ -38684,7 +38692,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d1923)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d1921)
-					if d1921.Loc == LocReg {
+					if d1921.Loc == LocReg || d1921.Loc == LocFPReg {
 						ctx.ProtectReg(d1921.Reg)
 					} else if d1921.Loc == LocRegPair {
 						ctx.ProtectReg(d1921.Reg)
@@ -38705,7 +38713,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d1924.Reg2, RegRSP, int32(phiBase216)+int32(56)+8)
 						ctx.EmitStoreRegMem(d1924.Reg3, RegRSP, int32(phiBase216)+int32(56)+16)
 					}
-					if d1921.Loc == LocReg {
+					if d1921.Loc == LocReg || d1921.Loc == LocFPReg {
 						ctx.UnprotectReg(d1921.Reg)
 					} else if d1921.Loc == LocRegPair {
 						ctx.UnprotectReg(d1921.Reg)
@@ -39407,7 +39415,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl835)
 							ctx.SyncDesc(&d1984)
-							if d1984.Loc == LocReg {
+							if d1984.Loc == LocReg || d1984.Loc == LocFPReg {
 								ctx.ProtectReg(d1984.Reg)
 							} else if d1984.Loc == LocRegPair {
 								ctx.ProtectReg(d1984.Reg)
@@ -39430,7 +39438,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d1988, int32(phiBase157)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase157)+int32(40))+8)
 							}
-							if d1984.Loc == LocReg {
+							if d1984.Loc == LocReg || d1984.Loc == LocFPReg {
 								ctx.UnprotectReg(d1984.Reg)
 							} else if d1984.Loc == LocRegPair {
 								ctx.UnprotectReg(d1984.Reg)
@@ -39446,7 +39454,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl121)
 						ctx.MarkLabel(lbl835)
 						ctx.SyncDesc(&d1984)
-						if d1984.Loc == LocReg {
+						if d1984.Loc == LocReg || d1984.Loc == LocFPReg {
 							ctx.ProtectReg(d1984.Reg)
 						} else if d1984.Loc == LocRegPair {
 							ctx.ProtectReg(d1984.Reg)
@@ -39469,7 +39477,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d1989, int32(phiBase157)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase157)+int32(40))+8)
 						}
-						if d1984.Loc == LocReg {
+						if d1984.Loc == LocReg || d1984.Loc == LocFPReg {
 							ctx.UnprotectReg(d1984.Reg)
 						} else if d1984.Loc == LocRegPair {
 							ctx.UnprotectReg(d1984.Reg)
@@ -39861,7 +39869,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d2019)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d2019)
-					if d2019.Loc == LocReg {
+					if d2019.Loc == LocReg || d2019.Loc == LocFPReg {
 						ctx.ProtectReg(d2019.Reg)
 					} else if d2019.Loc == LocRegPair {
 						ctx.ProtectReg(d2019.Reg)
@@ -39884,7 +39892,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d2020, int32(phiBase157)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase157)+int32(40))+8)
 					}
-					if d2019.Loc == LocReg {
+					if d2019.Loc == LocReg || d2019.Loc == LocFPReg {
 						ctx.UnprotectReg(d2019.Reg)
 					} else if d2019.Loc == LocRegPair {
 						ctx.UnprotectReg(d2019.Reg)
@@ -40117,7 +40125,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d2039)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d2037)
-					if d2037.Loc == LocReg {
+					if d2037.Loc == LocReg || d2037.Loc == LocFPReg {
 						ctx.ProtectReg(d2037.Reg)
 					} else if d2037.Loc == LocRegPair {
 						ctx.ProtectReg(d2037.Reg)
@@ -40138,7 +40146,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d2040.Reg2, RegRSP, int32(phiBase157)+int32(56)+8)
 						ctx.EmitStoreRegMem(d2040.Reg3, RegRSP, int32(phiBase157)+int32(56)+16)
 					}
-					if d2037.Loc == LocReg {
+					if d2037.Loc == LocReg || d2037.Loc == LocFPReg {
 						ctx.UnprotectReg(d2037.Reg)
 					} else if d2037.Loc == LocRegPair {
 						ctx.UnprotectReg(d2037.Reg)
@@ -40840,7 +40848,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl855)
 							ctx.SyncDesc(&d2100)
-							if d2100.Loc == LocReg {
+							if d2100.Loc == LocReg || d2100.Loc == LocFPReg {
 								ctx.ProtectReg(d2100.Reg)
 							} else if d2100.Loc == LocRegPair {
 								ctx.ProtectReg(d2100.Reg)
@@ -40863,7 +40871,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d2104, int32(phiBase98)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase98)+int32(40))+8)
 							}
-							if d2100.Loc == LocReg {
+							if d2100.Loc == LocReg || d2100.Loc == LocFPReg {
 								ctx.UnprotectReg(d2100.Reg)
 							} else if d2100.Loc == LocRegPair {
 								ctx.UnprotectReg(d2100.Reg)
@@ -40879,7 +40887,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl73)
 						ctx.MarkLabel(lbl855)
 						ctx.SyncDesc(&d2100)
-						if d2100.Loc == LocReg {
+						if d2100.Loc == LocReg || d2100.Loc == LocFPReg {
 							ctx.ProtectReg(d2100.Reg)
 						} else if d2100.Loc == LocRegPair {
 							ctx.ProtectReg(d2100.Reg)
@@ -40902,7 +40910,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d2105, int32(phiBase98)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase98)+int32(40))+8)
 						}
-						if d2100.Loc == LocReg {
+						if d2100.Loc == LocReg || d2100.Loc == LocFPReg {
 							ctx.UnprotectReg(d2100.Reg)
 						} else if d2100.Loc == LocRegPair {
 							ctx.UnprotectReg(d2100.Reg)
@@ -41294,7 +41302,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d2135)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d2135)
-					if d2135.Loc == LocReg {
+					if d2135.Loc == LocReg || d2135.Loc == LocFPReg {
 						ctx.ProtectReg(d2135.Reg)
 					} else if d2135.Loc == LocRegPair {
 						ctx.ProtectReg(d2135.Reg)
@@ -41317,7 +41325,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d2136, int32(phiBase98)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase98)+int32(40))+8)
 					}
-					if d2135.Loc == LocReg {
+					if d2135.Loc == LocReg || d2135.Loc == LocFPReg {
 						ctx.UnprotectReg(d2135.Reg)
 					} else if d2135.Loc == LocRegPair {
 						ctx.UnprotectReg(d2135.Reg)
@@ -41550,7 +41558,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d2155)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d2153)
-					if d2153.Loc == LocReg {
+					if d2153.Loc == LocReg || d2153.Loc == LocFPReg {
 						ctx.ProtectReg(d2153.Reg)
 					} else if d2153.Loc == LocRegPair {
 						ctx.ProtectReg(d2153.Reg)
@@ -41571,7 +41579,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d2156.Reg2, RegRSP, int32(phiBase98)+int32(56)+8)
 						ctx.EmitStoreRegMem(d2156.Reg3, RegRSP, int32(phiBase98)+int32(56)+16)
 					}
-					if d2153.Loc == LocReg {
+					if d2153.Loc == LocReg || d2153.Loc == LocFPReg {
 						ctx.UnprotectReg(d2153.Reg)
 					} else if d2153.Loc == LocRegPair {
 						ctx.UnprotectReg(d2153.Reg)
@@ -42273,7 +42281,7 @@ Patterns can be any of:
 						} else {
 							ctx.MarkLabel(lbl875)
 							ctx.SyncDesc(&d2216)
-							if d2216.Loc == LocReg {
+							if d2216.Loc == LocReg || d2216.Loc == LocFPReg {
 								ctx.ProtectReg(d2216.Reg)
 							} else if d2216.Loc == LocRegPair {
 								ctx.ProtectReg(d2216.Reg)
@@ -42296,7 +42304,7 @@ Patterns can be any of:
 								ctx.EmitStoreToStack(d2220, int32(phiBase39)+int32(40))
 								ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase39)+int32(40))+8)
 							}
-							if d2216.Loc == LocReg {
+							if d2216.Loc == LocReg || d2216.Loc == LocFPReg {
 								ctx.UnprotectReg(d2216.Reg)
 							} else if d2216.Loc == LocRegPair {
 								ctx.UnprotectReg(d2216.Reg)
@@ -42312,7 +42320,7 @@ Patterns can be any of:
 						ctx.EmitJmp(lbl25)
 						ctx.MarkLabel(lbl875)
 						ctx.SyncDesc(&d2216)
-						if d2216.Loc == LocReg {
+						if d2216.Loc == LocReg || d2216.Loc == LocFPReg {
 							ctx.ProtectReg(d2216.Reg)
 						} else if d2216.Loc == LocRegPair {
 							ctx.ProtectReg(d2216.Reg)
@@ -42335,7 +42343,7 @@ Patterns can be any of:
 							ctx.EmitStoreToStack(d2221, int32(phiBase39)+int32(40))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase39)+int32(40))+8)
 						}
-						if d2216.Loc == LocReg {
+						if d2216.Loc == LocReg || d2216.Loc == LocFPReg {
 							ctx.UnprotectReg(d2216.Reg)
 						} else if d2216.Loc == LocRegPair {
 							ctx.UnprotectReg(d2216.Reg)
@@ -42727,7 +42735,7 @@ Patterns can be any of:
 					ctx.StabilizeDescForControlFlow(&d2251)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d2251)
-					if d2251.Loc == LocReg {
+					if d2251.Loc == LocReg || d2251.Loc == LocFPReg {
 						ctx.ProtectReg(d2251.Reg)
 					} else if d2251.Loc == LocRegPair {
 						ctx.ProtectReg(d2251.Reg)
@@ -42750,7 +42758,7 @@ Patterns can be any of:
 						ctx.EmitStoreToStack(d2252, int32(phiBase39)+int32(40))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(phiBase39)+int32(40))+8)
 					}
-					if d2251.Loc == LocReg {
+					if d2251.Loc == LocReg || d2251.Loc == LocFPReg {
 						ctx.UnprotectReg(d2251.Reg)
 					} else if d2251.Loc == LocRegPair {
 						ctx.UnprotectReg(d2251.Reg)
@@ -42983,7 +42991,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d2271)
 					ctx.ReclaimUntrackedRegs()
 					ctx.SyncDesc(&d2269)
-					if d2269.Loc == LocReg {
+					if d2269.Loc == LocReg || d2269.Loc == LocFPReg {
 						ctx.ProtectReg(d2269.Reg)
 					} else if d2269.Loc == LocRegPair {
 						ctx.ProtectReg(d2269.Reg)
@@ -43004,7 +43012,7 @@ Patterns can be any of:
 						ctx.EmitStoreRegMem(d2272.Reg2, RegRSP, int32(phiBase39)+int32(56)+8)
 						ctx.EmitStoreRegMem(d2272.Reg3, RegRSP, int32(phiBase39)+int32(56)+16)
 					}
-					if d2269.Loc == LocReg {
+					if d2269.Loc == LocReg || d2269.Loc == LocFPReg {
 						ctx.UnprotectReg(d2269.Reg)
 					} else if d2269.Loc == LocRegPair {
 						ctx.UnprotectReg(d2269.Reg)
@@ -43878,7 +43886,7 @@ Patterns can be any of:
 					ctx.FreeDesc(&d24)
 					if ps.General {
 						ctx.SyncDesc(&d26)
-						if d26.Loc == LocReg {
+						if d26.Loc == LocReg || d26.Loc == LocFPReg {
 							ctx.ProtectReg(d26.Reg)
 						} else if d26.Loc == LocRegPair {
 							ctx.ProtectReg(d26.Reg)
@@ -43890,7 +43898,7 @@ Patterns can be any of:
 						}
 						ctx.EnsureDesc(&d28)
 						ctx.EmitStoreToStack(d28, int32(bbs[2].PhiBase)+int32(0))
-						if d26.Loc == LocReg {
+						if d26.Loc == LocReg || d26.Loc == LocFPReg {
 							ctx.UnprotectReg(d26.Reg)
 						} else if d26.Loc == LocRegPair {
 							ctx.UnprotectReg(d26.Reg)

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -1869,7 +1869,7 @@ func init_strings() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d34)
-							if d34.Loc == LocReg {
+							if d34.Loc == LocReg || d34.Loc == LocFPReg {
 								ctx.ProtectReg(d34.Reg)
 							} else if d34.Loc == LocRegPair {
 								ctx.ProtectReg(d34.Reg)
@@ -1881,7 +1881,7 @@ func init_strings() {
 							}
 							ctx.EnsureDesc(&d38)
 							ctx.EmitStoreToStack(d38, int32(bbs[4].PhiBase)+int32(0))
-							if d34.Loc == LocReg {
+							if d34.Loc == LocReg || d34.Loc == LocFPReg {
 								ctx.UnprotectReg(d34.Reg)
 							} else if d34.Loc == LocRegPair {
 								ctx.UnprotectReg(d34.Reg)
@@ -1966,7 +1966,7 @@ func init_strings() {
 					d40 = snap60
 					ctx.MarkLabel(lbl15)
 					ctx.SyncDesc(&d34)
-					if d34.Loc == LocReg {
+					if d34.Loc == LocReg || d34.Loc == LocFPReg {
 						ctx.ProtectReg(d34.Reg)
 					} else if d34.Loc == LocRegPair {
 						ctx.ProtectReg(d34.Reg)
@@ -1978,7 +1978,7 @@ func init_strings() {
 					}
 					ctx.EnsureDesc(&d62)
 					ctx.EmitStoreToStack(d62, int32(bbs[4].PhiBase)+int32(0))
-					if d34.Loc == LocReg {
+					if d34.Loc == LocReg || d34.Loc == LocFPReg {
 						ctx.UnprotectReg(d34.Reg)
 					} else if d34.Loc == LocRegPair {
 						ctx.UnprotectReg(d34.Reg)
@@ -3504,7 +3504,7 @@ func init_strings() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d232)
-							if d232.Loc == LocReg {
+							if d232.Loc == LocReg || d232.Loc == LocFPReg {
 								ctx.ProtectReg(d232.Reg)
 							} else if d232.Loc == LocRegPair {
 								ctx.ProtectReg(d232.Reg)
@@ -3516,7 +3516,7 @@ func init_strings() {
 							}
 							ctx.EnsureDesc(&d238)
 							ctx.EmitStoreToStack(d238, int32(bbs[10].PhiBase)+int32(0))
-							if d232.Loc == LocReg {
+							if d232.Loc == LocReg || d232.Loc == LocFPReg {
 								ctx.UnprotectReg(d232.Reg)
 							} else if d232.Loc == LocRegPair {
 								ctx.UnprotectReg(d232.Reg)
@@ -3664,7 +3664,7 @@ func init_strings() {
 					d240 = snap281
 					ctx.MarkLabel(lbl17)
 					ctx.SyncDesc(&d232)
-					if d232.Loc == LocReg {
+					if d232.Loc == LocReg || d232.Loc == LocFPReg {
 						ctx.ProtectReg(d232.Reg)
 					} else if d232.Loc == LocRegPair {
 						ctx.ProtectReg(d232.Reg)
@@ -3676,7 +3676,7 @@ func init_strings() {
 					}
 					ctx.EnsureDesc(&d283)
 					ctx.EmitStoreToStack(d283, int32(bbs[10].PhiBase)+int32(0))
-					if d232.Loc == LocReg {
+					if d232.Loc == LocReg || d232.Loc == LocFPReg {
 						ctx.UnprotectReg(d232.Reg)
 					} else if d232.Loc == LocRegPair {
 						ctx.UnprotectReg(d232.Reg)
@@ -6884,7 +6884,7 @@ func init_strings() {
 					ctx.StabilizeDescForControlFlow(&d128)
 					if ps.General {
 						ctx.SyncDesc(&d128)
-						if d128.Loc == LocReg {
+						if d128.Loc == LocReg || d128.Loc == LocFPReg {
 							ctx.ProtectReg(d128.Reg)
 						} else if d128.Loc == LocRegPair {
 							ctx.ProtectReg(d128.Reg)
@@ -6907,7 +6907,7 @@ func init_strings() {
 							ctx.EmitStoreToStack(d129, int32(bbs[5].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[5].PhiBase)+int32(0))+8)
 						}
-						if d128.Loc == LocReg {
+						if d128.Loc == LocReg || d128.Loc == LocFPReg {
 							ctx.UnprotectReg(d128.Reg)
 						} else if d128.Loc == LocRegPair {
 							ctx.UnprotectReg(d128.Reg)
@@ -9977,7 +9977,7 @@ func init_strings() {
 					ctx.FreeDesc(&d27)
 					if ps.General {
 						ctx.SyncDesc(&d28)
-						if d28.Loc == LocReg {
+						if d28.Loc == LocReg || d28.Loc == LocFPReg {
 							ctx.ProtectReg(d28.Reg)
 						} else if d28.Loc == LocRegPair {
 							ctx.ProtectReg(d28.Reg)
@@ -10000,7 +10000,7 @@ func init_strings() {
 							ctx.EmitStoreToStack(d30, int32(bbs[2].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[2].PhiBase)+int32(0))+8)
 						}
-						if d28.Loc == LocReg {
+						if d28.Loc == LocReg || d28.Loc == LocFPReg {
 							ctx.UnprotectReg(d28.Reg)
 						} else if d28.Loc == LocRegPair {
 							ctx.UnprotectReg(d28.Reg)
@@ -10810,7 +10810,7 @@ func init_strings() {
 					ctx.FreeDesc(&d110)
 					if ps.General {
 						ctx.SyncDesc(&d45)
-						if d45.Loc == LocReg {
+						if d45.Loc == LocReg || d45.Loc == LocFPReg {
 							ctx.ProtectReg(d45.Reg)
 						} else if d45.Loc == LocRegPair {
 							ctx.ProtectReg(d45.Reg)
@@ -10822,7 +10822,7 @@ func init_strings() {
 						}
 						ctx.EnsureDesc(&d111)
 						ctx.EmitStoreToStack(d111, int32(bbs[3].PhiBase)+int32(0))
-						if d45.Loc == LocReg {
+						if d45.Loc == LocReg || d45.Loc == LocFPReg {
 							ctx.UnprotectReg(d45.Reg)
 						} else if d45.Loc == LocRegPair {
 							ctx.UnprotectReg(d45.Reg)
@@ -21255,6 +21255,159 @@ func init_strings() {
 			Params: []*TypeDescriptor{{Kind: "string", Label: "str", Description: "input string to hash"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
+			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				declaration := declarations["md5"]
+				if !jitGeneratedEmitterInline(ctx, declaration, args) {
+					ctx.Coverage.NativeCalls++
+					return jitEmitGeneratedCallBoundary(ctx, declaration, sourceArgs, args, result)
+				}
+				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
+				for i := range args {
+					ctx.StabilizeDescForControlFlow(&args[i])
+				}
+				d0 := ctx.EmitGoCallScalar(GoFuncAddr(func() *[16]byte { return new([16]byte) }), nil, 1)
+				d1 := args[0]
+				d1.ID = 0
+				d3 := d1
+				ctx.SyncDesc(&d3)
+				if d3.Loc == LocMem {
+					tmpScalar := JITValueDesc{Loc: LocReg, Type: d3.Type, Reg: ctx.AllocReg()}
+					scratch := ctx.AllocRegExcept(tmpScalar.Reg)
+					ctx.EmitMovRegImm64(scratch, uint64(d3.MemPtr))
+					ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
+					ctx.FreeReg(scratch)
+					ctx.BindReg(tmpScalar.Reg, &tmpScalar)
+					d3 = tmpScalar
+				}
+				d3 = JITPrepareScmerGoArg(ctx, d3)
+				if d3.Loc != LocRegPair && d3.Loc != LocStackPair && d3.Loc != LocInputPair {
+					panic("jit: Scmer.String receiver not materialized as pair")
+				}
+				d2 := ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d3}, 2)
+				ctx.FreeDesc(&d1)
+				ctx.EnsureDesc(&d2)
+				ctx.EnsureDesc(&d2)
+				ctx.EnsureDesc(&d2)
+				callResults5 := JITEmitGoCallResults(ctx, GoFuncAddr(jitStringToBytes), []JITValueDesc{d2}, []uint8{3}, []uint8{1})
+				d4 := callResults5[0]
+				d4.Type = tagSlice
+				d4 = JITPrepareGoSliceArg(ctx, d4)
+				if d4.Loc != LocRegTriple && d4.Loc != LocStackTriple {
+					panic("jit: generic call arg expects 3-word Go slice (md5.Sum arg0)")
+				}
+				ctx.SyncDesc(&d4)
+				d6 := ctx.EmitGoCallScalar(GoFuncAddr(md5.Sum), []JITValueDesc{d4}, 2)
+				d6.NoHeapPointer = true
+				ctx.BindReg(d6.Reg, &d6)
+				ctx.BindReg(d6.Reg2, &d6)
+				ctx.EnsureDesc(&d6)
+				ctx.EmitGoCallVoid(GoFuncAddr(func(dst *[16]byte, src [16]byte) { *dst = src }), []JITValueDesc{d0, d6})
+				sliceResults7 := JITEmitGoCallResults(ctx, GoFuncAddr(func(value *[16]byte) []byte { return value[0:16:16] }), []JITValueDesc{d0}, []uint8{3}, []uint8{1})
+				d8 := sliceResults7[0]
+				ctx.EnsureDesc(&d8)
+				d9 := d8
+				_ = d9
+				bbpos_1_0 := int32(-1)
+				_ = bbpos_1_0
+				lbl0 := ctx.ReserveLabel()
+				_ = lbl0
+				bbpos_1_0 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+				ctx.MarkLabel(lbl0)
+				ctx.ResolveFixups()
+				ctx.ReclaimUntrackedRegs()
+				ctx.ReclaimUntrackedRegs()
+				var d10 JITValueDesc
+				if d9.SliceSizeKnown {
+					d10 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d9.KnownSliceLen))}
+				} else if d9.Loc == LocImm {
+					d10 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d9.StackOff))}
+				} else if d9.Loc == LocStackTriple {
+					d10 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: d9.StackOff + 8, NoHeapPointer: true}
+				} else {
+					ctx.EnsureDesc(&d9)
+					if d9.Loc == LocRegPair || d9.Loc == LocRegTriple {
+						d10 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d9.Reg2, ID: 0}
+					} else if d9.Loc == LocReg {
+						d10 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d9.Reg, ID: 0}
+					} else {
+						panic("len on unsupported descriptor location")
+					}
+				}
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d10)
+				d11 := d10
+				_ = d11
+				bbpos_2_0 := int32(-1)
+				_ = bbpos_2_0
+				lbl1 := ctx.ReserveLabel()
+				_ = lbl1
+				bbpos_2_0 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+				ctx.MarkLabel(lbl1)
+				ctx.ResolveFixups()
+				ctx.ReclaimUntrackedRegs()
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d11)
+				ctx.EnsureDesc(&d11)
+				var d12 JITValueDesc
+				if d11.Loc == LocImm {
+					d12 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d11.Imm.Int() * 2)}
+				} else {
+					scratch := ctx.AllocRegExcept(d11.Reg)
+					ctx.EmitMovRegReg(scratch, d11.Reg)
+					ctx.EmitAddInt64(scratch, scratch)
+					d12 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+					ctx.BindReg(scratch, &d12)
+				}
+				if d12.Loc == LocReg && d11.Loc == LocReg && d12.Reg == d11.Reg {
+					ctx.TransferReg(d11.Reg)
+					d11.Loc = LocNone
+				}
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d12)
+				ctx.FreeDesc(&d10)
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d12)
+				ctx.EnsureDesc(&d12)
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d12)
+				ctx.EnsureDesc(&d12)
+				callResults13 := JITEmitGoCallResults(ctx, GoFuncAddr(jitMakeByteSlice), []JITValueDesc{d12, d12}, []uint8{3}, []uint8{1})
+				d14 := callResults13[0]
+				d14.Type = tagSlice
+				ctx.FreeDesc(&d12)
+				ctx.ReclaimUntrackedRegs()
+				d14 = JITPrepareGoSliceArg(ctx, d14)
+				if d14.Loc != LocRegTriple && d14.Loc != LocStackTriple {
+					panic("jit: generic call arg expects 3-word Go slice (hex.Encode arg0)")
+				}
+				d9 = JITPrepareGoSliceArg(ctx, d9)
+				if d9.Loc != LocRegTriple && d9.Loc != LocStackTriple {
+					panic("jit: generic call arg expects 3-word Go slice (hex.Encode arg1)")
+				}
+				ctx.SyncDesc(&d14)
+				ctx.SyncDesc(&d9)
+				d15 := ctx.EmitGoCallScalar(GoFuncAddr(hex.Encode), []JITValueDesc{d14, d9}, 1)
+				d15.NoHeapPointer = true
+				ctx.BindReg(d15.Reg, &d15)
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d14)
+				ctx.EnsureDesc(&d14)
+				ctx.EnsureDesc(&d14)
+				callResults17 := JITEmitGoCallResults(ctx, GoFuncAddr(jitBytesToString), []JITValueDesc{d14}, []uint8{2}, []uint8{1})
+				d16 := callResults17[0]
+				ctx.ReclaimUntrackedRegs()
+				ctx.EnsureDesc(&d16)
+				ctx.EnsureDesc(&d16)
+				d18 := ctx.EmitGoCallScalar(GoFuncAddr(NewString), []JITValueDesc{d16}, 2)
+				if result.Loc == LocAny {
+					return d18
+				}
+				ctx.EmitMovPairToResult(&d18, &result)
+				result.Type = tagString
+				return result
+				return result
+			},
+			JITInlineCost: 19,
 		},
 	})
 	Declare(&Globalenv, &Declaration{

--- a/scm/timezone.go
+++ b/scm/timezone.go
@@ -1286,12 +1286,8 @@ func init_timezone() {
 				_ = d235
 				var d236 JITValueDesc
 				_ = d236
-				var d311 JITValueDesc
-				_ = d311
-				var d312 JITValueDesc
-				_ = d312
-				var d313 JITValueDesc
-				_ = d313
+				var d237 JITValueDesc
+				_ = d237
 				var d314 JITValueDesc
 				_ = d314
 				var d315 JITValueDesc
@@ -1340,30 +1336,36 @@ func init_timezone() {
 				_ = d336
 				var d337 JITValueDesc
 				_ = d337
+				var d338 JITValueDesc
+				_ = d338
 				var d339 JITValueDesc
 				_ = d339
 				var d340 JITValueDesc
 				_ = d340
-				var d341 JITValueDesc
-				_ = d341
 				var d342 JITValueDesc
 				_ = d342
+				var d343 JITValueDesc
+				_ = d343
 				var d344 JITValueDesc
 				_ = d344
 				var d345 JITValueDesc
 				_ = d345
-				var d346 JITValueDesc
-				_ = d346
-				var d489 JITValueDesc
-				_ = d489
-				var d490 JITValueDesc
-				_ = d490
-				var d491 JITValueDesc
-				_ = d491
-				var d492 JITValueDesc
-				_ = d492
+				var d347 JITValueDesc
+				_ = d347
+				var d348 JITValueDesc
+				_ = d348
+				var d349 JITValueDesc
+				_ = d349
 				var d494 JITValueDesc
 				_ = d494
+				var d495 JITValueDesc
+				_ = d495
+				var d496 JITValueDesc
+				_ = d496
+				var d497 JITValueDesc
+				_ = d497
+				var d499 JITValueDesc
+				_ = d499
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				phiBase0 := ctx.AllocStack(int32(16))
 				var bbs [14]BBDescriptor
@@ -1727,7 +1729,7 @@ func init_timezone() {
 						if d28.Loc != LocReg && d28.Loc != LocRegPair && d28.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r0 := ctx.AllocReg()
+						r0 := ctx.AllocRegExcept(d28.Reg)
 						ctx.EmitCmpRegImm32(d28.Reg, 0)
 						ctx.EmitSetcc(r0, CondNotEqual)
 						d29 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}
@@ -2737,7 +2739,7 @@ func init_timezone() {
 						if d165.Loc != LocReg && d165.Loc != LocRegPair && d165.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r1 := ctx.AllocReg()
+						r1 := ctx.AllocRegExcept(d165.Reg)
 						ctx.EmitCmpRegImm32(d165.Reg, 0)
 						ctx.EmitSetcc(r1, CondNotEqual)
 						d166 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
@@ -3300,367 +3302,378 @@ func init_timezone() {
 					ctx.ReclaimUntrackedRegs()
 					d233 = args[0]
 					d233.ID = 0
-					d234 = ctx.EmitGetTagDesc(&d233, JITValueDesc{Loc: LocAny})
+					d234 = d233
+					d234.ID = 0
+					d235 = ctx.EmitGetTagDesc(&d234, JITValueDesc{Loc: LocAny})
 					ctx.FreeDesc(&d233)
-					ctx.EnsureDesc(&d234)
-					var d235 JITValueDesc
-					if d234.Loc == LocImm {
-						d235 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d234.Imm.Int()) == uint64(0x10))}
+					ctx.EnsureDesc(&d235)
+					var d236 JITValueDesc
+					if d235.Loc == LocImm {
+						d236 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d235.Imm.Int()) == uint64(0x10))}
 					} else {
 						r2 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d234.Reg, 16)
-						d235 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondEqual}
-						ctx.BindReg(r2, &d235)
+						ctx.EmitCmpRegImm32(d235.Reg, 16)
+						d236 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r2, Condition: CondEqual}
+						ctx.BindReg(r2, &d236)
 					}
-					ctx.FreeDesc(&d234)
-					d236 = d235
-					ctx.EnsureDesc(&d236)
-					if d236.Loc != LocImm && d236.Loc != LocFlags {
+					ctx.FreeDesc(&d235)
+					d237 = d236
+					ctx.EnsureDesc(&d237)
+					if d237.Loc != LocImm && d237.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d236.Loc == LocImm {
-						if d236.Imm.Bool() {
+					if d237.Loc == LocImm {
+						if d237.Imm.Bool() {
 							if ps.General {
 							}
-							ps237 := PhiState{General: ps.General}
-							ps237.OverlayValues = make([]JITValueDesc, 237)
-							ps237.OverlayValues[1] = d1
-							ps237.OverlayValues[2] = d2
-							ps237.OverlayValues[3] = d3
-							ps237.OverlayValues[4] = d4
-							ps237.OverlayValues[5] = d5
-							ps237.OverlayValues[22] = d22
-							ps237.OverlayValues[23] = d23
-							ps237.OverlayValues[24] = d24
-							ps237.OverlayValues[25] = d25
-							ps237.OverlayValues[27] = d27
-							ps237.OverlayValues[28] = d28
-							ps237.OverlayValues[29] = d29
-							ps237.OverlayValues[30] = d30
-							ps237.OverlayValues[63] = d63
-							ps237.OverlayValues[64] = d64
-							ps237.OverlayValues[65] = d65
-							ps237.OverlayValues[66] = d66
-							ps237.OverlayValues[107] = d107
-							ps237.OverlayValues[108] = d108
-							ps237.OverlayValues[109] = d109
-							ps237.OverlayValues[110] = d110
-							ps237.OverlayValues[159] = d159
-							ps237.OverlayValues[160] = d160
-							ps237.OverlayValues[161] = d161
-							ps237.OverlayValues[162] = d162
-							ps237.OverlayValues[164] = d164
-							ps237.OverlayValues[165] = d165
-							ps237.OverlayValues[166] = d166
-							ps237.OverlayValues[167] = d167
-							ps237.OverlayValues[232] = d232
-							ps237.OverlayValues[233] = d233
-							ps237.OverlayValues[234] = d234
-							ps237.OverlayValues[235] = d235
-							ps237.OverlayValues[236] = d236
-							return bbs[10].RenderPS(ps237)
+							ps238 := PhiState{General: ps.General}
+							ps238.OverlayValues = make([]JITValueDesc, 238)
+							ps238.OverlayValues[1] = d1
+							ps238.OverlayValues[2] = d2
+							ps238.OverlayValues[3] = d3
+							ps238.OverlayValues[4] = d4
+							ps238.OverlayValues[5] = d5
+							ps238.OverlayValues[22] = d22
+							ps238.OverlayValues[23] = d23
+							ps238.OverlayValues[24] = d24
+							ps238.OverlayValues[25] = d25
+							ps238.OverlayValues[27] = d27
+							ps238.OverlayValues[28] = d28
+							ps238.OverlayValues[29] = d29
+							ps238.OverlayValues[30] = d30
+							ps238.OverlayValues[63] = d63
+							ps238.OverlayValues[64] = d64
+							ps238.OverlayValues[65] = d65
+							ps238.OverlayValues[66] = d66
+							ps238.OverlayValues[107] = d107
+							ps238.OverlayValues[108] = d108
+							ps238.OverlayValues[109] = d109
+							ps238.OverlayValues[110] = d110
+							ps238.OverlayValues[159] = d159
+							ps238.OverlayValues[160] = d160
+							ps238.OverlayValues[161] = d161
+							ps238.OverlayValues[162] = d162
+							ps238.OverlayValues[164] = d164
+							ps238.OverlayValues[165] = d165
+							ps238.OverlayValues[166] = d166
+							ps238.OverlayValues[167] = d167
+							ps238.OverlayValues[232] = d232
+							ps238.OverlayValues[233] = d233
+							ps238.OverlayValues[234] = d234
+							ps238.OverlayValues[235] = d235
+							ps238.OverlayValues[236] = d236
+							ps238.OverlayValues[237] = d237
+							return bbs[10].RenderPS(ps238)
 						}
 						if ps.General {
 						}
-						ps238 := PhiState{General: ps.General}
-						ps238.OverlayValues = make([]JITValueDesc, 237)
-						ps238.OverlayValues[1] = d1
-						ps238.OverlayValues[2] = d2
-						ps238.OverlayValues[3] = d3
-						ps238.OverlayValues[4] = d4
-						ps238.OverlayValues[5] = d5
-						ps238.OverlayValues[22] = d22
-						ps238.OverlayValues[23] = d23
-						ps238.OverlayValues[24] = d24
-						ps238.OverlayValues[25] = d25
-						ps238.OverlayValues[27] = d27
-						ps238.OverlayValues[28] = d28
-						ps238.OverlayValues[29] = d29
-						ps238.OverlayValues[30] = d30
-						ps238.OverlayValues[63] = d63
-						ps238.OverlayValues[64] = d64
-						ps238.OverlayValues[65] = d65
-						ps238.OverlayValues[66] = d66
-						ps238.OverlayValues[107] = d107
-						ps238.OverlayValues[108] = d108
-						ps238.OverlayValues[109] = d109
-						ps238.OverlayValues[110] = d110
-						ps238.OverlayValues[159] = d159
-						ps238.OverlayValues[160] = d160
-						ps238.OverlayValues[161] = d161
-						ps238.OverlayValues[162] = d162
-						ps238.OverlayValues[164] = d164
-						ps238.OverlayValues[165] = d165
-						ps238.OverlayValues[166] = d166
-						ps238.OverlayValues[167] = d167
-						ps238.OverlayValues[232] = d232
-						ps238.OverlayValues[233] = d233
-						ps238.OverlayValues[234] = d234
-						ps238.OverlayValues[235] = d235
-						ps238.OverlayValues[236] = d236
-						return bbs[11].RenderPS(ps238)
+						ps239 := PhiState{General: ps.General}
+						ps239.OverlayValues = make([]JITValueDesc, 238)
+						ps239.OverlayValues[1] = d1
+						ps239.OverlayValues[2] = d2
+						ps239.OverlayValues[3] = d3
+						ps239.OverlayValues[4] = d4
+						ps239.OverlayValues[5] = d5
+						ps239.OverlayValues[22] = d22
+						ps239.OverlayValues[23] = d23
+						ps239.OverlayValues[24] = d24
+						ps239.OverlayValues[25] = d25
+						ps239.OverlayValues[27] = d27
+						ps239.OverlayValues[28] = d28
+						ps239.OverlayValues[29] = d29
+						ps239.OverlayValues[30] = d30
+						ps239.OverlayValues[63] = d63
+						ps239.OverlayValues[64] = d64
+						ps239.OverlayValues[65] = d65
+						ps239.OverlayValues[66] = d66
+						ps239.OverlayValues[107] = d107
+						ps239.OverlayValues[108] = d108
+						ps239.OverlayValues[109] = d109
+						ps239.OverlayValues[110] = d110
+						ps239.OverlayValues[159] = d159
+						ps239.OverlayValues[160] = d160
+						ps239.OverlayValues[161] = d161
+						ps239.OverlayValues[162] = d162
+						ps239.OverlayValues[164] = d164
+						ps239.OverlayValues[165] = d165
+						ps239.OverlayValues[166] = d166
+						ps239.OverlayValues[167] = d167
+						ps239.OverlayValues[232] = d232
+						ps239.OverlayValues[233] = d233
+						ps239.OverlayValues[234] = d234
+						ps239.OverlayValues[235] = d235
+						ps239.OverlayValues[236] = d236
+						ps239.OverlayValues[237] = d237
+						return bbs[11].RenderPS(ps239)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[8].RenderPS(ps)
 					}
-					ctx.EmitJump(d236.Condition, lbl11)
+					ctx.EmitJump(d237.Condition, lbl11)
 					if bbs[11].Rendered {
 						ctx.EmitJmp(lbl12)
 					}
-					ctx.FreeDesc(&d235)
-					snap239 := d1
-					snap240 := d2
-					snap241 := d3
-					snap242 := d4
-					snap243 := d5
-					snap244 := d22
-					snap245 := d23
-					snap246 := d24
-					snap247 := d25
-					snap248 := d27
-					snap249 := d28
-					snap250 := d29
-					snap251 := d30
-					snap252 := d63
-					snap253 := d64
-					snap254 := d65
-					snap255 := d66
-					snap256 := d107
-					snap257 := d108
-					snap258 := d109
-					snap259 := d110
-					snap260 := d159
-					snap261 := d160
-					snap262 := d161
-					snap263 := d162
-					snap264 := d164
-					snap265 := d165
-					snap266 := d166
-					snap267 := d167
-					snap268 := d232
-					snap269 := d233
-					snap270 := d234
-					snap271 := d235
-					snap272 := d236
-					alloc273 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc273)
-					d1 = snap239
-					d2 = snap240
-					d3 = snap241
-					d4 = snap242
-					d5 = snap243
-					d22 = snap244
-					d23 = snap245
-					d24 = snap246
-					d25 = snap247
-					d27 = snap248
-					d28 = snap249
-					d29 = snap250
-					d30 = snap251
-					d63 = snap252
-					d64 = snap253
-					d65 = snap254
-					d66 = snap255
-					d107 = snap256
-					d108 = snap257
-					d109 = snap258
-					d110 = snap259
-					d159 = snap260
-					d160 = snap261
-					d161 = snap262
-					d162 = snap263
-					d164 = snap264
-					d165 = snap265
-					d166 = snap266
-					d167 = snap267
-					d232 = snap268
-					d233 = snap269
-					d234 = snap270
-					d235 = snap271
-					d236 = snap272
-					ctx.RestoreAllocState(alloc273)
-					d1 = snap239
-					d2 = snap240
-					d3 = snap241
-					d4 = snap242
-					d5 = snap243
-					d22 = snap244
-					d23 = snap245
-					d24 = snap246
-					d25 = snap247
-					d27 = snap248
-					d28 = snap249
-					d29 = snap250
-					d30 = snap251
-					d63 = snap252
-					d64 = snap253
-					d65 = snap254
-					d66 = snap255
-					d107 = snap256
-					d108 = snap257
-					d109 = snap258
-					d110 = snap259
-					d159 = snap260
-					d160 = snap261
-					d161 = snap262
-					d162 = snap263
-					d164 = snap264
-					d165 = snap265
-					d166 = snap266
-					d167 = snap267
-					d232 = snap268
-					d233 = snap269
-					d234 = snap270
-					d235 = snap271
-					d236 = snap272
-					ps274 := PhiState{General: true}
-					ps274.OverlayValues = make([]JITValueDesc, 237)
-					ps274.OverlayValues[1] = d1
-					ps274.OverlayValues[2] = d2
-					ps274.OverlayValues[3] = d3
-					ps274.OverlayValues[4] = d4
-					ps274.OverlayValues[5] = d5
-					ps274.OverlayValues[22] = d22
-					ps274.OverlayValues[23] = d23
-					ps274.OverlayValues[24] = d24
-					ps274.OverlayValues[25] = d25
-					ps274.OverlayValues[27] = d27
-					ps274.OverlayValues[28] = d28
-					ps274.OverlayValues[29] = d29
-					ps274.OverlayValues[30] = d30
-					ps274.OverlayValues[63] = d63
-					ps274.OverlayValues[64] = d64
-					ps274.OverlayValues[65] = d65
-					ps274.OverlayValues[66] = d66
-					ps274.OverlayValues[107] = d107
-					ps274.OverlayValues[108] = d108
-					ps274.OverlayValues[109] = d109
-					ps274.OverlayValues[110] = d110
-					ps274.OverlayValues[159] = d159
-					ps274.OverlayValues[160] = d160
-					ps274.OverlayValues[161] = d161
-					ps274.OverlayValues[162] = d162
-					ps274.OverlayValues[164] = d164
-					ps274.OverlayValues[165] = d165
-					ps274.OverlayValues[166] = d166
-					ps274.OverlayValues[167] = d167
-					ps274.OverlayValues[232] = d232
-					ps274.OverlayValues[233] = d233
-					ps274.OverlayValues[234] = d234
-					ps274.OverlayValues[235] = d235
-					ps274.OverlayValues[236] = d236
-					ps275 := PhiState{General: true}
-					ps275.OverlayValues = make([]JITValueDesc, 237)
-					ps275.OverlayValues[1] = d1
-					ps275.OverlayValues[2] = d2
-					ps275.OverlayValues[3] = d3
-					ps275.OverlayValues[4] = d4
-					ps275.OverlayValues[5] = d5
-					ps275.OverlayValues[22] = d22
-					ps275.OverlayValues[23] = d23
-					ps275.OverlayValues[24] = d24
-					ps275.OverlayValues[25] = d25
-					ps275.OverlayValues[27] = d27
-					ps275.OverlayValues[28] = d28
-					ps275.OverlayValues[29] = d29
-					ps275.OverlayValues[30] = d30
-					ps275.OverlayValues[63] = d63
-					ps275.OverlayValues[64] = d64
-					ps275.OverlayValues[65] = d65
-					ps275.OverlayValues[66] = d66
-					ps275.OverlayValues[107] = d107
-					ps275.OverlayValues[108] = d108
-					ps275.OverlayValues[109] = d109
-					ps275.OverlayValues[110] = d110
-					ps275.OverlayValues[159] = d159
-					ps275.OverlayValues[160] = d160
-					ps275.OverlayValues[161] = d161
-					ps275.OverlayValues[162] = d162
-					ps275.OverlayValues[164] = d164
-					ps275.OverlayValues[165] = d165
-					ps275.OverlayValues[166] = d166
-					ps275.OverlayValues[167] = d167
-					ps275.OverlayValues[232] = d232
-					ps275.OverlayValues[233] = d233
-					ps275.OverlayValues[234] = d234
-					ps275.OverlayValues[235] = d235
-					ps275.OverlayValues[236] = d236
-					snap276 := d1
-					snap277 := d2
-					snap278 := d3
-					snap279 := d4
-					snap280 := d5
-					snap281 := d22
-					snap282 := d23
-					snap283 := d24
-					snap284 := d25
-					snap285 := d27
-					snap286 := d28
-					snap287 := d29
-					snap288 := d30
-					snap289 := d63
-					snap290 := d64
-					snap291 := d65
-					snap292 := d66
-					snap293 := d107
-					snap294 := d108
-					snap295 := d109
-					snap296 := d110
-					snap297 := d159
-					snap298 := d160
-					snap299 := d161
-					snap300 := d162
-					snap301 := d164
-					snap302 := d165
-					snap303 := d166
-					snap304 := d167
-					snap305 := d232
-					snap306 := d233
-					snap307 := d234
-					snap308 := d235
-					snap309 := d236
-					alloc310 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d236)
+					snap240 := d1
+					snap241 := d2
+					snap242 := d3
+					snap243 := d4
+					snap244 := d5
+					snap245 := d22
+					snap246 := d23
+					snap247 := d24
+					snap248 := d25
+					snap249 := d27
+					snap250 := d28
+					snap251 := d29
+					snap252 := d30
+					snap253 := d63
+					snap254 := d64
+					snap255 := d65
+					snap256 := d66
+					snap257 := d107
+					snap258 := d108
+					snap259 := d109
+					snap260 := d110
+					snap261 := d159
+					snap262 := d160
+					snap263 := d161
+					snap264 := d162
+					snap265 := d164
+					snap266 := d165
+					snap267 := d166
+					snap268 := d167
+					snap269 := d232
+					snap270 := d233
+					snap271 := d234
+					snap272 := d235
+					snap273 := d236
+					snap274 := d237
+					alloc275 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc275)
+					d1 = snap240
+					d2 = snap241
+					d3 = snap242
+					d4 = snap243
+					d5 = snap244
+					d22 = snap245
+					d23 = snap246
+					d24 = snap247
+					d25 = snap248
+					d27 = snap249
+					d28 = snap250
+					d29 = snap251
+					d30 = snap252
+					d63 = snap253
+					d64 = snap254
+					d65 = snap255
+					d66 = snap256
+					d107 = snap257
+					d108 = snap258
+					d109 = snap259
+					d110 = snap260
+					d159 = snap261
+					d160 = snap262
+					d161 = snap263
+					d162 = snap264
+					d164 = snap265
+					d165 = snap266
+					d166 = snap267
+					d167 = snap268
+					d232 = snap269
+					d233 = snap270
+					d234 = snap271
+					d235 = snap272
+					d236 = snap273
+					d237 = snap274
+					ctx.RestoreAllocState(alloc275)
+					d1 = snap240
+					d2 = snap241
+					d3 = snap242
+					d4 = snap243
+					d5 = snap244
+					d22 = snap245
+					d23 = snap246
+					d24 = snap247
+					d25 = snap248
+					d27 = snap249
+					d28 = snap250
+					d29 = snap251
+					d30 = snap252
+					d63 = snap253
+					d64 = snap254
+					d65 = snap255
+					d66 = snap256
+					d107 = snap257
+					d108 = snap258
+					d109 = snap259
+					d110 = snap260
+					d159 = snap261
+					d160 = snap262
+					d161 = snap263
+					d162 = snap264
+					d164 = snap265
+					d165 = snap266
+					d166 = snap267
+					d167 = snap268
+					d232 = snap269
+					d233 = snap270
+					d234 = snap271
+					d235 = snap272
+					d236 = snap273
+					d237 = snap274
+					ps276 := PhiState{General: true}
+					ps276.OverlayValues = make([]JITValueDesc, 238)
+					ps276.OverlayValues[1] = d1
+					ps276.OverlayValues[2] = d2
+					ps276.OverlayValues[3] = d3
+					ps276.OverlayValues[4] = d4
+					ps276.OverlayValues[5] = d5
+					ps276.OverlayValues[22] = d22
+					ps276.OverlayValues[23] = d23
+					ps276.OverlayValues[24] = d24
+					ps276.OverlayValues[25] = d25
+					ps276.OverlayValues[27] = d27
+					ps276.OverlayValues[28] = d28
+					ps276.OverlayValues[29] = d29
+					ps276.OverlayValues[30] = d30
+					ps276.OverlayValues[63] = d63
+					ps276.OverlayValues[64] = d64
+					ps276.OverlayValues[65] = d65
+					ps276.OverlayValues[66] = d66
+					ps276.OverlayValues[107] = d107
+					ps276.OverlayValues[108] = d108
+					ps276.OverlayValues[109] = d109
+					ps276.OverlayValues[110] = d110
+					ps276.OverlayValues[159] = d159
+					ps276.OverlayValues[160] = d160
+					ps276.OverlayValues[161] = d161
+					ps276.OverlayValues[162] = d162
+					ps276.OverlayValues[164] = d164
+					ps276.OverlayValues[165] = d165
+					ps276.OverlayValues[166] = d166
+					ps276.OverlayValues[167] = d167
+					ps276.OverlayValues[232] = d232
+					ps276.OverlayValues[233] = d233
+					ps276.OverlayValues[234] = d234
+					ps276.OverlayValues[235] = d235
+					ps276.OverlayValues[236] = d236
+					ps276.OverlayValues[237] = d237
+					ps277 := PhiState{General: true}
+					ps277.OverlayValues = make([]JITValueDesc, 238)
+					ps277.OverlayValues[1] = d1
+					ps277.OverlayValues[2] = d2
+					ps277.OverlayValues[3] = d3
+					ps277.OverlayValues[4] = d4
+					ps277.OverlayValues[5] = d5
+					ps277.OverlayValues[22] = d22
+					ps277.OverlayValues[23] = d23
+					ps277.OverlayValues[24] = d24
+					ps277.OverlayValues[25] = d25
+					ps277.OverlayValues[27] = d27
+					ps277.OverlayValues[28] = d28
+					ps277.OverlayValues[29] = d29
+					ps277.OverlayValues[30] = d30
+					ps277.OverlayValues[63] = d63
+					ps277.OverlayValues[64] = d64
+					ps277.OverlayValues[65] = d65
+					ps277.OverlayValues[66] = d66
+					ps277.OverlayValues[107] = d107
+					ps277.OverlayValues[108] = d108
+					ps277.OverlayValues[109] = d109
+					ps277.OverlayValues[110] = d110
+					ps277.OverlayValues[159] = d159
+					ps277.OverlayValues[160] = d160
+					ps277.OverlayValues[161] = d161
+					ps277.OverlayValues[162] = d162
+					ps277.OverlayValues[164] = d164
+					ps277.OverlayValues[165] = d165
+					ps277.OverlayValues[166] = d166
+					ps277.OverlayValues[167] = d167
+					ps277.OverlayValues[232] = d232
+					ps277.OverlayValues[233] = d233
+					ps277.OverlayValues[234] = d234
+					ps277.OverlayValues[235] = d235
+					ps277.OverlayValues[236] = d236
+					ps277.OverlayValues[237] = d237
+					snap278 := d1
+					snap279 := d2
+					snap280 := d3
+					snap281 := d4
+					snap282 := d5
+					snap283 := d22
+					snap284 := d23
+					snap285 := d24
+					snap286 := d25
+					snap287 := d27
+					snap288 := d28
+					snap289 := d29
+					snap290 := d30
+					snap291 := d63
+					snap292 := d64
+					snap293 := d65
+					snap294 := d66
+					snap295 := d107
+					snap296 := d108
+					snap297 := d109
+					snap298 := d110
+					snap299 := d159
+					snap300 := d160
+					snap301 := d161
+					snap302 := d162
+					snap303 := d164
+					snap304 := d165
+					snap305 := d166
+					snap306 := d167
+					snap307 := d232
+					snap308 := d233
+					snap309 := d234
+					snap310 := d235
+					snap311 := d236
+					snap312 := d237
+					alloc313 := ctx.SnapshotAllocState()
 					if !bbs[11].Rendered {
-						bbs[11].RenderPS(ps275)
+						bbs[11].RenderPS(ps277)
 					}
-					ctx.RestoreAllocState(alloc310)
-					d1 = snap276
-					d2 = snap277
-					d3 = snap278
-					d4 = snap279
-					d5 = snap280
-					d22 = snap281
-					d23 = snap282
-					d24 = snap283
-					d25 = snap284
-					d27 = snap285
-					d28 = snap286
-					d29 = snap287
-					d30 = snap288
-					d63 = snap289
-					d64 = snap290
-					d65 = snap291
-					d66 = snap292
-					d107 = snap293
-					d108 = snap294
-					d109 = snap295
-					d110 = snap296
-					d159 = snap297
-					d160 = snap298
-					d161 = snap299
-					d162 = snap300
-					d164 = snap301
-					d165 = snap302
-					d166 = snap303
-					d167 = snap304
-					d232 = snap305
-					d233 = snap306
-					d234 = snap307
-					d235 = snap308
-					d236 = snap309
+					ctx.RestoreAllocState(alloc313)
+					d1 = snap278
+					d2 = snap279
+					d3 = snap280
+					d4 = snap281
+					d5 = snap282
+					d22 = snap283
+					d23 = snap284
+					d24 = snap285
+					d25 = snap286
+					d27 = snap287
+					d28 = snap288
+					d29 = snap289
+					d30 = snap290
+					d63 = snap291
+					d64 = snap292
+					d65 = snap293
+					d66 = snap294
+					d107 = snap295
+					d108 = snap296
+					d109 = snap297
+					d110 = snap298
+					d159 = snap299
+					d160 = snap300
+					d161 = snap301
+					d162 = snap302
+					d164 = snap303
+					d165 = snap304
+					d166 = snap305
+					d167 = snap306
+					d232 = snap307
+					d233 = snap308
+					d234 = snap309
+					d235 = snap310
+					d236 = snap311
+					d237 = snap312
 					if !bbs[10].Rendered {
-						return bbs[10].RenderPS(ps274)
+						return bbs[10].RenderPS(ps276)
 					}
 					return result
 					return result
@@ -3668,9 +3681,9 @@ func init_timezone() {
 				bbs[9].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d311 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d311)
-							ctx.EmitStoreScmerToStack(d311, int32(bbs[9].PhiBase)+int32(0))
+							d314 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d314)
+							ctx.EmitStoreScmerToStack(d314, int32(bbs[9].PhiBase)+int32(0))
 						}
 						if bbs[9].VisitCount >= 0 {
 							ps.General = true
@@ -3792,8 +3805,11 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 236 && ps.OverlayValues[236].Loc != LocNone {
 						d236 = ps.OverlayValues[236]
 					}
-					if len(ps.OverlayValues) > 311 && ps.OverlayValues[311].Loc != LocNone {
-						d311 = ps.OverlayValues[311]
+					if len(ps.OverlayValues) > 237 && ps.OverlayValues[237].Loc != LocNone {
+						d237 = ps.OverlayValues[237]
+					}
+					if len(ps.OverlayValues) > 314 && ps.OverlayValues[314].Loc != LocNone {
+						d314 = ps.OverlayValues[314]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
 						d1 = ps.PhiValues[0]
@@ -3808,71 +3824,62 @@ func init_timezone() {
 					}
 					ctx.SyncDesc(&d1)
 					ctx.SyncDesc(&d164)
-					d312 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).In), []JITValueDesc{d1, d164}, 3)
-					d312.NoHeapPointer = false
-					ctx.BindReg(d312.Reg, &d312)
-					ctx.BindReg(d312.Reg2, &d312)
-					ctx.BindReg(d312.Reg3, &d312)
+					d315 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).In), []JITValueDesc{d1, d164}, 3)
+					d315.NoHeapPointer = false
+					ctx.BindReg(d315.Reg, &d315)
+					ctx.BindReg(d315.Reg2, &d315)
+					ctx.BindReg(d315.Reg3, &d315)
 					ctx.FreeDesc(&d1)
-					d312 = JITPrepareGoSliceArg(ctx, d312)
-					if d312.Loc != LocRegTriple && d312.Loc != LocStackTriple {
+					d315 = JITPrepareGoSliceArg(ctx, d315)
+					if d315.Loc != LocRegTriple && d315.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Year arg0)")
 					}
-					ctx.SyncDesc(&d312)
-					d313 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Year), []JITValueDesc{d312}, 1)
-					d313.NoHeapPointer = true
-					ctx.BindReg(d313.Reg, &d313)
-					d312 = JITPrepareGoSliceArg(ctx, d312)
-					if d312.Loc != LocRegTriple && d312.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
-					}
-					ctx.SyncDesc(&d312)
-					d314 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d312}, 1)
-					d314.NoHeapPointer = true
-					ctx.BindReg(d314.Reg, &d314)
-					d312 = JITPrepareGoSliceArg(ctx, d312)
-					if d312.Loc != LocRegTriple && d312.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
-					}
-					ctx.SyncDesc(&d312)
-					d315 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d312}, 1)
-					d315.NoHeapPointer = true
-					ctx.BindReg(d315.Reg, &d315)
-					d312 = JITPrepareGoSliceArg(ctx, d312)
-					if d312.Loc != LocRegTriple && d312.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Hour arg0)")
-					}
-					ctx.SyncDesc(&d312)
-					d316 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Hour), []JITValueDesc{d312}, 1)
+					ctx.SyncDesc(&d315)
+					d316 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Year), []JITValueDesc{d315}, 1)
 					d316.NoHeapPointer = true
 					ctx.BindReg(d316.Reg, &d316)
-					d312 = JITPrepareGoSliceArg(ctx, d312)
-					if d312.Loc != LocRegTriple && d312.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Minute arg0)")
+					d315 = JITPrepareGoSliceArg(ctx, d315)
+					if d315.Loc != LocRegTriple && d315.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
 					}
-					ctx.SyncDesc(&d312)
-					d317 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Minute), []JITValueDesc{d312}, 1)
+					ctx.SyncDesc(&d315)
+					d317 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d315}, 1)
 					d317.NoHeapPointer = true
 					ctx.BindReg(d317.Reg, &d317)
-					d312 = JITPrepareGoSliceArg(ctx, d312)
-					if d312.Loc != LocRegTriple && d312.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Second arg0)")
+					d315 = JITPrepareGoSliceArg(ctx, d315)
+					if d315.Loc != LocRegTriple && d315.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
 					}
-					ctx.SyncDesc(&d312)
-					d318 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Second), []JITValueDesc{d312}, 1)
+					ctx.SyncDesc(&d315)
+					d318 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d315}, 1)
 					d318.NoHeapPointer = true
 					ctx.BindReg(d318.Reg, &d318)
-					ctx.FreeDesc(&d312)
-					d319 = ctx.EmitGoCallScalar(GoFuncAddr(func() *time.Location { return time.UTC }), nil, 1)
-					if d313.Loc == LocRegPair || d313.Loc == LocStackPair || d313.Loc == LocRegTriple || d313.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					d315 = JITPrepareGoSliceArg(ctx, d315)
+					if d315.Loc != LocRegTriple && d315.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Hour arg0)")
 					}
-					if d314.Loc == LocRegPair || d314.Loc == LocStackPair || d314.Loc == LocRegTriple || d314.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d315)
+					d319 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Hour), []JITValueDesc{d315}, 1)
+					d319.NoHeapPointer = true
+					ctx.BindReg(d319.Reg, &d319)
+					d315 = JITPrepareGoSliceArg(ctx, d315)
+					if d315.Loc != LocRegTriple && d315.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Minute arg0)")
 					}
-					if d315.Loc == LocRegPair || d315.Loc == LocStackPair || d315.Loc == LocRegTriple || d315.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d315)
+					d320 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Minute), []JITValueDesc{d315}, 1)
+					d320.NoHeapPointer = true
+					ctx.BindReg(d320.Reg, &d320)
+					d315 = JITPrepareGoSliceArg(ctx, d315)
+					if d315.Loc != LocRegTriple && d315.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Second arg0)")
 					}
+					ctx.SyncDesc(&d315)
+					d321 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Second), []JITValueDesc{d315}, 1)
+					d321.NoHeapPointer = true
+					ctx.BindReg(d321.Reg, &d321)
+					ctx.FreeDesc(&d315)
+					d322 = ctx.EmitGoCallScalar(GoFuncAddr(func() *time.Location { return time.UTC }), nil, 1)
 					if d316.Loc == LocRegPair || d316.Loc == LocStackPair || d316.Loc == LocRegTriple || d316.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
@@ -3882,73 +3889,82 @@ func init_timezone() {
 					if d318.Loc == LocRegPair || d318.Loc == LocStackPair || d318.Loc == LocRegTriple || d318.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					d320 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					if d320.Loc == LocRegPair || d320.Loc == LocStackPair || d320.Loc == LocRegTriple || d320.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
-					}
 					if d319.Loc == LocRegPair || d319.Loc == LocStackPair || d319.Loc == LocRegTriple || d319.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d313)
-					ctx.SyncDesc(&d314)
-					ctx.SyncDesc(&d315)
+					if d320.Loc == LocRegPair || d320.Loc == LocStackPair || d320.Loc == LocRegTriple || d320.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					if d321.Loc == LocRegPair || d321.Loc == LocStackPair || d321.Loc == LocRegTriple || d321.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					d323 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					if d323.Loc == LocRegPair || d323.Loc == LocStackPair || d323.Loc == LocRegTriple || d323.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					if d322.Loc == LocRegPair || d322.Loc == LocStackPair || d322.Loc == LocRegTriple || d322.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
 					ctx.SyncDesc(&d316)
 					ctx.SyncDesc(&d317)
 					ctx.SyncDesc(&d318)
-					ctx.SyncDesc(&d320)
 					ctx.SyncDesc(&d319)
-					d321 = ctx.EmitGoCallScalar(GoFuncAddr(time.Date), []JITValueDesc{d313, d314, d315, d316, d317, d318, d320, d319}, 3)
-					d321.NoHeapPointer = false
-					ctx.BindReg(d321.Reg, &d321)
-					ctx.BindReg(d321.Reg2, &d321)
-					ctx.BindReg(d321.Reg3, &d321)
-					ctx.FreeDesc(&d320)
-					ctx.FreeDesc(&d313)
-					ctx.FreeDesc(&d314)
-					ctx.FreeDesc(&d315)
+					ctx.SyncDesc(&d320)
+					ctx.SyncDesc(&d321)
+					ctx.SyncDesc(&d323)
+					ctx.SyncDesc(&d322)
+					d324 = ctx.EmitGoCallScalar(GoFuncAddr(time.Date), []JITValueDesc{d316, d317, d318, d319, d320, d321, d323, d322}, 3)
+					d324.NoHeapPointer = false
+					ctx.BindReg(d324.Reg, &d324)
+					ctx.BindReg(d324.Reg2, &d324)
+					ctx.BindReg(d324.Reg3, &d324)
+					ctx.FreeDesc(&d323)
 					ctx.FreeDesc(&d316)
 					ctx.FreeDesc(&d317)
 					ctx.FreeDesc(&d318)
 					ctx.FreeDesc(&d319)
-					d321 = JITPrepareGoSliceArg(ctx, d321)
-					if d321.Loc != LocRegTriple && d321.Loc != LocStackTriple {
+					ctx.FreeDesc(&d320)
+					ctx.FreeDesc(&d321)
+					ctx.FreeDesc(&d322)
+					d324 = JITPrepareGoSliceArg(ctx, d324)
+					if d324.Loc != LocRegTriple && d324.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Unix arg0)")
 					}
-					ctx.SyncDesc(&d321)
-					d322 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Unix), []JITValueDesc{d321}, 1)
-					d322.NoHeapPointer = true
-					ctx.BindReg(d322.Reg, &d322)
-					ctx.FreeDesc(&d321)
-					if d322.Loc == LocRegPair || d322.Loc == LocStackPair || d322.Loc == LocRegTriple || d322.Loc == LocStackTriple {
+					ctx.SyncDesc(&d324)
+					d325 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Unix), []JITValueDesc{d324}, 1)
+					d325.NoHeapPointer = true
+					ctx.BindReg(d325.Reg, &d325)
+					ctx.FreeDesc(&d324)
+					if d325.Loc == LocRegPair || d325.Loc == LocStackPair || d325.Loc == LocRegTriple || d325.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d322)
-					d323 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d322}, 2)
-					d323.NoHeapPointer = false
-					ctx.BindReg(d323.Reg, &d323)
-					ctx.BindReg(d323.Reg2, &d323)
-					ctx.FreeDesc(&d322)
-					ctx.SyncDesc(&d323)
-					if d323.Loc == LocRegPair || d323.Loc == LocStackPair || d323.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d323, &result)
-						result.Type = d323.Type
+					ctx.SyncDesc(&d325)
+					d326 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d325}, 2)
+					d326.NoHeapPointer = false
+					ctx.BindReg(d326.Reg, &d326)
+					ctx.BindReg(d326.Reg2, &d326)
+					ctx.FreeDesc(&d325)
+					ctx.SyncDesc(&d326)
+					if d326.Loc == LocRegPair || d326.Loc == LocStackPair || d326.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d326, &result)
+						result.Type = d326.Type
 					} else {
-						switch d323.Type {
+						switch d326.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d323)
+							ctx.EmitMakeBool(result, d326)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d323)
+							ctx.EmitMakeInt(result, d326)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d323)
+							ctx.EmitMakeFloat(result, d326)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d323, &result)
-							result.Type = d323.Type
+							ctx.EmitMovPairToResult(&d326, &result)
+							result.Type = d326.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -4076,14 +4092,8 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 236 && ps.OverlayValues[236].Loc != LocNone {
 						d236 = ps.OverlayValues[236]
 					}
-					if len(ps.OverlayValues) > 311 && ps.OverlayValues[311].Loc != LocNone {
-						d311 = ps.OverlayValues[311]
-					}
-					if len(ps.OverlayValues) > 312 && ps.OverlayValues[312].Loc != LocNone {
-						d312 = ps.OverlayValues[312]
-					}
-					if len(ps.OverlayValues) > 313 && ps.OverlayValues[313].Loc != LocNone {
-						d313 = ps.OverlayValues[313]
+					if len(ps.OverlayValues) > 237 && ps.OverlayValues[237].Loc != LocNone {
+						d237 = ps.OverlayValues[237]
 					}
 					if len(ps.OverlayValues) > 314 && ps.OverlayValues[314].Loc != LocNone {
 						d314 = ps.OverlayValues[314]
@@ -4115,112 +4125,112 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 323 && ps.OverlayValues[323].Loc != LocNone {
 						d323 = ps.OverlayValues[323]
 					}
+					if len(ps.OverlayValues) > 324 && ps.OverlayValues[324].Loc != LocNone {
+						d324 = ps.OverlayValues[324]
+					}
+					if len(ps.OverlayValues) > 325 && ps.OverlayValues[325].Loc != LocNone {
+						d325 = ps.OverlayValues[325]
+					}
+					if len(ps.OverlayValues) > 326 && ps.OverlayValues[326].Loc != LocNone {
+						d326 = ps.OverlayValues[326]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d324 = args[0]
-					d324.ID = 0
-					var d325 JITValueDesc
-					if d324.Loc == LocImm {
-						d325 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d324.Imm.Int())}
-					} else if d324.Type == tagInt && d324.Loc == LocRegPair {
-						ctx.FreeReg(d324.Reg)
-						d325 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d324.Reg2}
-						ctx.BindReg(d324.Reg2, &d325)
-						ctx.BindReg(d324.Reg2, &d325)
-					} else if d324.Type == tagInt && d324.Loc == LocReg {
-						d325 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d324.Reg}
-						ctx.BindReg(d324.Reg, &d325)
-						ctx.BindReg(d324.Reg, &d325)
+					d327 = args[0]
+					d327.ID = 0
+					var d328 JITValueDesc
+					if d327.Loc == LocImm {
+						d328 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d327.Imm.Int())}
+					} else if d327.Type == tagInt && d327.Loc == LocRegPair {
+						ctx.FreeReg(d327.Reg)
+						d328 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d327.Reg2}
+						ctx.BindReg(d327.Reg2, &d328)
+						ctx.BindReg(d327.Reg2, &d328)
+					} else if d327.Type == tagInt && d327.Loc == LocReg {
+						d328 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d327.Reg}
+						ctx.BindReg(d327.Reg, &d328)
+						ctx.BindReg(d327.Reg, &d328)
 					} else {
-						d325 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{d324}, 1)
-						d325.Type = tagInt
-						ctx.BindReg(d325.Reg, &d325)
+						d328 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{d327}, 1)
+						d328.Type = tagInt
+						ctx.BindReg(d328.Reg, &d328)
 					}
-					ctx.FreeDesc(&d324)
-					if d325.Loc == LocRegPair || d325.Loc == LocStackPair || d325.Loc == LocRegTriple || d325.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
-					}
-					d326 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					if d326.Loc == LocRegPair || d326.Loc == LocStackPair || d326.Loc == LocRegTriple || d326.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
-					}
-					ctx.SyncDesc(&d325)
-					ctx.SyncDesc(&d326)
-					d327 = ctx.EmitGoCallScalar(GoFuncAddr(time.Unix), []JITValueDesc{d325, d326}, 3)
-					d327.NoHeapPointer = false
-					ctx.BindReg(d327.Reg, &d327)
-					ctx.BindReg(d327.Reg2, &d327)
-					ctx.BindReg(d327.Reg3, &d327)
-					ctx.FreeDesc(&d326)
-					ctx.FreeDesc(&d325)
-					d327 = JITPrepareGoSliceArg(ctx, d327)
-					if d327.Loc != LocRegTriple && d327.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).UTC arg0)")
-					}
-					ctx.SyncDesc(&d327)
-					d328 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).UTC), []JITValueDesc{d327}, 3)
-					d328.NoHeapPointer = false
-					ctx.BindReg(d328.Reg, &d328)
-					ctx.BindReg(d328.Reg2, &d328)
-					ctx.BindReg(d328.Reg3, &d328)
 					ctx.FreeDesc(&d327)
-					d328 = JITPrepareGoSliceArg(ctx, d328)
-					if d328.Loc != LocRegTriple && d328.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Year arg0)")
+					if d328.Loc == LocRegPair || d328.Loc == LocStackPair || d328.Loc == LocRegTriple || d328.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d328)
-					d329 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Year), []JITValueDesc{d328}, 1)
-					d329.NoHeapPointer = true
-					ctx.BindReg(d329.Reg, &d329)
-					d328 = JITPrepareGoSliceArg(ctx, d328)
-					if d328.Loc != LocRegTriple && d328.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
-					}
-					ctx.SyncDesc(&d328)
-					d330 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d328}, 1)
-					d330.NoHeapPointer = true
-					ctx.BindReg(d330.Reg, &d330)
-					d328 = JITPrepareGoSliceArg(ctx, d328)
-					if d328.Loc != LocRegTriple && d328.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
-					}
-					ctx.SyncDesc(&d328)
-					d331 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d328}, 1)
-					d331.NoHeapPointer = true
-					ctx.BindReg(d331.Reg, &d331)
-					d328 = JITPrepareGoSliceArg(ctx, d328)
-					if d328.Loc != LocRegTriple && d328.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Hour arg0)")
-					}
-					ctx.SyncDesc(&d328)
-					d332 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Hour), []JITValueDesc{d328}, 1)
-					d332.NoHeapPointer = true
-					ctx.BindReg(d332.Reg, &d332)
-					d328 = JITPrepareGoSliceArg(ctx, d328)
-					if d328.Loc != LocRegTriple && d328.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Minute arg0)")
-					}
-					ctx.SyncDesc(&d328)
-					d333 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Minute), []JITValueDesc{d328}, 1)
-					d333.NoHeapPointer = true
-					ctx.BindReg(d333.Reg, &d333)
-					d328 = JITPrepareGoSliceArg(ctx, d328)
-					if d328.Loc != LocRegTriple && d328.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Second arg0)")
-					}
-					ctx.SyncDesc(&d328)
-					d334 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Second), []JITValueDesc{d328}, 1)
-					d334.NoHeapPointer = true
-					ctx.BindReg(d334.Reg, &d334)
-					ctx.FreeDesc(&d328)
+					d329 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
 					if d329.Loc == LocRegPair || d329.Loc == LocStackPair || d329.Loc == LocRegTriple || d329.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					if d330.Loc == LocRegPair || d330.Loc == LocStackPair || d330.Loc == LocRegTriple || d330.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d328)
+					ctx.SyncDesc(&d329)
+					d330 = ctx.EmitGoCallScalar(GoFuncAddr(time.Unix), []JITValueDesc{d328, d329}, 3)
+					d330.NoHeapPointer = false
+					ctx.BindReg(d330.Reg, &d330)
+					ctx.BindReg(d330.Reg2, &d330)
+					ctx.BindReg(d330.Reg3, &d330)
+					ctx.FreeDesc(&d329)
+					ctx.FreeDesc(&d328)
+					d330 = JITPrepareGoSliceArg(ctx, d330)
+					if d330.Loc != LocRegTriple && d330.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).UTC arg0)")
 					}
-					if d331.Loc == LocRegPair || d331.Loc == LocStackPair || d331.Loc == LocRegTriple || d331.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d330)
+					d331 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).UTC), []JITValueDesc{d330}, 3)
+					d331.NoHeapPointer = false
+					ctx.BindReg(d331.Reg, &d331)
+					ctx.BindReg(d331.Reg2, &d331)
+					ctx.BindReg(d331.Reg3, &d331)
+					ctx.FreeDesc(&d330)
+					d331 = JITPrepareGoSliceArg(ctx, d331)
+					if d331.Loc != LocRegTriple && d331.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Year arg0)")
 					}
+					ctx.SyncDesc(&d331)
+					d332 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Year), []JITValueDesc{d331}, 1)
+					d332.NoHeapPointer = true
+					ctx.BindReg(d332.Reg, &d332)
+					d331 = JITPrepareGoSliceArg(ctx, d331)
+					if d331.Loc != LocRegTriple && d331.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
+					}
+					ctx.SyncDesc(&d331)
+					d333 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d331}, 1)
+					d333.NoHeapPointer = true
+					ctx.BindReg(d333.Reg, &d333)
+					d331 = JITPrepareGoSliceArg(ctx, d331)
+					if d331.Loc != LocRegTriple && d331.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
+					}
+					ctx.SyncDesc(&d331)
+					d334 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d331}, 1)
+					d334.NoHeapPointer = true
+					ctx.BindReg(d334.Reg, &d334)
+					d331 = JITPrepareGoSliceArg(ctx, d331)
+					if d331.Loc != LocRegTriple && d331.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Hour arg0)")
+					}
+					ctx.SyncDesc(&d331)
+					d335 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Hour), []JITValueDesc{d331}, 1)
+					d335.NoHeapPointer = true
+					ctx.BindReg(d335.Reg, &d335)
+					d331 = JITPrepareGoSliceArg(ctx, d331)
+					if d331.Loc != LocRegTriple && d331.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Minute arg0)")
+					}
+					ctx.SyncDesc(&d331)
+					d336 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Minute), []JITValueDesc{d331}, 1)
+					d336.NoHeapPointer = true
+					ctx.BindReg(d336.Reg, &d336)
+					d331 = JITPrepareGoSliceArg(ctx, d331)
+					if d331.Loc != LocRegTriple && d331.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Second arg0)")
+					}
+					ctx.SyncDesc(&d331)
+					d337 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Second), []JITValueDesc{d331}, 1)
+					d337.NoHeapPointer = true
+					ctx.BindReg(d337.Reg, &d337)
+					ctx.FreeDesc(&d331)
 					if d332.Loc == LocRegPair || d332.Loc == LocStackPair || d332.Loc == LocRegTriple || d332.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
@@ -4230,137 +4240,147 @@ func init_timezone() {
 					if d334.Loc == LocRegPair || d334.Loc == LocStackPair || d334.Loc == LocRegTriple || d334.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					d335 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
 					if d335.Loc == LocRegPair || d335.Loc == LocStackPair || d335.Loc == LocRegTriple || d335.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					if d336.Loc == LocRegPair || d336.Loc == LocStackPair || d336.Loc == LocRegTriple || d336.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					if d337.Loc == LocRegPair || d337.Loc == LocStackPair || d337.Loc == LocRegTriple || d337.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					d338 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					if d338.Loc == LocRegPair || d338.Loc == LocStackPair || d338.Loc == LocRegTriple || d338.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
 					if d27.Loc == LocRegPair || d27.Loc == LocStackPair || d27.Loc == LocRegTriple || d27.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d329)
-					ctx.SyncDesc(&d330)
-					ctx.SyncDesc(&d331)
 					ctx.SyncDesc(&d332)
 					ctx.SyncDesc(&d333)
 					ctx.SyncDesc(&d334)
 					ctx.SyncDesc(&d335)
+					ctx.SyncDesc(&d336)
+					ctx.SyncDesc(&d337)
+					ctx.SyncDesc(&d338)
 					ctx.SyncDesc(&d27)
-					d336 = ctx.EmitGoCallScalar(GoFuncAddr(time.Date), []JITValueDesc{d329, d330, d331, d332, d333, d334, d335, d27}, 3)
-					d336.NoHeapPointer = false
-					ctx.BindReg(d336.Reg, &d336)
-					ctx.BindReg(d336.Reg2, &d336)
-					ctx.BindReg(d336.Reg3, &d336)
-					ctx.FreeDesc(&d335)
-					ctx.StabilizeDescForControlFlow(&d336)
-					ctx.FreeDesc(&d329)
-					ctx.FreeDesc(&d330)
-					ctx.FreeDesc(&d331)
+					d339 = ctx.EmitGoCallScalar(GoFuncAddr(time.Date), []JITValueDesc{d332, d333, d334, d335, d336, d337, d338, d27}, 3)
+					d339.NoHeapPointer = false
+					ctx.BindReg(d339.Reg, &d339)
+					ctx.BindReg(d339.Reg2, &d339)
+					ctx.BindReg(d339.Reg3, &d339)
+					ctx.FreeDesc(&d338)
+					ctx.StabilizeDescForControlFlow(&d339)
 					ctx.FreeDesc(&d332)
 					ctx.FreeDesc(&d333)
 					ctx.FreeDesc(&d334)
+					ctx.FreeDesc(&d335)
+					ctx.FreeDesc(&d336)
+					ctx.FreeDesc(&d337)
 					if ps.General {
-						ctx.SyncDesc(&d336)
-						if d336.Loc == LocReg {
-							ctx.ProtectReg(d336.Reg)
-						} else if d336.Loc == LocRegPair {
-							ctx.ProtectReg(d336.Reg)
-							ctx.ProtectReg(d336.Reg2)
+						ctx.SyncDesc(&d339)
+						if d339.Loc == LocReg || d339.Loc == LocFPReg {
+							ctx.ProtectReg(d339.Reg)
+						} else if d339.Loc == LocRegPair {
+							ctx.ProtectReg(d339.Reg)
+							ctx.ProtectReg(d339.Reg2)
 						}
-						d337 = d336
-						if d337.Loc == LocNone {
+						d340 = d339
+						if d340.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.SyncDesc(&d337)
-						if d337.Loc == LocStackPair {
-							ctx.EmitCopyStackWords(d337, int32(bbs[9].PhiBase)+int32(0), 2)
-						} else if d337.Loc == LocInputPair {
-							ctx.EnsureDesc(&d337)
-							ctx.EmitStoreScmerToStack(d337, int32(bbs[9].PhiBase)+int32(0))
-						} else if d337.Loc == LocRegPair || d337.Loc == LocImm {
-							ctx.EmitStoreScmerToStack(d337, int32(bbs[9].PhiBase)+int32(0))
+						ctx.SyncDesc(&d340)
+						if d340.Loc == LocStackPair {
+							ctx.EmitCopyStackWords(d340, int32(bbs[9].PhiBase)+int32(0), 2)
+						} else if d340.Loc == LocInputPair {
+							ctx.EnsureDesc(&d340)
+							ctx.EmitStoreScmerToStack(d340, int32(bbs[9].PhiBase)+int32(0))
+						} else if d340.Loc == LocRegPair || d340.Loc == LocImm {
+							ctx.EmitStoreScmerToStack(d340, int32(bbs[9].PhiBase)+int32(0))
 						} else {
-							ctx.EnsureDesc(&d337)
-							ctx.EmitStoreToStack(d337, int32(bbs[9].PhiBase)+int32(0))
+							ctx.EnsureDesc(&d340)
+							ctx.EmitStoreToStack(d340, int32(bbs[9].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[9].PhiBase)+int32(0))+8)
 						}
-						if d336.Loc == LocReg {
-							ctx.UnprotectReg(d336.Reg)
-						} else if d336.Loc == LocRegPair {
-							ctx.UnprotectReg(d336.Reg)
-							ctx.UnprotectReg(d336.Reg2)
+						if d339.Loc == LocReg || d339.Loc == LocFPReg {
+							ctx.UnprotectReg(d339.Reg)
+						} else if d339.Loc == LocRegPair {
+							ctx.UnprotectReg(d339.Reg)
+							ctx.UnprotectReg(d339.Reg2)
 						}
 					}
-					ps338 := PhiState{General: ps.General}
-					ps338.OverlayValues = make([]JITValueDesc, 338)
-					ps338.OverlayValues[1] = d1
-					ps338.OverlayValues[2] = d2
-					ps338.OverlayValues[3] = d3
-					ps338.OverlayValues[4] = d4
-					ps338.OverlayValues[5] = d5
-					ps338.OverlayValues[22] = d22
-					ps338.OverlayValues[23] = d23
-					ps338.OverlayValues[24] = d24
-					ps338.OverlayValues[25] = d25
-					ps338.OverlayValues[27] = d27
-					ps338.OverlayValues[28] = d28
-					ps338.OverlayValues[29] = d29
-					ps338.OverlayValues[30] = d30
-					ps338.OverlayValues[63] = d63
-					ps338.OverlayValues[64] = d64
-					ps338.OverlayValues[65] = d65
-					ps338.OverlayValues[66] = d66
-					ps338.OverlayValues[107] = d107
-					ps338.OverlayValues[108] = d108
-					ps338.OverlayValues[109] = d109
-					ps338.OverlayValues[110] = d110
-					ps338.OverlayValues[159] = d159
-					ps338.OverlayValues[160] = d160
-					ps338.OverlayValues[161] = d161
-					ps338.OverlayValues[162] = d162
-					ps338.OverlayValues[164] = d164
-					ps338.OverlayValues[165] = d165
-					ps338.OverlayValues[166] = d166
-					ps338.OverlayValues[167] = d167
-					ps338.OverlayValues[232] = d232
-					ps338.OverlayValues[233] = d233
-					ps338.OverlayValues[234] = d234
-					ps338.OverlayValues[235] = d235
-					ps338.OverlayValues[236] = d236
-					ps338.OverlayValues[311] = d311
-					ps338.OverlayValues[312] = d312
-					ps338.OverlayValues[313] = d313
-					ps338.OverlayValues[314] = d314
-					ps338.OverlayValues[315] = d315
-					ps338.OverlayValues[316] = d316
-					ps338.OverlayValues[317] = d317
-					ps338.OverlayValues[318] = d318
-					ps338.OverlayValues[319] = d319
-					ps338.OverlayValues[320] = d320
-					ps338.OverlayValues[321] = d321
-					ps338.OverlayValues[322] = d322
-					ps338.OverlayValues[323] = d323
-					ps338.OverlayValues[324] = d324
-					ps338.OverlayValues[325] = d325
-					ps338.OverlayValues[326] = d326
-					ps338.OverlayValues[327] = d327
-					ps338.OverlayValues[328] = d328
-					ps338.OverlayValues[329] = d329
-					ps338.OverlayValues[330] = d330
-					ps338.OverlayValues[331] = d331
-					ps338.OverlayValues[332] = d332
-					ps338.OverlayValues[333] = d333
-					ps338.OverlayValues[334] = d334
-					ps338.OverlayValues[335] = d335
-					ps338.OverlayValues[336] = d336
-					ps338.OverlayValues[337] = d337
-					ps338.PhiValues = make([]JITValueDesc, 1)
-					d339 = d336
-					ps338.PhiValues[0] = d339
-					if ps338.General && bbs[9].Rendered {
+					ps341 := PhiState{General: ps.General}
+					ps341.OverlayValues = make([]JITValueDesc, 341)
+					ps341.OverlayValues[1] = d1
+					ps341.OverlayValues[2] = d2
+					ps341.OverlayValues[3] = d3
+					ps341.OverlayValues[4] = d4
+					ps341.OverlayValues[5] = d5
+					ps341.OverlayValues[22] = d22
+					ps341.OverlayValues[23] = d23
+					ps341.OverlayValues[24] = d24
+					ps341.OverlayValues[25] = d25
+					ps341.OverlayValues[27] = d27
+					ps341.OverlayValues[28] = d28
+					ps341.OverlayValues[29] = d29
+					ps341.OverlayValues[30] = d30
+					ps341.OverlayValues[63] = d63
+					ps341.OverlayValues[64] = d64
+					ps341.OverlayValues[65] = d65
+					ps341.OverlayValues[66] = d66
+					ps341.OverlayValues[107] = d107
+					ps341.OverlayValues[108] = d108
+					ps341.OverlayValues[109] = d109
+					ps341.OverlayValues[110] = d110
+					ps341.OverlayValues[159] = d159
+					ps341.OverlayValues[160] = d160
+					ps341.OverlayValues[161] = d161
+					ps341.OverlayValues[162] = d162
+					ps341.OverlayValues[164] = d164
+					ps341.OverlayValues[165] = d165
+					ps341.OverlayValues[166] = d166
+					ps341.OverlayValues[167] = d167
+					ps341.OverlayValues[232] = d232
+					ps341.OverlayValues[233] = d233
+					ps341.OverlayValues[234] = d234
+					ps341.OverlayValues[235] = d235
+					ps341.OverlayValues[236] = d236
+					ps341.OverlayValues[237] = d237
+					ps341.OverlayValues[314] = d314
+					ps341.OverlayValues[315] = d315
+					ps341.OverlayValues[316] = d316
+					ps341.OverlayValues[317] = d317
+					ps341.OverlayValues[318] = d318
+					ps341.OverlayValues[319] = d319
+					ps341.OverlayValues[320] = d320
+					ps341.OverlayValues[321] = d321
+					ps341.OverlayValues[322] = d322
+					ps341.OverlayValues[323] = d323
+					ps341.OverlayValues[324] = d324
+					ps341.OverlayValues[325] = d325
+					ps341.OverlayValues[326] = d326
+					ps341.OverlayValues[327] = d327
+					ps341.OverlayValues[328] = d328
+					ps341.OverlayValues[329] = d329
+					ps341.OverlayValues[330] = d330
+					ps341.OverlayValues[331] = d331
+					ps341.OverlayValues[332] = d332
+					ps341.OverlayValues[333] = d333
+					ps341.OverlayValues[334] = d334
+					ps341.OverlayValues[335] = d335
+					ps341.OverlayValues[336] = d336
+					ps341.OverlayValues[337] = d337
+					ps341.OverlayValues[338] = d338
+					ps341.OverlayValues[339] = d339
+					ps341.OverlayValues[340] = d340
+					ps341.PhiValues = make([]JITValueDesc, 1)
+					d342 = d339
+					ps341.PhiValues[0] = d342
+					if ps341.General && bbs[9].Rendered {
 						ctx.EmitJmp(lbl10)
 						return result
 					}
-					return bbs[9].RenderPS(ps338)
+					return bbs[9].RenderPS(ps341)
 					return result
 				}
 				bbs[11].RenderPS = func(ps PhiState) JITValueDesc {
@@ -4485,14 +4505,8 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 236 && ps.OverlayValues[236].Loc != LocNone {
 						d236 = ps.OverlayValues[236]
 					}
-					if len(ps.OverlayValues) > 311 && ps.OverlayValues[311].Loc != LocNone {
-						d311 = ps.OverlayValues[311]
-					}
-					if len(ps.OverlayValues) > 312 && ps.OverlayValues[312].Loc != LocNone {
-						d312 = ps.OverlayValues[312]
-					}
-					if len(ps.OverlayValues) > 313 && ps.OverlayValues[313].Loc != LocNone {
-						d313 = ps.OverlayValues[313]
+					if len(ps.OverlayValues) > 237 && ps.OverlayValues[237].Loc != LocNone {
+						d237 = ps.OverlayValues[237]
 					}
 					if len(ps.OverlayValues) > 314 && ps.OverlayValues[314].Loc != LocNone {
 						d314 = ps.OverlayValues[314]
@@ -4566,723 +4580,741 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 337 && ps.OverlayValues[337].Loc != LocNone {
 						d337 = ps.OverlayValues[337]
 					}
+					if len(ps.OverlayValues) > 338 && ps.OverlayValues[338].Loc != LocNone {
+						d338 = ps.OverlayValues[338]
+					}
 					if len(ps.OverlayValues) > 339 && ps.OverlayValues[339].Loc != LocNone {
 						d339 = ps.OverlayValues[339]
 					}
+					if len(ps.OverlayValues) > 340 && ps.OverlayValues[340].Loc != LocNone {
+						d340 = ps.OverlayValues[340]
+					}
+					if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
+						d342 = ps.OverlayValues[342]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d340 = args[0]
-					d340.ID = 0
-					d342 = d340
-					ctx.SyncDesc(&d342)
-					if d342.Loc == LocMem {
-						tmpScalar := JITValueDesc{Loc: LocReg, Type: d342.Type, Reg: ctx.AllocReg()}
+					d343 = args[0]
+					d343.ID = 0
+					d345 = d343
+					ctx.SyncDesc(&d345)
+					if d345.Loc == LocMem {
+						tmpScalar := JITValueDesc{Loc: LocReg, Type: d345.Type, Reg: ctx.AllocReg()}
 						scratch := ctx.AllocRegExcept(tmpScalar.Reg)
-						ctx.EmitMovRegImm64(scratch, uint64(d342.MemPtr))
+						ctx.EmitMovRegImm64(scratch, uint64(d345.MemPtr))
 						ctx.EmitMovRegMem(tmpScalar.Reg, scratch, 0)
 						ctx.FreeReg(scratch)
 						ctx.BindReg(tmpScalar.Reg, &tmpScalar)
-						d342 = tmpScalar
+						d345 = tmpScalar
 					}
-					d342 = JITPrepareScmerGoArg(ctx, d342)
-					if d342.Loc != LocRegPair && d342.Loc != LocStackPair && d342.Loc != LocInputPair {
+					d345 = JITPrepareScmerGoArg(ctx, d345)
+					if d345.Loc != LocRegPair && d345.Loc != LocStackPair && d345.Loc != LocInputPair {
 						panic("jit: Scmer.String receiver not materialized as pair")
 					}
-					d341 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d342}, 2)
-					ctx.FreeDesc(&d340)
-					ctx.EnsureDesc(&d341)
-					if d341.Loc == LocImm {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d341.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-						ctx.TrackImm(d341.Imm)
-						ptrWord, _ := d341.Imm.RawWords()
+					d344 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.String), []JITValueDesc{d345}, 2)
+					ctx.FreeDesc(&d343)
+					ctx.EnsureDesc(&d344)
+					if d344.Loc == LocImm {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d344.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.TrackImm(d344.Imm)
+						ptrWord, _ := d344.Imm.RawWords()
 						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d341.Imm.String())))
-						d341 = tmpPair
-					} else if d341.Loc == LocReg {
-						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d341.Type, Reg: ctx.AllocRegExcept(d341.Reg), Reg2: ctx.AllocRegExcept(d341.Reg)}
-						switch d341.Type {
+						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d344.Imm.String())))
+						d344 = tmpPair
+					} else if d344.Loc == LocReg {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d344.Type, Reg: ctx.AllocRegExcept(d344.Reg), Reg2: ctx.AllocRegExcept(d344.Reg)}
+						switch d344.Type {
 						case tagBool:
-							ctx.EmitMakeBool(tmpPair, d341)
+							ctx.EmitMakeBool(tmpPair, d344)
 						case tagInt:
-							ctx.EmitMakeInt(tmpPair, d341)
+							ctx.EmitMakeInt(tmpPair, d344)
 						case tagFloat:
-							ctx.EmitMakeFloat(tmpPair, d341)
+							ctx.EmitMakeFloat(tmpPair, d344)
 						default:
 							panic("jit: generic call arg scalar type unknown for 2-word value")
 						}
-						ctx.FreeDesc(&d341)
-						d341 = tmpPair
+						ctx.FreeDesc(&d344)
+						d344 = tmpPair
 					}
-					if d341.Loc != LocRegPair && d341.Loc != LocStackPair && d341.Loc != LocInputPair {
+					if d344.Loc != LocRegPair && d344.Loc != LocStackPair && d344.Loc != LocInputPair {
 						panic("jit: generic call arg expects 2-word value (parseDateStringInLoc arg0)")
 					}
 					if d27.Loc == LocRegPair || d27.Loc == LocStackPair || d27.Loc == LocRegTriple || d27.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d341)
+					ctx.SyncDesc(&d344)
 					ctx.SyncDesc(&d27)
-					callResults343 := JITEmitGoCallResults(ctx, GoFuncAddr(parseDateStringInLoc), []JITValueDesc{d341, d27}, []uint8{1, 1}, []uint8{0, 0})
-					d344 = callResults343[0]
-					_ = d344
-					d345 = callResults343[1]
-					_ = d345
-					ctx.StabilizeDescForControlFlow(&d344)
-					d346 = d345
-					ctx.EnsureDesc(&d346)
-					if d346.Loc != LocImm && d346.Loc != LocReg {
+					callResults346 := JITEmitGoCallResults(ctx, GoFuncAddr(parseDateStringInLoc), []JITValueDesc{d344, d27}, []uint8{1, 1}, []uint8{0, 0})
+					d347 = callResults346[0]
+					_ = d347
+					d348 = callResults346[1]
+					_ = d348
+					ctx.StabilizeDescForControlFlow(&d347)
+					d349 = d348
+					ctx.EnsureDesc(&d349)
+					if d349.Loc != LocImm && d349.Loc != LocReg {
 						panic("jit: If condition is neither LocImm nor LocReg")
 					}
-					if d346.Loc == LocImm {
-						if d346.Imm.Bool() {
+					if d349.Loc == LocImm {
+						if d349.Imm.Bool() {
 							if ps.General {
 							}
-							ps347 := PhiState{General: ps.General}
-							ps347.OverlayValues = make([]JITValueDesc, 347)
-							ps347.OverlayValues[1] = d1
-							ps347.OverlayValues[2] = d2
-							ps347.OverlayValues[3] = d3
-							ps347.OverlayValues[4] = d4
-							ps347.OverlayValues[5] = d5
-							ps347.OverlayValues[22] = d22
-							ps347.OverlayValues[23] = d23
-							ps347.OverlayValues[24] = d24
-							ps347.OverlayValues[25] = d25
-							ps347.OverlayValues[27] = d27
-							ps347.OverlayValues[28] = d28
-							ps347.OverlayValues[29] = d29
-							ps347.OverlayValues[30] = d30
-							ps347.OverlayValues[63] = d63
-							ps347.OverlayValues[64] = d64
-							ps347.OverlayValues[65] = d65
-							ps347.OverlayValues[66] = d66
-							ps347.OverlayValues[107] = d107
-							ps347.OverlayValues[108] = d108
-							ps347.OverlayValues[109] = d109
-							ps347.OverlayValues[110] = d110
-							ps347.OverlayValues[159] = d159
-							ps347.OverlayValues[160] = d160
-							ps347.OverlayValues[161] = d161
-							ps347.OverlayValues[162] = d162
-							ps347.OverlayValues[164] = d164
-							ps347.OverlayValues[165] = d165
-							ps347.OverlayValues[166] = d166
-							ps347.OverlayValues[167] = d167
-							ps347.OverlayValues[232] = d232
-							ps347.OverlayValues[233] = d233
-							ps347.OverlayValues[234] = d234
-							ps347.OverlayValues[235] = d235
-							ps347.OverlayValues[236] = d236
-							ps347.OverlayValues[311] = d311
-							ps347.OverlayValues[312] = d312
-							ps347.OverlayValues[313] = d313
-							ps347.OverlayValues[314] = d314
-							ps347.OverlayValues[315] = d315
-							ps347.OverlayValues[316] = d316
-							ps347.OverlayValues[317] = d317
-							ps347.OverlayValues[318] = d318
-							ps347.OverlayValues[319] = d319
-							ps347.OverlayValues[320] = d320
-							ps347.OverlayValues[321] = d321
-							ps347.OverlayValues[322] = d322
-							ps347.OverlayValues[323] = d323
-							ps347.OverlayValues[324] = d324
-							ps347.OverlayValues[325] = d325
-							ps347.OverlayValues[326] = d326
-							ps347.OverlayValues[327] = d327
-							ps347.OverlayValues[328] = d328
-							ps347.OverlayValues[329] = d329
-							ps347.OverlayValues[330] = d330
-							ps347.OverlayValues[331] = d331
-							ps347.OverlayValues[332] = d332
-							ps347.OverlayValues[333] = d333
-							ps347.OverlayValues[334] = d334
-							ps347.OverlayValues[335] = d335
-							ps347.OverlayValues[336] = d336
-							ps347.OverlayValues[337] = d337
-							ps347.OverlayValues[339] = d339
-							ps347.OverlayValues[340] = d340
-							ps347.OverlayValues[341] = d341
-							ps347.OverlayValues[342] = d342
-							ps347.OverlayValues[344] = d344
-							ps347.OverlayValues[345] = d345
-							ps347.OverlayValues[346] = d346
-							return bbs[13].RenderPS(ps347)
+							ps350 := PhiState{General: ps.General}
+							ps350.OverlayValues = make([]JITValueDesc, 350)
+							ps350.OverlayValues[1] = d1
+							ps350.OverlayValues[2] = d2
+							ps350.OverlayValues[3] = d3
+							ps350.OverlayValues[4] = d4
+							ps350.OverlayValues[5] = d5
+							ps350.OverlayValues[22] = d22
+							ps350.OverlayValues[23] = d23
+							ps350.OverlayValues[24] = d24
+							ps350.OverlayValues[25] = d25
+							ps350.OverlayValues[27] = d27
+							ps350.OverlayValues[28] = d28
+							ps350.OverlayValues[29] = d29
+							ps350.OverlayValues[30] = d30
+							ps350.OverlayValues[63] = d63
+							ps350.OverlayValues[64] = d64
+							ps350.OverlayValues[65] = d65
+							ps350.OverlayValues[66] = d66
+							ps350.OverlayValues[107] = d107
+							ps350.OverlayValues[108] = d108
+							ps350.OverlayValues[109] = d109
+							ps350.OverlayValues[110] = d110
+							ps350.OverlayValues[159] = d159
+							ps350.OverlayValues[160] = d160
+							ps350.OverlayValues[161] = d161
+							ps350.OverlayValues[162] = d162
+							ps350.OverlayValues[164] = d164
+							ps350.OverlayValues[165] = d165
+							ps350.OverlayValues[166] = d166
+							ps350.OverlayValues[167] = d167
+							ps350.OverlayValues[232] = d232
+							ps350.OverlayValues[233] = d233
+							ps350.OverlayValues[234] = d234
+							ps350.OverlayValues[235] = d235
+							ps350.OverlayValues[236] = d236
+							ps350.OverlayValues[237] = d237
+							ps350.OverlayValues[314] = d314
+							ps350.OverlayValues[315] = d315
+							ps350.OverlayValues[316] = d316
+							ps350.OverlayValues[317] = d317
+							ps350.OverlayValues[318] = d318
+							ps350.OverlayValues[319] = d319
+							ps350.OverlayValues[320] = d320
+							ps350.OverlayValues[321] = d321
+							ps350.OverlayValues[322] = d322
+							ps350.OverlayValues[323] = d323
+							ps350.OverlayValues[324] = d324
+							ps350.OverlayValues[325] = d325
+							ps350.OverlayValues[326] = d326
+							ps350.OverlayValues[327] = d327
+							ps350.OverlayValues[328] = d328
+							ps350.OverlayValues[329] = d329
+							ps350.OverlayValues[330] = d330
+							ps350.OverlayValues[331] = d331
+							ps350.OverlayValues[332] = d332
+							ps350.OverlayValues[333] = d333
+							ps350.OverlayValues[334] = d334
+							ps350.OverlayValues[335] = d335
+							ps350.OverlayValues[336] = d336
+							ps350.OverlayValues[337] = d337
+							ps350.OverlayValues[338] = d338
+							ps350.OverlayValues[339] = d339
+							ps350.OverlayValues[340] = d340
+							ps350.OverlayValues[342] = d342
+							ps350.OverlayValues[343] = d343
+							ps350.OverlayValues[344] = d344
+							ps350.OverlayValues[345] = d345
+							ps350.OverlayValues[347] = d347
+							ps350.OverlayValues[348] = d348
+							ps350.OverlayValues[349] = d349
+							return bbs[13].RenderPS(ps350)
 						}
 						if ps.General {
 						}
-						ps348 := PhiState{General: ps.General}
-						ps348.OverlayValues = make([]JITValueDesc, 347)
-						ps348.OverlayValues[1] = d1
-						ps348.OverlayValues[2] = d2
-						ps348.OverlayValues[3] = d3
-						ps348.OverlayValues[4] = d4
-						ps348.OverlayValues[5] = d5
-						ps348.OverlayValues[22] = d22
-						ps348.OverlayValues[23] = d23
-						ps348.OverlayValues[24] = d24
-						ps348.OverlayValues[25] = d25
-						ps348.OverlayValues[27] = d27
-						ps348.OverlayValues[28] = d28
-						ps348.OverlayValues[29] = d29
-						ps348.OverlayValues[30] = d30
-						ps348.OverlayValues[63] = d63
-						ps348.OverlayValues[64] = d64
-						ps348.OverlayValues[65] = d65
-						ps348.OverlayValues[66] = d66
-						ps348.OverlayValues[107] = d107
-						ps348.OverlayValues[108] = d108
-						ps348.OverlayValues[109] = d109
-						ps348.OverlayValues[110] = d110
-						ps348.OverlayValues[159] = d159
-						ps348.OverlayValues[160] = d160
-						ps348.OverlayValues[161] = d161
-						ps348.OverlayValues[162] = d162
-						ps348.OverlayValues[164] = d164
-						ps348.OverlayValues[165] = d165
-						ps348.OverlayValues[166] = d166
-						ps348.OverlayValues[167] = d167
-						ps348.OverlayValues[232] = d232
-						ps348.OverlayValues[233] = d233
-						ps348.OverlayValues[234] = d234
-						ps348.OverlayValues[235] = d235
-						ps348.OverlayValues[236] = d236
-						ps348.OverlayValues[311] = d311
-						ps348.OverlayValues[312] = d312
-						ps348.OverlayValues[313] = d313
-						ps348.OverlayValues[314] = d314
-						ps348.OverlayValues[315] = d315
-						ps348.OverlayValues[316] = d316
-						ps348.OverlayValues[317] = d317
-						ps348.OverlayValues[318] = d318
-						ps348.OverlayValues[319] = d319
-						ps348.OverlayValues[320] = d320
-						ps348.OverlayValues[321] = d321
-						ps348.OverlayValues[322] = d322
-						ps348.OverlayValues[323] = d323
-						ps348.OverlayValues[324] = d324
-						ps348.OverlayValues[325] = d325
-						ps348.OverlayValues[326] = d326
-						ps348.OverlayValues[327] = d327
-						ps348.OverlayValues[328] = d328
-						ps348.OverlayValues[329] = d329
-						ps348.OverlayValues[330] = d330
-						ps348.OverlayValues[331] = d331
-						ps348.OverlayValues[332] = d332
-						ps348.OverlayValues[333] = d333
-						ps348.OverlayValues[334] = d334
-						ps348.OverlayValues[335] = d335
-						ps348.OverlayValues[336] = d336
-						ps348.OverlayValues[337] = d337
-						ps348.OverlayValues[339] = d339
-						ps348.OverlayValues[340] = d340
-						ps348.OverlayValues[341] = d341
-						ps348.OverlayValues[342] = d342
-						ps348.OverlayValues[344] = d344
-						ps348.OverlayValues[345] = d345
-						ps348.OverlayValues[346] = d346
-						return bbs[12].RenderPS(ps348)
+						ps351 := PhiState{General: ps.General}
+						ps351.OverlayValues = make([]JITValueDesc, 350)
+						ps351.OverlayValues[1] = d1
+						ps351.OverlayValues[2] = d2
+						ps351.OverlayValues[3] = d3
+						ps351.OverlayValues[4] = d4
+						ps351.OverlayValues[5] = d5
+						ps351.OverlayValues[22] = d22
+						ps351.OverlayValues[23] = d23
+						ps351.OverlayValues[24] = d24
+						ps351.OverlayValues[25] = d25
+						ps351.OverlayValues[27] = d27
+						ps351.OverlayValues[28] = d28
+						ps351.OverlayValues[29] = d29
+						ps351.OverlayValues[30] = d30
+						ps351.OverlayValues[63] = d63
+						ps351.OverlayValues[64] = d64
+						ps351.OverlayValues[65] = d65
+						ps351.OverlayValues[66] = d66
+						ps351.OverlayValues[107] = d107
+						ps351.OverlayValues[108] = d108
+						ps351.OverlayValues[109] = d109
+						ps351.OverlayValues[110] = d110
+						ps351.OverlayValues[159] = d159
+						ps351.OverlayValues[160] = d160
+						ps351.OverlayValues[161] = d161
+						ps351.OverlayValues[162] = d162
+						ps351.OverlayValues[164] = d164
+						ps351.OverlayValues[165] = d165
+						ps351.OverlayValues[166] = d166
+						ps351.OverlayValues[167] = d167
+						ps351.OverlayValues[232] = d232
+						ps351.OverlayValues[233] = d233
+						ps351.OverlayValues[234] = d234
+						ps351.OverlayValues[235] = d235
+						ps351.OverlayValues[236] = d236
+						ps351.OverlayValues[237] = d237
+						ps351.OverlayValues[314] = d314
+						ps351.OverlayValues[315] = d315
+						ps351.OverlayValues[316] = d316
+						ps351.OverlayValues[317] = d317
+						ps351.OverlayValues[318] = d318
+						ps351.OverlayValues[319] = d319
+						ps351.OverlayValues[320] = d320
+						ps351.OverlayValues[321] = d321
+						ps351.OverlayValues[322] = d322
+						ps351.OverlayValues[323] = d323
+						ps351.OverlayValues[324] = d324
+						ps351.OverlayValues[325] = d325
+						ps351.OverlayValues[326] = d326
+						ps351.OverlayValues[327] = d327
+						ps351.OverlayValues[328] = d328
+						ps351.OverlayValues[329] = d329
+						ps351.OverlayValues[330] = d330
+						ps351.OverlayValues[331] = d331
+						ps351.OverlayValues[332] = d332
+						ps351.OverlayValues[333] = d333
+						ps351.OverlayValues[334] = d334
+						ps351.OverlayValues[335] = d335
+						ps351.OverlayValues[336] = d336
+						ps351.OverlayValues[337] = d337
+						ps351.OverlayValues[338] = d338
+						ps351.OverlayValues[339] = d339
+						ps351.OverlayValues[340] = d340
+						ps351.OverlayValues[342] = d342
+						ps351.OverlayValues[343] = d343
+						ps351.OverlayValues[344] = d344
+						ps351.OverlayValues[345] = d345
+						ps351.OverlayValues[347] = d347
+						ps351.OverlayValues[348] = d348
+						ps351.OverlayValues[349] = d349
+						return bbs[12].RenderPS(ps351)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[11].RenderPS(ps)
 					}
-					ctx.EmitCmpRegImm32(d346.Reg, 0)
+					ctx.EmitCmpRegImm32(d349.Reg, 0)
 					ctx.EmitJump(CondNotEqual, lbl14)
 					if bbs[12].Rendered {
 						ctx.EmitJmp(lbl13)
 					}
-					snap349 := d1
-					snap350 := d2
-					snap351 := d3
-					snap352 := d4
-					snap353 := d5
-					snap354 := d22
-					snap355 := d23
-					snap356 := d24
-					snap357 := d25
-					snap358 := d27
-					snap359 := d28
-					snap360 := d29
-					snap361 := d30
-					snap362 := d63
-					snap363 := d64
-					snap364 := d65
-					snap365 := d66
-					snap366 := d107
-					snap367 := d108
-					snap368 := d109
-					snap369 := d110
-					snap370 := d159
-					snap371 := d160
-					snap372 := d161
-					snap373 := d162
-					snap374 := d164
-					snap375 := d165
-					snap376 := d166
-					snap377 := d167
-					snap378 := d232
-					snap379 := d233
-					snap380 := d234
-					snap381 := d235
-					snap382 := d236
-					snap383 := d311
-					snap384 := d312
-					snap385 := d313
-					snap386 := d314
-					snap387 := d315
-					snap388 := d316
-					snap389 := d317
-					snap390 := d318
-					snap391 := d319
-					snap392 := d320
-					snap393 := d321
-					snap394 := d322
-					snap395 := d323
-					snap396 := d324
-					snap397 := d325
-					snap398 := d326
-					snap399 := d327
-					snap400 := d328
-					snap401 := d329
-					snap402 := d330
-					snap403 := d331
-					snap404 := d332
-					snap405 := d333
-					snap406 := d334
-					snap407 := d335
-					snap408 := d336
-					snap409 := d337
-					snap410 := d339
-					snap411 := d340
-					snap412 := d341
-					snap413 := d342
-					snap414 := d344
-					snap415 := d345
-					snap416 := d346
-					alloc417 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc417)
-					d1 = snap349
-					d2 = snap350
-					d3 = snap351
-					d4 = snap352
-					d5 = snap353
-					d22 = snap354
-					d23 = snap355
-					d24 = snap356
-					d25 = snap357
-					d27 = snap358
-					d28 = snap359
-					d29 = snap360
-					d30 = snap361
-					d63 = snap362
-					d64 = snap363
-					d65 = snap364
-					d66 = snap365
-					d107 = snap366
-					d108 = snap367
-					d109 = snap368
-					d110 = snap369
-					d159 = snap370
-					d160 = snap371
-					d161 = snap372
-					d162 = snap373
-					d164 = snap374
-					d165 = snap375
-					d166 = snap376
-					d167 = snap377
-					d232 = snap378
-					d233 = snap379
-					d234 = snap380
-					d235 = snap381
-					d236 = snap382
-					d311 = snap383
-					d312 = snap384
-					d313 = snap385
-					d314 = snap386
-					d315 = snap387
-					d316 = snap388
-					d317 = snap389
-					d318 = snap390
-					d319 = snap391
-					d320 = snap392
-					d321 = snap393
-					d322 = snap394
-					d323 = snap395
-					d324 = snap396
-					d325 = snap397
-					d326 = snap398
-					d327 = snap399
-					d328 = snap400
-					d329 = snap401
-					d330 = snap402
-					d331 = snap403
-					d332 = snap404
-					d333 = snap405
-					d334 = snap406
-					d335 = snap407
-					d336 = snap408
-					d337 = snap409
-					d339 = snap410
-					d340 = snap411
-					d341 = snap412
-					d342 = snap413
-					d344 = snap414
-					d345 = snap415
-					d346 = snap416
-					ctx.RestoreAllocState(alloc417)
-					d1 = snap349
-					d2 = snap350
-					d3 = snap351
-					d4 = snap352
-					d5 = snap353
-					d22 = snap354
-					d23 = snap355
-					d24 = snap356
-					d25 = snap357
-					d27 = snap358
-					d28 = snap359
-					d29 = snap360
-					d30 = snap361
-					d63 = snap362
-					d64 = snap363
-					d65 = snap364
-					d66 = snap365
-					d107 = snap366
-					d108 = snap367
-					d109 = snap368
-					d110 = snap369
-					d159 = snap370
-					d160 = snap371
-					d161 = snap372
-					d162 = snap373
-					d164 = snap374
-					d165 = snap375
-					d166 = snap376
-					d167 = snap377
-					d232 = snap378
-					d233 = snap379
-					d234 = snap380
-					d235 = snap381
-					d236 = snap382
-					d311 = snap383
-					d312 = snap384
-					d313 = snap385
-					d314 = snap386
-					d315 = snap387
-					d316 = snap388
-					d317 = snap389
-					d318 = snap390
-					d319 = snap391
-					d320 = snap392
-					d321 = snap393
-					d322 = snap394
-					d323 = snap395
-					d324 = snap396
-					d325 = snap397
-					d326 = snap398
-					d327 = snap399
-					d328 = snap400
-					d329 = snap401
-					d330 = snap402
-					d331 = snap403
-					d332 = snap404
-					d333 = snap405
-					d334 = snap406
-					d335 = snap407
-					d336 = snap408
-					d337 = snap409
-					d339 = snap410
-					d340 = snap411
-					d341 = snap412
-					d342 = snap413
-					d344 = snap414
-					d345 = snap415
-					d346 = snap416
-					ps418 := PhiState{General: true}
-					ps418.OverlayValues = make([]JITValueDesc, 347)
-					ps418.OverlayValues[1] = d1
-					ps418.OverlayValues[2] = d2
-					ps418.OverlayValues[3] = d3
-					ps418.OverlayValues[4] = d4
-					ps418.OverlayValues[5] = d5
-					ps418.OverlayValues[22] = d22
-					ps418.OverlayValues[23] = d23
-					ps418.OverlayValues[24] = d24
-					ps418.OverlayValues[25] = d25
-					ps418.OverlayValues[27] = d27
-					ps418.OverlayValues[28] = d28
-					ps418.OverlayValues[29] = d29
-					ps418.OverlayValues[30] = d30
-					ps418.OverlayValues[63] = d63
-					ps418.OverlayValues[64] = d64
-					ps418.OverlayValues[65] = d65
-					ps418.OverlayValues[66] = d66
-					ps418.OverlayValues[107] = d107
-					ps418.OverlayValues[108] = d108
-					ps418.OverlayValues[109] = d109
-					ps418.OverlayValues[110] = d110
-					ps418.OverlayValues[159] = d159
-					ps418.OverlayValues[160] = d160
-					ps418.OverlayValues[161] = d161
-					ps418.OverlayValues[162] = d162
-					ps418.OverlayValues[164] = d164
-					ps418.OverlayValues[165] = d165
-					ps418.OverlayValues[166] = d166
-					ps418.OverlayValues[167] = d167
-					ps418.OverlayValues[232] = d232
-					ps418.OverlayValues[233] = d233
-					ps418.OverlayValues[234] = d234
-					ps418.OverlayValues[235] = d235
-					ps418.OverlayValues[236] = d236
-					ps418.OverlayValues[311] = d311
-					ps418.OverlayValues[312] = d312
-					ps418.OverlayValues[313] = d313
-					ps418.OverlayValues[314] = d314
-					ps418.OverlayValues[315] = d315
-					ps418.OverlayValues[316] = d316
-					ps418.OverlayValues[317] = d317
-					ps418.OverlayValues[318] = d318
-					ps418.OverlayValues[319] = d319
-					ps418.OverlayValues[320] = d320
-					ps418.OverlayValues[321] = d321
-					ps418.OverlayValues[322] = d322
-					ps418.OverlayValues[323] = d323
-					ps418.OverlayValues[324] = d324
-					ps418.OverlayValues[325] = d325
-					ps418.OverlayValues[326] = d326
-					ps418.OverlayValues[327] = d327
-					ps418.OverlayValues[328] = d328
-					ps418.OverlayValues[329] = d329
-					ps418.OverlayValues[330] = d330
-					ps418.OverlayValues[331] = d331
-					ps418.OverlayValues[332] = d332
-					ps418.OverlayValues[333] = d333
-					ps418.OverlayValues[334] = d334
-					ps418.OverlayValues[335] = d335
-					ps418.OverlayValues[336] = d336
-					ps418.OverlayValues[337] = d337
-					ps418.OverlayValues[339] = d339
-					ps418.OverlayValues[340] = d340
-					ps418.OverlayValues[341] = d341
-					ps418.OverlayValues[342] = d342
-					ps418.OverlayValues[344] = d344
-					ps418.OverlayValues[345] = d345
-					ps418.OverlayValues[346] = d346
-					ps419 := PhiState{General: true}
-					ps419.OverlayValues = make([]JITValueDesc, 347)
-					ps419.OverlayValues[1] = d1
-					ps419.OverlayValues[2] = d2
-					ps419.OverlayValues[3] = d3
-					ps419.OverlayValues[4] = d4
-					ps419.OverlayValues[5] = d5
-					ps419.OverlayValues[22] = d22
-					ps419.OverlayValues[23] = d23
-					ps419.OverlayValues[24] = d24
-					ps419.OverlayValues[25] = d25
-					ps419.OverlayValues[27] = d27
-					ps419.OverlayValues[28] = d28
-					ps419.OverlayValues[29] = d29
-					ps419.OverlayValues[30] = d30
-					ps419.OverlayValues[63] = d63
-					ps419.OverlayValues[64] = d64
-					ps419.OverlayValues[65] = d65
-					ps419.OverlayValues[66] = d66
-					ps419.OverlayValues[107] = d107
-					ps419.OverlayValues[108] = d108
-					ps419.OverlayValues[109] = d109
-					ps419.OverlayValues[110] = d110
-					ps419.OverlayValues[159] = d159
-					ps419.OverlayValues[160] = d160
-					ps419.OverlayValues[161] = d161
-					ps419.OverlayValues[162] = d162
-					ps419.OverlayValues[164] = d164
-					ps419.OverlayValues[165] = d165
-					ps419.OverlayValues[166] = d166
-					ps419.OverlayValues[167] = d167
-					ps419.OverlayValues[232] = d232
-					ps419.OverlayValues[233] = d233
-					ps419.OverlayValues[234] = d234
-					ps419.OverlayValues[235] = d235
-					ps419.OverlayValues[236] = d236
-					ps419.OverlayValues[311] = d311
-					ps419.OverlayValues[312] = d312
-					ps419.OverlayValues[313] = d313
-					ps419.OverlayValues[314] = d314
-					ps419.OverlayValues[315] = d315
-					ps419.OverlayValues[316] = d316
-					ps419.OverlayValues[317] = d317
-					ps419.OverlayValues[318] = d318
-					ps419.OverlayValues[319] = d319
-					ps419.OverlayValues[320] = d320
-					ps419.OverlayValues[321] = d321
-					ps419.OverlayValues[322] = d322
-					ps419.OverlayValues[323] = d323
-					ps419.OverlayValues[324] = d324
-					ps419.OverlayValues[325] = d325
-					ps419.OverlayValues[326] = d326
-					ps419.OverlayValues[327] = d327
-					ps419.OverlayValues[328] = d328
-					ps419.OverlayValues[329] = d329
-					ps419.OverlayValues[330] = d330
-					ps419.OverlayValues[331] = d331
-					ps419.OverlayValues[332] = d332
-					ps419.OverlayValues[333] = d333
-					ps419.OverlayValues[334] = d334
-					ps419.OverlayValues[335] = d335
-					ps419.OverlayValues[336] = d336
-					ps419.OverlayValues[337] = d337
-					ps419.OverlayValues[339] = d339
-					ps419.OverlayValues[340] = d340
-					ps419.OverlayValues[341] = d341
-					ps419.OverlayValues[342] = d342
-					ps419.OverlayValues[344] = d344
-					ps419.OverlayValues[345] = d345
-					ps419.OverlayValues[346] = d346
-					snap420 := d1
-					snap421 := d2
-					snap422 := d3
-					snap423 := d4
-					snap424 := d5
-					snap425 := d22
-					snap426 := d23
-					snap427 := d24
-					snap428 := d25
-					snap429 := d27
-					snap430 := d28
-					snap431 := d29
-					snap432 := d30
-					snap433 := d63
-					snap434 := d64
-					snap435 := d65
-					snap436 := d66
-					snap437 := d107
-					snap438 := d108
-					snap439 := d109
-					snap440 := d110
-					snap441 := d159
-					snap442 := d160
-					snap443 := d161
-					snap444 := d162
-					snap445 := d164
-					snap446 := d165
-					snap447 := d166
-					snap448 := d167
-					snap449 := d232
-					snap450 := d233
-					snap451 := d234
-					snap452 := d235
-					snap453 := d236
-					snap454 := d311
-					snap455 := d312
-					snap456 := d313
-					snap457 := d314
-					snap458 := d315
-					snap459 := d316
-					snap460 := d317
-					snap461 := d318
-					snap462 := d319
-					snap463 := d320
-					snap464 := d321
-					snap465 := d322
-					snap466 := d323
-					snap467 := d324
-					snap468 := d325
-					snap469 := d326
-					snap470 := d327
-					snap471 := d328
-					snap472 := d329
-					snap473 := d330
-					snap474 := d331
-					snap475 := d332
-					snap476 := d333
-					snap477 := d334
-					snap478 := d335
-					snap479 := d336
-					snap480 := d337
-					snap481 := d339
-					snap482 := d340
-					snap483 := d341
-					snap484 := d342
-					snap485 := d344
-					snap486 := d345
-					snap487 := d346
-					alloc488 := ctx.SnapshotAllocState()
+					snap352 := d1
+					snap353 := d2
+					snap354 := d3
+					snap355 := d4
+					snap356 := d5
+					snap357 := d22
+					snap358 := d23
+					snap359 := d24
+					snap360 := d25
+					snap361 := d27
+					snap362 := d28
+					snap363 := d29
+					snap364 := d30
+					snap365 := d63
+					snap366 := d64
+					snap367 := d65
+					snap368 := d66
+					snap369 := d107
+					snap370 := d108
+					snap371 := d109
+					snap372 := d110
+					snap373 := d159
+					snap374 := d160
+					snap375 := d161
+					snap376 := d162
+					snap377 := d164
+					snap378 := d165
+					snap379 := d166
+					snap380 := d167
+					snap381 := d232
+					snap382 := d233
+					snap383 := d234
+					snap384 := d235
+					snap385 := d236
+					snap386 := d237
+					snap387 := d314
+					snap388 := d315
+					snap389 := d316
+					snap390 := d317
+					snap391 := d318
+					snap392 := d319
+					snap393 := d320
+					snap394 := d321
+					snap395 := d322
+					snap396 := d323
+					snap397 := d324
+					snap398 := d325
+					snap399 := d326
+					snap400 := d327
+					snap401 := d328
+					snap402 := d329
+					snap403 := d330
+					snap404 := d331
+					snap405 := d332
+					snap406 := d333
+					snap407 := d334
+					snap408 := d335
+					snap409 := d336
+					snap410 := d337
+					snap411 := d338
+					snap412 := d339
+					snap413 := d340
+					snap414 := d342
+					snap415 := d343
+					snap416 := d344
+					snap417 := d345
+					snap418 := d347
+					snap419 := d348
+					snap420 := d349
+					alloc421 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc421)
+					d1 = snap352
+					d2 = snap353
+					d3 = snap354
+					d4 = snap355
+					d5 = snap356
+					d22 = snap357
+					d23 = snap358
+					d24 = snap359
+					d25 = snap360
+					d27 = snap361
+					d28 = snap362
+					d29 = snap363
+					d30 = snap364
+					d63 = snap365
+					d64 = snap366
+					d65 = snap367
+					d66 = snap368
+					d107 = snap369
+					d108 = snap370
+					d109 = snap371
+					d110 = snap372
+					d159 = snap373
+					d160 = snap374
+					d161 = snap375
+					d162 = snap376
+					d164 = snap377
+					d165 = snap378
+					d166 = snap379
+					d167 = snap380
+					d232 = snap381
+					d233 = snap382
+					d234 = snap383
+					d235 = snap384
+					d236 = snap385
+					d237 = snap386
+					d314 = snap387
+					d315 = snap388
+					d316 = snap389
+					d317 = snap390
+					d318 = snap391
+					d319 = snap392
+					d320 = snap393
+					d321 = snap394
+					d322 = snap395
+					d323 = snap396
+					d324 = snap397
+					d325 = snap398
+					d326 = snap399
+					d327 = snap400
+					d328 = snap401
+					d329 = snap402
+					d330 = snap403
+					d331 = snap404
+					d332 = snap405
+					d333 = snap406
+					d334 = snap407
+					d335 = snap408
+					d336 = snap409
+					d337 = snap410
+					d338 = snap411
+					d339 = snap412
+					d340 = snap413
+					d342 = snap414
+					d343 = snap415
+					d344 = snap416
+					d345 = snap417
+					d347 = snap418
+					d348 = snap419
+					d349 = snap420
+					ctx.RestoreAllocState(alloc421)
+					d1 = snap352
+					d2 = snap353
+					d3 = snap354
+					d4 = snap355
+					d5 = snap356
+					d22 = snap357
+					d23 = snap358
+					d24 = snap359
+					d25 = snap360
+					d27 = snap361
+					d28 = snap362
+					d29 = snap363
+					d30 = snap364
+					d63 = snap365
+					d64 = snap366
+					d65 = snap367
+					d66 = snap368
+					d107 = snap369
+					d108 = snap370
+					d109 = snap371
+					d110 = snap372
+					d159 = snap373
+					d160 = snap374
+					d161 = snap375
+					d162 = snap376
+					d164 = snap377
+					d165 = snap378
+					d166 = snap379
+					d167 = snap380
+					d232 = snap381
+					d233 = snap382
+					d234 = snap383
+					d235 = snap384
+					d236 = snap385
+					d237 = snap386
+					d314 = snap387
+					d315 = snap388
+					d316 = snap389
+					d317 = snap390
+					d318 = snap391
+					d319 = snap392
+					d320 = snap393
+					d321 = snap394
+					d322 = snap395
+					d323 = snap396
+					d324 = snap397
+					d325 = snap398
+					d326 = snap399
+					d327 = snap400
+					d328 = snap401
+					d329 = snap402
+					d330 = snap403
+					d331 = snap404
+					d332 = snap405
+					d333 = snap406
+					d334 = snap407
+					d335 = snap408
+					d336 = snap409
+					d337 = snap410
+					d338 = snap411
+					d339 = snap412
+					d340 = snap413
+					d342 = snap414
+					d343 = snap415
+					d344 = snap416
+					d345 = snap417
+					d347 = snap418
+					d348 = snap419
+					d349 = snap420
+					ps422 := PhiState{General: true}
+					ps422.OverlayValues = make([]JITValueDesc, 350)
+					ps422.OverlayValues[1] = d1
+					ps422.OverlayValues[2] = d2
+					ps422.OverlayValues[3] = d3
+					ps422.OverlayValues[4] = d4
+					ps422.OverlayValues[5] = d5
+					ps422.OverlayValues[22] = d22
+					ps422.OverlayValues[23] = d23
+					ps422.OverlayValues[24] = d24
+					ps422.OverlayValues[25] = d25
+					ps422.OverlayValues[27] = d27
+					ps422.OverlayValues[28] = d28
+					ps422.OverlayValues[29] = d29
+					ps422.OverlayValues[30] = d30
+					ps422.OverlayValues[63] = d63
+					ps422.OverlayValues[64] = d64
+					ps422.OverlayValues[65] = d65
+					ps422.OverlayValues[66] = d66
+					ps422.OverlayValues[107] = d107
+					ps422.OverlayValues[108] = d108
+					ps422.OverlayValues[109] = d109
+					ps422.OverlayValues[110] = d110
+					ps422.OverlayValues[159] = d159
+					ps422.OverlayValues[160] = d160
+					ps422.OverlayValues[161] = d161
+					ps422.OverlayValues[162] = d162
+					ps422.OverlayValues[164] = d164
+					ps422.OverlayValues[165] = d165
+					ps422.OverlayValues[166] = d166
+					ps422.OverlayValues[167] = d167
+					ps422.OverlayValues[232] = d232
+					ps422.OverlayValues[233] = d233
+					ps422.OverlayValues[234] = d234
+					ps422.OverlayValues[235] = d235
+					ps422.OverlayValues[236] = d236
+					ps422.OverlayValues[237] = d237
+					ps422.OverlayValues[314] = d314
+					ps422.OverlayValues[315] = d315
+					ps422.OverlayValues[316] = d316
+					ps422.OverlayValues[317] = d317
+					ps422.OverlayValues[318] = d318
+					ps422.OverlayValues[319] = d319
+					ps422.OverlayValues[320] = d320
+					ps422.OverlayValues[321] = d321
+					ps422.OverlayValues[322] = d322
+					ps422.OverlayValues[323] = d323
+					ps422.OverlayValues[324] = d324
+					ps422.OverlayValues[325] = d325
+					ps422.OverlayValues[326] = d326
+					ps422.OverlayValues[327] = d327
+					ps422.OverlayValues[328] = d328
+					ps422.OverlayValues[329] = d329
+					ps422.OverlayValues[330] = d330
+					ps422.OverlayValues[331] = d331
+					ps422.OverlayValues[332] = d332
+					ps422.OverlayValues[333] = d333
+					ps422.OverlayValues[334] = d334
+					ps422.OverlayValues[335] = d335
+					ps422.OverlayValues[336] = d336
+					ps422.OverlayValues[337] = d337
+					ps422.OverlayValues[338] = d338
+					ps422.OverlayValues[339] = d339
+					ps422.OverlayValues[340] = d340
+					ps422.OverlayValues[342] = d342
+					ps422.OverlayValues[343] = d343
+					ps422.OverlayValues[344] = d344
+					ps422.OverlayValues[345] = d345
+					ps422.OverlayValues[347] = d347
+					ps422.OverlayValues[348] = d348
+					ps422.OverlayValues[349] = d349
+					ps423 := PhiState{General: true}
+					ps423.OverlayValues = make([]JITValueDesc, 350)
+					ps423.OverlayValues[1] = d1
+					ps423.OverlayValues[2] = d2
+					ps423.OverlayValues[3] = d3
+					ps423.OverlayValues[4] = d4
+					ps423.OverlayValues[5] = d5
+					ps423.OverlayValues[22] = d22
+					ps423.OverlayValues[23] = d23
+					ps423.OverlayValues[24] = d24
+					ps423.OverlayValues[25] = d25
+					ps423.OverlayValues[27] = d27
+					ps423.OverlayValues[28] = d28
+					ps423.OverlayValues[29] = d29
+					ps423.OverlayValues[30] = d30
+					ps423.OverlayValues[63] = d63
+					ps423.OverlayValues[64] = d64
+					ps423.OverlayValues[65] = d65
+					ps423.OverlayValues[66] = d66
+					ps423.OverlayValues[107] = d107
+					ps423.OverlayValues[108] = d108
+					ps423.OverlayValues[109] = d109
+					ps423.OverlayValues[110] = d110
+					ps423.OverlayValues[159] = d159
+					ps423.OverlayValues[160] = d160
+					ps423.OverlayValues[161] = d161
+					ps423.OverlayValues[162] = d162
+					ps423.OverlayValues[164] = d164
+					ps423.OverlayValues[165] = d165
+					ps423.OverlayValues[166] = d166
+					ps423.OverlayValues[167] = d167
+					ps423.OverlayValues[232] = d232
+					ps423.OverlayValues[233] = d233
+					ps423.OverlayValues[234] = d234
+					ps423.OverlayValues[235] = d235
+					ps423.OverlayValues[236] = d236
+					ps423.OverlayValues[237] = d237
+					ps423.OverlayValues[314] = d314
+					ps423.OverlayValues[315] = d315
+					ps423.OverlayValues[316] = d316
+					ps423.OverlayValues[317] = d317
+					ps423.OverlayValues[318] = d318
+					ps423.OverlayValues[319] = d319
+					ps423.OverlayValues[320] = d320
+					ps423.OverlayValues[321] = d321
+					ps423.OverlayValues[322] = d322
+					ps423.OverlayValues[323] = d323
+					ps423.OverlayValues[324] = d324
+					ps423.OverlayValues[325] = d325
+					ps423.OverlayValues[326] = d326
+					ps423.OverlayValues[327] = d327
+					ps423.OverlayValues[328] = d328
+					ps423.OverlayValues[329] = d329
+					ps423.OverlayValues[330] = d330
+					ps423.OverlayValues[331] = d331
+					ps423.OverlayValues[332] = d332
+					ps423.OverlayValues[333] = d333
+					ps423.OverlayValues[334] = d334
+					ps423.OverlayValues[335] = d335
+					ps423.OverlayValues[336] = d336
+					ps423.OverlayValues[337] = d337
+					ps423.OverlayValues[338] = d338
+					ps423.OverlayValues[339] = d339
+					ps423.OverlayValues[340] = d340
+					ps423.OverlayValues[342] = d342
+					ps423.OverlayValues[343] = d343
+					ps423.OverlayValues[344] = d344
+					ps423.OverlayValues[345] = d345
+					ps423.OverlayValues[347] = d347
+					ps423.OverlayValues[348] = d348
+					ps423.OverlayValues[349] = d349
+					snap424 := d1
+					snap425 := d2
+					snap426 := d3
+					snap427 := d4
+					snap428 := d5
+					snap429 := d22
+					snap430 := d23
+					snap431 := d24
+					snap432 := d25
+					snap433 := d27
+					snap434 := d28
+					snap435 := d29
+					snap436 := d30
+					snap437 := d63
+					snap438 := d64
+					snap439 := d65
+					snap440 := d66
+					snap441 := d107
+					snap442 := d108
+					snap443 := d109
+					snap444 := d110
+					snap445 := d159
+					snap446 := d160
+					snap447 := d161
+					snap448 := d162
+					snap449 := d164
+					snap450 := d165
+					snap451 := d166
+					snap452 := d167
+					snap453 := d232
+					snap454 := d233
+					snap455 := d234
+					snap456 := d235
+					snap457 := d236
+					snap458 := d237
+					snap459 := d314
+					snap460 := d315
+					snap461 := d316
+					snap462 := d317
+					snap463 := d318
+					snap464 := d319
+					snap465 := d320
+					snap466 := d321
+					snap467 := d322
+					snap468 := d323
+					snap469 := d324
+					snap470 := d325
+					snap471 := d326
+					snap472 := d327
+					snap473 := d328
+					snap474 := d329
+					snap475 := d330
+					snap476 := d331
+					snap477 := d332
+					snap478 := d333
+					snap479 := d334
+					snap480 := d335
+					snap481 := d336
+					snap482 := d337
+					snap483 := d338
+					snap484 := d339
+					snap485 := d340
+					snap486 := d342
+					snap487 := d343
+					snap488 := d344
+					snap489 := d345
+					snap490 := d347
+					snap491 := d348
+					snap492 := d349
+					alloc493 := ctx.SnapshotAllocState()
 					if !bbs[12].Rendered {
-						bbs[12].RenderPS(ps419)
+						bbs[12].RenderPS(ps423)
 					}
-					ctx.RestoreAllocState(alloc488)
-					d1 = snap420
-					d2 = snap421
-					d3 = snap422
-					d4 = snap423
-					d5 = snap424
-					d22 = snap425
-					d23 = snap426
-					d24 = snap427
-					d25 = snap428
-					d27 = snap429
-					d28 = snap430
-					d29 = snap431
-					d30 = snap432
-					d63 = snap433
-					d64 = snap434
-					d65 = snap435
-					d66 = snap436
-					d107 = snap437
-					d108 = snap438
-					d109 = snap439
-					d110 = snap440
-					d159 = snap441
-					d160 = snap442
-					d161 = snap443
-					d162 = snap444
-					d164 = snap445
-					d165 = snap446
-					d166 = snap447
-					d167 = snap448
-					d232 = snap449
-					d233 = snap450
-					d234 = snap451
-					d235 = snap452
-					d236 = snap453
-					d311 = snap454
-					d312 = snap455
-					d313 = snap456
-					d314 = snap457
-					d315 = snap458
-					d316 = snap459
-					d317 = snap460
-					d318 = snap461
-					d319 = snap462
-					d320 = snap463
-					d321 = snap464
-					d322 = snap465
-					d323 = snap466
-					d324 = snap467
-					d325 = snap468
-					d326 = snap469
-					d327 = snap470
-					d328 = snap471
-					d329 = snap472
-					d330 = snap473
-					d331 = snap474
-					d332 = snap475
-					d333 = snap476
-					d334 = snap477
-					d335 = snap478
-					d336 = snap479
-					d337 = snap480
-					d339 = snap481
-					d340 = snap482
-					d341 = snap483
-					d342 = snap484
-					d344 = snap485
-					d345 = snap486
-					d346 = snap487
+					ctx.RestoreAllocState(alloc493)
+					d1 = snap424
+					d2 = snap425
+					d3 = snap426
+					d4 = snap427
+					d5 = snap428
+					d22 = snap429
+					d23 = snap430
+					d24 = snap431
+					d25 = snap432
+					d27 = snap433
+					d28 = snap434
+					d29 = snap435
+					d30 = snap436
+					d63 = snap437
+					d64 = snap438
+					d65 = snap439
+					d66 = snap440
+					d107 = snap441
+					d108 = snap442
+					d109 = snap443
+					d110 = snap444
+					d159 = snap445
+					d160 = snap446
+					d161 = snap447
+					d162 = snap448
+					d164 = snap449
+					d165 = snap450
+					d166 = snap451
+					d167 = snap452
+					d232 = snap453
+					d233 = snap454
+					d234 = snap455
+					d235 = snap456
+					d236 = snap457
+					d237 = snap458
+					d314 = snap459
+					d315 = snap460
+					d316 = snap461
+					d317 = snap462
+					d318 = snap463
+					d319 = snap464
+					d320 = snap465
+					d321 = snap466
+					d322 = snap467
+					d323 = snap468
+					d324 = snap469
+					d325 = snap470
+					d326 = snap471
+					d327 = snap472
+					d328 = snap473
+					d329 = snap474
+					d330 = snap475
+					d331 = snap476
+					d332 = snap477
+					d333 = snap478
+					d334 = snap479
+					d335 = snap480
+					d336 = snap481
+					d337 = snap482
+					d338 = snap483
+					d339 = snap484
+					d340 = snap485
+					d342 = snap486
+					d343 = snap487
+					d344 = snap488
+					d345 = snap489
+					d347 = snap490
+					d348 = snap491
+					d349 = snap492
 					if !bbs[13].Rendered {
-						return bbs[13].RenderPS(ps418)
+						return bbs[13].RenderPS(ps422)
 					}
 					return result
-					ctx.FreeDesc(&d345)
+					ctx.FreeDesc(&d348)
 					return result
 				}
 				bbs[12].RenderPS = func(ps PhiState) JITValueDesc {
@@ -5407,14 +5439,8 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 236 && ps.OverlayValues[236].Loc != LocNone {
 						d236 = ps.OverlayValues[236]
 					}
-					if len(ps.OverlayValues) > 311 && ps.OverlayValues[311].Loc != LocNone {
-						d311 = ps.OverlayValues[311]
-					}
-					if len(ps.OverlayValues) > 312 && ps.OverlayValues[312].Loc != LocNone {
-						d312 = ps.OverlayValues[312]
-					}
-					if len(ps.OverlayValues) > 313 && ps.OverlayValues[313].Loc != LocNone {
-						d313 = ps.OverlayValues[313]
+					if len(ps.OverlayValues) > 237 && ps.OverlayValues[237].Loc != LocNone {
+						d237 = ps.OverlayValues[237]
 					}
 					if len(ps.OverlayValues) > 314 && ps.OverlayValues[314].Loc != LocNone {
 						d314 = ps.OverlayValues[314]
@@ -5488,17 +5514,20 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 337 && ps.OverlayValues[337].Loc != LocNone {
 						d337 = ps.OverlayValues[337]
 					}
+					if len(ps.OverlayValues) > 338 && ps.OverlayValues[338].Loc != LocNone {
+						d338 = ps.OverlayValues[338]
+					}
 					if len(ps.OverlayValues) > 339 && ps.OverlayValues[339].Loc != LocNone {
 						d339 = ps.OverlayValues[339]
 					}
 					if len(ps.OverlayValues) > 340 && ps.OverlayValues[340].Loc != LocNone {
 						d340 = ps.OverlayValues[340]
 					}
-					if len(ps.OverlayValues) > 341 && ps.OverlayValues[341].Loc != LocNone {
-						d341 = ps.OverlayValues[341]
-					}
 					if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
 						d342 = ps.OverlayValues[342]
+					}
+					if len(ps.OverlayValues) > 343 && ps.OverlayValues[343].Loc != LocNone {
+						d343 = ps.OverlayValues[343]
 					}
 					if len(ps.OverlayValues) > 344 && ps.OverlayValues[344].Loc != LocNone {
 						d344 = ps.OverlayValues[344]
@@ -5506,32 +5535,38 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 345 && ps.OverlayValues[345].Loc != LocNone {
 						d345 = ps.OverlayValues[345]
 					}
-					if len(ps.OverlayValues) > 346 && ps.OverlayValues[346].Loc != LocNone {
-						d346 = ps.OverlayValues[346]
+					if len(ps.OverlayValues) > 347 && ps.OverlayValues[347].Loc != LocNone {
+						d347 = ps.OverlayValues[347]
+					}
+					if len(ps.OverlayValues) > 348 && ps.OverlayValues[348].Loc != LocNone {
+						d348 = ps.OverlayValues[348]
+					}
+					if len(ps.OverlayValues) > 349 && ps.OverlayValues[349].Loc != LocNone {
+						d349 = ps.OverlayValues[349]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d489 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
-					ctx.SyncDesc(&d489)
-					if d489.Loc == LocRegPair || d489.Loc == LocStackPair || d489.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d489, &result)
-						result.Type = d489.Type
+					d494 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+					ctx.SyncDesc(&d494)
+					if d494.Loc == LocRegPair || d494.Loc == LocStackPair || d494.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d494, &result)
+						result.Type = d494.Type
 					} else {
-						switch d489.Type {
+						switch d494.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d489)
+							ctx.EmitMakeBool(result, d494)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d489)
+							ctx.EmitMakeInt(result, d494)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d489)
+							ctx.EmitMakeFloat(result, d494)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d489, &result)
-							result.Type = d489.Type
+							ctx.EmitMovPairToResult(&d494, &result)
+							result.Type = d494.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -5659,14 +5694,8 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 236 && ps.OverlayValues[236].Loc != LocNone {
 						d236 = ps.OverlayValues[236]
 					}
-					if len(ps.OverlayValues) > 311 && ps.OverlayValues[311].Loc != LocNone {
-						d311 = ps.OverlayValues[311]
-					}
-					if len(ps.OverlayValues) > 312 && ps.OverlayValues[312].Loc != LocNone {
-						d312 = ps.OverlayValues[312]
-					}
-					if len(ps.OverlayValues) > 313 && ps.OverlayValues[313].Loc != LocNone {
-						d313 = ps.OverlayValues[313]
+					if len(ps.OverlayValues) > 237 && ps.OverlayValues[237].Loc != LocNone {
+						d237 = ps.OverlayValues[237]
 					}
 					if len(ps.OverlayValues) > 314 && ps.OverlayValues[314].Loc != LocNone {
 						d314 = ps.OverlayValues[314]
@@ -5740,17 +5769,20 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 337 && ps.OverlayValues[337].Loc != LocNone {
 						d337 = ps.OverlayValues[337]
 					}
+					if len(ps.OverlayValues) > 338 && ps.OverlayValues[338].Loc != LocNone {
+						d338 = ps.OverlayValues[338]
+					}
 					if len(ps.OverlayValues) > 339 && ps.OverlayValues[339].Loc != LocNone {
 						d339 = ps.OverlayValues[339]
 					}
 					if len(ps.OverlayValues) > 340 && ps.OverlayValues[340].Loc != LocNone {
 						d340 = ps.OverlayValues[340]
 					}
-					if len(ps.OverlayValues) > 341 && ps.OverlayValues[341].Loc != LocNone {
-						d341 = ps.OverlayValues[341]
-					}
 					if len(ps.OverlayValues) > 342 && ps.OverlayValues[342].Loc != LocNone {
 						d342 = ps.OverlayValues[342]
+					}
+					if len(ps.OverlayValues) > 343 && ps.OverlayValues[343].Loc != LocNone {
+						d343 = ps.OverlayValues[343]
 					}
 					if len(ps.OverlayValues) > 344 && ps.OverlayValues[344].Loc != LocNone {
 						d344 = ps.OverlayValues[344]
@@ -5758,147 +5790,154 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 345 && ps.OverlayValues[345].Loc != LocNone {
 						d345 = ps.OverlayValues[345]
 					}
-					if len(ps.OverlayValues) > 346 && ps.OverlayValues[346].Loc != LocNone {
-						d346 = ps.OverlayValues[346]
+					if len(ps.OverlayValues) > 347 && ps.OverlayValues[347].Loc != LocNone {
+						d347 = ps.OverlayValues[347]
 					}
-					if len(ps.OverlayValues) > 489 && ps.OverlayValues[489].Loc != LocNone {
-						d489 = ps.OverlayValues[489]
+					if len(ps.OverlayValues) > 348 && ps.OverlayValues[348].Loc != LocNone {
+						d348 = ps.OverlayValues[348]
+					}
+					if len(ps.OverlayValues) > 349 && ps.OverlayValues[349].Loc != LocNone {
+						d349 = ps.OverlayValues[349]
+					}
+					if len(ps.OverlayValues) > 494 && ps.OverlayValues[494].Loc != LocNone {
+						d494 = ps.OverlayValues[494]
 					}
 					ctx.ReclaimUntrackedRegs()
-					if d344.Loc == LocRegPair || d344.Loc == LocStackPair || d344.Loc == LocRegTriple || d344.Loc == LocStackTriple {
+					if d347.Loc == LocRegPair || d347.Loc == LocStackPair || d347.Loc == LocRegTriple || d347.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					d490 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					if d490.Loc == LocRegPair || d490.Loc == LocStackPair || d490.Loc == LocRegTriple || d490.Loc == LocStackTriple {
+					d495 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					if d495.Loc == LocRegPair || d495.Loc == LocStackPair || d495.Loc == LocRegTriple || d495.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d344)
-					ctx.SyncDesc(&d490)
-					d491 = ctx.EmitGoCallScalar(GoFuncAddr(time.Unix), []JITValueDesc{d344, d490}, 3)
-					d491.NoHeapPointer = false
-					ctx.BindReg(d491.Reg, &d491)
-					ctx.BindReg(d491.Reg2, &d491)
-					ctx.BindReg(d491.Reg3, &d491)
-					ctx.FreeDesc(&d490)
-					ctx.StabilizeDescForControlFlow(&d491)
+					ctx.SyncDesc(&d347)
+					ctx.SyncDesc(&d495)
+					d496 = ctx.EmitGoCallScalar(GoFuncAddr(time.Unix), []JITValueDesc{d347, d495}, 3)
+					d496.NoHeapPointer = false
+					ctx.BindReg(d496.Reg, &d496)
+					ctx.BindReg(d496.Reg2, &d496)
+					ctx.BindReg(d496.Reg3, &d496)
+					ctx.FreeDesc(&d495)
+					ctx.StabilizeDescForControlFlow(&d496)
 					if ps.General {
-						ctx.SyncDesc(&d491)
-						if d491.Loc == LocReg {
-							ctx.ProtectReg(d491.Reg)
-						} else if d491.Loc == LocRegPair {
-							ctx.ProtectReg(d491.Reg)
-							ctx.ProtectReg(d491.Reg2)
+						ctx.SyncDesc(&d496)
+						if d496.Loc == LocReg || d496.Loc == LocFPReg {
+							ctx.ProtectReg(d496.Reg)
+						} else if d496.Loc == LocRegPair {
+							ctx.ProtectReg(d496.Reg)
+							ctx.ProtectReg(d496.Reg2)
 						}
-						d492 = d491
-						if d492.Loc == LocNone {
+						d497 = d496
+						if d497.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.SyncDesc(&d492)
-						if d492.Loc == LocStackPair {
-							ctx.EmitCopyStackWords(d492, int32(bbs[9].PhiBase)+int32(0), 2)
-						} else if d492.Loc == LocInputPair {
-							ctx.EnsureDesc(&d492)
-							ctx.EmitStoreScmerToStack(d492, int32(bbs[9].PhiBase)+int32(0))
-						} else if d492.Loc == LocRegPair || d492.Loc == LocImm {
-							ctx.EmitStoreScmerToStack(d492, int32(bbs[9].PhiBase)+int32(0))
+						ctx.SyncDesc(&d497)
+						if d497.Loc == LocStackPair {
+							ctx.EmitCopyStackWords(d497, int32(bbs[9].PhiBase)+int32(0), 2)
+						} else if d497.Loc == LocInputPair {
+							ctx.EnsureDesc(&d497)
+							ctx.EmitStoreScmerToStack(d497, int32(bbs[9].PhiBase)+int32(0))
+						} else if d497.Loc == LocRegPair || d497.Loc == LocImm {
+							ctx.EmitStoreScmerToStack(d497, int32(bbs[9].PhiBase)+int32(0))
 						} else {
-							ctx.EnsureDesc(&d492)
-							ctx.EmitStoreToStack(d492, int32(bbs[9].PhiBase)+int32(0))
+							ctx.EnsureDesc(&d497)
+							ctx.EmitStoreToStack(d497, int32(bbs[9].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[9].PhiBase)+int32(0))+8)
 						}
-						if d491.Loc == LocReg {
-							ctx.UnprotectReg(d491.Reg)
-						} else if d491.Loc == LocRegPair {
-							ctx.UnprotectReg(d491.Reg)
-							ctx.UnprotectReg(d491.Reg2)
+						if d496.Loc == LocReg || d496.Loc == LocFPReg {
+							ctx.UnprotectReg(d496.Reg)
+						} else if d496.Loc == LocRegPair {
+							ctx.UnprotectReg(d496.Reg)
+							ctx.UnprotectReg(d496.Reg2)
 						}
 					}
-					ps493 := PhiState{General: ps.General}
-					ps493.OverlayValues = make([]JITValueDesc, 493)
-					ps493.OverlayValues[1] = d1
-					ps493.OverlayValues[2] = d2
-					ps493.OverlayValues[3] = d3
-					ps493.OverlayValues[4] = d4
-					ps493.OverlayValues[5] = d5
-					ps493.OverlayValues[22] = d22
-					ps493.OverlayValues[23] = d23
-					ps493.OverlayValues[24] = d24
-					ps493.OverlayValues[25] = d25
-					ps493.OverlayValues[27] = d27
-					ps493.OverlayValues[28] = d28
-					ps493.OverlayValues[29] = d29
-					ps493.OverlayValues[30] = d30
-					ps493.OverlayValues[63] = d63
-					ps493.OverlayValues[64] = d64
-					ps493.OverlayValues[65] = d65
-					ps493.OverlayValues[66] = d66
-					ps493.OverlayValues[107] = d107
-					ps493.OverlayValues[108] = d108
-					ps493.OverlayValues[109] = d109
-					ps493.OverlayValues[110] = d110
-					ps493.OverlayValues[159] = d159
-					ps493.OverlayValues[160] = d160
-					ps493.OverlayValues[161] = d161
-					ps493.OverlayValues[162] = d162
-					ps493.OverlayValues[164] = d164
-					ps493.OverlayValues[165] = d165
-					ps493.OverlayValues[166] = d166
-					ps493.OverlayValues[167] = d167
-					ps493.OverlayValues[232] = d232
-					ps493.OverlayValues[233] = d233
-					ps493.OverlayValues[234] = d234
-					ps493.OverlayValues[235] = d235
-					ps493.OverlayValues[236] = d236
-					ps493.OverlayValues[311] = d311
-					ps493.OverlayValues[312] = d312
-					ps493.OverlayValues[313] = d313
-					ps493.OverlayValues[314] = d314
-					ps493.OverlayValues[315] = d315
-					ps493.OverlayValues[316] = d316
-					ps493.OverlayValues[317] = d317
-					ps493.OverlayValues[318] = d318
-					ps493.OverlayValues[319] = d319
-					ps493.OverlayValues[320] = d320
-					ps493.OverlayValues[321] = d321
-					ps493.OverlayValues[322] = d322
-					ps493.OverlayValues[323] = d323
-					ps493.OverlayValues[324] = d324
-					ps493.OverlayValues[325] = d325
-					ps493.OverlayValues[326] = d326
-					ps493.OverlayValues[327] = d327
-					ps493.OverlayValues[328] = d328
-					ps493.OverlayValues[329] = d329
-					ps493.OverlayValues[330] = d330
-					ps493.OverlayValues[331] = d331
-					ps493.OverlayValues[332] = d332
-					ps493.OverlayValues[333] = d333
-					ps493.OverlayValues[334] = d334
-					ps493.OverlayValues[335] = d335
-					ps493.OverlayValues[336] = d336
-					ps493.OverlayValues[337] = d337
-					ps493.OverlayValues[339] = d339
-					ps493.OverlayValues[340] = d340
-					ps493.OverlayValues[341] = d341
-					ps493.OverlayValues[342] = d342
-					ps493.OverlayValues[344] = d344
-					ps493.OverlayValues[345] = d345
-					ps493.OverlayValues[346] = d346
-					ps493.OverlayValues[489] = d489
-					ps493.OverlayValues[490] = d490
-					ps493.OverlayValues[491] = d491
-					ps493.OverlayValues[492] = d492
-					ps493.PhiValues = make([]JITValueDesc, 1)
-					d494 = d491
-					ps493.PhiValues[0] = d494
-					if ps493.General && bbs[9].Rendered {
+					ps498 := PhiState{General: ps.General}
+					ps498.OverlayValues = make([]JITValueDesc, 498)
+					ps498.OverlayValues[1] = d1
+					ps498.OverlayValues[2] = d2
+					ps498.OverlayValues[3] = d3
+					ps498.OverlayValues[4] = d4
+					ps498.OverlayValues[5] = d5
+					ps498.OverlayValues[22] = d22
+					ps498.OverlayValues[23] = d23
+					ps498.OverlayValues[24] = d24
+					ps498.OverlayValues[25] = d25
+					ps498.OverlayValues[27] = d27
+					ps498.OverlayValues[28] = d28
+					ps498.OverlayValues[29] = d29
+					ps498.OverlayValues[30] = d30
+					ps498.OverlayValues[63] = d63
+					ps498.OverlayValues[64] = d64
+					ps498.OverlayValues[65] = d65
+					ps498.OverlayValues[66] = d66
+					ps498.OverlayValues[107] = d107
+					ps498.OverlayValues[108] = d108
+					ps498.OverlayValues[109] = d109
+					ps498.OverlayValues[110] = d110
+					ps498.OverlayValues[159] = d159
+					ps498.OverlayValues[160] = d160
+					ps498.OverlayValues[161] = d161
+					ps498.OverlayValues[162] = d162
+					ps498.OverlayValues[164] = d164
+					ps498.OverlayValues[165] = d165
+					ps498.OverlayValues[166] = d166
+					ps498.OverlayValues[167] = d167
+					ps498.OverlayValues[232] = d232
+					ps498.OverlayValues[233] = d233
+					ps498.OverlayValues[234] = d234
+					ps498.OverlayValues[235] = d235
+					ps498.OverlayValues[236] = d236
+					ps498.OverlayValues[237] = d237
+					ps498.OverlayValues[314] = d314
+					ps498.OverlayValues[315] = d315
+					ps498.OverlayValues[316] = d316
+					ps498.OverlayValues[317] = d317
+					ps498.OverlayValues[318] = d318
+					ps498.OverlayValues[319] = d319
+					ps498.OverlayValues[320] = d320
+					ps498.OverlayValues[321] = d321
+					ps498.OverlayValues[322] = d322
+					ps498.OverlayValues[323] = d323
+					ps498.OverlayValues[324] = d324
+					ps498.OverlayValues[325] = d325
+					ps498.OverlayValues[326] = d326
+					ps498.OverlayValues[327] = d327
+					ps498.OverlayValues[328] = d328
+					ps498.OverlayValues[329] = d329
+					ps498.OverlayValues[330] = d330
+					ps498.OverlayValues[331] = d331
+					ps498.OverlayValues[332] = d332
+					ps498.OverlayValues[333] = d333
+					ps498.OverlayValues[334] = d334
+					ps498.OverlayValues[335] = d335
+					ps498.OverlayValues[336] = d336
+					ps498.OverlayValues[337] = d337
+					ps498.OverlayValues[338] = d338
+					ps498.OverlayValues[339] = d339
+					ps498.OverlayValues[340] = d340
+					ps498.OverlayValues[342] = d342
+					ps498.OverlayValues[343] = d343
+					ps498.OverlayValues[344] = d344
+					ps498.OverlayValues[345] = d345
+					ps498.OverlayValues[347] = d347
+					ps498.OverlayValues[348] = d348
+					ps498.OverlayValues[349] = d349
+					ps498.OverlayValues[494] = d494
+					ps498.OverlayValues[495] = d495
+					ps498.OverlayValues[496] = d496
+					ps498.OverlayValues[497] = d497
+					ps498.PhiValues = make([]JITValueDesc, 1)
+					d499 = d496
+					ps498.PhiValues[0] = d499
+					if ps498.General && bbs[9].Rendered {
 						ctx.EmitJmp(lbl10)
 						return result
 					}
-					return bbs[9].RenderPS(ps493)
+					return bbs[9].RenderPS(ps498)
 					return result
 				}
-				ps495 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps495)
+				ps500 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps500)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -6644,7 +6683,7 @@ func init_timezone() {
 					ctx.FreeDesc(&d66)
 					if ps.General {
 						ctx.SyncDesc(&d67)
-						if d67.Loc == LocReg {
+						if d67.Loc == LocReg || d67.Loc == LocFPReg {
 							ctx.ProtectReg(d67.Reg)
 						} else if d67.Loc == LocRegPair {
 							ctx.ProtectReg(d67.Reg)
@@ -6667,7 +6706,7 @@ func init_timezone() {
 							ctx.EmitStoreToStack(d69, int32(bbs[4].PhiBase)+int32(0))
 							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[4].PhiBase)+int32(0))+8)
 						}
-						if d67.Loc == LocReg {
+						if d67.Loc == LocReg || d67.Loc == LocFPReg {
 							ctx.UnprotectReg(d67.Reg)
 						} else if d67.Loc == LocRegPair {
 							ctx.UnprotectReg(d67.Reg)
@@ -6837,7 +6876,7 @@ func init_timezone() {
 						if d75.Loc != LocReg && d75.Loc != LocRegPair && d75.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r1 := ctx.AllocReg()
+						r1 := ctx.AllocRegExcept(d75.Reg)
 						ctx.EmitCmpRegImm32(d75.Reg, 0)
 						ctx.EmitSetcc(r1, CondNotEqual)
 						d76 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
@@ -6883,7 +6922,7 @@ func init_timezone() {
 						}
 						if ps.General {
 							ctx.SyncDesc(&d74)
-							if d74.Loc == LocReg {
+							if d74.Loc == LocReg || d74.Loc == LocFPReg {
 								ctx.ProtectReg(d74.Reg)
 							} else if d74.Loc == LocRegPair {
 								ctx.ProtectReg(d74.Reg)
@@ -6895,7 +6934,7 @@ func init_timezone() {
 							}
 							ctx.EnsureDesc(&d79)
 							ctx.EmitStoreToStack(d79, int32(bbs[6].PhiBase)+int32(0))
-							if d74.Loc == LocReg {
+							if d74.Loc == LocReg || d74.Loc == LocFPReg {
 								ctx.UnprotectReg(d74.Reg)
 							} else if d74.Loc == LocRegPair {
 								ctx.UnprotectReg(d74.Reg)
@@ -7005,7 +7044,7 @@ func init_timezone() {
 					d82 = snap109
 					ctx.MarkLabel(lbl12)
 					ctx.SyncDesc(&d74)
-					if d74.Loc == LocReg {
+					if d74.Loc == LocReg || d74.Loc == LocFPReg {
 						ctx.ProtectReg(d74.Reg)
 					} else if d74.Loc == LocRegPair {
 						ctx.ProtectReg(d74.Reg)
@@ -7017,7 +7056,7 @@ func init_timezone() {
 					}
 					ctx.EnsureDesc(&d111)
 					ctx.EmitStoreToStack(d111, int32(bbs[6].PhiBase)+int32(0))
-					if d74.Loc == LocReg {
+					if d74.Loc == LocReg || d74.Loc == LocFPReg {
 						ctx.UnprotectReg(d74.Reg)
 					} else if d74.Loc == LocRegPair {
 						ctx.UnprotectReg(d74.Reg)
@@ -7298,7 +7337,7 @@ func init_timezone() {
 					ctx.StabilizeDescForControlFlow(&d145)
 					if ps.General {
 						ctx.SyncDesc(&d145)
-						if d145.Loc == LocReg {
+						if d145.Loc == LocReg || d145.Loc == LocFPReg {
 							ctx.ProtectReg(d145.Reg)
 						} else if d145.Loc == LocRegPair {
 							ctx.ProtectReg(d145.Reg)
@@ -7310,7 +7349,7 @@ func init_timezone() {
 						}
 						ctx.EnsureDesc(&d146)
 						ctx.EmitStoreToStack(d146, int32(bbs[6].PhiBase)+int32(0))
-						if d145.Loc == LocReg {
+						if d145.Loc == LocReg || d145.Loc == LocFPReg {
 							ctx.UnprotectReg(d145.Reg)
 						} else if d145.Loc == LocRegPair {
 							ctx.UnprotectReg(d145.Reg)
@@ -9643,12 +9682,8 @@ func init_timezone() {
 				_ = d117
 				var d118 JITValueDesc
 				_ = d118
-				var d171 JITValueDesc
-				_ = d171
-				var d172 JITValueDesc
-				_ = d172
-				var d173 JITValueDesc
-				_ = d173
+				var d119 JITValueDesc
+				_ = d119
 				var d174 JITValueDesc
 				_ = d174
 				var d175 JITValueDesc
@@ -9681,38 +9716,34 @@ func init_timezone() {
 				_ = d188
 				var d189 JITValueDesc
 				_ = d189
+				var d190 JITValueDesc
+				_ = d190
 				var d191 JITValueDesc
 				_ = d191
 				var d192 JITValueDesc
 				_ = d192
-				var d193 JITValueDesc
-				_ = d193
 				var d194 JITValueDesc
 				_ = d194
 				var d195 JITValueDesc
 				_ = d195
 				var d196 JITValueDesc
 				_ = d196
+				var d197 JITValueDesc
+				_ = d197
+				var d198 JITValueDesc
+				_ = d198
 				var d199 JITValueDesc
 				_ = d199
-				var d200 JITValueDesc
-				_ = d200
-				var d305 JITValueDesc
-				_ = d305
-				var d306 JITValueDesc
-				_ = d306
-				var d307 JITValueDesc
-				_ = d307
-				var d309 JITValueDesc
-				_ = d309
+				var d202 JITValueDesc
+				_ = d202
+				var d203 JITValueDesc
+				_ = d203
 				var d310 JITValueDesc
 				_ = d310
 				var d311 JITValueDesc
 				_ = d311
 				var d312 JITValueDesc
 				_ = d312
-				var d313 JITValueDesc
-				_ = d313
 				var d314 JITValueDesc
 				_ = d314
 				var d315 JITValueDesc
@@ -9763,6 +9794,16 @@ func init_timezone() {
 				_ = d337
 				var d338 JITValueDesc
 				_ = d338
+				var d339 JITValueDesc
+				_ = d339
+				var d340 JITValueDesc
+				_ = d340
+				var d341 JITValueDesc
+				_ = d341
+				var d342 JITValueDesc
+				_ = d342
+				var d343 JITValueDesc
+				_ = d343
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 				phiBase0 := ctx.AllocStack(int32(32))
 				var bbs [11]BBDescriptor
@@ -10136,7 +10177,7 @@ func init_timezone() {
 						if d31.Loc != LocReg && d31.Loc != LocRegPair && d31.Loc != LocRegTriple {
 							panic("jit: nil comparison requires a register value")
 						}
-						r0 := ctx.AllocReg()
+						r0 := ctx.AllocRegExcept(d31.Reg)
 						ctx.EmitCmpRegImm32(d31.Reg, 0)
 						ctx.EmitSetcc(r0, CondNotEqual)
 						d32 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}
@@ -10779,268 +10820,279 @@ func init_timezone() {
 					ctx.ReclaimUntrackedRegs()
 					d115 = args[0]
 					d115.ID = 0
-					d116 = ctx.EmitGetTagDesc(&d115, JITValueDesc{Loc: LocAny})
+					d116 = d115
+					d116.ID = 0
+					d117 = ctx.EmitGetTagDesc(&d116, JITValueDesc{Loc: LocAny})
 					ctx.FreeDesc(&d115)
-					ctx.EnsureDesc(&d116)
-					var d117 JITValueDesc
-					if d116.Loc == LocImm {
-						d117 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d116.Imm.Int()) == uint64(0x10))}
+					ctx.EnsureDesc(&d117)
+					var d118 JITValueDesc
+					if d117.Loc == LocImm {
+						d118 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(uint64(d117.Imm.Int()) == uint64(0x10))}
 					} else {
 						r1 := ctx.AllocReg()
-						ctx.EmitCmpRegImm32(d116.Reg, 16)
-						d117 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondEqual}
-						ctx.BindReg(r1, &d117)
+						ctx.EmitCmpRegImm32(d117.Reg, 16)
+						d118 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r1, Condition: CondEqual}
+						ctx.BindReg(r1, &d118)
 					}
-					ctx.FreeDesc(&d116)
-					d118 = d117
-					ctx.EnsureDesc(&d118)
-					if d118.Loc != LocImm && d118.Loc != LocFlags {
+					ctx.FreeDesc(&d117)
+					d119 = d118
+					ctx.EnsureDesc(&d119)
+					if d119.Loc != LocImm && d119.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d118.Loc == LocImm {
-						if d118.Imm.Bool() {
+					if d119.Loc == LocImm {
+						if d119.Imm.Bool() {
 							if ps.General {
 							}
-							ps119 := PhiState{General: ps.General}
-							ps119.OverlayValues = make([]JITValueDesc, 119)
-							ps119.OverlayValues[1] = d1
-							ps119.OverlayValues[2] = d2
-							ps119.OverlayValues[3] = d3
-							ps119.OverlayValues[4] = d4
-							ps119.OverlayValues[5] = d5
-							ps119.OverlayValues[6] = d6
-							ps119.OverlayValues[25] = d25
-							ps119.OverlayValues[26] = d26
-							ps119.OverlayValues[27] = d27
-							ps119.OverlayValues[28] = d28
-							ps119.OverlayValues[30] = d30
-							ps119.OverlayValues[31] = d31
-							ps119.OverlayValues[32] = d32
-							ps119.OverlayValues[33] = d33
-							ps119.OverlayValues[68] = d68
-							ps119.OverlayValues[69] = d69
-							ps119.OverlayValues[70] = d70
-							ps119.OverlayValues[71] = d71
-							ps119.OverlayValues[114] = d114
-							ps119.OverlayValues[115] = d115
-							ps119.OverlayValues[116] = d116
-							ps119.OverlayValues[117] = d117
-							ps119.OverlayValues[118] = d118
-							return bbs[6].RenderPS(ps119)
+							ps120 := PhiState{General: ps.General}
+							ps120.OverlayValues = make([]JITValueDesc, 120)
+							ps120.OverlayValues[1] = d1
+							ps120.OverlayValues[2] = d2
+							ps120.OverlayValues[3] = d3
+							ps120.OverlayValues[4] = d4
+							ps120.OverlayValues[5] = d5
+							ps120.OverlayValues[6] = d6
+							ps120.OverlayValues[25] = d25
+							ps120.OverlayValues[26] = d26
+							ps120.OverlayValues[27] = d27
+							ps120.OverlayValues[28] = d28
+							ps120.OverlayValues[30] = d30
+							ps120.OverlayValues[31] = d31
+							ps120.OverlayValues[32] = d32
+							ps120.OverlayValues[33] = d33
+							ps120.OverlayValues[68] = d68
+							ps120.OverlayValues[69] = d69
+							ps120.OverlayValues[70] = d70
+							ps120.OverlayValues[71] = d71
+							ps120.OverlayValues[114] = d114
+							ps120.OverlayValues[115] = d115
+							ps120.OverlayValues[116] = d116
+							ps120.OverlayValues[117] = d117
+							ps120.OverlayValues[118] = d118
+							ps120.OverlayValues[119] = d119
+							return bbs[6].RenderPS(ps120)
 						}
 						if ps.General {
 						}
-						ps120 := PhiState{General: ps.General}
-						ps120.OverlayValues = make([]JITValueDesc, 119)
-						ps120.OverlayValues[1] = d1
-						ps120.OverlayValues[2] = d2
-						ps120.OverlayValues[3] = d3
-						ps120.OverlayValues[4] = d4
-						ps120.OverlayValues[5] = d5
-						ps120.OverlayValues[6] = d6
-						ps120.OverlayValues[25] = d25
-						ps120.OverlayValues[26] = d26
-						ps120.OverlayValues[27] = d27
-						ps120.OverlayValues[28] = d28
-						ps120.OverlayValues[30] = d30
-						ps120.OverlayValues[31] = d31
-						ps120.OverlayValues[32] = d32
-						ps120.OverlayValues[33] = d33
-						ps120.OverlayValues[68] = d68
-						ps120.OverlayValues[69] = d69
-						ps120.OverlayValues[70] = d70
-						ps120.OverlayValues[71] = d71
-						ps120.OverlayValues[114] = d114
-						ps120.OverlayValues[115] = d115
-						ps120.OverlayValues[116] = d116
-						ps120.OverlayValues[117] = d117
-						ps120.OverlayValues[118] = d118
-						return bbs[8].RenderPS(ps120)
+						ps121 := PhiState{General: ps.General}
+						ps121.OverlayValues = make([]JITValueDesc, 120)
+						ps121.OverlayValues[1] = d1
+						ps121.OverlayValues[2] = d2
+						ps121.OverlayValues[3] = d3
+						ps121.OverlayValues[4] = d4
+						ps121.OverlayValues[5] = d5
+						ps121.OverlayValues[6] = d6
+						ps121.OverlayValues[25] = d25
+						ps121.OverlayValues[26] = d26
+						ps121.OverlayValues[27] = d27
+						ps121.OverlayValues[28] = d28
+						ps121.OverlayValues[30] = d30
+						ps121.OverlayValues[31] = d31
+						ps121.OverlayValues[32] = d32
+						ps121.OverlayValues[33] = d33
+						ps121.OverlayValues[68] = d68
+						ps121.OverlayValues[69] = d69
+						ps121.OverlayValues[70] = d70
+						ps121.OverlayValues[71] = d71
+						ps121.OverlayValues[114] = d114
+						ps121.OverlayValues[115] = d115
+						ps121.OverlayValues[116] = d116
+						ps121.OverlayValues[117] = d117
+						ps121.OverlayValues[118] = d118
+						ps121.OverlayValues[119] = d119
+						return bbs[8].RenderPS(ps121)
 					}
 					if !ps.General {
 						ps.General = true
 						return bbs[5].RenderPS(ps)
 					}
-					ctx.EmitJump(d118.Condition, lbl7)
+					ctx.EmitJump(d119.Condition, lbl7)
 					if bbs[8].Rendered {
 						ctx.EmitJmp(lbl9)
 					}
-					ctx.FreeDesc(&d117)
-					snap121 := d1
-					snap122 := d2
-					snap123 := d3
-					snap124 := d4
-					snap125 := d5
-					snap126 := d6
-					snap127 := d25
-					snap128 := d26
-					snap129 := d27
-					snap130 := d28
-					snap131 := d30
-					snap132 := d31
-					snap133 := d32
-					snap134 := d33
-					snap135 := d68
-					snap136 := d69
-					snap137 := d70
-					snap138 := d71
-					snap139 := d114
-					snap140 := d115
-					snap141 := d116
-					snap142 := d117
-					snap143 := d118
-					alloc144 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc144)
-					d1 = snap121
-					d2 = snap122
-					d3 = snap123
-					d4 = snap124
-					d5 = snap125
-					d6 = snap126
-					d25 = snap127
-					d26 = snap128
-					d27 = snap129
-					d28 = snap130
-					d30 = snap131
-					d31 = snap132
-					d32 = snap133
-					d33 = snap134
-					d68 = snap135
-					d69 = snap136
-					d70 = snap137
-					d71 = snap138
-					d114 = snap139
-					d115 = snap140
-					d116 = snap141
-					d117 = snap142
-					d118 = snap143
-					ctx.RestoreAllocState(alloc144)
-					d1 = snap121
-					d2 = snap122
-					d3 = snap123
-					d4 = snap124
-					d5 = snap125
-					d6 = snap126
-					d25 = snap127
-					d26 = snap128
-					d27 = snap129
-					d28 = snap130
-					d30 = snap131
-					d31 = snap132
-					d32 = snap133
-					d33 = snap134
-					d68 = snap135
-					d69 = snap136
-					d70 = snap137
-					d71 = snap138
-					d114 = snap139
-					d115 = snap140
-					d116 = snap141
-					d117 = snap142
-					d118 = snap143
-					ps145 := PhiState{General: true}
-					ps145.OverlayValues = make([]JITValueDesc, 119)
-					ps145.OverlayValues[1] = d1
-					ps145.OverlayValues[2] = d2
-					ps145.OverlayValues[3] = d3
-					ps145.OverlayValues[4] = d4
-					ps145.OverlayValues[5] = d5
-					ps145.OverlayValues[6] = d6
-					ps145.OverlayValues[25] = d25
-					ps145.OverlayValues[26] = d26
-					ps145.OverlayValues[27] = d27
-					ps145.OverlayValues[28] = d28
-					ps145.OverlayValues[30] = d30
-					ps145.OverlayValues[31] = d31
-					ps145.OverlayValues[32] = d32
-					ps145.OverlayValues[33] = d33
-					ps145.OverlayValues[68] = d68
-					ps145.OverlayValues[69] = d69
-					ps145.OverlayValues[70] = d70
-					ps145.OverlayValues[71] = d71
-					ps145.OverlayValues[114] = d114
-					ps145.OverlayValues[115] = d115
-					ps145.OverlayValues[116] = d116
-					ps145.OverlayValues[117] = d117
-					ps145.OverlayValues[118] = d118
-					ps146 := PhiState{General: true}
-					ps146.OverlayValues = make([]JITValueDesc, 119)
-					ps146.OverlayValues[1] = d1
-					ps146.OverlayValues[2] = d2
-					ps146.OverlayValues[3] = d3
-					ps146.OverlayValues[4] = d4
-					ps146.OverlayValues[5] = d5
-					ps146.OverlayValues[6] = d6
-					ps146.OverlayValues[25] = d25
-					ps146.OverlayValues[26] = d26
-					ps146.OverlayValues[27] = d27
-					ps146.OverlayValues[28] = d28
-					ps146.OverlayValues[30] = d30
-					ps146.OverlayValues[31] = d31
-					ps146.OverlayValues[32] = d32
-					ps146.OverlayValues[33] = d33
-					ps146.OverlayValues[68] = d68
-					ps146.OverlayValues[69] = d69
-					ps146.OverlayValues[70] = d70
-					ps146.OverlayValues[71] = d71
-					ps146.OverlayValues[114] = d114
-					ps146.OverlayValues[115] = d115
-					ps146.OverlayValues[116] = d116
-					ps146.OverlayValues[117] = d117
-					ps146.OverlayValues[118] = d118
-					snap147 := d1
-					snap148 := d2
-					snap149 := d3
-					snap150 := d4
-					snap151 := d5
-					snap152 := d6
-					snap153 := d25
-					snap154 := d26
-					snap155 := d27
-					snap156 := d28
-					snap157 := d30
-					snap158 := d31
-					snap159 := d32
-					snap160 := d33
-					snap161 := d68
-					snap162 := d69
-					snap163 := d70
-					snap164 := d71
-					snap165 := d114
-					snap166 := d115
-					snap167 := d116
-					snap168 := d117
-					snap169 := d118
-					alloc170 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d118)
+					snap122 := d1
+					snap123 := d2
+					snap124 := d3
+					snap125 := d4
+					snap126 := d5
+					snap127 := d6
+					snap128 := d25
+					snap129 := d26
+					snap130 := d27
+					snap131 := d28
+					snap132 := d30
+					snap133 := d31
+					snap134 := d32
+					snap135 := d33
+					snap136 := d68
+					snap137 := d69
+					snap138 := d70
+					snap139 := d71
+					snap140 := d114
+					snap141 := d115
+					snap142 := d116
+					snap143 := d117
+					snap144 := d118
+					snap145 := d119
+					alloc146 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc146)
+					d1 = snap122
+					d2 = snap123
+					d3 = snap124
+					d4 = snap125
+					d5 = snap126
+					d6 = snap127
+					d25 = snap128
+					d26 = snap129
+					d27 = snap130
+					d28 = snap131
+					d30 = snap132
+					d31 = snap133
+					d32 = snap134
+					d33 = snap135
+					d68 = snap136
+					d69 = snap137
+					d70 = snap138
+					d71 = snap139
+					d114 = snap140
+					d115 = snap141
+					d116 = snap142
+					d117 = snap143
+					d118 = snap144
+					d119 = snap145
+					ctx.RestoreAllocState(alloc146)
+					d1 = snap122
+					d2 = snap123
+					d3 = snap124
+					d4 = snap125
+					d5 = snap126
+					d6 = snap127
+					d25 = snap128
+					d26 = snap129
+					d27 = snap130
+					d28 = snap131
+					d30 = snap132
+					d31 = snap133
+					d32 = snap134
+					d33 = snap135
+					d68 = snap136
+					d69 = snap137
+					d70 = snap138
+					d71 = snap139
+					d114 = snap140
+					d115 = snap141
+					d116 = snap142
+					d117 = snap143
+					d118 = snap144
+					d119 = snap145
+					ps147 := PhiState{General: true}
+					ps147.OverlayValues = make([]JITValueDesc, 120)
+					ps147.OverlayValues[1] = d1
+					ps147.OverlayValues[2] = d2
+					ps147.OverlayValues[3] = d3
+					ps147.OverlayValues[4] = d4
+					ps147.OverlayValues[5] = d5
+					ps147.OverlayValues[6] = d6
+					ps147.OverlayValues[25] = d25
+					ps147.OverlayValues[26] = d26
+					ps147.OverlayValues[27] = d27
+					ps147.OverlayValues[28] = d28
+					ps147.OverlayValues[30] = d30
+					ps147.OverlayValues[31] = d31
+					ps147.OverlayValues[32] = d32
+					ps147.OverlayValues[33] = d33
+					ps147.OverlayValues[68] = d68
+					ps147.OverlayValues[69] = d69
+					ps147.OverlayValues[70] = d70
+					ps147.OverlayValues[71] = d71
+					ps147.OverlayValues[114] = d114
+					ps147.OverlayValues[115] = d115
+					ps147.OverlayValues[116] = d116
+					ps147.OverlayValues[117] = d117
+					ps147.OverlayValues[118] = d118
+					ps147.OverlayValues[119] = d119
+					ps148 := PhiState{General: true}
+					ps148.OverlayValues = make([]JITValueDesc, 120)
+					ps148.OverlayValues[1] = d1
+					ps148.OverlayValues[2] = d2
+					ps148.OverlayValues[3] = d3
+					ps148.OverlayValues[4] = d4
+					ps148.OverlayValues[5] = d5
+					ps148.OverlayValues[6] = d6
+					ps148.OverlayValues[25] = d25
+					ps148.OverlayValues[26] = d26
+					ps148.OverlayValues[27] = d27
+					ps148.OverlayValues[28] = d28
+					ps148.OverlayValues[30] = d30
+					ps148.OverlayValues[31] = d31
+					ps148.OverlayValues[32] = d32
+					ps148.OverlayValues[33] = d33
+					ps148.OverlayValues[68] = d68
+					ps148.OverlayValues[69] = d69
+					ps148.OverlayValues[70] = d70
+					ps148.OverlayValues[71] = d71
+					ps148.OverlayValues[114] = d114
+					ps148.OverlayValues[115] = d115
+					ps148.OverlayValues[116] = d116
+					ps148.OverlayValues[117] = d117
+					ps148.OverlayValues[118] = d118
+					ps148.OverlayValues[119] = d119
+					snap149 := d1
+					snap150 := d2
+					snap151 := d3
+					snap152 := d4
+					snap153 := d5
+					snap154 := d6
+					snap155 := d25
+					snap156 := d26
+					snap157 := d27
+					snap158 := d28
+					snap159 := d30
+					snap160 := d31
+					snap161 := d32
+					snap162 := d33
+					snap163 := d68
+					snap164 := d69
+					snap165 := d70
+					snap166 := d71
+					snap167 := d114
+					snap168 := d115
+					snap169 := d116
+					snap170 := d117
+					snap171 := d118
+					snap172 := d119
+					alloc173 := ctx.SnapshotAllocState()
 					if !bbs[8].Rendered {
-						bbs[8].RenderPS(ps146)
+						bbs[8].RenderPS(ps148)
 					}
-					ctx.RestoreAllocState(alloc170)
-					d1 = snap147
-					d2 = snap148
-					d3 = snap149
-					d4 = snap150
-					d5 = snap151
-					d6 = snap152
-					d25 = snap153
-					d26 = snap154
-					d27 = snap155
-					d28 = snap156
-					d30 = snap157
-					d31 = snap158
-					d32 = snap159
-					d33 = snap160
-					d68 = snap161
-					d69 = snap162
-					d70 = snap163
-					d71 = snap164
-					d114 = snap165
-					d115 = snap166
-					d116 = snap167
-					d117 = snap168
-					d118 = snap169
+					ctx.RestoreAllocState(alloc173)
+					d1 = snap149
+					d2 = snap150
+					d3 = snap151
+					d4 = snap152
+					d5 = snap153
+					d6 = snap154
+					d25 = snap155
+					d26 = snap156
+					d27 = snap157
+					d28 = snap158
+					d30 = snap159
+					d31 = snap160
+					d32 = snap161
+					d33 = snap162
+					d68 = snap163
+					d69 = snap164
+					d70 = snap165
+					d71 = snap166
+					d114 = snap167
+					d115 = snap168
+					d116 = snap169
+					d117 = snap170
+					d118 = snap171
+					d119 = snap172
 					if !bbs[6].Rendered {
-						return bbs[6].RenderPS(ps145)
+						return bbs[6].RenderPS(ps147)
 					}
 					return result
 					return result
@@ -11135,26 +11187,29 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
 						d118 = ps.OverlayValues[118]
 					}
+					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+						d119 = ps.OverlayValues[119]
+					}
 					ctx.ReclaimUntrackedRegs()
-					d171 = args[0]
-					d171.ID = 0
-					var d172 JITValueDesc
-					ctx.EnsureDesc(&d171)
-					if d171.Loc == LocImm {
-						_, auxWord := d171.Imm.RawWords()
-						d172 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(auxWord))}
+					d174 = args[0]
+					d174.ID = 0
+					var d175 JITValueDesc
+					ctx.EnsureDesc(&d174)
+					if d174.Loc == LocImm {
+						_, auxWord := d174.Imm.RawWords()
+						d175 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(auxWord))}
 					} else {
-						if d171.Loc != LocRegPair {
+						if d174.Loc != LocRegPair {
 							panic("jitgen: desc field base is not LocRegPair")
 						}
 						r2 := ctx.AllocReg()
-						ctx.EmitMovRegReg(r2, d171.Reg2)
-						d172 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r2}
-						ctx.BindReg(r2, &d172)
+						ctx.EmitMovRegReg(r2, d174.Reg2)
+						d175 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r2}
+						ctx.BindReg(r2, &d175)
 					}
-					ctx.EnsureDesc(&d172)
-					d173 = d172
-					_ = d173
+					ctx.EnsureDesc(&d175)
+					d176 = d175
+					_ = d176
 					bbpos_1_0 := int32(-1)
 					_ = bbpos_1_0
 					lbl12 := ctx.ReserveLabel()
@@ -11164,27 +11219,27 @@ func init_timezone() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d173)
-					var d174 JITValueDesc
-					if d173.Loc == LocImm {
-						d174 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d173.Imm.Int()) >> 8))}
+					ctx.EnsureDesc(&d176)
+					var d177 JITValueDesc
+					if d176.Loc == LocImm {
+						d177 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d176.Imm.Int()) >> 8))}
 					} else {
-						r3 := ctx.AllocRegExcept(d173.Reg)
-						ctx.EmitMovRegReg(r3, d173.Reg)
+						r3 := ctx.AllocRegExcept(d176.Reg)
+						ctx.EmitMovRegReg(r3, d176.Reg)
 						ctx.EmitShrRegImm8(r3, 8)
-						d174 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3}
-						ctx.BindReg(r3, &d174)
+						d177 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r3}
+						ctx.BindReg(r3, &d177)
 					}
-					if d174.Loc == LocReg && d173.Loc == LocReg && d174.Reg == d173.Reg {
-						ctx.TransferReg(d173.Reg)
-						d173.Loc = LocNone
+					if d177.Loc == LocReg && d176.Loc == LocReg && d177.Reg == d176.Reg {
+						ctx.TransferReg(d176.Reg)
+						d176.Loc = LocNone
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d174)
-					ctx.FreeDesc(&d172)
-					ctx.EnsureDesc(&d174)
-					d175 = d174
-					_ = d175
+					ctx.EnsureDesc(&d177)
+					ctx.FreeDesc(&d175)
+					ctx.EnsureDesc(&d177)
+					d178 = d177
+					_ = d178
 					bbpos_2_0 := int32(-1)
 					_ = bbpos_2_0
 					lbl13 := ctx.ReserveLabel()
@@ -11194,88 +11249,88 @@ func init_timezone() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d175)
-					var d176 JITValueDesc
-					if d175.Loc == LocImm {
-						d176 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d175.Imm.Int() & 35184372088831)}
-					} else {
-						r4 := ctx.AllocRegExcept(d175.Reg)
-						ctx.EmitMovRegReg(r4, d175.Reg)
-						ctx.EmitMovRegImm64(RegR11, 0x1fffffffffff)
-						ctx.EmitAndInt64(r4, RegR11)
-						d176 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r4}
-						ctx.BindReg(r4, &d176)
-					}
-					if d176.Loc == LocReg && d175.Loc == LocReg && d176.Reg == d175.Reg {
-						ctx.TransferReg(d175.Reg)
-						d175.Loc = LocNone
-					}
-					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d176)
-					var d177 JITValueDesc
-					if d176.Loc == LocImm {
-						d177 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d176.Imm.Int()) << 19))}
-					} else {
-						ctx.EmitShlRegImm8(d176.Reg, 19)
-						d177 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d176.Reg}
-						ctx.BindReg(d176.Reg, &d177)
-					}
-					if d177.Loc == LocReg && d176.Loc == LocReg && d177.Reg == d176.Reg {
-						ctx.TransferReg(d176.Reg)
-						d176.Loc = LocNone
-					}
-					ctx.FreeDesc(&d176)
-					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d177)
-					ctx.EnsureDesc(&d177)
-					var d178 JITValueDesc
-					if d177.Loc == LocImm {
-						d178 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(int64(uint64(d177.Imm.Int()))))}
-					} else {
-						r5 := ctx.AllocReg()
-						ctx.EmitMovRegReg(r5, d177.Reg)
-						d178 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5}
-						ctx.BindReg(r5, &d178)
-					}
-					ctx.FreeDesc(&d177)
-					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d178)
 					var d179 JITValueDesc
 					if d178.Loc == LocImm {
-						d179 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d178.Imm.Int()) >> 19))}
+						d179 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d178.Imm.Int() & 35184372088831)}
 					} else {
-						ctx.EmitShrRegImm8(d178.Reg, 19)
-						d179 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d178.Reg}
-						ctx.BindReg(d178.Reg, &d179)
+						r4 := ctx.AllocRegExcept(d178.Reg)
+						ctx.EmitMovRegReg(r4, d178.Reg)
+						ctx.EmitMovRegImm64(RegR11, 0x1fffffffffff)
+						ctx.EmitAndInt64(r4, RegR11)
+						d179 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r4}
+						ctx.BindReg(r4, &d179)
 					}
 					if d179.Loc == LocReg && d178.Loc == LocReg && d179.Reg == d178.Reg {
 						ctx.TransferReg(d178.Reg)
 						d178.Loc = LocNone
 					}
-					ctx.FreeDesc(&d178)
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d179)
-					ctx.StabilizeDescForControlFlow(&d179)
-					ctx.FreeDesc(&d174)
-					d180 = args[0]
-					d180.ID = 0
-					var d181 JITValueDesc
-					ctx.EnsureDesc(&d180)
-					if d180.Loc == LocImm {
-						_, auxWord := d180.Imm.RawWords()
-						d181 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(auxWord))}
+					var d180 JITValueDesc
+					if d179.Loc == LocImm {
+						d180 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d179.Imm.Int()) << 19))}
 					} else {
-						if d180.Loc != LocRegPair {
+						ctx.EmitShlRegImm8(d179.Reg, 19)
+						d180 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d179.Reg}
+						ctx.BindReg(d179.Reg, &d180)
+					}
+					if d180.Loc == LocReg && d179.Loc == LocReg && d180.Reg == d179.Reg {
+						ctx.TransferReg(d179.Reg)
+						d179.Loc = LocNone
+					}
+					ctx.FreeDesc(&d179)
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d180)
+					ctx.EnsureDesc(&d180)
+					var d181 JITValueDesc
+					if d180.Loc == LocImm {
+						d181 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(int64(uint64(d180.Imm.Int()))))}
+					} else {
+						r5 := ctx.AllocReg()
+						ctx.EmitMovRegReg(r5, d180.Reg)
+						d181 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r5}
+						ctx.BindReg(r5, &d181)
+					}
+					ctx.FreeDesc(&d180)
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d181)
+					var d182 JITValueDesc
+					if d181.Loc == LocImm {
+						d182 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d181.Imm.Int()) >> 19))}
+					} else {
+						ctx.EmitShrRegImm8(d181.Reg, 19)
+						d182 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d181.Reg}
+						ctx.BindReg(d181.Reg, &d182)
+					}
+					if d182.Loc == LocReg && d181.Loc == LocReg && d182.Reg == d181.Reg {
+						ctx.TransferReg(d181.Reg)
+						d181.Loc = LocNone
+					}
+					ctx.FreeDesc(&d181)
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d182)
+					ctx.StabilizeDescForControlFlow(&d182)
+					ctx.FreeDesc(&d177)
+					d183 = args[0]
+					d183.ID = 0
+					var d184 JITValueDesc
+					ctx.EnsureDesc(&d183)
+					if d183.Loc == LocImm {
+						_, auxWord := d183.Imm.RawWords()
+						d184 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(auxWord))}
+					} else {
+						if d183.Loc != LocRegPair {
 							panic("jitgen: desc field base is not LocRegPair")
 						}
 						r6 := ctx.AllocReg()
-						ctx.EmitMovRegReg(r6, d180.Reg2)
-						d181 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r6}
-						ctx.BindReg(r6, &d181)
+						ctx.EmitMovRegReg(r6, d183.Reg2)
+						d184 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r6}
+						ctx.BindReg(r6, &d184)
 					}
-					ctx.EnsureDesc(&d181)
-					d182 = d181
-					_ = d182
+					ctx.EnsureDesc(&d184)
+					d185 = d184
+					_ = d185
 					bbpos_3_0 := int32(-1)
 					_ = bbpos_3_0
 					lbl14 := ctx.ReserveLabel()
@@ -11285,27 +11340,27 @@ func init_timezone() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d182)
-					var d183 JITValueDesc
-					if d182.Loc == LocImm {
-						d183 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d182.Imm.Int()) >> 8))}
+					ctx.EnsureDesc(&d185)
+					var d186 JITValueDesc
+					if d185.Loc == LocImm {
+						d186 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d185.Imm.Int()) >> 8))}
 					} else {
-						r7 := ctx.AllocRegExcept(d182.Reg)
-						ctx.EmitMovRegReg(r7, d182.Reg)
+						r7 := ctx.AllocRegExcept(d185.Reg)
+						ctx.EmitMovRegReg(r7, d185.Reg)
 						ctx.EmitShrRegImm8(r7, 8)
-						d183 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r7}
-						ctx.BindReg(r7, &d183)
+						d186 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r7}
+						ctx.BindReg(r7, &d186)
 					}
-					if d183.Loc == LocReg && d182.Loc == LocReg && d183.Reg == d182.Reg {
-						ctx.TransferReg(d182.Reg)
-						d182.Loc = LocNone
+					if d186.Loc == LocReg && d185.Loc == LocReg && d186.Reg == d185.Reg {
+						ctx.TransferReg(d185.Reg)
+						d185.Loc = LocNone
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d183)
-					ctx.FreeDesc(&d181)
-					ctx.EnsureDesc(&d183)
-					d184 = d183
-					_ = d184
+					ctx.EnsureDesc(&d186)
+					ctx.FreeDesc(&d184)
+					ctx.EnsureDesc(&d186)
+					d187 = d186
+					_ = d187
 					bbpos_4_0 := int32(-1)
 					_ = bbpos_4_0
 					lbl15 := ctx.ReserveLabel()
@@ -11315,160 +11370,161 @@ func init_timezone() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d184)
-					var d185 JITValueDesc
-					if d184.Loc == LocImm {
-						d185 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d184.Imm.Int()) >> 45))}
+					ctx.EnsureDesc(&d187)
+					var d188 JITValueDesc
+					if d187.Loc == LocImm {
+						d188 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d187.Imm.Int()) >> 45))}
 					} else {
-						r8 := ctx.AllocRegExcept(d184.Reg)
-						ctx.EmitMovRegReg(r8, d184.Reg)
+						r8 := ctx.AllocRegExcept(d187.Reg)
+						ctx.EmitMovRegReg(r8, d187.Reg)
 						ctx.EmitShrRegImm8(r8, 45)
-						d185 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r8}
-						ctx.BindReg(r8, &d185)
+						d188 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r8}
+						ctx.BindReg(r8, &d188)
 					}
-					if d185.Loc == LocReg && d184.Loc == LocReg && d185.Reg == d184.Reg {
-						ctx.TransferReg(d184.Reg)
-						d184.Loc = LocNone
+					if d188.Loc == LocReg && d187.Loc == LocReg && d188.Reg == d187.Reg {
+						ctx.TransferReg(d187.Reg)
+						d187.Loc = LocNone
 					}
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d185)
-					var d186 JITValueDesc
-					if d185.Loc == LocImm {
-						d186 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d185.Imm.Int() & 2047)}
+					ctx.EnsureDesc(&d188)
+					var d189 JITValueDesc
+					if d188.Loc == LocImm {
+						d189 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d188.Imm.Int() & 2047)}
 					} else {
-						ctx.EmitAndRegImm32(d185.Reg, int32(2047))
-						d186 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d185.Reg}
-						ctx.BindReg(d185.Reg, &d186)
+						ctx.EmitAndRegImm32(d188.Reg, int32(2047))
+						d189 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d188.Reg}
+						ctx.BindReg(d188.Reg, &d189)
 					}
-					if d186.Loc == LocReg && d185.Loc == LocReg && d186.Reg == d185.Reg {
-						ctx.TransferReg(d185.Reg)
-						d185.Loc = LocNone
+					if d189.Loc == LocReg && d188.Loc == LocReg && d189.Reg == d188.Reg {
+						ctx.TransferReg(d188.Reg)
+						d188.Loc = LocNone
 					}
-					ctx.FreeDesc(&d185)
+					ctx.FreeDesc(&d188)
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d186)
-					ctx.EnsureDesc(&d186)
-					var d187 JITValueDesc
-					if d186.Loc == LocImm {
-						d187 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(int64(uint64(d186.Imm.Int()))))}
+					ctx.EnsureDesc(&d189)
+					ctx.EnsureDesc(&d189)
+					var d190 JITValueDesc
+					if d189.Loc == LocImm {
+						d190 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(int64(uint64(d189.Imm.Int()))))}
 					} else {
 						r9 := ctx.AllocReg()
-						ctx.EmitMovRegReg(r9, d186.Reg)
-						d187 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r9}
-						ctx.BindReg(r9, &d187)
+						ctx.EmitMovRegReg(r9, d189.Reg)
+						d190 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r9}
+						ctx.BindReg(r9, &d190)
 					}
-					ctx.FreeDesc(&d186)
+					ctx.FreeDesc(&d189)
 					ctx.ReclaimUntrackedRegs()
-					ctx.EnsureDesc(&d187)
-					ctx.StabilizeDescForControlFlow(&d187)
-					ctx.FreeDesc(&d183)
+					ctx.EnsureDesc(&d190)
+					ctx.StabilizeDescForControlFlow(&d190)
+					ctx.FreeDesc(&d186)
 					if ps.General {
-						ctx.SyncDesc(&d179)
-						if d179.Loc == LocReg {
-							ctx.ProtectReg(d179.Reg)
-						} else if d179.Loc == LocRegPair {
-							ctx.ProtectReg(d179.Reg)
-							ctx.ProtectReg(d179.Reg2)
+						ctx.SyncDesc(&d182)
+						if d182.Loc == LocReg || d182.Loc == LocFPReg {
+							ctx.ProtectReg(d182.Reg)
+						} else if d182.Loc == LocRegPair {
+							ctx.ProtectReg(d182.Reg)
+							ctx.ProtectReg(d182.Reg2)
 						}
-						ctx.SyncDesc(&d187)
-						if d187.Loc == LocReg {
-							ctx.ProtectReg(d187.Reg)
-						} else if d187.Loc == LocRegPair {
-							ctx.ProtectReg(d187.Reg)
-							ctx.ProtectReg(d187.Reg2)
+						ctx.SyncDesc(&d190)
+						if d190.Loc == LocReg || d190.Loc == LocFPReg {
+							ctx.ProtectReg(d190.Reg)
+						} else if d190.Loc == LocRegPair {
+							ctx.ProtectReg(d190.Reg)
+							ctx.ProtectReg(d190.Reg2)
 						}
-						d188 = d179
-						if d188.Loc == LocNone {
+						d191 = d182
+						if d191.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.EnsureDesc(&d188)
-						ctx.EmitStoreToStack(d188, int32(bbs[7].PhiBase)+int32(0))
-						d189 = d187
-						if d189.Loc == LocNone {
+						ctx.EnsureDesc(&d191)
+						ctx.EmitStoreToStack(d191, int32(bbs[7].PhiBase)+int32(0))
+						d192 = d190
+						if d192.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.EnsureDesc(&d189)
-						ctx.EmitStoreToStack(d189, int32(bbs[7].PhiBase)+int32(16))
-						if d179.Loc == LocReg {
-							ctx.UnprotectReg(d179.Reg)
-						} else if d179.Loc == LocRegPair {
-							ctx.UnprotectReg(d179.Reg)
-							ctx.UnprotectReg(d179.Reg2)
+						ctx.EnsureDesc(&d192)
+						ctx.EmitStoreToStack(d192, int32(bbs[7].PhiBase)+int32(16))
+						if d182.Loc == LocReg || d182.Loc == LocFPReg {
+							ctx.UnprotectReg(d182.Reg)
+						} else if d182.Loc == LocRegPair {
+							ctx.UnprotectReg(d182.Reg)
+							ctx.UnprotectReg(d182.Reg2)
 						}
-						if d187.Loc == LocReg {
-							ctx.UnprotectReg(d187.Reg)
-						} else if d187.Loc == LocRegPair {
-							ctx.UnprotectReg(d187.Reg)
-							ctx.UnprotectReg(d187.Reg2)
+						if d190.Loc == LocReg || d190.Loc == LocFPReg {
+							ctx.UnprotectReg(d190.Reg)
+						} else if d190.Loc == LocRegPair {
+							ctx.UnprotectReg(d190.Reg)
+							ctx.UnprotectReg(d190.Reg2)
 						}
 					}
-					ps190 := PhiState{General: ps.General}
-					ps190.OverlayValues = make([]JITValueDesc, 190)
-					ps190.OverlayValues[1] = d1
-					ps190.OverlayValues[2] = d2
-					ps190.OverlayValues[3] = d3
-					ps190.OverlayValues[4] = d4
-					ps190.OverlayValues[5] = d5
-					ps190.OverlayValues[6] = d6
-					ps190.OverlayValues[25] = d25
-					ps190.OverlayValues[26] = d26
-					ps190.OverlayValues[27] = d27
-					ps190.OverlayValues[28] = d28
-					ps190.OverlayValues[30] = d30
-					ps190.OverlayValues[31] = d31
-					ps190.OverlayValues[32] = d32
-					ps190.OverlayValues[33] = d33
-					ps190.OverlayValues[68] = d68
-					ps190.OverlayValues[69] = d69
-					ps190.OverlayValues[70] = d70
-					ps190.OverlayValues[71] = d71
-					ps190.OverlayValues[114] = d114
-					ps190.OverlayValues[115] = d115
-					ps190.OverlayValues[116] = d116
-					ps190.OverlayValues[117] = d117
-					ps190.OverlayValues[118] = d118
-					ps190.OverlayValues[171] = d171
-					ps190.OverlayValues[172] = d172
-					ps190.OverlayValues[173] = d173
-					ps190.OverlayValues[174] = d174
-					ps190.OverlayValues[175] = d175
-					ps190.OverlayValues[176] = d176
-					ps190.OverlayValues[177] = d177
-					ps190.OverlayValues[178] = d178
-					ps190.OverlayValues[179] = d179
-					ps190.OverlayValues[180] = d180
-					ps190.OverlayValues[181] = d181
-					ps190.OverlayValues[182] = d182
-					ps190.OverlayValues[183] = d183
-					ps190.OverlayValues[184] = d184
-					ps190.OverlayValues[185] = d185
-					ps190.OverlayValues[186] = d186
-					ps190.OverlayValues[187] = d187
-					ps190.OverlayValues[188] = d188
-					ps190.OverlayValues[189] = d189
-					ps190.PhiValues = make([]JITValueDesc, 2)
-					d191 = d179
-					ps190.PhiValues[0] = d191
-					d192 = d187
-					ps190.PhiValues[1] = d192
-					if ps190.General && bbs[7].Rendered {
+					ps193 := PhiState{General: ps.General}
+					ps193.OverlayValues = make([]JITValueDesc, 193)
+					ps193.OverlayValues[1] = d1
+					ps193.OverlayValues[2] = d2
+					ps193.OverlayValues[3] = d3
+					ps193.OverlayValues[4] = d4
+					ps193.OverlayValues[5] = d5
+					ps193.OverlayValues[6] = d6
+					ps193.OverlayValues[25] = d25
+					ps193.OverlayValues[26] = d26
+					ps193.OverlayValues[27] = d27
+					ps193.OverlayValues[28] = d28
+					ps193.OverlayValues[30] = d30
+					ps193.OverlayValues[31] = d31
+					ps193.OverlayValues[32] = d32
+					ps193.OverlayValues[33] = d33
+					ps193.OverlayValues[68] = d68
+					ps193.OverlayValues[69] = d69
+					ps193.OverlayValues[70] = d70
+					ps193.OverlayValues[71] = d71
+					ps193.OverlayValues[114] = d114
+					ps193.OverlayValues[115] = d115
+					ps193.OverlayValues[116] = d116
+					ps193.OverlayValues[117] = d117
+					ps193.OverlayValues[118] = d118
+					ps193.OverlayValues[119] = d119
+					ps193.OverlayValues[174] = d174
+					ps193.OverlayValues[175] = d175
+					ps193.OverlayValues[176] = d176
+					ps193.OverlayValues[177] = d177
+					ps193.OverlayValues[178] = d178
+					ps193.OverlayValues[179] = d179
+					ps193.OverlayValues[180] = d180
+					ps193.OverlayValues[181] = d181
+					ps193.OverlayValues[182] = d182
+					ps193.OverlayValues[183] = d183
+					ps193.OverlayValues[184] = d184
+					ps193.OverlayValues[185] = d185
+					ps193.OverlayValues[186] = d186
+					ps193.OverlayValues[187] = d187
+					ps193.OverlayValues[188] = d188
+					ps193.OverlayValues[189] = d189
+					ps193.OverlayValues[190] = d190
+					ps193.OverlayValues[191] = d191
+					ps193.OverlayValues[192] = d192
+					ps193.PhiValues = make([]JITValueDesc, 2)
+					d194 = d182
+					ps193.PhiValues[0] = d194
+					d195 = d190
+					ps193.PhiValues[1] = d195
+					if ps193.General && bbs[7].Rendered {
 						ctx.EmitJmp(lbl8)
 						return result
 					}
-					return bbs[7].RenderPS(ps190)
+					return bbs[7].RenderPS(ps193)
 					return result
 				}
 				bbs[7].RenderPS = func(ps PhiState) JITValueDesc {
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d193 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d193)
-							ctx.EmitStoreToStack(d193, int32(bbs[7].PhiBase)+int32(0))
+							d196 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d196)
+							ctx.EmitStoreToStack(d196, int32(bbs[7].PhiBase)+int32(0))
 						}
 						if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
-							d194 := ps.PhiValues[1]
-							ctx.EnsureDesc(&d194)
-							ctx.EmitStoreToStack(d194, int32(bbs[7].PhiBase)+int32(16))
+							d197 := ps.PhiValues[1]
+							ctx.EnsureDesc(&d197)
+							ctx.EmitStoreToStack(d197, int32(bbs[7].PhiBase)+int32(16))
 						}
 						if bbs[7].VisitCount >= 0 {
 							ps.General = true
@@ -11558,14 +11614,8 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
 						d118 = ps.OverlayValues[118]
 					}
-					if len(ps.OverlayValues) > 171 && ps.OverlayValues[171].Loc != LocNone {
-						d171 = ps.OverlayValues[171]
-					}
-					if len(ps.OverlayValues) > 172 && ps.OverlayValues[172].Loc != LocNone {
-						d172 = ps.OverlayValues[172]
-					}
-					if len(ps.OverlayValues) > 173 && ps.OverlayValues[173].Loc != LocNone {
-						d173 = ps.OverlayValues[173]
+					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+						d119 = ps.OverlayValues[119]
 					}
 					if len(ps.OverlayValues) > 174 && ps.OverlayValues[174].Loc != LocNone {
 						d174 = ps.OverlayValues[174]
@@ -11615,17 +11665,26 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 189 && ps.OverlayValues[189].Loc != LocNone {
 						d189 = ps.OverlayValues[189]
 					}
+					if len(ps.OverlayValues) > 190 && ps.OverlayValues[190].Loc != LocNone {
+						d190 = ps.OverlayValues[190]
+					}
 					if len(ps.OverlayValues) > 191 && ps.OverlayValues[191].Loc != LocNone {
 						d191 = ps.OverlayValues[191]
 					}
 					if len(ps.OverlayValues) > 192 && ps.OverlayValues[192].Loc != LocNone {
 						d192 = ps.OverlayValues[192]
 					}
-					if len(ps.OverlayValues) > 193 && ps.OverlayValues[193].Loc != LocNone {
-						d193 = ps.OverlayValues[193]
-					}
 					if len(ps.OverlayValues) > 194 && ps.OverlayValues[194].Loc != LocNone {
 						d194 = ps.OverlayValues[194]
+					}
+					if len(ps.OverlayValues) > 195 && ps.OverlayValues[195].Loc != LocNone {
+						d195 = ps.OverlayValues[195]
+					}
+					if len(ps.OverlayValues) > 196 && ps.OverlayValues[196].Loc != LocNone {
+						d196 = ps.OverlayValues[196]
+					}
+					if len(ps.OverlayValues) > 197 && ps.OverlayValues[197].Loc != LocNone {
+						d197 = ps.OverlayValues[197]
 					}
 					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
 						d1 = ps.PhiValues[0]
@@ -11636,514 +11695,523 @@ func init_timezone() {
 					ctx.ReclaimUntrackedRegs()
 					ctx.StabilizeDescForControlFlow(&d1)
 					ctx.EnsureDesc(&d2)
-					var d195 JITValueDesc
+					var d198 JITValueDesc
 					if d2.Loc == LocImm {
-						d195 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d2.Imm.Int() == 0)}
+						d198 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d2.Imm.Int() == 0)}
 					} else {
 						r10 := ctx.AllocReg()
 						ctx.EmitCmpRegImm32(d2.Reg, 0)
-						d195 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r10, Condition: CondEqual}
-						ctx.BindReg(r10, &d195)
+						d198 = JITValueDesc{Loc: LocFlags, Type: tagBool, Reg: r10, Condition: CondEqual}
+						ctx.BindReg(r10, &d198)
 					}
 					ctx.FreeDesc(&d2)
-					d196 = d195
-					ctx.EnsureDesc(&d196)
-					if d196.Loc != LocImm && d196.Loc != LocFlags {
+					d199 = d198
+					ctx.EnsureDesc(&d199)
+					if d199.Loc != LocImm && d199.Loc != LocFlags {
 						panic("jit: fused If condition is neither LocImm nor LocFlags")
 					}
-					if d196.Loc == LocImm {
-						if d196.Imm.Bool() {
+					if d199.Loc == LocImm {
+						if d199.Imm.Bool() {
 							if ps.General {
 							}
-							ps197 := PhiState{General: ps.General}
-							ps197.OverlayValues = make([]JITValueDesc, 197)
-							ps197.OverlayValues[1] = d1
-							ps197.OverlayValues[2] = d2
-							ps197.OverlayValues[3] = d3
-							ps197.OverlayValues[4] = d4
-							ps197.OverlayValues[5] = d5
-							ps197.OverlayValues[6] = d6
-							ps197.OverlayValues[25] = d25
-							ps197.OverlayValues[26] = d26
-							ps197.OverlayValues[27] = d27
-							ps197.OverlayValues[28] = d28
-							ps197.OverlayValues[30] = d30
-							ps197.OverlayValues[31] = d31
-							ps197.OverlayValues[32] = d32
-							ps197.OverlayValues[33] = d33
-							ps197.OverlayValues[68] = d68
-							ps197.OverlayValues[69] = d69
-							ps197.OverlayValues[70] = d70
-							ps197.OverlayValues[71] = d71
-							ps197.OverlayValues[114] = d114
-							ps197.OverlayValues[115] = d115
-							ps197.OverlayValues[116] = d116
-							ps197.OverlayValues[117] = d117
-							ps197.OverlayValues[118] = d118
-							ps197.OverlayValues[171] = d171
-							ps197.OverlayValues[172] = d172
-							ps197.OverlayValues[173] = d173
-							ps197.OverlayValues[174] = d174
-							ps197.OverlayValues[175] = d175
-							ps197.OverlayValues[176] = d176
-							ps197.OverlayValues[177] = d177
-							ps197.OverlayValues[178] = d178
-							ps197.OverlayValues[179] = d179
-							ps197.OverlayValues[180] = d180
-							ps197.OverlayValues[181] = d181
-							ps197.OverlayValues[182] = d182
-							ps197.OverlayValues[183] = d183
-							ps197.OverlayValues[184] = d184
-							ps197.OverlayValues[185] = d185
-							ps197.OverlayValues[186] = d186
-							ps197.OverlayValues[187] = d187
-							ps197.OverlayValues[188] = d188
-							ps197.OverlayValues[189] = d189
-							ps197.OverlayValues[191] = d191
-							ps197.OverlayValues[192] = d192
-							ps197.OverlayValues[193] = d193
-							ps197.OverlayValues[194] = d194
-							ps197.OverlayValues[195] = d195
-							ps197.OverlayValues[196] = d196
-							return bbs[9].RenderPS(ps197)
+							ps200 := PhiState{General: ps.General}
+							ps200.OverlayValues = make([]JITValueDesc, 200)
+							ps200.OverlayValues[1] = d1
+							ps200.OverlayValues[2] = d2
+							ps200.OverlayValues[3] = d3
+							ps200.OverlayValues[4] = d4
+							ps200.OverlayValues[5] = d5
+							ps200.OverlayValues[6] = d6
+							ps200.OverlayValues[25] = d25
+							ps200.OverlayValues[26] = d26
+							ps200.OverlayValues[27] = d27
+							ps200.OverlayValues[28] = d28
+							ps200.OverlayValues[30] = d30
+							ps200.OverlayValues[31] = d31
+							ps200.OverlayValues[32] = d32
+							ps200.OverlayValues[33] = d33
+							ps200.OverlayValues[68] = d68
+							ps200.OverlayValues[69] = d69
+							ps200.OverlayValues[70] = d70
+							ps200.OverlayValues[71] = d71
+							ps200.OverlayValues[114] = d114
+							ps200.OverlayValues[115] = d115
+							ps200.OverlayValues[116] = d116
+							ps200.OverlayValues[117] = d117
+							ps200.OverlayValues[118] = d118
+							ps200.OverlayValues[119] = d119
+							ps200.OverlayValues[174] = d174
+							ps200.OverlayValues[175] = d175
+							ps200.OverlayValues[176] = d176
+							ps200.OverlayValues[177] = d177
+							ps200.OverlayValues[178] = d178
+							ps200.OverlayValues[179] = d179
+							ps200.OverlayValues[180] = d180
+							ps200.OverlayValues[181] = d181
+							ps200.OverlayValues[182] = d182
+							ps200.OverlayValues[183] = d183
+							ps200.OverlayValues[184] = d184
+							ps200.OverlayValues[185] = d185
+							ps200.OverlayValues[186] = d186
+							ps200.OverlayValues[187] = d187
+							ps200.OverlayValues[188] = d188
+							ps200.OverlayValues[189] = d189
+							ps200.OverlayValues[190] = d190
+							ps200.OverlayValues[191] = d191
+							ps200.OverlayValues[192] = d192
+							ps200.OverlayValues[194] = d194
+							ps200.OverlayValues[195] = d195
+							ps200.OverlayValues[196] = d196
+							ps200.OverlayValues[197] = d197
+							ps200.OverlayValues[198] = d198
+							ps200.OverlayValues[199] = d199
+							return bbs[9].RenderPS(ps200)
 						}
 						if ps.General {
 						}
-						ps198 := PhiState{General: ps.General}
-						ps198.OverlayValues = make([]JITValueDesc, 197)
-						ps198.OverlayValues[1] = d1
-						ps198.OverlayValues[2] = d2
-						ps198.OverlayValues[3] = d3
-						ps198.OverlayValues[4] = d4
-						ps198.OverlayValues[5] = d5
-						ps198.OverlayValues[6] = d6
-						ps198.OverlayValues[25] = d25
-						ps198.OverlayValues[26] = d26
-						ps198.OverlayValues[27] = d27
-						ps198.OverlayValues[28] = d28
-						ps198.OverlayValues[30] = d30
-						ps198.OverlayValues[31] = d31
-						ps198.OverlayValues[32] = d32
-						ps198.OverlayValues[33] = d33
-						ps198.OverlayValues[68] = d68
-						ps198.OverlayValues[69] = d69
-						ps198.OverlayValues[70] = d70
-						ps198.OverlayValues[71] = d71
-						ps198.OverlayValues[114] = d114
-						ps198.OverlayValues[115] = d115
-						ps198.OverlayValues[116] = d116
-						ps198.OverlayValues[117] = d117
-						ps198.OverlayValues[118] = d118
-						ps198.OverlayValues[171] = d171
-						ps198.OverlayValues[172] = d172
-						ps198.OverlayValues[173] = d173
-						ps198.OverlayValues[174] = d174
-						ps198.OverlayValues[175] = d175
-						ps198.OverlayValues[176] = d176
-						ps198.OverlayValues[177] = d177
-						ps198.OverlayValues[178] = d178
-						ps198.OverlayValues[179] = d179
-						ps198.OverlayValues[180] = d180
-						ps198.OverlayValues[181] = d181
-						ps198.OverlayValues[182] = d182
-						ps198.OverlayValues[183] = d183
-						ps198.OverlayValues[184] = d184
-						ps198.OverlayValues[185] = d185
-						ps198.OverlayValues[186] = d186
-						ps198.OverlayValues[187] = d187
-						ps198.OverlayValues[188] = d188
-						ps198.OverlayValues[189] = d189
-						ps198.OverlayValues[191] = d191
-						ps198.OverlayValues[192] = d192
-						ps198.OverlayValues[193] = d193
-						ps198.OverlayValues[194] = d194
-						ps198.OverlayValues[195] = d195
-						ps198.OverlayValues[196] = d196
-						return bbs[10].RenderPS(ps198)
+						ps201 := PhiState{General: ps.General}
+						ps201.OverlayValues = make([]JITValueDesc, 200)
+						ps201.OverlayValues[1] = d1
+						ps201.OverlayValues[2] = d2
+						ps201.OverlayValues[3] = d3
+						ps201.OverlayValues[4] = d4
+						ps201.OverlayValues[5] = d5
+						ps201.OverlayValues[6] = d6
+						ps201.OverlayValues[25] = d25
+						ps201.OverlayValues[26] = d26
+						ps201.OverlayValues[27] = d27
+						ps201.OverlayValues[28] = d28
+						ps201.OverlayValues[30] = d30
+						ps201.OverlayValues[31] = d31
+						ps201.OverlayValues[32] = d32
+						ps201.OverlayValues[33] = d33
+						ps201.OverlayValues[68] = d68
+						ps201.OverlayValues[69] = d69
+						ps201.OverlayValues[70] = d70
+						ps201.OverlayValues[71] = d71
+						ps201.OverlayValues[114] = d114
+						ps201.OverlayValues[115] = d115
+						ps201.OverlayValues[116] = d116
+						ps201.OverlayValues[117] = d117
+						ps201.OverlayValues[118] = d118
+						ps201.OverlayValues[119] = d119
+						ps201.OverlayValues[174] = d174
+						ps201.OverlayValues[175] = d175
+						ps201.OverlayValues[176] = d176
+						ps201.OverlayValues[177] = d177
+						ps201.OverlayValues[178] = d178
+						ps201.OverlayValues[179] = d179
+						ps201.OverlayValues[180] = d180
+						ps201.OverlayValues[181] = d181
+						ps201.OverlayValues[182] = d182
+						ps201.OverlayValues[183] = d183
+						ps201.OverlayValues[184] = d184
+						ps201.OverlayValues[185] = d185
+						ps201.OverlayValues[186] = d186
+						ps201.OverlayValues[187] = d187
+						ps201.OverlayValues[188] = d188
+						ps201.OverlayValues[189] = d189
+						ps201.OverlayValues[190] = d190
+						ps201.OverlayValues[191] = d191
+						ps201.OverlayValues[192] = d192
+						ps201.OverlayValues[194] = d194
+						ps201.OverlayValues[195] = d195
+						ps201.OverlayValues[196] = d196
+						ps201.OverlayValues[197] = d197
+						ps201.OverlayValues[198] = d198
+						ps201.OverlayValues[199] = d199
+						return bbs[10].RenderPS(ps201)
 					}
 					if !ps.General {
 						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
-							d199 := ps.PhiValues[0]
-							ctx.EnsureDesc(&d199)
-							ctx.EmitStoreToStack(d199, int32(bbs[7].PhiBase)+int32(0))
+							d202 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d202)
+							ctx.EmitStoreToStack(d202, int32(bbs[7].PhiBase)+int32(0))
 						}
 						if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
-							d200 := ps.PhiValues[1]
-							ctx.EnsureDesc(&d200)
-							ctx.EmitStoreToStack(d200, int32(bbs[7].PhiBase)+int32(16))
+							d203 := ps.PhiValues[1]
+							ctx.EnsureDesc(&d203)
+							ctx.EmitStoreToStack(d203, int32(bbs[7].PhiBase)+int32(16))
 						}
 						ps.General = true
 						return bbs[7].RenderPS(ps)
 					}
-					ctx.EmitJump(d196.Condition, lbl10)
+					ctx.EmitJump(d199.Condition, lbl10)
 					if bbs[10].Rendered {
 						ctx.EmitJmp(lbl11)
 					}
-					ctx.FreeDesc(&d195)
-					snap201 := d1
-					snap202 := d2
-					snap203 := d3
-					snap204 := d4
-					snap205 := d5
-					snap206 := d6
-					snap207 := d25
-					snap208 := d26
-					snap209 := d27
-					snap210 := d28
-					snap211 := d30
-					snap212 := d31
-					snap213 := d32
-					snap214 := d33
-					snap215 := d68
-					snap216 := d69
-					snap217 := d70
-					snap218 := d71
-					snap219 := d114
-					snap220 := d115
-					snap221 := d116
-					snap222 := d117
-					snap223 := d118
-					snap224 := d171
-					snap225 := d172
-					snap226 := d173
-					snap227 := d174
-					snap228 := d175
-					snap229 := d176
-					snap230 := d177
-					snap231 := d178
-					snap232 := d179
-					snap233 := d180
-					snap234 := d181
-					snap235 := d182
-					snap236 := d183
-					snap237 := d184
-					snap238 := d185
-					snap239 := d186
-					snap240 := d187
-					snap241 := d188
-					snap242 := d189
-					snap243 := d191
-					snap244 := d192
-					snap245 := d193
-					snap246 := d194
-					snap247 := d195
-					snap248 := d196
-					snap249 := d199
-					snap250 := d200
-					alloc251 := ctx.SnapshotAllocState()
-					ctx.RestoreAllocState(alloc251)
-					d1 = snap201
-					d2 = snap202
-					d3 = snap203
-					d4 = snap204
-					d5 = snap205
-					d6 = snap206
-					d25 = snap207
-					d26 = snap208
-					d27 = snap209
-					d28 = snap210
-					d30 = snap211
-					d31 = snap212
-					d32 = snap213
-					d33 = snap214
-					d68 = snap215
-					d69 = snap216
-					d70 = snap217
-					d71 = snap218
-					d114 = snap219
-					d115 = snap220
-					d116 = snap221
-					d117 = snap222
-					d118 = snap223
-					d171 = snap224
-					d172 = snap225
-					d173 = snap226
-					d174 = snap227
-					d175 = snap228
-					d176 = snap229
-					d177 = snap230
-					d178 = snap231
-					d179 = snap232
-					d180 = snap233
-					d181 = snap234
-					d182 = snap235
-					d183 = snap236
-					d184 = snap237
-					d185 = snap238
-					d186 = snap239
-					d187 = snap240
-					d188 = snap241
-					d189 = snap242
-					d191 = snap243
-					d192 = snap244
-					d193 = snap245
-					d194 = snap246
-					d195 = snap247
-					d196 = snap248
-					d199 = snap249
-					d200 = snap250
-					ctx.RestoreAllocState(alloc251)
-					d1 = snap201
-					d2 = snap202
-					d3 = snap203
-					d4 = snap204
-					d5 = snap205
-					d6 = snap206
-					d25 = snap207
-					d26 = snap208
-					d27 = snap209
-					d28 = snap210
-					d30 = snap211
-					d31 = snap212
-					d32 = snap213
-					d33 = snap214
-					d68 = snap215
-					d69 = snap216
-					d70 = snap217
-					d71 = snap218
-					d114 = snap219
-					d115 = snap220
-					d116 = snap221
-					d117 = snap222
-					d118 = snap223
-					d171 = snap224
-					d172 = snap225
-					d173 = snap226
-					d174 = snap227
-					d175 = snap228
-					d176 = snap229
-					d177 = snap230
-					d178 = snap231
-					d179 = snap232
-					d180 = snap233
-					d181 = snap234
-					d182 = snap235
-					d183 = snap236
-					d184 = snap237
-					d185 = snap238
-					d186 = snap239
-					d187 = snap240
-					d188 = snap241
-					d189 = snap242
-					d191 = snap243
-					d192 = snap244
-					d193 = snap245
-					d194 = snap246
-					d195 = snap247
-					d196 = snap248
-					d199 = snap249
-					d200 = snap250
-					ps252 := PhiState{General: true}
-					ps252.OverlayValues = make([]JITValueDesc, 201)
-					ps252.OverlayValues[1] = d1
-					ps252.OverlayValues[2] = d2
-					ps252.OverlayValues[3] = d3
-					ps252.OverlayValues[4] = d4
-					ps252.OverlayValues[5] = d5
-					ps252.OverlayValues[6] = d6
-					ps252.OverlayValues[25] = d25
-					ps252.OverlayValues[26] = d26
-					ps252.OverlayValues[27] = d27
-					ps252.OverlayValues[28] = d28
-					ps252.OverlayValues[30] = d30
-					ps252.OverlayValues[31] = d31
-					ps252.OverlayValues[32] = d32
-					ps252.OverlayValues[33] = d33
-					ps252.OverlayValues[68] = d68
-					ps252.OverlayValues[69] = d69
-					ps252.OverlayValues[70] = d70
-					ps252.OverlayValues[71] = d71
-					ps252.OverlayValues[114] = d114
-					ps252.OverlayValues[115] = d115
-					ps252.OverlayValues[116] = d116
-					ps252.OverlayValues[117] = d117
-					ps252.OverlayValues[118] = d118
-					ps252.OverlayValues[171] = d171
-					ps252.OverlayValues[172] = d172
-					ps252.OverlayValues[173] = d173
-					ps252.OverlayValues[174] = d174
-					ps252.OverlayValues[175] = d175
-					ps252.OverlayValues[176] = d176
-					ps252.OverlayValues[177] = d177
-					ps252.OverlayValues[178] = d178
-					ps252.OverlayValues[179] = d179
-					ps252.OverlayValues[180] = d180
-					ps252.OverlayValues[181] = d181
-					ps252.OverlayValues[182] = d182
-					ps252.OverlayValues[183] = d183
-					ps252.OverlayValues[184] = d184
-					ps252.OverlayValues[185] = d185
-					ps252.OverlayValues[186] = d186
-					ps252.OverlayValues[187] = d187
-					ps252.OverlayValues[188] = d188
-					ps252.OverlayValues[189] = d189
-					ps252.OverlayValues[191] = d191
-					ps252.OverlayValues[192] = d192
-					ps252.OverlayValues[193] = d193
-					ps252.OverlayValues[194] = d194
-					ps252.OverlayValues[195] = d195
-					ps252.OverlayValues[196] = d196
-					ps252.OverlayValues[199] = d199
-					ps252.OverlayValues[200] = d200
-					ps253 := PhiState{General: true}
-					ps253.OverlayValues = make([]JITValueDesc, 201)
-					ps253.OverlayValues[1] = d1
-					ps253.OverlayValues[2] = d2
-					ps253.OverlayValues[3] = d3
-					ps253.OverlayValues[4] = d4
-					ps253.OverlayValues[5] = d5
-					ps253.OverlayValues[6] = d6
-					ps253.OverlayValues[25] = d25
-					ps253.OverlayValues[26] = d26
-					ps253.OverlayValues[27] = d27
-					ps253.OverlayValues[28] = d28
-					ps253.OverlayValues[30] = d30
-					ps253.OverlayValues[31] = d31
-					ps253.OverlayValues[32] = d32
-					ps253.OverlayValues[33] = d33
-					ps253.OverlayValues[68] = d68
-					ps253.OverlayValues[69] = d69
-					ps253.OverlayValues[70] = d70
-					ps253.OverlayValues[71] = d71
-					ps253.OverlayValues[114] = d114
-					ps253.OverlayValues[115] = d115
-					ps253.OverlayValues[116] = d116
-					ps253.OverlayValues[117] = d117
-					ps253.OverlayValues[118] = d118
-					ps253.OverlayValues[171] = d171
-					ps253.OverlayValues[172] = d172
-					ps253.OverlayValues[173] = d173
-					ps253.OverlayValues[174] = d174
-					ps253.OverlayValues[175] = d175
-					ps253.OverlayValues[176] = d176
-					ps253.OverlayValues[177] = d177
-					ps253.OverlayValues[178] = d178
-					ps253.OverlayValues[179] = d179
-					ps253.OverlayValues[180] = d180
-					ps253.OverlayValues[181] = d181
-					ps253.OverlayValues[182] = d182
-					ps253.OverlayValues[183] = d183
-					ps253.OverlayValues[184] = d184
-					ps253.OverlayValues[185] = d185
-					ps253.OverlayValues[186] = d186
-					ps253.OverlayValues[187] = d187
-					ps253.OverlayValues[188] = d188
-					ps253.OverlayValues[189] = d189
-					ps253.OverlayValues[191] = d191
-					ps253.OverlayValues[192] = d192
-					ps253.OverlayValues[193] = d193
-					ps253.OverlayValues[194] = d194
-					ps253.OverlayValues[195] = d195
-					ps253.OverlayValues[196] = d196
-					ps253.OverlayValues[199] = d199
-					ps253.OverlayValues[200] = d200
-					snap254 := d1
-					snap255 := d2
-					snap256 := d3
-					snap257 := d4
-					snap258 := d5
-					snap259 := d6
-					snap260 := d25
-					snap261 := d26
-					snap262 := d27
-					snap263 := d28
-					snap264 := d30
-					snap265 := d31
-					snap266 := d32
-					snap267 := d33
-					snap268 := d68
-					snap269 := d69
-					snap270 := d70
-					snap271 := d71
-					snap272 := d114
-					snap273 := d115
-					snap274 := d116
-					snap275 := d117
-					snap276 := d118
-					snap277 := d171
-					snap278 := d172
-					snap279 := d173
-					snap280 := d174
-					snap281 := d175
-					snap282 := d176
-					snap283 := d177
-					snap284 := d178
-					snap285 := d179
-					snap286 := d180
-					snap287 := d181
-					snap288 := d182
-					snap289 := d183
-					snap290 := d184
-					snap291 := d185
-					snap292 := d186
-					snap293 := d187
-					snap294 := d188
-					snap295 := d189
-					snap296 := d191
-					snap297 := d192
-					snap298 := d193
-					snap299 := d194
-					snap300 := d195
-					snap301 := d196
-					snap302 := d199
-					snap303 := d200
-					alloc304 := ctx.SnapshotAllocState()
+					ctx.FreeDesc(&d198)
+					snap204 := d1
+					snap205 := d2
+					snap206 := d3
+					snap207 := d4
+					snap208 := d5
+					snap209 := d6
+					snap210 := d25
+					snap211 := d26
+					snap212 := d27
+					snap213 := d28
+					snap214 := d30
+					snap215 := d31
+					snap216 := d32
+					snap217 := d33
+					snap218 := d68
+					snap219 := d69
+					snap220 := d70
+					snap221 := d71
+					snap222 := d114
+					snap223 := d115
+					snap224 := d116
+					snap225 := d117
+					snap226 := d118
+					snap227 := d119
+					snap228 := d174
+					snap229 := d175
+					snap230 := d176
+					snap231 := d177
+					snap232 := d178
+					snap233 := d179
+					snap234 := d180
+					snap235 := d181
+					snap236 := d182
+					snap237 := d183
+					snap238 := d184
+					snap239 := d185
+					snap240 := d186
+					snap241 := d187
+					snap242 := d188
+					snap243 := d189
+					snap244 := d190
+					snap245 := d191
+					snap246 := d192
+					snap247 := d194
+					snap248 := d195
+					snap249 := d196
+					snap250 := d197
+					snap251 := d198
+					snap252 := d199
+					snap253 := d202
+					snap254 := d203
+					alloc255 := ctx.SnapshotAllocState()
+					ctx.RestoreAllocState(alloc255)
+					d1 = snap204
+					d2 = snap205
+					d3 = snap206
+					d4 = snap207
+					d5 = snap208
+					d6 = snap209
+					d25 = snap210
+					d26 = snap211
+					d27 = snap212
+					d28 = snap213
+					d30 = snap214
+					d31 = snap215
+					d32 = snap216
+					d33 = snap217
+					d68 = snap218
+					d69 = snap219
+					d70 = snap220
+					d71 = snap221
+					d114 = snap222
+					d115 = snap223
+					d116 = snap224
+					d117 = snap225
+					d118 = snap226
+					d119 = snap227
+					d174 = snap228
+					d175 = snap229
+					d176 = snap230
+					d177 = snap231
+					d178 = snap232
+					d179 = snap233
+					d180 = snap234
+					d181 = snap235
+					d182 = snap236
+					d183 = snap237
+					d184 = snap238
+					d185 = snap239
+					d186 = snap240
+					d187 = snap241
+					d188 = snap242
+					d189 = snap243
+					d190 = snap244
+					d191 = snap245
+					d192 = snap246
+					d194 = snap247
+					d195 = snap248
+					d196 = snap249
+					d197 = snap250
+					d198 = snap251
+					d199 = snap252
+					d202 = snap253
+					d203 = snap254
+					ctx.RestoreAllocState(alloc255)
+					d1 = snap204
+					d2 = snap205
+					d3 = snap206
+					d4 = snap207
+					d5 = snap208
+					d6 = snap209
+					d25 = snap210
+					d26 = snap211
+					d27 = snap212
+					d28 = snap213
+					d30 = snap214
+					d31 = snap215
+					d32 = snap216
+					d33 = snap217
+					d68 = snap218
+					d69 = snap219
+					d70 = snap220
+					d71 = snap221
+					d114 = snap222
+					d115 = snap223
+					d116 = snap224
+					d117 = snap225
+					d118 = snap226
+					d119 = snap227
+					d174 = snap228
+					d175 = snap229
+					d176 = snap230
+					d177 = snap231
+					d178 = snap232
+					d179 = snap233
+					d180 = snap234
+					d181 = snap235
+					d182 = snap236
+					d183 = snap237
+					d184 = snap238
+					d185 = snap239
+					d186 = snap240
+					d187 = snap241
+					d188 = snap242
+					d189 = snap243
+					d190 = snap244
+					d191 = snap245
+					d192 = snap246
+					d194 = snap247
+					d195 = snap248
+					d196 = snap249
+					d197 = snap250
+					d198 = snap251
+					d199 = snap252
+					d202 = snap253
+					d203 = snap254
+					ps256 := PhiState{General: true}
+					ps256.OverlayValues = make([]JITValueDesc, 204)
+					ps256.OverlayValues[1] = d1
+					ps256.OverlayValues[2] = d2
+					ps256.OverlayValues[3] = d3
+					ps256.OverlayValues[4] = d4
+					ps256.OverlayValues[5] = d5
+					ps256.OverlayValues[6] = d6
+					ps256.OverlayValues[25] = d25
+					ps256.OverlayValues[26] = d26
+					ps256.OverlayValues[27] = d27
+					ps256.OverlayValues[28] = d28
+					ps256.OverlayValues[30] = d30
+					ps256.OverlayValues[31] = d31
+					ps256.OverlayValues[32] = d32
+					ps256.OverlayValues[33] = d33
+					ps256.OverlayValues[68] = d68
+					ps256.OverlayValues[69] = d69
+					ps256.OverlayValues[70] = d70
+					ps256.OverlayValues[71] = d71
+					ps256.OverlayValues[114] = d114
+					ps256.OverlayValues[115] = d115
+					ps256.OverlayValues[116] = d116
+					ps256.OverlayValues[117] = d117
+					ps256.OverlayValues[118] = d118
+					ps256.OverlayValues[119] = d119
+					ps256.OverlayValues[174] = d174
+					ps256.OverlayValues[175] = d175
+					ps256.OverlayValues[176] = d176
+					ps256.OverlayValues[177] = d177
+					ps256.OverlayValues[178] = d178
+					ps256.OverlayValues[179] = d179
+					ps256.OverlayValues[180] = d180
+					ps256.OverlayValues[181] = d181
+					ps256.OverlayValues[182] = d182
+					ps256.OverlayValues[183] = d183
+					ps256.OverlayValues[184] = d184
+					ps256.OverlayValues[185] = d185
+					ps256.OverlayValues[186] = d186
+					ps256.OverlayValues[187] = d187
+					ps256.OverlayValues[188] = d188
+					ps256.OverlayValues[189] = d189
+					ps256.OverlayValues[190] = d190
+					ps256.OverlayValues[191] = d191
+					ps256.OverlayValues[192] = d192
+					ps256.OverlayValues[194] = d194
+					ps256.OverlayValues[195] = d195
+					ps256.OverlayValues[196] = d196
+					ps256.OverlayValues[197] = d197
+					ps256.OverlayValues[198] = d198
+					ps256.OverlayValues[199] = d199
+					ps256.OverlayValues[202] = d202
+					ps256.OverlayValues[203] = d203
+					ps257 := PhiState{General: true}
+					ps257.OverlayValues = make([]JITValueDesc, 204)
+					ps257.OverlayValues[1] = d1
+					ps257.OverlayValues[2] = d2
+					ps257.OverlayValues[3] = d3
+					ps257.OverlayValues[4] = d4
+					ps257.OverlayValues[5] = d5
+					ps257.OverlayValues[6] = d6
+					ps257.OverlayValues[25] = d25
+					ps257.OverlayValues[26] = d26
+					ps257.OverlayValues[27] = d27
+					ps257.OverlayValues[28] = d28
+					ps257.OverlayValues[30] = d30
+					ps257.OverlayValues[31] = d31
+					ps257.OverlayValues[32] = d32
+					ps257.OverlayValues[33] = d33
+					ps257.OverlayValues[68] = d68
+					ps257.OverlayValues[69] = d69
+					ps257.OverlayValues[70] = d70
+					ps257.OverlayValues[71] = d71
+					ps257.OverlayValues[114] = d114
+					ps257.OverlayValues[115] = d115
+					ps257.OverlayValues[116] = d116
+					ps257.OverlayValues[117] = d117
+					ps257.OverlayValues[118] = d118
+					ps257.OverlayValues[119] = d119
+					ps257.OverlayValues[174] = d174
+					ps257.OverlayValues[175] = d175
+					ps257.OverlayValues[176] = d176
+					ps257.OverlayValues[177] = d177
+					ps257.OverlayValues[178] = d178
+					ps257.OverlayValues[179] = d179
+					ps257.OverlayValues[180] = d180
+					ps257.OverlayValues[181] = d181
+					ps257.OverlayValues[182] = d182
+					ps257.OverlayValues[183] = d183
+					ps257.OverlayValues[184] = d184
+					ps257.OverlayValues[185] = d185
+					ps257.OverlayValues[186] = d186
+					ps257.OverlayValues[187] = d187
+					ps257.OverlayValues[188] = d188
+					ps257.OverlayValues[189] = d189
+					ps257.OverlayValues[190] = d190
+					ps257.OverlayValues[191] = d191
+					ps257.OverlayValues[192] = d192
+					ps257.OverlayValues[194] = d194
+					ps257.OverlayValues[195] = d195
+					ps257.OverlayValues[196] = d196
+					ps257.OverlayValues[197] = d197
+					ps257.OverlayValues[198] = d198
+					ps257.OverlayValues[199] = d199
+					ps257.OverlayValues[202] = d202
+					ps257.OverlayValues[203] = d203
+					snap258 := d1
+					snap259 := d2
+					snap260 := d3
+					snap261 := d4
+					snap262 := d5
+					snap263 := d6
+					snap264 := d25
+					snap265 := d26
+					snap266 := d27
+					snap267 := d28
+					snap268 := d30
+					snap269 := d31
+					snap270 := d32
+					snap271 := d33
+					snap272 := d68
+					snap273 := d69
+					snap274 := d70
+					snap275 := d71
+					snap276 := d114
+					snap277 := d115
+					snap278 := d116
+					snap279 := d117
+					snap280 := d118
+					snap281 := d119
+					snap282 := d174
+					snap283 := d175
+					snap284 := d176
+					snap285 := d177
+					snap286 := d178
+					snap287 := d179
+					snap288 := d180
+					snap289 := d181
+					snap290 := d182
+					snap291 := d183
+					snap292 := d184
+					snap293 := d185
+					snap294 := d186
+					snap295 := d187
+					snap296 := d188
+					snap297 := d189
+					snap298 := d190
+					snap299 := d191
+					snap300 := d192
+					snap301 := d194
+					snap302 := d195
+					snap303 := d196
+					snap304 := d197
+					snap305 := d198
+					snap306 := d199
+					snap307 := d202
+					snap308 := d203
+					alloc309 := ctx.SnapshotAllocState()
 					if !bbs[10].Rendered {
-						bbs[10].RenderPS(ps253)
+						bbs[10].RenderPS(ps257)
 					}
-					ctx.RestoreAllocState(alloc304)
-					d1 = snap254
-					d2 = snap255
-					d3 = snap256
-					d4 = snap257
-					d5 = snap258
-					d6 = snap259
-					d25 = snap260
-					d26 = snap261
-					d27 = snap262
-					d28 = snap263
-					d30 = snap264
-					d31 = snap265
-					d32 = snap266
-					d33 = snap267
-					d68 = snap268
-					d69 = snap269
-					d70 = snap270
-					d71 = snap271
-					d114 = snap272
-					d115 = snap273
-					d116 = snap274
-					d117 = snap275
-					d118 = snap276
-					d171 = snap277
-					d172 = snap278
-					d173 = snap279
-					d174 = snap280
-					d175 = snap281
-					d176 = snap282
-					d177 = snap283
-					d178 = snap284
-					d179 = snap285
-					d180 = snap286
-					d181 = snap287
-					d182 = snap288
-					d183 = snap289
-					d184 = snap290
-					d185 = snap291
-					d186 = snap292
-					d187 = snap293
-					d188 = snap294
-					d189 = snap295
-					d191 = snap296
-					d192 = snap297
-					d193 = snap298
-					d194 = snap299
-					d195 = snap300
-					d196 = snap301
-					d199 = snap302
-					d200 = snap303
+					ctx.RestoreAllocState(alloc309)
+					d1 = snap258
+					d2 = snap259
+					d3 = snap260
+					d4 = snap261
+					d5 = snap262
+					d6 = snap263
+					d25 = snap264
+					d26 = snap265
+					d27 = snap266
+					d28 = snap267
+					d30 = snap268
+					d31 = snap269
+					d32 = snap270
+					d33 = snap271
+					d68 = snap272
+					d69 = snap273
+					d70 = snap274
+					d71 = snap275
+					d114 = snap276
+					d115 = snap277
+					d116 = snap278
+					d117 = snap279
+					d118 = snap280
+					d119 = snap281
+					d174 = snap282
+					d175 = snap283
+					d176 = snap284
+					d177 = snap285
+					d178 = snap286
+					d179 = snap287
+					d180 = snap288
+					d181 = snap289
+					d182 = snap290
+					d183 = snap291
+					d184 = snap292
+					d185 = snap293
+					d186 = snap294
+					d187 = snap295
+					d188 = snap296
+					d189 = snap297
+					d190 = snap298
+					d191 = snap299
+					d192 = snap300
+					d194 = snap301
+					d195 = snap302
+					d196 = snap303
+					d197 = snap304
+					d198 = snap305
+					d199 = snap306
+					d202 = snap307
+					d203 = snap308
 					if !bbs[9].Rendered {
-						return bbs[9].RenderPS(ps252)
+						return bbs[9].RenderPS(ps256)
 					}
 					return result
 					return result
@@ -12238,14 +12306,8 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
 						d118 = ps.OverlayValues[118]
 					}
-					if len(ps.OverlayValues) > 171 && ps.OverlayValues[171].Loc != LocNone {
-						d171 = ps.OverlayValues[171]
-					}
-					if len(ps.OverlayValues) > 172 && ps.OverlayValues[172].Loc != LocNone {
-						d172 = ps.OverlayValues[172]
-					}
-					if len(ps.OverlayValues) > 173 && ps.OverlayValues[173].Loc != LocNone {
-						d173 = ps.OverlayValues[173]
+					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+						d119 = ps.OverlayValues[119]
 					}
 					if len(ps.OverlayValues) > 174 && ps.OverlayValues[174].Loc != LocNone {
 						d174 = ps.OverlayValues[174]
@@ -12295,14 +12357,14 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 189 && ps.OverlayValues[189].Loc != LocNone {
 						d189 = ps.OverlayValues[189]
 					}
+					if len(ps.OverlayValues) > 190 && ps.OverlayValues[190].Loc != LocNone {
+						d190 = ps.OverlayValues[190]
+					}
 					if len(ps.OverlayValues) > 191 && ps.OverlayValues[191].Loc != LocNone {
 						d191 = ps.OverlayValues[191]
 					}
 					if len(ps.OverlayValues) > 192 && ps.OverlayValues[192].Loc != LocNone {
 						d192 = ps.OverlayValues[192]
-					}
-					if len(ps.OverlayValues) > 193 && ps.OverlayValues[193].Loc != LocNone {
-						d193 = ps.OverlayValues[193]
 					}
 					if len(ps.OverlayValues) > 194 && ps.OverlayValues[194].Loc != LocNone {
 						d194 = ps.OverlayValues[194]
@@ -12313,121 +12375,131 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 196 && ps.OverlayValues[196].Loc != LocNone {
 						d196 = ps.OverlayValues[196]
 					}
+					if len(ps.OverlayValues) > 197 && ps.OverlayValues[197].Loc != LocNone {
+						d197 = ps.OverlayValues[197]
+					}
+					if len(ps.OverlayValues) > 198 && ps.OverlayValues[198].Loc != LocNone {
+						d198 = ps.OverlayValues[198]
+					}
 					if len(ps.OverlayValues) > 199 && ps.OverlayValues[199].Loc != LocNone {
 						d199 = ps.OverlayValues[199]
 					}
-					if len(ps.OverlayValues) > 200 && ps.OverlayValues[200].Loc != LocNone {
-						d200 = ps.OverlayValues[200]
+					if len(ps.OverlayValues) > 202 && ps.OverlayValues[202].Loc != LocNone {
+						d202 = ps.OverlayValues[202]
+					}
+					if len(ps.OverlayValues) > 203 && ps.OverlayValues[203].Loc != LocNone {
+						d203 = ps.OverlayValues[203]
 					}
 					ctx.ReclaimUntrackedRegs()
-					d305 = args[0]
-					d305.ID = 0
-					var d306 JITValueDesc
-					if d305.Loc == LocImm {
-						d306 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d305.Imm.Int())}
-					} else if d305.Type == tagInt && d305.Loc == LocRegPair {
-						ctx.FreeReg(d305.Reg)
-						d306 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d305.Reg2}
-						ctx.BindReg(d305.Reg2, &d306)
-						ctx.BindReg(d305.Reg2, &d306)
-					} else if d305.Type == tagInt && d305.Loc == LocReg {
-						d306 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d305.Reg}
-						ctx.BindReg(d305.Reg, &d306)
-						ctx.BindReg(d305.Reg, &d306)
+					d310 = args[0]
+					d310.ID = 0
+					var d311 JITValueDesc
+					if d310.Loc == LocImm {
+						d311 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d310.Imm.Int())}
+					} else if d310.Type == tagInt && d310.Loc == LocRegPair {
+						ctx.FreeReg(d310.Reg)
+						d311 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d310.Reg2}
+						ctx.BindReg(d310.Reg2, &d311)
+						ctx.BindReg(d310.Reg2, &d311)
+					} else if d310.Type == tagInt && d310.Loc == LocReg {
+						d311 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d310.Reg}
+						ctx.BindReg(d310.Reg, &d311)
+						ctx.BindReg(d310.Reg, &d311)
 					} else {
-						d306 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{d305}, 1)
-						d306.Type = tagInt
-						ctx.BindReg(d306.Reg, &d306)
+						d311 = ctx.EmitGoCallScalar(GoFuncAddr(Scmer.Int), []JITValueDesc{d310}, 1)
+						d311.Type = tagInt
+						ctx.BindReg(d311.Reg, &d311)
 					}
-					ctx.StabilizeDescForControlFlow(&d306)
-					ctx.FreeDesc(&d305)
+					ctx.StabilizeDescForControlFlow(&d311)
+					ctx.FreeDesc(&d310)
 					if ps.General {
-						ctx.SyncDesc(&d306)
-						if d306.Loc == LocReg {
-							ctx.ProtectReg(d306.Reg)
-						} else if d306.Loc == LocRegPair {
-							ctx.ProtectReg(d306.Reg)
-							ctx.ProtectReg(d306.Reg2)
+						ctx.SyncDesc(&d311)
+						if d311.Loc == LocReg || d311.Loc == LocFPReg {
+							ctx.ProtectReg(d311.Reg)
+						} else if d311.Loc == LocRegPair {
+							ctx.ProtectReg(d311.Reg)
+							ctx.ProtectReg(d311.Reg2)
 						}
-						d307 = d306
-						if d307.Loc == LocNone {
+						d312 = d311
+						if d312.Loc == LocNone {
 							panic("jit: phi source has no location")
 						}
-						ctx.EnsureDesc(&d307)
-						ctx.EmitStoreToStack(d307, int32(bbs[7].PhiBase)+int32(0))
+						ctx.EnsureDesc(&d312)
+						ctx.EmitStoreToStack(d312, int32(bbs[7].PhiBase)+int32(0))
 						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[7].PhiBase)+int32(16))
-						if d306.Loc == LocReg {
-							ctx.UnprotectReg(d306.Reg)
-						} else if d306.Loc == LocRegPair {
-							ctx.UnprotectReg(d306.Reg)
-							ctx.UnprotectReg(d306.Reg2)
+						if d311.Loc == LocReg || d311.Loc == LocFPReg {
+							ctx.UnprotectReg(d311.Reg)
+						} else if d311.Loc == LocRegPair {
+							ctx.UnprotectReg(d311.Reg)
+							ctx.UnprotectReg(d311.Reg2)
 						}
 					}
-					ps308 := PhiState{General: ps.General}
-					ps308.OverlayValues = make([]JITValueDesc, 308)
-					ps308.OverlayValues[1] = d1
-					ps308.OverlayValues[2] = d2
-					ps308.OverlayValues[3] = d3
-					ps308.OverlayValues[4] = d4
-					ps308.OverlayValues[5] = d5
-					ps308.OverlayValues[6] = d6
-					ps308.OverlayValues[25] = d25
-					ps308.OverlayValues[26] = d26
-					ps308.OverlayValues[27] = d27
-					ps308.OverlayValues[28] = d28
-					ps308.OverlayValues[30] = d30
-					ps308.OverlayValues[31] = d31
-					ps308.OverlayValues[32] = d32
-					ps308.OverlayValues[33] = d33
-					ps308.OverlayValues[68] = d68
-					ps308.OverlayValues[69] = d69
-					ps308.OverlayValues[70] = d70
-					ps308.OverlayValues[71] = d71
-					ps308.OverlayValues[114] = d114
-					ps308.OverlayValues[115] = d115
-					ps308.OverlayValues[116] = d116
-					ps308.OverlayValues[117] = d117
-					ps308.OverlayValues[118] = d118
-					ps308.OverlayValues[171] = d171
-					ps308.OverlayValues[172] = d172
-					ps308.OverlayValues[173] = d173
-					ps308.OverlayValues[174] = d174
-					ps308.OverlayValues[175] = d175
-					ps308.OverlayValues[176] = d176
-					ps308.OverlayValues[177] = d177
-					ps308.OverlayValues[178] = d178
-					ps308.OverlayValues[179] = d179
-					ps308.OverlayValues[180] = d180
-					ps308.OverlayValues[181] = d181
-					ps308.OverlayValues[182] = d182
-					ps308.OverlayValues[183] = d183
-					ps308.OverlayValues[184] = d184
-					ps308.OverlayValues[185] = d185
-					ps308.OverlayValues[186] = d186
-					ps308.OverlayValues[187] = d187
-					ps308.OverlayValues[188] = d188
-					ps308.OverlayValues[189] = d189
-					ps308.OverlayValues[191] = d191
-					ps308.OverlayValues[192] = d192
-					ps308.OverlayValues[193] = d193
-					ps308.OverlayValues[194] = d194
-					ps308.OverlayValues[195] = d195
-					ps308.OverlayValues[196] = d196
-					ps308.OverlayValues[199] = d199
-					ps308.OverlayValues[200] = d200
-					ps308.OverlayValues[305] = d305
-					ps308.OverlayValues[306] = d306
-					ps308.OverlayValues[307] = d307
-					ps308.PhiValues = make([]JITValueDesc, 2)
-					d309 = d306
-					ps308.PhiValues[0] = d309
-					d310 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					ps308.PhiValues[1] = d310
-					if ps308.General && bbs[7].Rendered {
+					ps313 := PhiState{General: ps.General}
+					ps313.OverlayValues = make([]JITValueDesc, 313)
+					ps313.OverlayValues[1] = d1
+					ps313.OverlayValues[2] = d2
+					ps313.OverlayValues[3] = d3
+					ps313.OverlayValues[4] = d4
+					ps313.OverlayValues[5] = d5
+					ps313.OverlayValues[6] = d6
+					ps313.OverlayValues[25] = d25
+					ps313.OverlayValues[26] = d26
+					ps313.OverlayValues[27] = d27
+					ps313.OverlayValues[28] = d28
+					ps313.OverlayValues[30] = d30
+					ps313.OverlayValues[31] = d31
+					ps313.OverlayValues[32] = d32
+					ps313.OverlayValues[33] = d33
+					ps313.OverlayValues[68] = d68
+					ps313.OverlayValues[69] = d69
+					ps313.OverlayValues[70] = d70
+					ps313.OverlayValues[71] = d71
+					ps313.OverlayValues[114] = d114
+					ps313.OverlayValues[115] = d115
+					ps313.OverlayValues[116] = d116
+					ps313.OverlayValues[117] = d117
+					ps313.OverlayValues[118] = d118
+					ps313.OverlayValues[119] = d119
+					ps313.OverlayValues[174] = d174
+					ps313.OverlayValues[175] = d175
+					ps313.OverlayValues[176] = d176
+					ps313.OverlayValues[177] = d177
+					ps313.OverlayValues[178] = d178
+					ps313.OverlayValues[179] = d179
+					ps313.OverlayValues[180] = d180
+					ps313.OverlayValues[181] = d181
+					ps313.OverlayValues[182] = d182
+					ps313.OverlayValues[183] = d183
+					ps313.OverlayValues[184] = d184
+					ps313.OverlayValues[185] = d185
+					ps313.OverlayValues[186] = d186
+					ps313.OverlayValues[187] = d187
+					ps313.OverlayValues[188] = d188
+					ps313.OverlayValues[189] = d189
+					ps313.OverlayValues[190] = d190
+					ps313.OverlayValues[191] = d191
+					ps313.OverlayValues[192] = d192
+					ps313.OverlayValues[194] = d194
+					ps313.OverlayValues[195] = d195
+					ps313.OverlayValues[196] = d196
+					ps313.OverlayValues[197] = d197
+					ps313.OverlayValues[198] = d198
+					ps313.OverlayValues[199] = d199
+					ps313.OverlayValues[202] = d202
+					ps313.OverlayValues[203] = d203
+					ps313.OverlayValues[310] = d310
+					ps313.OverlayValues[311] = d311
+					ps313.OverlayValues[312] = d312
+					ps313.PhiValues = make([]JITValueDesc, 2)
+					d314 = d311
+					ps313.PhiValues[0] = d314
+					d315 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					ps313.PhiValues[1] = d315
+					if ps313.General && bbs[7].Rendered {
 						ctx.EmitJmp(lbl8)
 						return result
 					}
-					return bbs[7].RenderPS(ps308)
+					return bbs[7].RenderPS(ps313)
 					return result
 				}
 				bbs[9].RenderPS = func(ps PhiState) JITValueDesc {
@@ -12520,14 +12592,8 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
 						d118 = ps.OverlayValues[118]
 					}
-					if len(ps.OverlayValues) > 171 && ps.OverlayValues[171].Loc != LocNone {
-						d171 = ps.OverlayValues[171]
-					}
-					if len(ps.OverlayValues) > 172 && ps.OverlayValues[172].Loc != LocNone {
-						d172 = ps.OverlayValues[172]
-					}
-					if len(ps.OverlayValues) > 173 && ps.OverlayValues[173].Loc != LocNone {
-						d173 = ps.OverlayValues[173]
+					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+						d119 = ps.OverlayValues[119]
 					}
 					if len(ps.OverlayValues) > 174 && ps.OverlayValues[174].Loc != LocNone {
 						d174 = ps.OverlayValues[174]
@@ -12577,14 +12643,14 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 189 && ps.OverlayValues[189].Loc != LocNone {
 						d189 = ps.OverlayValues[189]
 					}
+					if len(ps.OverlayValues) > 190 && ps.OverlayValues[190].Loc != LocNone {
+						d190 = ps.OverlayValues[190]
+					}
 					if len(ps.OverlayValues) > 191 && ps.OverlayValues[191].Loc != LocNone {
 						d191 = ps.OverlayValues[191]
 					}
 					if len(ps.OverlayValues) > 192 && ps.OverlayValues[192].Loc != LocNone {
 						d192 = ps.OverlayValues[192]
-					}
-					if len(ps.OverlayValues) > 193 && ps.OverlayValues[193].Loc != LocNone {
-						d193 = ps.OverlayValues[193]
 					}
 					if len(ps.OverlayValues) > 194 && ps.OverlayValues[194].Loc != LocNone {
 						d194 = ps.OverlayValues[194]
@@ -12595,198 +12661,207 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 196 && ps.OverlayValues[196].Loc != LocNone {
 						d196 = ps.OverlayValues[196]
 					}
+					if len(ps.OverlayValues) > 197 && ps.OverlayValues[197].Loc != LocNone {
+						d197 = ps.OverlayValues[197]
+					}
+					if len(ps.OverlayValues) > 198 && ps.OverlayValues[198].Loc != LocNone {
+						d198 = ps.OverlayValues[198]
+					}
 					if len(ps.OverlayValues) > 199 && ps.OverlayValues[199].Loc != LocNone {
 						d199 = ps.OverlayValues[199]
 					}
-					if len(ps.OverlayValues) > 200 && ps.OverlayValues[200].Loc != LocNone {
-						d200 = ps.OverlayValues[200]
+					if len(ps.OverlayValues) > 202 && ps.OverlayValues[202].Loc != LocNone {
+						d202 = ps.OverlayValues[202]
 					}
-					if len(ps.OverlayValues) > 305 && ps.OverlayValues[305].Loc != LocNone {
-						d305 = ps.OverlayValues[305]
-					}
-					if len(ps.OverlayValues) > 306 && ps.OverlayValues[306].Loc != LocNone {
-						d306 = ps.OverlayValues[306]
-					}
-					if len(ps.OverlayValues) > 307 && ps.OverlayValues[307].Loc != LocNone {
-						d307 = ps.OverlayValues[307]
-					}
-					if len(ps.OverlayValues) > 309 && ps.OverlayValues[309].Loc != LocNone {
-						d309 = ps.OverlayValues[309]
+					if len(ps.OverlayValues) > 203 && ps.OverlayValues[203].Loc != LocNone {
+						d203 = ps.OverlayValues[203]
 					}
 					if len(ps.OverlayValues) > 310 && ps.OverlayValues[310].Loc != LocNone {
 						d310 = ps.OverlayValues[310]
+					}
+					if len(ps.OverlayValues) > 311 && ps.OverlayValues[311].Loc != LocNone {
+						d311 = ps.OverlayValues[311]
+					}
+					if len(ps.OverlayValues) > 312 && ps.OverlayValues[312].Loc != LocNone {
+						d312 = ps.OverlayValues[312]
+					}
+					if len(ps.OverlayValues) > 314 && ps.OverlayValues[314].Loc != LocNone {
+						d314 = ps.OverlayValues[314]
+					}
+					if len(ps.OverlayValues) > 315 && ps.OverlayValues[315].Loc != LocNone {
+						d315 = ps.OverlayValues[315]
 					}
 					ctx.ReclaimUntrackedRegs()
 					if d1.Loc == LocRegPair || d1.Loc == LocStackPair || d1.Loc == LocRegTriple || d1.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					d311 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					if d311.Loc == LocRegPair || d311.Loc == LocStackPair || d311.Loc == LocRegTriple || d311.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
-					}
-					ctx.SyncDesc(&d1)
-					ctx.SyncDesc(&d311)
-					d312 = ctx.EmitGoCallScalar(GoFuncAddr(time.Unix), []JITValueDesc{d1, d311}, 3)
-					d312.NoHeapPointer = false
-					ctx.BindReg(d312.Reg, &d312)
-					ctx.BindReg(d312.Reg2, &d312)
-					ctx.BindReg(d312.Reg3, &d312)
-					ctx.FreeDesc(&d311)
-					d312 = JITPrepareGoSliceArg(ctx, d312)
-					if d312.Loc != LocRegTriple && d312.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).UTC arg0)")
-					}
-					ctx.SyncDesc(&d312)
-					d313 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).UTC), []JITValueDesc{d312}, 3)
-					d313.NoHeapPointer = false
-					ctx.BindReg(d313.Reg, &d313)
-					ctx.BindReg(d313.Reg2, &d313)
-					ctx.BindReg(d313.Reg3, &d313)
-					ctx.FreeDesc(&d312)
-					d313 = JITPrepareGoSliceArg(ctx, d313)
-					if d313.Loc != LocRegTriple && d313.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Year arg0)")
-					}
-					ctx.SyncDesc(&d313)
-					d314 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Year), []JITValueDesc{d313}, 1)
-					d314.NoHeapPointer = true
-					ctx.BindReg(d314.Reg, &d314)
-					d313 = JITPrepareGoSliceArg(ctx, d313)
-					if d313.Loc != LocRegTriple && d313.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
-					}
-					ctx.SyncDesc(&d313)
-					d315 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d313}, 1)
-					d315.NoHeapPointer = true
-					ctx.BindReg(d315.Reg, &d315)
-					d313 = JITPrepareGoSliceArg(ctx, d313)
-					if d313.Loc != LocRegTriple && d313.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
-					}
-					ctx.SyncDesc(&d313)
-					d316 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d313}, 1)
-					d316.NoHeapPointer = true
-					ctx.BindReg(d316.Reg, &d316)
-					d313 = JITPrepareGoSliceArg(ctx, d313)
-					if d313.Loc != LocRegTriple && d313.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Hour arg0)")
-					}
-					ctx.SyncDesc(&d313)
-					d317 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Hour), []JITValueDesc{d313}, 1)
-					d317.NoHeapPointer = true
-					ctx.BindReg(d317.Reg, &d317)
-					d313 = JITPrepareGoSliceArg(ctx, d313)
-					if d313.Loc != LocRegTriple && d313.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Minute arg0)")
-					}
-					ctx.SyncDesc(&d313)
-					d318 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Minute), []JITValueDesc{d313}, 1)
-					d318.NoHeapPointer = true
-					ctx.BindReg(d318.Reg, &d318)
-					d313 = JITPrepareGoSliceArg(ctx, d313)
-					if d313.Loc != LocRegTriple && d313.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Second arg0)")
-					}
-					ctx.SyncDesc(&d313)
-					d319 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Second), []JITValueDesc{d313}, 1)
-					d319.NoHeapPointer = true
-					ctx.BindReg(d319.Reg, &d319)
-					ctx.FreeDesc(&d313)
-					if d314.Loc == LocRegPair || d314.Loc == LocStackPair || d314.Loc == LocRegTriple || d314.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
-					}
-					if d315.Loc == LocRegPair || d315.Loc == LocStackPair || d315.Loc == LocRegTriple || d315.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
-					}
+					d316 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
 					if d316.Loc == LocRegPair || d316.Loc == LocStackPair || d316.Loc == LocRegTriple || d316.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					if d317.Loc == LocRegPair || d317.Loc == LocStackPair || d317.Loc == LocRegTriple || d317.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d1)
+					ctx.SyncDesc(&d316)
+					d317 = ctx.EmitGoCallScalar(GoFuncAddr(time.Unix), []JITValueDesc{d1, d316}, 3)
+					d317.NoHeapPointer = false
+					ctx.BindReg(d317.Reg, &d317)
+					ctx.BindReg(d317.Reg2, &d317)
+					ctx.BindReg(d317.Reg3, &d317)
+					ctx.FreeDesc(&d316)
+					d317 = JITPrepareGoSliceArg(ctx, d317)
+					if d317.Loc != LocRegTriple && d317.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).UTC arg0)")
 					}
-					if d318.Loc == LocRegPair || d318.Loc == LocStackPair || d318.Loc == LocRegTriple || d318.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d317)
+					d318 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).UTC), []JITValueDesc{d317}, 3)
+					d318.NoHeapPointer = false
+					ctx.BindReg(d318.Reg, &d318)
+					ctx.BindReg(d318.Reg2, &d318)
+					ctx.BindReg(d318.Reg3, &d318)
+					ctx.FreeDesc(&d317)
+					d318 = JITPrepareGoSliceArg(ctx, d318)
+					if d318.Loc != LocRegTriple && d318.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Year arg0)")
 					}
+					ctx.SyncDesc(&d318)
+					d319 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Year), []JITValueDesc{d318}, 1)
+					d319.NoHeapPointer = true
+					ctx.BindReg(d319.Reg, &d319)
+					d318 = JITPrepareGoSliceArg(ctx, d318)
+					if d318.Loc != LocRegTriple && d318.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
+					}
+					ctx.SyncDesc(&d318)
+					d320 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d318}, 1)
+					d320.NoHeapPointer = true
+					ctx.BindReg(d320.Reg, &d320)
+					d318 = JITPrepareGoSliceArg(ctx, d318)
+					if d318.Loc != LocRegTriple && d318.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
+					}
+					ctx.SyncDesc(&d318)
+					d321 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d318}, 1)
+					d321.NoHeapPointer = true
+					ctx.BindReg(d321.Reg, &d321)
+					d318 = JITPrepareGoSliceArg(ctx, d318)
+					if d318.Loc != LocRegTriple && d318.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Hour arg0)")
+					}
+					ctx.SyncDesc(&d318)
+					d322 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Hour), []JITValueDesc{d318}, 1)
+					d322.NoHeapPointer = true
+					ctx.BindReg(d322.Reg, &d322)
+					d318 = JITPrepareGoSliceArg(ctx, d318)
+					if d318.Loc != LocRegTriple && d318.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Minute arg0)")
+					}
+					ctx.SyncDesc(&d318)
+					d323 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Minute), []JITValueDesc{d318}, 1)
+					d323.NoHeapPointer = true
+					ctx.BindReg(d323.Reg, &d323)
+					d318 = JITPrepareGoSliceArg(ctx, d318)
+					if d318.Loc != LocRegTriple && d318.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Second arg0)")
+					}
+					ctx.SyncDesc(&d318)
+					d324 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Second), []JITValueDesc{d318}, 1)
+					d324.NoHeapPointer = true
+					ctx.BindReg(d324.Reg, &d324)
+					ctx.FreeDesc(&d318)
 					if d319.Loc == LocRegPair || d319.Loc == LocStackPair || d319.Loc == LocRegTriple || d319.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					d320 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
 					if d320.Loc == LocRegPair || d320.Loc == LocStackPair || d320.Loc == LocRegTriple || d320.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					if d321.Loc == LocRegPair || d321.Loc == LocStackPair || d321.Loc == LocRegTriple || d321.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					if d322.Loc == LocRegPair || d322.Loc == LocStackPair || d322.Loc == LocRegTriple || d322.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					if d323.Loc == LocRegPair || d323.Loc == LocStackPair || d323.Loc == LocRegTriple || d323.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					if d324.Loc == LocRegPair || d324.Loc == LocStackPair || d324.Loc == LocRegTriple || d324.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					d325 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					if d325.Loc == LocRegPair || d325.Loc == LocStackPair || d325.Loc == LocRegTriple || d325.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
 					if d30.Loc == LocRegPair || d30.Loc == LocStackPair || d30.Loc == LocRegTriple || d30.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d314)
-					ctx.SyncDesc(&d315)
-					ctx.SyncDesc(&d316)
-					ctx.SyncDesc(&d317)
-					ctx.SyncDesc(&d318)
 					ctx.SyncDesc(&d319)
 					ctx.SyncDesc(&d320)
+					ctx.SyncDesc(&d321)
+					ctx.SyncDesc(&d322)
+					ctx.SyncDesc(&d323)
+					ctx.SyncDesc(&d324)
+					ctx.SyncDesc(&d325)
 					ctx.SyncDesc(&d30)
-					d321 = ctx.EmitGoCallScalar(GoFuncAddr(time.Date), []JITValueDesc{d314, d315, d316, d317, d318, d319, d320, d30}, 3)
-					d321.NoHeapPointer = false
-					ctx.BindReg(d321.Reg, &d321)
-					ctx.BindReg(d321.Reg2, &d321)
-					ctx.BindReg(d321.Reg3, &d321)
-					ctx.FreeDesc(&d320)
-					ctx.FreeDesc(&d314)
-					ctx.FreeDesc(&d315)
-					ctx.FreeDesc(&d316)
-					ctx.FreeDesc(&d317)
-					ctx.FreeDesc(&d318)
+					d326 = ctx.EmitGoCallScalar(GoFuncAddr(time.Date), []JITValueDesc{d319, d320, d321, d322, d323, d324, d325, d30}, 3)
+					d326.NoHeapPointer = false
+					ctx.BindReg(d326.Reg, &d326)
+					ctx.BindReg(d326.Reg2, &d326)
+					ctx.BindReg(d326.Reg3, &d326)
+					ctx.FreeDesc(&d325)
 					ctx.FreeDesc(&d319)
-					d321 = JITPrepareGoSliceArg(ctx, d321)
-					if d321.Loc != LocRegTriple && d321.Loc != LocStackTriple {
+					ctx.FreeDesc(&d320)
+					ctx.FreeDesc(&d321)
+					ctx.FreeDesc(&d322)
+					ctx.FreeDesc(&d323)
+					ctx.FreeDesc(&d324)
+					d326 = JITPrepareGoSliceArg(ctx, d326)
+					if d326.Loc != LocRegTriple && d326.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).UTC arg0)")
 					}
-					ctx.SyncDesc(&d321)
-					d322 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).UTC), []JITValueDesc{d321}, 3)
-					d322.NoHeapPointer = false
-					ctx.BindReg(d322.Reg, &d322)
-					ctx.BindReg(d322.Reg2, &d322)
-					ctx.BindReg(d322.Reg3, &d322)
-					ctx.FreeDesc(&d321)
-					d322 = JITPrepareGoSliceArg(ctx, d322)
-					if d322.Loc != LocRegTriple && d322.Loc != LocStackTriple {
+					ctx.SyncDesc(&d326)
+					d327 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).UTC), []JITValueDesc{d326}, 3)
+					d327.NoHeapPointer = false
+					ctx.BindReg(d327.Reg, &d327)
+					ctx.BindReg(d327.Reg2, &d327)
+					ctx.BindReg(d327.Reg3, &d327)
+					ctx.FreeDesc(&d326)
+					d327 = JITPrepareGoSliceArg(ctx, d327)
+					if d327.Loc != LocRegTriple && d327.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Unix arg0)")
 					}
-					ctx.SyncDesc(&d322)
-					d323 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Unix), []JITValueDesc{d322}, 1)
-					d323.NoHeapPointer = true
-					ctx.BindReg(d323.Reg, &d323)
-					ctx.FreeDesc(&d322)
-					if d323.Loc == LocRegPair || d323.Loc == LocStackPair || d323.Loc == LocRegTriple || d323.Loc == LocStackTriple {
+					ctx.SyncDesc(&d327)
+					d328 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Unix), []JITValueDesc{d327}, 1)
+					d328.NoHeapPointer = true
+					ctx.BindReg(d328.Reg, &d328)
+					ctx.FreeDesc(&d327)
+					if d328.Loc == LocRegPair || d328.Loc == LocStackPair || d328.Loc == LocRegTriple || d328.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d323)
-					d324 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d323}, 2)
-					d324.NoHeapPointer = false
-					ctx.BindReg(d324.Reg, &d324)
-					ctx.BindReg(d324.Reg2, &d324)
-					ctx.FreeDesc(&d323)
-					ctx.SyncDesc(&d324)
-					if d324.Loc == LocRegPair || d324.Loc == LocStackPair || d324.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d324, &result)
-						result.Type = d324.Type
+					ctx.SyncDesc(&d328)
+					d329 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d328}, 2)
+					d329.NoHeapPointer = false
+					ctx.BindReg(d329.Reg, &d329)
+					ctx.BindReg(d329.Reg2, &d329)
+					ctx.FreeDesc(&d328)
+					ctx.SyncDesc(&d329)
+					if d329.Loc == LocRegPair || d329.Loc == LocStackPair || d329.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d329, &result)
+						result.Type = d329.Type
 					} else {
-						switch d324.Type {
+						switch d329.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d324)
+							ctx.EmitMakeBool(result, d329)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d324)
+							ctx.EmitMakeInt(result, d329)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d324)
+							ctx.EmitMakeFloat(result, d329)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d324, &result)
-							result.Type = d324.Type
+							ctx.EmitMovPairToResult(&d329, &result)
+							result.Type = d329.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
@@ -12882,14 +12957,8 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 118 && ps.OverlayValues[118].Loc != LocNone {
 						d118 = ps.OverlayValues[118]
 					}
-					if len(ps.OverlayValues) > 171 && ps.OverlayValues[171].Loc != LocNone {
-						d171 = ps.OverlayValues[171]
-					}
-					if len(ps.OverlayValues) > 172 && ps.OverlayValues[172].Loc != LocNone {
-						d172 = ps.OverlayValues[172]
-					}
-					if len(ps.OverlayValues) > 173 && ps.OverlayValues[173].Loc != LocNone {
-						d173 = ps.OverlayValues[173]
+					if len(ps.OverlayValues) > 119 && ps.OverlayValues[119].Loc != LocNone {
+						d119 = ps.OverlayValues[119]
 					}
 					if len(ps.OverlayValues) > 174 && ps.OverlayValues[174].Loc != LocNone {
 						d174 = ps.OverlayValues[174]
@@ -12939,14 +13008,14 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 189 && ps.OverlayValues[189].Loc != LocNone {
 						d189 = ps.OverlayValues[189]
 					}
+					if len(ps.OverlayValues) > 190 && ps.OverlayValues[190].Loc != LocNone {
+						d190 = ps.OverlayValues[190]
+					}
 					if len(ps.OverlayValues) > 191 && ps.OverlayValues[191].Loc != LocNone {
 						d191 = ps.OverlayValues[191]
 					}
 					if len(ps.OverlayValues) > 192 && ps.OverlayValues[192].Loc != LocNone {
 						d192 = ps.OverlayValues[192]
-					}
-					if len(ps.OverlayValues) > 193 && ps.OverlayValues[193].Loc != LocNone {
-						d193 = ps.OverlayValues[193]
 					}
 					if len(ps.OverlayValues) > 194 && ps.OverlayValues[194].Loc != LocNone {
 						d194 = ps.OverlayValues[194]
@@ -12957,23 +13026,20 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 196 && ps.OverlayValues[196].Loc != LocNone {
 						d196 = ps.OverlayValues[196]
 					}
+					if len(ps.OverlayValues) > 197 && ps.OverlayValues[197].Loc != LocNone {
+						d197 = ps.OverlayValues[197]
+					}
+					if len(ps.OverlayValues) > 198 && ps.OverlayValues[198].Loc != LocNone {
+						d198 = ps.OverlayValues[198]
+					}
 					if len(ps.OverlayValues) > 199 && ps.OverlayValues[199].Loc != LocNone {
 						d199 = ps.OverlayValues[199]
 					}
-					if len(ps.OverlayValues) > 200 && ps.OverlayValues[200].Loc != LocNone {
-						d200 = ps.OverlayValues[200]
+					if len(ps.OverlayValues) > 202 && ps.OverlayValues[202].Loc != LocNone {
+						d202 = ps.OverlayValues[202]
 					}
-					if len(ps.OverlayValues) > 305 && ps.OverlayValues[305].Loc != LocNone {
-						d305 = ps.OverlayValues[305]
-					}
-					if len(ps.OverlayValues) > 306 && ps.OverlayValues[306].Loc != LocNone {
-						d306 = ps.OverlayValues[306]
-					}
-					if len(ps.OverlayValues) > 307 && ps.OverlayValues[307].Loc != LocNone {
-						d307 = ps.OverlayValues[307]
-					}
-					if len(ps.OverlayValues) > 309 && ps.OverlayValues[309].Loc != LocNone {
-						d309 = ps.OverlayValues[309]
+					if len(ps.OverlayValues) > 203 && ps.OverlayValues[203].Loc != LocNone {
+						d203 = ps.OverlayValues[203]
 					}
 					if len(ps.OverlayValues) > 310 && ps.OverlayValues[310].Loc != LocNone {
 						d310 = ps.OverlayValues[310]
@@ -12983,9 +13049,6 @@ func init_timezone() {
 					}
 					if len(ps.OverlayValues) > 312 && ps.OverlayValues[312].Loc != LocNone {
 						d312 = ps.OverlayValues[312]
-					}
-					if len(ps.OverlayValues) > 313 && ps.OverlayValues[313].Loc != LocNone {
-						d313 = ps.OverlayValues[313]
 					}
 					if len(ps.OverlayValues) > 314 && ps.OverlayValues[314].Loc != LocNone {
 						d314 = ps.OverlayValues[314]
@@ -13020,179 +13083,194 @@ func init_timezone() {
 					if len(ps.OverlayValues) > 324 && ps.OverlayValues[324].Loc != LocNone {
 						d324 = ps.OverlayValues[324]
 					}
+					if len(ps.OverlayValues) > 325 && ps.OverlayValues[325].Loc != LocNone {
+						d325 = ps.OverlayValues[325]
+					}
+					if len(ps.OverlayValues) > 326 && ps.OverlayValues[326].Loc != LocNone {
+						d326 = ps.OverlayValues[326]
+					}
+					if len(ps.OverlayValues) > 327 && ps.OverlayValues[327].Loc != LocNone {
+						d327 = ps.OverlayValues[327]
+					}
+					if len(ps.OverlayValues) > 328 && ps.OverlayValues[328].Loc != LocNone {
+						d328 = ps.OverlayValues[328]
+					}
+					if len(ps.OverlayValues) > 329 && ps.OverlayValues[329].Loc != LocNone {
+						d329 = ps.OverlayValues[329]
+					}
 					ctx.ReclaimUntrackedRegs()
 					if d1.Loc == LocRegPair || d1.Loc == LocStackPair || d1.Loc == LocRegTriple || d1.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					d325 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					if d325.Loc == LocRegPair || d325.Loc == LocStackPair || d325.Loc == LocRegTriple || d325.Loc == LocStackTriple {
+					d330 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					if d330.Loc == LocRegPair || d330.Loc == LocStackPair || d330.Loc == LocRegTriple || d330.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
 					ctx.SyncDesc(&d1)
-					ctx.SyncDesc(&d325)
-					d326 = ctx.EmitGoCallScalar(GoFuncAddr(time.Unix), []JITValueDesc{d1, d325}, 3)
-					d326.NoHeapPointer = false
-					ctx.BindReg(d326.Reg, &d326)
-					ctx.BindReg(d326.Reg2, &d326)
-					ctx.BindReg(d326.Reg3, &d326)
-					ctx.FreeDesc(&d325)
-					d326 = JITPrepareGoSliceArg(ctx, d326)
-					if d326.Loc != LocRegTriple && d326.Loc != LocStackTriple {
+					ctx.SyncDesc(&d330)
+					d331 = ctx.EmitGoCallScalar(GoFuncAddr(time.Unix), []JITValueDesc{d1, d330}, 3)
+					d331.NoHeapPointer = false
+					ctx.BindReg(d331.Reg, &d331)
+					ctx.BindReg(d331.Reg2, &d331)
+					ctx.BindReg(d331.Reg3, &d331)
+					ctx.FreeDesc(&d330)
+					d331 = JITPrepareGoSliceArg(ctx, d331)
+					if d331.Loc != LocRegTriple && d331.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).In arg0)")
 					}
 					if d30.Loc == LocRegPair || d30.Loc == LocStackPair || d30.Loc == LocRegTriple || d30.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d326)
+					ctx.SyncDesc(&d331)
 					ctx.SyncDesc(&d30)
-					d327 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).In), []JITValueDesc{d326, d30}, 3)
-					d327.NoHeapPointer = false
-					ctx.BindReg(d327.Reg, &d327)
-					ctx.BindReg(d327.Reg2, &d327)
-					ctx.BindReg(d327.Reg3, &d327)
-					ctx.FreeDesc(&d326)
-					d327 = JITPrepareGoSliceArg(ctx, d327)
-					if d327.Loc != LocRegTriple && d327.Loc != LocStackTriple {
+					d332 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).In), []JITValueDesc{d331, d30}, 3)
+					d332.NoHeapPointer = false
+					ctx.BindReg(d332.Reg, &d332)
+					ctx.BindReg(d332.Reg2, &d332)
+					ctx.BindReg(d332.Reg3, &d332)
+					ctx.FreeDesc(&d331)
+					d332 = JITPrepareGoSliceArg(ctx, d332)
+					if d332.Loc != LocRegTriple && d332.Loc != LocStackTriple {
 						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Year arg0)")
 					}
-					ctx.SyncDesc(&d327)
-					d328 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Year), []JITValueDesc{d327}, 1)
-					d328.NoHeapPointer = true
-					ctx.BindReg(d328.Reg, &d328)
-					d327 = JITPrepareGoSliceArg(ctx, d327)
-					if d327.Loc != LocRegTriple && d327.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
-					}
-					ctx.SyncDesc(&d327)
-					d329 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d327}, 1)
-					d329.NoHeapPointer = true
-					ctx.BindReg(d329.Reg, &d329)
-					d327 = JITPrepareGoSliceArg(ctx, d327)
-					if d327.Loc != LocRegTriple && d327.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
-					}
-					ctx.SyncDesc(&d327)
-					d330 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d327}, 1)
-					d330.NoHeapPointer = true
-					ctx.BindReg(d330.Reg, &d330)
-					d327 = JITPrepareGoSliceArg(ctx, d327)
-					if d327.Loc != LocRegTriple && d327.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Hour arg0)")
-					}
-					ctx.SyncDesc(&d327)
-					d331 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Hour), []JITValueDesc{d327}, 1)
-					d331.NoHeapPointer = true
-					ctx.BindReg(d331.Reg, &d331)
-					d327 = JITPrepareGoSliceArg(ctx, d327)
-					if d327.Loc != LocRegTriple && d327.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Minute arg0)")
-					}
-					ctx.SyncDesc(&d327)
-					d332 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Minute), []JITValueDesc{d327}, 1)
-					d332.NoHeapPointer = true
-					ctx.BindReg(d332.Reg, &d332)
-					d327 = JITPrepareGoSliceArg(ctx, d327)
-					if d327.Loc != LocRegTriple && d327.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Second arg0)")
-					}
-					ctx.SyncDesc(&d327)
-					d333 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Second), []JITValueDesc{d327}, 1)
+					ctx.SyncDesc(&d332)
+					d333 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Year), []JITValueDesc{d332}, 1)
 					d333.NoHeapPointer = true
 					ctx.BindReg(d333.Reg, &d333)
-					ctx.FreeDesc(&d327)
-					d334 = ctx.EmitGoCallScalar(GoFuncAddr(func() *time.Location { return time.UTC }), nil, 1)
-					if d328.Loc == LocRegPair || d328.Loc == LocStackPair || d328.Loc == LocRegTriple || d328.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					d332 = JITPrepareGoSliceArg(ctx, d332)
+					if d332.Loc != LocRegTriple && d332.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Month arg0)")
 					}
-					if d329.Loc == LocRegPair || d329.Loc == LocStackPair || d329.Loc == LocRegTriple || d329.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d332)
+					d334 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Month), []JITValueDesc{d332}, 1)
+					d334.NoHeapPointer = true
+					ctx.BindReg(d334.Reg, &d334)
+					d332 = JITPrepareGoSliceArg(ctx, d332)
+					if d332.Loc != LocRegTriple && d332.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Day arg0)")
 					}
-					if d330.Loc == LocRegPair || d330.Loc == LocStackPair || d330.Loc == LocRegTriple || d330.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d332)
+					d335 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Day), []JITValueDesc{d332}, 1)
+					d335.NoHeapPointer = true
+					ctx.BindReg(d335.Reg, &d335)
+					d332 = JITPrepareGoSliceArg(ctx, d332)
+					if d332.Loc != LocRegTriple && d332.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Hour arg0)")
 					}
-					if d331.Loc == LocRegPair || d331.Loc == LocStackPair || d331.Loc == LocRegTriple || d331.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d332)
+					d336 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Hour), []JITValueDesc{d332}, 1)
+					d336.NoHeapPointer = true
+					ctx.BindReg(d336.Reg, &d336)
+					d332 = JITPrepareGoSliceArg(ctx, d332)
+					if d332.Loc != LocRegTriple && d332.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Minute arg0)")
 					}
-					if d332.Loc == LocRegPair || d332.Loc == LocStackPair || d332.Loc == LocRegTriple || d332.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
+					ctx.SyncDesc(&d332)
+					d337 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Minute), []JITValueDesc{d332}, 1)
+					d337.NoHeapPointer = true
+					ctx.BindReg(d337.Reg, &d337)
+					d332 = JITPrepareGoSliceArg(ctx, d332)
+					if d332.Loc != LocRegTriple && d332.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Second arg0)")
 					}
+					ctx.SyncDesc(&d332)
+					d338 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Second), []JITValueDesc{d332}, 1)
+					d338.NoHeapPointer = true
+					ctx.BindReg(d338.Reg, &d338)
+					ctx.FreeDesc(&d332)
+					d339 = ctx.EmitGoCallScalar(GoFuncAddr(func() *time.Location { return time.UTC }), nil, 1)
 					if d333.Loc == LocRegPair || d333.Loc == LocStackPair || d333.Loc == LocRegTriple || d333.Loc == LocStackTriple {
-						panic("jit: generic call arg expects 1-word value")
-					}
-					d335 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-					if d335.Loc == LocRegPair || d335.Loc == LocStackPair || d335.Loc == LocRegTriple || d335.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
 					if d334.Loc == LocRegPair || d334.Loc == LocStackPair || d334.Loc == LocRegTriple || d334.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d328)
-					ctx.SyncDesc(&d329)
-					ctx.SyncDesc(&d330)
-					ctx.SyncDesc(&d331)
-					ctx.SyncDesc(&d332)
-					ctx.SyncDesc(&d333)
-					ctx.SyncDesc(&d335)
-					ctx.SyncDesc(&d334)
-					d336 = ctx.EmitGoCallScalar(GoFuncAddr(time.Date), []JITValueDesc{d328, d329, d330, d331, d332, d333, d335, d334}, 3)
-					d336.NoHeapPointer = false
-					ctx.BindReg(d336.Reg, &d336)
-					ctx.BindReg(d336.Reg2, &d336)
-					ctx.BindReg(d336.Reg3, &d336)
-					ctx.FreeDesc(&d335)
-					ctx.FreeDesc(&d328)
-					ctx.FreeDesc(&d329)
-					ctx.FreeDesc(&d330)
-					ctx.FreeDesc(&d331)
-					ctx.FreeDesc(&d332)
-					ctx.FreeDesc(&d333)
-					ctx.FreeDesc(&d334)
-					d336 = JITPrepareGoSliceArg(ctx, d336)
-					if d336.Loc != LocRegTriple && d336.Loc != LocStackTriple {
-						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Unix arg0)")
+					if d335.Loc == LocRegPair || d335.Loc == LocStackPair || d335.Loc == LocRegTriple || d335.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
 					}
-					ctx.SyncDesc(&d336)
-					d337 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Unix), []JITValueDesc{d336}, 1)
-					d337.NoHeapPointer = true
-					ctx.BindReg(d337.Reg, &d337)
-					ctx.FreeDesc(&d336)
+					if d336.Loc == LocRegPair || d336.Loc == LocStackPair || d336.Loc == LocRegTriple || d336.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
 					if d337.Loc == LocRegPair || d337.Loc == LocStackPair || d337.Loc == LocRegTriple || d337.Loc == LocStackTriple {
 						panic("jit: generic call arg expects 1-word value")
 					}
+					if d338.Loc == LocRegPair || d338.Loc == LocStackPair || d338.Loc == LocRegTriple || d338.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					d340 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					if d340.Loc == LocRegPair || d340.Loc == LocStackPair || d340.Loc == LocRegTriple || d340.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					if d339.Loc == LocRegPair || d339.Loc == LocStackPair || d339.Loc == LocRegTriple || d339.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					ctx.SyncDesc(&d333)
+					ctx.SyncDesc(&d334)
+					ctx.SyncDesc(&d335)
+					ctx.SyncDesc(&d336)
 					ctx.SyncDesc(&d337)
-					d338 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d337}, 2)
-					d338.NoHeapPointer = false
-					ctx.BindReg(d338.Reg, &d338)
-					ctx.BindReg(d338.Reg2, &d338)
-					ctx.FreeDesc(&d337)
 					ctx.SyncDesc(&d338)
-					if d338.Loc == LocRegPair || d338.Loc == LocStackPair || d338.Loc == LocInputPair {
-						ctx.EmitMovPairToResult(&d338, &result)
-						result.Type = d338.Type
+					ctx.SyncDesc(&d340)
+					ctx.SyncDesc(&d339)
+					d341 = ctx.EmitGoCallScalar(GoFuncAddr(time.Date), []JITValueDesc{d333, d334, d335, d336, d337, d338, d340, d339}, 3)
+					d341.NoHeapPointer = false
+					ctx.BindReg(d341.Reg, &d341)
+					ctx.BindReg(d341.Reg2, &d341)
+					ctx.BindReg(d341.Reg3, &d341)
+					ctx.FreeDesc(&d340)
+					ctx.FreeDesc(&d333)
+					ctx.FreeDesc(&d334)
+					ctx.FreeDesc(&d335)
+					ctx.FreeDesc(&d336)
+					ctx.FreeDesc(&d337)
+					ctx.FreeDesc(&d338)
+					ctx.FreeDesc(&d339)
+					d341 = JITPrepareGoSliceArg(ctx, d341)
+					if d341.Loc != LocRegTriple && d341.Loc != LocStackTriple {
+						panic("jit: generic call arg expects 3-word Go slice ((time.Time).Unix arg0)")
+					}
+					ctx.SyncDesc(&d341)
+					d342 = ctx.EmitGoCallScalar(GoFuncAddr((time.Time).Unix), []JITValueDesc{d341}, 1)
+					d342.NoHeapPointer = true
+					ctx.BindReg(d342.Reg, &d342)
+					ctx.FreeDesc(&d341)
+					if d342.Loc == LocRegPair || d342.Loc == LocStackPair || d342.Loc == LocRegTriple || d342.Loc == LocStackTriple {
+						panic("jit: generic call arg expects 1-word value")
+					}
+					ctx.SyncDesc(&d342)
+					d343 = ctx.EmitGoCallScalar(GoFuncAddr(NewDate), []JITValueDesc{d342}, 2)
+					d343.NoHeapPointer = false
+					ctx.BindReg(d343.Reg, &d343)
+					ctx.BindReg(d343.Reg2, &d343)
+					ctx.FreeDesc(&d342)
+					ctx.SyncDesc(&d343)
+					if d343.Loc == LocRegPair || d343.Loc == LocStackPair || d343.Loc == LocInputPair {
+						ctx.EmitMovPairToResult(&d343, &result)
+						result.Type = d343.Type
 					} else {
-						switch d338.Type {
+						switch d343.Type {
 						case tagBool:
-							ctx.EmitMakeBool(result, d338)
+							ctx.EmitMakeBool(result, d343)
 							result.Type = tagBool
 						case tagInt:
-							ctx.EmitMakeInt(result, d338)
+							ctx.EmitMakeInt(result, d343)
 							result.Type = tagInt
 						case tagFloat:
-							ctx.EmitMakeFloat(result, d338)
+							ctx.EmitMakeFloat(result, d343)
 							result.Type = tagFloat
 						case tagNil:
 							ctx.EmitMakeNil(result)
 							result.Type = tagNil
 						default:
-							ctx.EmitMovPairToResult(&d338, &result)
-							result.Type = d338.Type
+							ctx.EmitMovPairToResult(&d343, &result)
+							result.Type = d343.Type
 						}
 					}
 					ctx.EmitJmp(lbl0)
 					return result
 				}
-				ps339 := PhiState{General: false}
-				_ = bbs[0].RenderPS(ps339)
+				ps344 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps344)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
 				if resultRegsProtected {
@@ -15283,8 +15361,9 @@ func init_timezone() {
 					if d229.Loc == LocImm {
 						d231 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d229.Imm.Int()))}
 					} else {
-						r1 := ctx.AllocRegExcept(d229.Reg)
-						ctx.EmitMovRegReg(r1, d229.Reg)
+						var r1 Reg
+						r1 = d229.Reg
+						d229.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r1)
 						d231 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r1}
 						ctx.BindReg(r1, &d231)
@@ -15297,8 +15376,9 @@ func init_timezone() {
 					if d230.Loc == LocImm {
 						d232 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d230.Imm.Int()))}
 					} else {
-						r2 := ctx.AllocRegExcept(d230.Reg)
-						ctx.EmitMovRegReg(r2, d230.Reg)
+						var r2 Reg
+						r2 = d230.Reg
+						d230.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r2)
 						d232 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r2}
 						ctx.BindReg(r2, &d232)
@@ -15556,8 +15636,9 @@ func init_timezone() {
 					if d237.Loc == LocImm {
 						d239 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d237.Imm.Int()))}
 					} else {
-						r6 := ctx.AllocRegExcept(d237.Reg)
-						ctx.EmitMovRegReg(r6, d237.Reg)
+						var r6 Reg
+						r6 = d237.Reg
+						d237.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r6)
 						d239 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r6}
 						ctx.BindReg(r6, &d239)
@@ -15570,8 +15651,9 @@ func init_timezone() {
 					if d238.Loc == LocImm {
 						d240 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d238.Imm.Int()))}
 					} else {
-						r7 := ctx.AllocRegExcept(d238.Reg)
-						ctx.EmitMovRegReg(r7, d238.Reg)
+						var r7 Reg
+						r7 = d238.Reg
+						d238.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r7)
 						d240 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r7}
 						ctx.BindReg(r7, &d240)
@@ -16502,8 +16584,9 @@ func init_timezone() {
 					if d349.Loc == LocImm {
 						d351 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d349.Imm.Int()))}
 					} else {
-						r11 := ctx.AllocRegExcept(d349.Reg)
-						ctx.EmitMovRegReg(r11, d349.Reg)
+						var r11 Reg
+						r11 = d349.Reg
+						d349.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r11)
 						d351 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r11}
 						ctx.BindReg(r11, &d351)
@@ -16516,8 +16599,9 @@ func init_timezone() {
 					if d350.Loc == LocImm {
 						d352 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d350.Imm.Int()))}
 					} else {
-						r12 := ctx.AllocRegExcept(d350.Reg)
-						ctx.EmitMovRegReg(r12, d350.Reg)
+						var r12 Reg
+						r12 = d350.Reg
+						d350.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r12)
 						d352 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r12}
 						ctx.BindReg(r12, &d352)
@@ -17628,8 +17712,9 @@ func init_timezone() {
 					if d485.Loc == LocImm {
 						d487 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d485.Imm.Int()))}
 					} else {
-						r16 := ctx.AllocRegExcept(d485.Reg)
-						ctx.EmitMovRegReg(r16, d485.Reg)
+						var r16 Reg
+						r16 = d485.Reg
+						d485.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r16)
 						d487 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r16}
 						ctx.BindReg(r16, &d487)
@@ -17642,8 +17727,9 @@ func init_timezone() {
 					if d486.Loc == LocImm {
 						d488 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d486.Imm.Int()))}
 					} else {
-						r17 := ctx.AllocRegExcept(d486.Reg)
-						ctx.EmitMovRegReg(r17, d486.Reg)
+						var r17 Reg
+						r17 = d486.Reg
+						d486.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r17)
 						d488 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r17}
 						ctx.BindReg(r17, &d488)
@@ -18964,8 +19050,9 @@ func init_timezone() {
 					if d648.Loc == LocImm {
 						d650 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d648.Imm.Int()))}
 					} else {
-						r21 := ctx.AllocRegExcept(d648.Reg)
-						ctx.EmitMovRegReg(r21, d648.Reg)
+						var r21 Reg
+						r21 = d648.Reg
+						d648.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r21)
 						d650 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r21}
 						ctx.BindReg(r21, &d650)
@@ -18978,8 +19065,9 @@ func init_timezone() {
 					if d649.Loc == LocImm {
 						d651 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(d649.Imm.Int()))}
 					} else {
-						r22 := ctx.AllocRegExcept(d649.Reg)
-						ctx.EmitMovRegReg(r22, d649.Reg)
+						var r22 Reg
+						r22 = d649.Reg
+						d649.Loc = LocNone
 						ctx.EmitCvtInt64ToFloat64(RegX0, r22)
 						d651 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: r22}
 						ctx.BindReg(r22, &d651)

--- a/scm/window.go
+++ b/scm/window.go
@@ -6155,7 +6155,7 @@ func init_window() {
 					ctx.FreeDesc(&d786)
 					if ps.General {
 						ctx.SyncDesc(&d374)
-						if d374.Loc == LocReg {
+						if d374.Loc == LocReg || d374.Loc == LocFPReg {
 							ctx.ProtectReg(d374.Reg)
 						} else if d374.Loc == LocRegPair {
 							ctx.ProtectReg(d374.Reg)
@@ -6167,7 +6167,7 @@ func init_window() {
 						}
 						ctx.EnsureDesc(&d790)
 						ctx.EmitStoreToStack(d790, int32(bbs[7].PhiBase)+int32(0))
-						if d374.Loc == LocReg {
+						if d374.Loc == LocReg || d374.Loc == LocFPReg {
 							ctx.UnprotectReg(d374.Reg)
 						} else if d374.Loc == LocRegPair {
 							ctx.UnprotectReg(d374.Reg)
@@ -6523,7 +6523,7 @@ func init_window() {
 					ctx.FreeDesc(&d793)
 					if ps.General {
 						ctx.SyncDesc(&d374)
-						if d374.Loc == LocReg {
+						if d374.Loc == LocReg || d374.Loc == LocFPReg {
 							ctx.ProtectReg(d374.Reg)
 						} else if d374.Loc == LocRegPair {
 							ctx.ProtectReg(d374.Reg)
@@ -6535,7 +6535,7 @@ func init_window() {
 						}
 						ctx.EnsureDesc(&d796)
 						ctx.EmitStoreToStack(d796, int32(bbs[7].PhiBase)+int32(0))
-						if d374.Loc == LocReg {
+						if d374.Loc == LocReg || d374.Loc == LocFPReg {
 							ctx.UnprotectReg(d374.Reg)
 						} else if d374.Loc == LocRegPair {
 							ctx.UnprotectReg(d374.Reg)

--- a/storage/jit_getters.go
+++ b/storage/jit_getters.go
@@ -2975,7 +2975,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		ctx.FreeDesc(&d155)
 		if ps.General {
 			ctx.SyncDesc(&d153)
-			if d153.Loc == scm.LocReg {
+			if d153.Loc == scm.LocReg || d153.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d153.Reg)
 			} else if d153.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d153.Reg)
@@ -2996,7 +2996,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			} else {
 				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}, int32(bbs[19].PhiBase)+int32(16))
 			}
-			if d153.Loc == scm.LocReg {
+			if d153.Loc == scm.LocReg || d153.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d153.Reg)
 			} else if d153.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d153.Reg)
@@ -7211,14 +7211,14 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		}
 		if ps.General {
 			ctx.SyncDesc(&d652)
-			if d652.Loc == scm.LocReg {
+			if d652.Loc == scm.LocReg || d652.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d652.Reg)
 			} else if d652.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d652.Reg)
 				ctx.ProtectReg(d652.Reg2)
 			}
 			ctx.SyncDesc(&d653)
-			if d653.Loc == scm.LocReg {
+			if d653.Loc == scm.LocReg || d653.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d653.Reg)
 			} else if d653.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d653.Reg)
@@ -7244,13 +7244,13 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			} else {
 				ctx.EmitStoreToStack(d655, int32(bbs[10].PhiBase)+int32(16))
 			}
-			if d652.Loc == scm.LocReg {
+			if d652.Loc == scm.LocReg || d652.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d652.Reg)
 			} else if d652.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d652.Reg)
 				ctx.UnprotectReg(d652.Reg2)
 			}
-			if d653.Loc == scm.LocReg {
+			if d653.Loc == scm.LocReg || d653.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d653.Reg)
 			} else if d653.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d653.Reg)
@@ -12535,14 +12535,14 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		}
 		if ps.General {
 			ctx.SyncDesc(&d1208)
-			if d1208.Loc == scm.LocReg {
+			if d1208.Loc == scm.LocReg || d1208.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1208.Reg)
 			} else if d1208.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1208.Reg)
 				ctx.ProtectReg(d1208.Reg2)
 			}
 			ctx.SyncDesc(&d1209)
-			if d1209.Loc == scm.LocReg {
+			if d1209.Loc == scm.LocReg || d1209.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1209.Reg)
 			} else if d1209.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1209.Reg)
@@ -12568,13 +12568,13 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			} else {
 				ctx.EmitStoreToStack(d1211, int32(bbs[19].PhiBase)+int32(16))
 			}
-			if d1208.Loc == scm.LocReg {
+			if d1208.Loc == scm.LocReg || d1208.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1208.Reg)
 			} else if d1208.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1208.Reg)
 				ctx.UnprotectReg(d1208.Reg2)
 			}
-			if d1209.Loc == scm.LocReg {
+			if d1209.Loc == scm.LocReg || d1209.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1209.Reg)
 			} else if d1209.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1209.Reg)
@@ -20470,14 +20470,14 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		}
 		if ps.General {
 			ctx.SyncDesc(&d391)
-			if d391.Loc == scm.LocReg {
+			if d391.Loc == scm.LocReg || d391.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d391.Reg)
 			} else if d391.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d391.Reg)
 				ctx.ProtectReg(d391.Reg2)
 			}
 			ctx.SyncDesc(&d617)
-			if d617.Loc == scm.LocReg {
+			if d617.Loc == scm.LocReg || d617.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d617.Reg)
 			} else if d617.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d617.Reg)
@@ -20503,13 +20503,13 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d619, int32(bbs[10].PhiBase)+int32(16))
 			}
-			if d391.Loc == scm.LocReg {
+			if d391.Loc == scm.LocReg || d391.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d391.Reg)
 			} else if d391.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d391.Reg)
 				ctx.UnprotectReg(d391.Reg2)
 			}
-			if d617.Loc == scm.LocReg {
+			if d617.Loc == scm.LocReg || d617.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d617.Reg)
 			} else if d617.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d617.Reg)
@@ -25610,14 +25610,14 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		}
 		if ps.General {
 			ctx.SyncDesc(&d1146)
-			if d1146.Loc == scm.LocReg {
+			if d1146.Loc == scm.LocReg || d1146.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1146.Reg)
 			} else if d1146.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1146.Reg)
 				ctx.ProtectReg(d1146.Reg2)
 			}
 			ctx.SyncDesc(&d1147)
-			if d1147.Loc == scm.LocReg {
+			if d1147.Loc == scm.LocReg || d1147.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1147.Reg)
 			} else if d1147.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1147.Reg)
@@ -25643,13 +25643,13 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d1149, int32(bbs[17].PhiBase)+int32(16))
 			}
-			if d1146.Loc == scm.LocReg {
+			if d1146.Loc == scm.LocReg || d1146.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1146.Reg)
 			} else if d1146.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1146.Reg)
 				ctx.UnprotectReg(d1146.Reg2)
 			}
-			if d1147.Loc == scm.LocReg {
+			if d1147.Loc == scm.LocReg || d1147.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1147.Reg)
 			} else if d1147.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1147.Reg)
@@ -29547,14 +29547,14 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 		}
 		if ps.General {
 			ctx.SyncDesc(&d155)
-			if d155.Loc == scm.LocReg {
+			if d155.Loc == scm.LocReg || d155.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d155.Reg)
 			} else if d155.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d155.Reg)
 				ctx.ProtectReg(d155.Reg2)
 			}
 			ctx.SyncDesc(&d156)
-			if d156.Loc == scm.LocReg {
+			if d156.Loc == scm.LocReg || d156.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d156.Reg)
 			} else if d156.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d156.Reg)
@@ -29580,13 +29580,13 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 			} else {
 				ctx.EmitStoreToStack(d158, int32(bbs[3].PhiBase)+int32(16))
 			}
-			if d155.Loc == scm.LocReg {
+			if d155.Loc == scm.LocReg || d155.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d155.Reg)
 			} else if d155.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d155.Reg)
 				ctx.UnprotectReg(d155.Reg2)
 			}
-			if d156.Loc == scm.LocReg {
+			if d156.Loc == scm.LocReg || d156.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d156.Reg)
 			} else if d156.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d156.Reg)
@@ -31681,14 +31681,14 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 		}
 		if ps.General {
 			ctx.SyncDesc(&d160)
-			if d160.Loc == scm.LocReg {
+			if d160.Loc == scm.LocReg || d160.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d160.Reg)
 			} else if d160.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d160.Reg)
 				ctx.ProtectReg(d160.Reg2)
 			}
 			ctx.SyncDesc(&d161)
-			if d161.Loc == scm.LocReg {
+			if d161.Loc == scm.LocReg || d161.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d161.Reg)
 			} else if d161.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d161.Reg)
@@ -31714,13 +31714,13 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 			} else {
 				ctx.EmitStoreToStack(d163, int32(bbs[3].PhiBase)+int32(16))
 			}
-			if d160.Loc == scm.LocReg {
+			if d160.Loc == scm.LocReg || d160.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d160.Reg)
 			} else if d160.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d160.Reg)
 				ctx.UnprotectReg(d160.Reg2)
 			}
-			if d161.Loc == scm.LocReg {
+			if d161.Loc == scm.LocReg || d161.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d161.Reg)
 			} else if d161.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d161.Reg)
@@ -33389,7 +33389,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		ctx.FreeDesc(&d128)
 		if ps.General {
 			ctx.SyncDesc(&d75)
-			if d75.Loc == scm.LocReg {
+			if d75.Loc == scm.LocReg || d75.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d75.Reg)
 			} else if d75.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d75.Reg)
@@ -33405,7 +33405,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 			} else {
 				ctx.EmitStoreToStack(d132, int32(bbs[5].PhiBase)+int32(0))
 			}
-			if d75.Loc == scm.LocReg {
+			if d75.Loc == scm.LocReg || d75.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d75.Reg)
 			} else if d75.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d75.Reg)
@@ -35711,14 +35711,14 @@ func (s *StorageEnum) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 		}
 		if ps.General {
 			ctx.SyncDesc(&d98)
-			if d98.Loc == scm.LocReg {
+			if d98.Loc == scm.LocReg || d98.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d98.Reg)
 			} else if d98.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d98.Reg)
 				ctx.ProtectReg(d98.Reg2)
 			}
 			ctx.SyncDesc(&d99)
-			if d99.Loc == scm.LocReg {
+			if d99.Loc == scm.LocReg || d99.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d99.Reg)
 			} else if d99.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d99.Reg)
@@ -35744,13 +35744,13 @@ func (s *StorageEnum) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 			} else {
 				ctx.EmitStoreToStack(d101, int32(bbs[3].PhiBase)+int32(16))
 			}
-			if d98.Loc == scm.LocReg {
+			if d98.Loc == scm.LocReg || d98.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d98.Reg)
 			} else if d98.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d98.Reg)
 				ctx.UnprotectReg(d98.Reg2)
 			}
-			if d99.Loc == scm.LocReg {
+			if d99.Loc == scm.LocReg || d99.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d99.Reg)
 			} else if d99.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d99.Reg)
@@ -37112,14 +37112,14 @@ func (s *StorageEnum) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 		}
 		if ps.General {
 			ctx.SyncDesc(&d45)
-			if d45.Loc == scm.LocReg {
+			if d45.Loc == scm.LocReg || d45.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d45.Reg)
 			} else if d45.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d45.Reg)
 				ctx.ProtectReg(d45.Reg2)
 			}
 			ctx.SyncDesc(&d104)
-			if d104.Loc == scm.LocReg {
+			if d104.Loc == scm.LocReg || d104.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d104.Reg)
 			} else if d104.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d104.Reg)
@@ -37145,13 +37145,13 @@ func (s *StorageEnum) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 			} else {
 				ctx.EmitStoreToStack(d106, int32(bbs[3].PhiBase)+int32(16))
 			}
-			if d45.Loc == scm.LocReg {
+			if d45.Loc == scm.LocReg || d45.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d45.Reg)
 			} else if d45.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d45.Reg)
 				ctx.UnprotectReg(d45.Reg2)
 			}
-			if d104.Loc == scm.LocReg {
+			if d104.Loc == scm.LocReg || d104.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d104.Reg)
 			} else if d104.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d104.Reg)
@@ -39110,7 +39110,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		ctx.StabilizeDescForControlFlow(&d133)
 		if ps.General {
 			ctx.SyncDesc(&d133)
-			if d133.Loc == scm.LocReg {
+			if d133.Loc == scm.LocReg || d133.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d133.Reg)
 			} else if d133.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d133.Reg)
@@ -39143,7 +39143,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 			} else {
 				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewInt(0)}, int32(bbs[5].PhiBase)+int32(32))
 			}
-			if d133.Loc == scm.LocReg {
+			if d133.Loc == scm.LocReg || d133.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d133.Reg)
 			} else if d133.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d133.Reg)
@@ -40247,21 +40247,21 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		ctx.FreeDesc(&recid)
 		if ps.General {
 			ctx.SyncDesc(&d11)
-			if d11.Loc == scm.LocReg {
+			if d11.Loc == scm.LocReg || d11.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d11.Reg)
 			} else if d11.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d11.Reg)
 				ctx.ProtectReg(d11.Reg2)
 			}
 			ctx.SyncDesc(&d12)
-			if d12.Loc == scm.LocReg {
+			if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d12.Reg)
 			} else if d12.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d12.Reg)
 				ctx.ProtectReg(d12.Reg2)
 			}
 			ctx.SyncDesc(&d13)
-			if d13.Loc == scm.LocReg {
+			if d13.Loc == scm.LocReg || d13.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d13.Reg)
 			} else if d13.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d13.Reg)
@@ -40311,19 +40311,19 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 			} else {
 				ctx.EmitStoreToStack(d257, int32(bbs[8].PhiBase)+int32(32))
 			}
-			if d11.Loc == scm.LocReg {
+			if d11.Loc == scm.LocReg || d11.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d11.Reg)
 			} else if d11.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d11.Reg)
 				ctx.UnprotectReg(d11.Reg2)
 			}
-			if d12.Loc == scm.LocReg {
+			if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d12.Reg)
 			} else if d12.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d12.Reg)
 				ctx.UnprotectReg(d12.Reg2)
 			}
-			if d13.Loc == scm.LocReg {
+			if d13.Loc == scm.LocReg || d13.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d13.Reg)
 			} else if d13.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d13.Reg)
@@ -40932,14 +40932,14 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 			if d265.Imm.Bool() {
 				if ps.General {
 					ctx.SyncDesc(&d17)
-					if d17.Loc == scm.LocReg {
+					if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d17.Reg)
 					} else if d17.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d17.Reg)
 						ctx.ProtectReg(d17.Reg2)
 					}
 					ctx.SyncDesc(&d18)
-					if d18.Loc == scm.LocReg {
+					if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d18.Reg)
 					} else if d18.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d18.Reg)
@@ -40964,13 +40964,13 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 					}
 					ctx.EnsureDesc(&d268)
 					ctx.EmitStoreToStack(d268, int32(bbs[11].PhiBase)+int32(16))
-					if d17.Loc == scm.LocReg {
+					if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d17.Reg)
 					} else if d17.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d17.Reg)
 						ctx.UnprotectReg(d17.Reg2)
 					}
-					if d18.Loc == scm.LocReg {
+					if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d18.Reg)
 					} else if d18.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d18.Reg)
@@ -41223,14 +41223,14 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		alloc343 := ctx.SnapshotAllocState()
 		ctx.MarkLabel(lbl20)
 		ctx.SyncDesc(&d17)
-		if d17.Loc == scm.LocReg {
+		if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d17.Reg)
 		} else if d17.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d17.Reg)
 			ctx.ProtectReg(d17.Reg2)
 		}
 		ctx.SyncDesc(&d18)
-		if d18.Loc == scm.LocReg {
+		if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d18.Reg)
 		} else if d18.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d18.Reg)
@@ -41255,13 +41255,13 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		}
 		ctx.EnsureDesc(&d346)
 		ctx.EmitStoreToStack(d346, int32(bbs[11].PhiBase)+int32(16))
-		if d17.Loc == scm.LocReg {
+		if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d17.Reg)
 		} else if d17.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d17.Reg)
 			ctx.UnprotectReg(d17.Reg2)
 		}
-		if d18.Loc == scm.LocReg {
+		if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d18.Reg)
 		} else if d18.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d18.Reg)
@@ -43101,14 +43101,14 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 			if d590.Imm.Bool() {
 				if ps.General {
 					ctx.SyncDesc(&d17)
-					if d17.Loc == scm.LocReg {
+					if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d17.Reg)
 					} else if d17.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d17.Reg)
 						ctx.ProtectReg(d17.Reg2)
 					}
 					ctx.SyncDesc(&d18)
-					if d18.Loc == scm.LocReg {
+					if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d18.Reg)
 					} else if d18.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d18.Reg)
@@ -43133,13 +43133,13 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 					}
 					ctx.EnsureDesc(&d593)
 					ctx.EmitStoreToStack(d593, int32(bbs[9].PhiBase)+int32(16))
-					if d17.Loc == scm.LocReg {
+					if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d17.Reg)
 					} else if d17.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d17.Reg)
 						ctx.UnprotectReg(d17.Reg2)
 					}
-					if d18.Loc == scm.LocReg {
+					if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d18.Reg)
 					} else if d18.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d18.Reg)
@@ -43422,14 +43422,14 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		alloc682 := ctx.SnapshotAllocState()
 		ctx.MarkLabel(lbl21)
 		ctx.SyncDesc(&d17)
-		if d17.Loc == scm.LocReg {
+		if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d17.Reg)
 		} else if d17.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d17.Reg)
 			ctx.ProtectReg(d17.Reg2)
 		}
 		ctx.SyncDesc(&d18)
-		if d18.Loc == scm.LocReg {
+		if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d18.Reg)
 		} else if d18.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d18.Reg)
@@ -43454,13 +43454,13 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		}
 		ctx.EnsureDesc(&d685)
 		ctx.EmitStoreToStack(d685, int32(bbs[9].PhiBase)+int32(16))
-		if d17.Loc == scm.LocReg {
+		if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d17.Reg)
 		} else if d17.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d17.Reg)
 			ctx.UnprotectReg(d17.Reg2)
 		}
-		if d18.Loc == scm.LocReg {
+		if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d18.Reg)
 		} else if d18.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d18.Reg)
@@ -44507,14 +44507,14 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 			}
 			if ps.General {
 				ctx.SyncDesc(&d21)
-				if d21.Loc == scm.LocReg {
+				if d21.Loc == scm.LocReg || d21.Loc == scm.LocFPReg {
 					ctx.ProtectReg(d21.Reg)
 				} else if d21.Loc == scm.LocRegPair {
 					ctx.ProtectReg(d21.Reg)
 					ctx.ProtectReg(d21.Reg2)
 				}
 				ctx.SyncDesc(&d22)
-				if d22.Loc == scm.LocReg {
+				if d22.Loc == scm.LocReg || d22.Loc == scm.LocFPReg {
 					ctx.ProtectReg(d22.Reg)
 				} else if d22.Loc == scm.LocRegPair {
 					ctx.ProtectReg(d22.Reg)
@@ -44539,13 +44539,13 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				}
 				ctx.EnsureDesc(&d787)
 				ctx.EmitStoreToStack(d787, int32(bbs[9].PhiBase)+int32(16))
-				if d21.Loc == scm.LocReg {
+				if d21.Loc == scm.LocReg || d21.Loc == scm.LocFPReg {
 					ctx.UnprotectReg(d21.Reg)
 				} else if d21.Loc == scm.LocRegPair {
 					ctx.UnprotectReg(d21.Reg)
 					ctx.UnprotectReg(d21.Reg2)
 				}
-				if d22.Loc == scm.LocReg {
+				if d22.Loc == scm.LocReg || d22.Loc == scm.LocFPReg {
 					ctx.UnprotectReg(d22.Reg)
 				} else if d22.Loc == scm.LocRegPair {
 					ctx.UnprotectReg(d22.Reg)
@@ -44879,14 +44879,14 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		d792 = snap892
 		ctx.MarkLabel(lbl22)
 		ctx.SyncDesc(&d21)
-		if d21.Loc == scm.LocReg {
+		if d21.Loc == scm.LocReg || d21.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d21.Reg)
 		} else if d21.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d21.Reg)
 			ctx.ProtectReg(d21.Reg2)
 		}
 		ctx.SyncDesc(&d22)
-		if d22.Loc == scm.LocReg {
+		if d22.Loc == scm.LocReg || d22.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d22.Reg)
 		} else if d22.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d22.Reg)
@@ -44911,13 +44911,13 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		}
 		ctx.EnsureDesc(&d896)
 		ctx.EmitStoreToStack(d896, int32(bbs[9].PhiBase)+int32(16))
-		if d21.Loc == scm.LocReg {
+		if d21.Loc == scm.LocReg || d21.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d21.Reg)
 		} else if d21.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d21.Reg)
 			ctx.UnprotectReg(d21.Reg2)
 		}
-		if d22.Loc == scm.LocReg {
+		if d22.Loc == scm.LocReg || d22.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d22.Reg)
 		} else if d22.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d22.Reg)
@@ -46979,14 +46979,14 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		}
 		if ps.General {
 			ctx.SyncDesc(&d21)
-			if d21.Loc == scm.LocReg {
+			if d21.Loc == scm.LocReg || d21.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d21.Reg)
 			} else if d21.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d21.Reg)
 				ctx.ProtectReg(d21.Reg2)
 			}
 			ctx.SyncDesc(&d1032)
-			if d1032.Loc == scm.LocReg {
+			if d1032.Loc == scm.LocReg || d1032.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1032.Reg)
 			} else if d1032.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1032.Reg)
@@ -47024,13 +47024,13 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 			} else {
 				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewInt(0)}, int32(bbs[8].PhiBase)+int32(32))
 			}
-			if d21.Loc == scm.LocReg {
+			if d21.Loc == scm.LocReg || d21.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d21.Reg)
 			} else if d21.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d21.Reg)
 				ctx.UnprotectReg(d21.Reg2)
 			}
-			if d1032.Loc == scm.LocReg {
+			if d1032.Loc == scm.LocReg || d1032.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1032.Reg)
 			} else if d1032.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1032.Reg)
@@ -48438,21 +48438,21 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 		}
 		if ps.General {
 			ctx.SyncDesc(&d16)
-			if d16.Loc == scm.LocReg {
+			if d16.Loc == scm.LocReg || d16.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d16.Reg)
 			} else if d16.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d16.Reg)
 				ctx.ProtectReg(d16.Reg2)
 			}
 			ctx.SyncDesc(&d19)
-			if d19.Loc == scm.LocReg {
+			if d19.Loc == scm.LocReg || d19.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d19.Reg)
 			} else if d19.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d19.Reg)
 				ctx.ProtectReg(d19.Reg2)
 			}
 			ctx.SyncDesc(&d20)
-			if d20.Loc == scm.LocReg {
+			if d20.Loc == scm.LocReg || d20.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d20.Reg)
 			} else if d20.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d20.Reg)
@@ -48502,33 +48502,33 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 			} else {
 				ctx.EmitStoreToStack(d1052, int32(bbs[5].PhiBase)+int32(32))
 			}
-			if d16.Loc == scm.LocReg {
+			if d16.Loc == scm.LocReg || d16.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d16.Reg)
 			} else if d16.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d16.Reg)
 				ctx.UnprotectReg(d16.Reg2)
 			}
-			if d19.Loc == scm.LocReg {
+			if d19.Loc == scm.LocReg || d19.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d19.Reg)
 			} else if d19.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d19.Reg)
 				ctx.UnprotectReg(d19.Reg2)
 			}
-			if d20.Loc == scm.LocReg {
+			if d20.Loc == scm.LocReg || d20.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d20.Reg)
 			} else if d20.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d20.Reg)
 				ctx.UnprotectReg(d20.Reg2)
 			}
 			ctx.SyncDesc(&d1046)
-			if d1046.Loc == scm.LocReg {
+			if d1046.Loc == scm.LocReg || d1046.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1046.Reg)
 			} else if d1046.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1046.Reg)
 				ctx.ProtectReg(d1046.Reg2)
 			}
 			ctx.SyncDesc(&d1047)
-			if d1047.Loc == scm.LocReg {
+			if d1047.Loc == scm.LocReg || d1047.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1047.Reg)
 			} else if d1047.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1047.Reg)
@@ -48554,13 +48554,13 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 			} else {
 				ctx.EmitStoreToStack(d1054, int32(bbs[5].PhiBase)+int32(64))
 			}
-			if d1046.Loc == scm.LocReg {
+			if d1046.Loc == scm.LocReg || d1046.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1046.Reg)
 			} else if d1046.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1046.Reg)
 				ctx.UnprotectReg(d1046.Reg2)
 			}
-			if d1047.Loc == scm.LocReg {
+			if d1047.Loc == scm.LocReg || d1047.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1047.Reg)
 			} else if d1047.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1047.Reg)
@@ -56145,7 +56145,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		}
 		if ps.General {
 			ctx.SyncDesc(&d434)
-			if d434.Loc == scm.LocReg {
+			if d434.Loc == scm.LocReg || d434.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d434.Reg)
 			} else if d434.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d434.Reg)
@@ -56161,7 +56161,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			} else {
 				ctx.EmitStoreToStack(d435, int32(bbs[5].PhiBase)+int32(0))
 			}
-			if d434.Loc == scm.LocReg {
+			if d434.Loc == scm.LocReg || d434.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d434.Reg)
 			} else if d434.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d434.Reg)
@@ -56847,7 +56847,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		ctx.StabilizeDescForControlFlow(&d447)
 		if ps.General {
 			ctx.SyncDesc(&d446)
-			if d446.Loc == scm.LocReg {
+			if d446.Loc == scm.LocReg || d446.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d446.Reg)
 			} else if d446.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d446.Reg)
@@ -56880,7 +56880,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			} else {
 				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewInt(0)}, int32(bbs[15].PhiBase)+int32(32))
 			}
-			if d446.Loc == scm.LocReg {
+			if d446.Loc == scm.LocReg || d446.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d446.Reg)
 			} else if d446.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d446.Reg)
@@ -58426,14 +58426,14 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		}
 		if ps.General {
 			ctx.SyncDesc(&d458)
-			if d458.Loc == scm.LocReg {
+			if d458.Loc == scm.LocReg || d458.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d458.Reg)
 			} else if d458.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d458.Reg)
 				ctx.ProtectReg(d458.Reg2)
 			}
 			ctx.SyncDesc(&d616)
-			if d616.Loc == scm.LocReg {
+			if d616.Loc == scm.LocReg || d616.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d616.Reg)
 			} else if d616.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d616.Reg)
@@ -58459,13 +58459,13 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			} else {
 				ctx.EmitStoreToStack(d618, int32(bbs[12].PhiBase)+int32(16))
 			}
-			if d458.Loc == scm.LocReg {
+			if d458.Loc == scm.LocReg || d458.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d458.Reg)
 			} else if d458.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d458.Reg)
 				ctx.UnprotectReg(d458.Reg2)
 			}
-			if d616.Loc == scm.LocReg {
+			if d616.Loc == scm.LocReg || d616.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d616.Reg)
 			} else if d616.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d616.Reg)
@@ -60656,21 +60656,21 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		ctx.StabilizeDescForControlFlow(&d829)
 		if ps.General {
 			ctx.SyncDesc(&d18)
-			if d18.Loc == scm.LocReg {
+			if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d18.Reg)
 			} else if d18.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d18.Reg)
 				ctx.ProtectReg(d18.Reg2)
 			}
 			ctx.SyncDesc(&d19)
-			if d19.Loc == scm.LocReg {
+			if d19.Loc == scm.LocReg || d19.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d19.Reg)
 			} else if d19.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d19.Reg)
 				ctx.ProtectReg(d19.Reg2)
 			}
 			ctx.SyncDesc(&d20)
-			if d20.Loc == scm.LocReg {
+			if d20.Loc == scm.LocReg || d20.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d20.Reg)
 			} else if d20.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d20.Reg)
@@ -60720,19 +60720,19 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			} else {
 				ctx.EmitStoreToStack(d834, int32(bbs[18].PhiBase)+int32(32))
 			}
-			if d18.Loc == scm.LocReg {
+			if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d18.Reg)
 			} else if d18.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d18.Reg)
 				ctx.UnprotectReg(d18.Reg2)
 			}
-			if d19.Loc == scm.LocReg {
+			if d19.Loc == scm.LocReg || d19.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d19.Reg)
 			} else if d19.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d19.Reg)
 				ctx.UnprotectReg(d19.Reg2)
 			}
-			if d20.Loc == scm.LocReg {
+			if d20.Loc == scm.LocReg || d20.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d20.Reg)
 			} else if d20.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d20.Reg)
@@ -61707,14 +61707,14 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			if d842.Imm.Bool() {
 				if ps.General {
 					ctx.SyncDesc(&d24)
-					if d24.Loc == scm.LocReg {
+					if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d24.Reg)
 					} else if d24.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d24.Reg)
 						ctx.ProtectReg(d24.Reg2)
 					}
 					ctx.SyncDesc(&d25)
-					if d25.Loc == scm.LocReg {
+					if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d25.Reg)
 					} else if d25.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d25.Reg)
@@ -61739,13 +61739,13 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 					}
 					ctx.EnsureDesc(&d845)
 					ctx.EmitStoreToStack(d845, int32(bbs[21].PhiBase)+int32(16))
-					if d24.Loc == scm.LocReg {
+					if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d24.Reg)
 					} else if d24.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d24.Reg)
 						ctx.UnprotectReg(d24.Reg2)
 					}
-					if d25.Loc == scm.LocReg {
+					if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d25.Reg)
 					} else if d25.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d25.Reg)
@@ -62142,14 +62142,14 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		alloc968 := ctx.SnapshotAllocState()
 		ctx.MarkLabel(lbl31)
 		ctx.SyncDesc(&d24)
-		if d24.Loc == scm.LocReg {
+		if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d24.Reg)
 		} else if d24.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d24.Reg)
 			ctx.ProtectReg(d24.Reg2)
 		}
 		ctx.SyncDesc(&d25)
-		if d25.Loc == scm.LocReg {
+		if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d25.Reg)
 		} else if d25.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d25.Reg)
@@ -62174,13 +62174,13 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		}
 		ctx.EnsureDesc(&d971)
 		ctx.EmitStoreToStack(d971, int32(bbs[21].PhiBase)+int32(16))
-		if d24.Loc == scm.LocReg {
+		if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d24.Reg)
 		} else if d24.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d24.Reg)
 			ctx.UnprotectReg(d24.Reg2)
 		}
-		if d25.Loc == scm.LocReg {
+		if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d25.Reg)
 		} else if d25.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d25.Reg)
@@ -65058,14 +65058,14 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			if d1359.Imm.Bool() {
 				if ps.General {
 					ctx.SyncDesc(&d24)
-					if d24.Loc == scm.LocReg {
+					if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d24.Reg)
 					} else if d24.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d24.Reg)
 						ctx.ProtectReg(d24.Reg2)
 					}
 					ctx.SyncDesc(&d25)
-					if d25.Loc == scm.LocReg {
+					if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d25.Reg)
 					} else if d25.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d25.Reg)
@@ -65090,13 +65090,13 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 					}
 					ctx.EnsureDesc(&d1362)
 					ctx.EmitStoreToStack(d1362, int32(bbs[19].PhiBase)+int32(16))
-					if d24.Loc == scm.LocReg {
+					if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d24.Reg)
 					} else if d24.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d24.Reg)
 						ctx.UnprotectReg(d24.Reg2)
 					}
-					if d25.Loc == scm.LocReg {
+					if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d25.Reg)
 					} else if d25.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d25.Reg)
@@ -65523,14 +65523,14 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		alloc1499 := ctx.SnapshotAllocState()
 		ctx.MarkLabel(lbl32)
 		ctx.SyncDesc(&d24)
-		if d24.Loc == scm.LocReg {
+		if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d24.Reg)
 		} else if d24.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d24.Reg)
 			ctx.ProtectReg(d24.Reg2)
 		}
 		ctx.SyncDesc(&d25)
-		if d25.Loc == scm.LocReg {
+		if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d25.Reg)
 		} else if d25.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d25.Reg)
@@ -65555,13 +65555,13 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		}
 		ctx.EnsureDesc(&d1502)
 		ctx.EmitStoreToStack(d1502, int32(bbs[19].PhiBase)+int32(16))
-		if d24.Loc == scm.LocReg {
+		if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d24.Reg)
 		} else if d24.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d24.Reg)
 			ctx.UnprotectReg(d24.Reg2)
 		}
-		if d25.Loc == scm.LocReg {
+		if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d25.Reg)
 		} else if d25.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d25.Reg)
@@ -67103,14 +67103,14 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			}
 			if ps.General {
 				ctx.SyncDesc(&d28)
-				if d28.Loc == scm.LocReg {
+				if d28.Loc == scm.LocReg || d28.Loc == scm.LocFPReg {
 					ctx.ProtectReg(d28.Reg)
 				} else if d28.Loc == scm.LocRegPair {
 					ctx.ProtectReg(d28.Reg)
 					ctx.ProtectReg(d28.Reg2)
 				}
 				ctx.SyncDesc(&d29)
-				if d29.Loc == scm.LocReg {
+				if d29.Loc == scm.LocReg || d29.Loc == scm.LocFPReg {
 					ctx.ProtectReg(d29.Reg)
 				} else if d29.Loc == scm.LocRegPair {
 					ctx.ProtectReg(d29.Reg)
@@ -67135,13 +67135,13 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				}
 				ctx.EnsureDesc(&d1652)
 				ctx.EmitStoreToStack(d1652, int32(bbs[19].PhiBase)+int32(16))
-				if d28.Loc == scm.LocReg {
+				if d28.Loc == scm.LocReg || d28.Loc == scm.LocFPReg {
 					ctx.UnprotectReg(d28.Reg)
 				} else if d28.Loc == scm.LocRegPair {
 					ctx.UnprotectReg(d28.Reg)
 					ctx.UnprotectReg(d28.Reg2)
 				}
-				if d29.Loc == scm.LocReg {
+				if d29.Loc == scm.LocReg || d29.Loc == scm.LocFPReg {
 					ctx.UnprotectReg(d29.Reg)
 				} else if d29.Loc == scm.LocRegPair {
 					ctx.UnprotectReg(d29.Reg)
@@ -67619,14 +67619,14 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		d1657 = snap1805
 		ctx.MarkLabel(lbl33)
 		ctx.SyncDesc(&d28)
-		if d28.Loc == scm.LocReg {
+		if d28.Loc == scm.LocReg || d28.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d28.Reg)
 		} else if d28.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d28.Reg)
 			ctx.ProtectReg(d28.Reg2)
 		}
 		ctx.SyncDesc(&d29)
-		if d29.Loc == scm.LocReg {
+		if d29.Loc == scm.LocReg || d29.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d29.Reg)
 		} else if d29.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d29.Reg)
@@ -67651,13 +67651,13 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		}
 		ctx.EnsureDesc(&d1809)
 		ctx.EmitStoreToStack(d1809, int32(bbs[19].PhiBase)+int32(16))
-		if d28.Loc == scm.LocReg {
+		if d28.Loc == scm.LocReg || d28.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d28.Reg)
 		} else if d28.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d28.Reg)
 			ctx.UnprotectReg(d28.Reg2)
 		}
-		if d29.Loc == scm.LocReg {
+		if d29.Loc == scm.LocReg || d29.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d29.Reg)
 		} else if d29.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d29.Reg)
@@ -70325,14 +70325,14 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		}
 		if ps.General {
 			ctx.SyncDesc(&d28)
-			if d28.Loc == scm.LocReg {
+			if d28.Loc == scm.LocReg || d28.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d28.Reg)
 			} else if d28.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d28.Reg)
 				ctx.ProtectReg(d28.Reg2)
 			}
 			ctx.SyncDesc(&d1993)
-			if d1993.Loc == scm.LocReg {
+			if d1993.Loc == scm.LocReg || d1993.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1993.Reg)
 			} else if d1993.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1993.Reg)
@@ -70370,13 +70370,13 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			} else {
 				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewInt(0)}, int32(bbs[18].PhiBase)+int32(32))
 			}
-			if d28.Loc == scm.LocReg {
+			if d28.Loc == scm.LocReg || d28.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d28.Reg)
 			} else if d28.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d28.Reg)
 				ctx.UnprotectReg(d28.Reg2)
 			}
-			if d1993.Loc == scm.LocReg {
+			if d1993.Loc == scm.LocReg || d1993.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1993.Reg)
 			} else if d1993.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1993.Reg)
@@ -72177,21 +72177,21 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 		}
 		if ps.General {
 			ctx.SyncDesc(&d23)
-			if d23.Loc == scm.LocReg {
+			if d23.Loc == scm.LocReg || d23.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d23.Reg)
 			} else if d23.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d23.Reg)
 				ctx.ProtectReg(d23.Reg2)
 			}
 			ctx.SyncDesc(&d26)
-			if d26.Loc == scm.LocReg {
+			if d26.Loc == scm.LocReg || d26.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d26.Reg)
 			} else if d26.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d26.Reg)
 				ctx.ProtectReg(d26.Reg2)
 			}
 			ctx.SyncDesc(&d27)
-			if d27.Loc == scm.LocReg {
+			if d27.Loc == scm.LocReg || d27.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d27.Reg)
 			} else if d27.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d27.Reg)
@@ -72241,33 +72241,33 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			} else {
 				ctx.EmitStoreToStack(d2012, int32(bbs[15].PhiBase)+int32(32))
 			}
-			if d23.Loc == scm.LocReg {
+			if d23.Loc == scm.LocReg || d23.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d23.Reg)
 			} else if d23.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d23.Reg)
 				ctx.UnprotectReg(d23.Reg2)
 			}
-			if d26.Loc == scm.LocReg {
+			if d26.Loc == scm.LocReg || d26.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d26.Reg)
 			} else if d26.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d26.Reg)
 				ctx.UnprotectReg(d26.Reg2)
 			}
-			if d27.Loc == scm.LocReg {
+			if d27.Loc == scm.LocReg || d27.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d27.Reg)
 			} else if d27.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d27.Reg)
 				ctx.UnprotectReg(d27.Reg2)
 			}
 			ctx.SyncDesc(&d627)
-			if d627.Loc == scm.LocReg {
+			if d627.Loc == scm.LocReg || d627.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d627.Reg)
 			} else if d627.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d627.Reg)
 				ctx.ProtectReg(d627.Reg2)
 			}
 			ctx.SyncDesc(&d2007)
-			if d2007.Loc == scm.LocReg {
+			if d2007.Loc == scm.LocReg || d2007.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d2007.Reg)
 			} else if d2007.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d2007.Reg)
@@ -72293,13 +72293,13 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 			} else {
 				ctx.EmitStoreToStack(d2014, int32(bbs[15].PhiBase)+int32(64))
 			}
-			if d627.Loc == scm.LocReg {
+			if d627.Loc == scm.LocReg || d627.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d627.Reg)
 			} else if d627.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d627.Reg)
 				ctx.UnprotectReg(d627.Reg2)
 			}
-			if d2007.Loc == scm.LocReg {
+			if d2007.Loc == scm.LocReg || d2007.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d2007.Reg)
 			} else if d2007.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d2007.Reg)
@@ -77191,14 +77191,14 @@ func (s *StorageConst) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 		}
 		if ps.General {
 			ctx.SyncDesc(&d94)
-			if d94.Loc == scm.LocReg {
+			if d94.Loc == scm.LocReg || d94.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d94.Reg)
 			} else if d94.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d94.Reg)
 				ctx.ProtectReg(d94.Reg2)
 			}
 			ctx.SyncDesc(&d95)
-			if d95.Loc == scm.LocReg {
+			if d95.Loc == scm.LocReg || d95.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d95.Reg)
 			} else if d95.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d95.Reg)
@@ -77224,13 +77224,13 @@ func (s *StorageConst) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 			} else {
 				ctx.EmitStoreToStack(d97, int32(bbs[3].PhiBase)+int32(16))
 			}
-			if d94.Loc == scm.LocReg {
+			if d94.Loc == scm.LocReg || d94.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d94.Reg)
 			} else if d94.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d94.Reg)
 				ctx.UnprotectReg(d94.Reg2)
 			}
-			if d95.Loc == scm.LocReg {
+			if d95.Loc == scm.LocReg || d95.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d95.Reg)
 			} else if d95.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d95.Reg)
@@ -78553,14 +78553,14 @@ func (s *StorageConst) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 		}
 		if ps.General {
 			ctx.SyncDesc(&d44)
-			if d44.Loc == scm.LocReg {
+			if d44.Loc == scm.LocReg || d44.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d44.Reg)
 			} else if d44.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d44.Reg)
 				ctx.ProtectReg(d44.Reg2)
 			}
 			ctx.SyncDesc(&d100)
-			if d100.Loc == scm.LocReg {
+			if d100.Loc == scm.LocReg || d100.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d100.Reg)
 			} else if d100.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d100.Reg)
@@ -78586,13 +78586,13 @@ func (s *StorageConst) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 			} else {
 				ctx.EmitStoreToStack(d102, int32(bbs[3].PhiBase)+int32(16))
 			}
-			if d44.Loc == scm.LocReg {
+			if d44.Loc == scm.LocReg || d44.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d44.Reg)
 			} else if d44.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d44.Reg)
 				ctx.UnprotectReg(d44.Reg2)
 			}
-			if d100.Loc == scm.LocReg {
+			if d100.Loc == scm.LocReg || d100.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d100.Reg)
 			} else if d100.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d100.Reg)
@@ -81009,14 +81009,14 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 		}
 		if ps.General {
 			ctx.SyncDesc(&d100)
-			if d100.Loc == scm.LocReg {
+			if d100.Loc == scm.LocReg || d100.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d100.Reg)
 			} else if d100.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d100.Reg)
 				ctx.ProtectReg(d100.Reg2)
 			}
 			ctx.SyncDesc(&d199)
-			if d199.Loc == scm.LocReg {
+			if d199.Loc == scm.LocReg || d199.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d199.Reg)
 			} else if d199.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d199.Reg)
@@ -81042,13 +81042,13 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 			} else {
 				ctx.EmitStoreToStack(d201, int32(bbs[5].PhiBase)+int32(16))
 			}
-			if d100.Loc == scm.LocReg {
+			if d100.Loc == scm.LocReg || d100.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d100.Reg)
 			} else if d100.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d100.Reg)
 				ctx.UnprotectReg(d100.Reg2)
 			}
-			if d199.Loc == scm.LocReg {
+			if d199.Loc == scm.LocReg || d199.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d199.Reg)
 			} else if d199.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d199.Reg)
@@ -82509,14 +82509,14 @@ func (s *StorageSCMER) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 		}
 		if ps.General {
 			ctx.SyncDesc(&d45)
-			if d45.Loc == scm.LocReg {
+			if d45.Loc == scm.LocReg || d45.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d45.Reg)
 			} else if d45.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d45.Reg)
 				ctx.ProtectReg(d45.Reg2)
 			}
 			ctx.SyncDesc(&d105)
-			if d105.Loc == scm.LocReg {
+			if d105.Loc == scm.LocReg || d105.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d105.Reg)
 			} else if d105.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d105.Reg)
@@ -82542,13 +82542,13 @@ func (s *StorageSCMER) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 			} else {
 				ctx.EmitStoreToStack(d107, int32(bbs[3].PhiBase)+int32(16))
 			}
-			if d45.Loc == scm.LocReg {
+			if d45.Loc == scm.LocReg || d45.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d45.Reg)
 			} else if d45.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d45.Reg)
 				ctx.UnprotectReg(d45.Reg2)
 			}
-			if d105.Loc == scm.LocReg {
+			if d105.Loc == scm.LocReg || d105.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d105.Reg)
 			} else if d105.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d105.Reg)
@@ -85466,21 +85466,21 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		ctx.FreeDesc(&d144)
 		if ps.General {
 			ctx.SyncDesc(&d135)
-			if d135.Loc == scm.LocReg {
+			if d135.Loc == scm.LocReg || d135.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d135.Reg)
 			} else if d135.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d135.Reg)
 				ctx.ProtectReg(d135.Reg2)
 			}
 			ctx.SyncDesc(&d138)
-			if d138.Loc == scm.LocReg {
+			if d138.Loc == scm.LocReg || d138.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d138.Reg)
 			} else if d138.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d138.Reg)
 				ctx.ProtectReg(d138.Reg2)
 			}
 			ctx.SyncDesc(&d140)
-			if d140.Loc == scm.LocReg {
+			if d140.Loc == scm.LocReg || d140.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d140.Reg)
 			} else if d140.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d140.Reg)
@@ -85523,33 +85523,33 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			} else {
 				ctx.EmitStoreToStack(d149, int32(bbs[5].PhiBase)+int32(32))
 			}
-			if d135.Loc == scm.LocReg {
+			if d135.Loc == scm.LocReg || d135.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d135.Reg)
 			} else if d135.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d135.Reg)
 				ctx.UnprotectReg(d135.Reg2)
 			}
-			if d138.Loc == scm.LocReg {
+			if d138.Loc == scm.LocReg || d138.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d138.Reg)
 			} else if d138.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d138.Reg)
 				ctx.UnprotectReg(d138.Reg2)
 			}
-			if d140.Loc == scm.LocReg {
+			if d140.Loc == scm.LocReg || d140.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d140.Reg)
 			} else if d140.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d140.Reg)
 				ctx.UnprotectReg(d140.Reg2)
 			}
 			ctx.SyncDesc(&d141)
-			if d141.Loc == scm.LocReg {
+			if d141.Loc == scm.LocReg || d141.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d141.Reg)
 			} else if d141.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d141.Reg)
 				ctx.ProtectReg(d141.Reg2)
 			}
 			ctx.SyncDesc(&d145)
-			if d145.Loc == scm.LocReg {
+			if d145.Loc == scm.LocReg || d145.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d145.Reg)
 			} else if d145.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d145.Reg)
@@ -85580,13 +85580,13 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			} else {
 				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}, int32(bbs[5].PhiBase)+int32(80))
 			}
-			if d141.Loc == scm.LocReg {
+			if d141.Loc == scm.LocReg || d141.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d141.Reg)
 			} else if d141.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d141.Reg)
 				ctx.UnprotectReg(d141.Reg2)
 			}
-			if d145.Loc == scm.LocReg {
+			if d145.Loc == scm.LocReg || d145.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d145.Reg)
 			} else if d145.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d145.Reg)
@@ -87129,21 +87129,21 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			}
 			if ps.General {
 				ctx.SyncDesc(&d10)
-				if d10.Loc == scm.LocReg {
+				if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 					ctx.ProtectReg(d10.Reg)
 				} else if d10.Loc == scm.LocRegPair {
 					ctx.ProtectReg(d10.Reg)
 					ctx.ProtectReg(d10.Reg2)
 				}
 				ctx.SyncDesc(&d11)
-				if d11.Loc == scm.LocReg {
+				if d11.Loc == scm.LocReg || d11.Loc == scm.LocFPReg {
 					ctx.ProtectReg(d11.Reg)
 				} else if d11.Loc == scm.LocRegPair {
 					ctx.ProtectReg(d11.Reg)
 					ctx.ProtectReg(d11.Reg2)
 				}
 				ctx.SyncDesc(&d12)
-				if d12.Loc == scm.LocReg {
+				if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 					ctx.ProtectReg(d12.Reg)
 				} else if d12.Loc == scm.LocRegPair {
 					ctx.ProtectReg(d12.Reg)
@@ -87174,33 +87174,33 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				}
 				ctx.EnsureDesc(&d319)
 				ctx.EmitStoreToStack(d319, int32(bbs[9].PhiBase)+int32(32))
-				if d10.Loc == scm.LocReg {
+				if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 					ctx.UnprotectReg(d10.Reg)
 				} else if d10.Loc == scm.LocRegPair {
 					ctx.UnprotectReg(d10.Reg)
 					ctx.UnprotectReg(d10.Reg2)
 				}
-				if d11.Loc == scm.LocReg {
+				if d11.Loc == scm.LocReg || d11.Loc == scm.LocFPReg {
 					ctx.UnprotectReg(d11.Reg)
 				} else if d11.Loc == scm.LocRegPair {
 					ctx.UnprotectReg(d11.Reg)
 					ctx.UnprotectReg(d11.Reg2)
 				}
-				if d12.Loc == scm.LocReg {
+				if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 					ctx.UnprotectReg(d12.Reg)
 				} else if d12.Loc == scm.LocRegPair {
 					ctx.UnprotectReg(d12.Reg)
 					ctx.UnprotectReg(d12.Reg2)
 				}
 				ctx.SyncDesc(&d13)
-				if d13.Loc == scm.LocReg {
+				if d13.Loc == scm.LocReg || d13.Loc == scm.LocFPReg {
 					ctx.ProtectReg(d13.Reg)
 				} else if d13.Loc == scm.LocRegPair {
 					ctx.ProtectReg(d13.Reg)
 					ctx.ProtectReg(d13.Reg2)
 				}
 				ctx.SyncDesc(&d14)
-				if d14.Loc == scm.LocReg {
+				if d14.Loc == scm.LocReg || d14.Loc == scm.LocFPReg {
 					ctx.ProtectReg(d14.Reg)
 				} else if d14.Loc == scm.LocRegPair {
 					ctx.ProtectReg(d14.Reg)
@@ -87218,13 +87218,13 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				}
 				ctx.EnsureDesc(&d321)
 				ctx.EmitStoreToStack(d321, int32(bbs[9].PhiBase)+int32(64))
-				if d13.Loc == scm.LocReg {
+				if d13.Loc == scm.LocReg || d13.Loc == scm.LocFPReg {
 					ctx.UnprotectReg(d13.Reg)
 				} else if d13.Loc == scm.LocRegPair {
 					ctx.UnprotectReg(d13.Reg)
 					ctx.UnprotectReg(d13.Reg2)
 				}
-				if d14.Loc == scm.LocReg {
+				if d14.Loc == scm.LocReg || d14.Loc == scm.LocFPReg {
 					ctx.UnprotectReg(d14.Reg)
 				} else if d14.Loc == scm.LocRegPair {
 					ctx.UnprotectReg(d14.Reg)
@@ -87493,21 +87493,21 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		d327 = snap407
 		ctx.MarkLabel(lbl15)
 		ctx.SyncDesc(&d10)
-		if d10.Loc == scm.LocReg {
+		if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d10.Reg)
 		} else if d10.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d10.Reg)
 			ctx.ProtectReg(d10.Reg2)
 		}
 		ctx.SyncDesc(&d11)
-		if d11.Loc == scm.LocReg {
+		if d11.Loc == scm.LocReg || d11.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d11.Reg)
 		} else if d11.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d11.Reg)
 			ctx.ProtectReg(d11.Reg2)
 		}
 		ctx.SyncDesc(&d12)
-		if d12.Loc == scm.LocReg {
+		if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d12.Reg)
 		} else if d12.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d12.Reg)
@@ -87538,33 +87538,33 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		}
 		ctx.EnsureDesc(&d412)
 		ctx.EmitStoreToStack(d412, int32(bbs[9].PhiBase)+int32(32))
-		if d10.Loc == scm.LocReg {
+		if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d10.Reg)
 		} else if d10.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d10.Reg)
 			ctx.UnprotectReg(d10.Reg2)
 		}
-		if d11.Loc == scm.LocReg {
+		if d11.Loc == scm.LocReg || d11.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d11.Reg)
 		} else if d11.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d11.Reg)
 			ctx.UnprotectReg(d11.Reg2)
 		}
-		if d12.Loc == scm.LocReg {
+		if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d12.Reg)
 		} else if d12.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d12.Reg)
 			ctx.UnprotectReg(d12.Reg2)
 		}
 		ctx.SyncDesc(&d13)
-		if d13.Loc == scm.LocReg {
+		if d13.Loc == scm.LocReg || d13.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d13.Reg)
 		} else if d13.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d13.Reg)
 			ctx.ProtectReg(d13.Reg2)
 		}
 		ctx.SyncDesc(&d14)
-		if d14.Loc == scm.LocReg {
+		if d14.Loc == scm.LocReg || d14.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d14.Reg)
 		} else if d14.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d14.Reg)
@@ -87582,13 +87582,13 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		}
 		ctx.EnsureDesc(&d414)
 		ctx.EmitStoreToStack(d414, int32(bbs[9].PhiBase)+int32(64))
-		if d13.Loc == scm.LocReg {
+		if d13.Loc == scm.LocReg || d13.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d13.Reg)
 		} else if d13.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d13.Reg)
 			ctx.UnprotectReg(d13.Reg2)
 		}
-		if d14.Loc == scm.LocReg {
+		if d14.Loc == scm.LocReg || d14.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d14.Reg)
 		} else if d14.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d14.Reg)
@@ -88911,21 +88911,21 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		ctx.FreeDesc(&d522)
 		if ps.General {
 			ctx.SyncDesc(&d517)
-			if d517.Loc == scm.LocReg {
+			if d517.Loc == scm.LocReg || d517.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d517.Reg)
 			} else if d517.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d517.Reg)
 				ctx.ProtectReg(d517.Reg2)
 			}
 			ctx.SyncDesc(&d519)
-			if d519.Loc == scm.LocReg {
+			if d519.Loc == scm.LocReg || d519.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d519.Reg)
 			} else if d519.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d519.Reg)
 				ctx.ProtectReg(d519.Reg2)
 			}
 			ctx.SyncDesc(&d520)
-			if d520.Loc == scm.LocReg {
+			if d520.Loc == scm.LocReg || d520.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d520.Reg)
 			} else if d520.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d520.Reg)
@@ -88949,19 +88949,19 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			}
 			ctx.EnsureDesc(&d526)
 			ctx.EmitStoreToStack(d526, int32(bbs[9].PhiBase)+int32(48))
-			if d517.Loc == scm.LocReg {
+			if d517.Loc == scm.LocReg || d517.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d517.Reg)
 			} else if d517.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d517.Reg)
 				ctx.UnprotectReg(d517.Reg2)
 			}
-			if d519.Loc == scm.LocReg {
+			if d519.Loc == scm.LocReg || d519.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d519.Reg)
 			} else if d519.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d519.Reg)
 				ctx.UnprotectReg(d519.Reg2)
 			}
-			if d520.Loc == scm.LocReg {
+			if d520.Loc == scm.LocReg || d520.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d520.Reg)
 			} else if d520.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d520.Reg)
@@ -91079,7 +91079,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		ctx.FreeDesc(&d782)
 		if ps.General {
 			ctx.SyncDesc(&d21)
-			if d21.Loc == scm.LocReg {
+			if d21.Loc == scm.LocReg || d21.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d21.Reg)
 			} else if d21.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d21.Reg)
@@ -91091,7 +91091,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			}
 			ctx.EnsureDesc(&d785)
 			ctx.EmitStoreToStack(d785, int32(bbs[11].PhiBase)+int32(0))
-			if d21.Loc == scm.LocReg {
+			if d21.Loc == scm.LocReg || d21.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d21.Reg)
 			} else if d21.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d21.Reg)
@@ -91760,21 +91760,21 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		}
 		if ps.General {
 			ctx.SyncDesc(&d17)
-			if d17.Loc == scm.LocReg {
+			if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d17.Reg)
 			} else if d17.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d17.Reg)
 				ctx.ProtectReg(d17.Reg2)
 			}
 			ctx.SyncDesc(&d18)
-			if d18.Loc == scm.LocReg {
+			if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d18.Reg)
 			} else if d18.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d18.Reg)
 				ctx.ProtectReg(d18.Reg2)
 			}
 			ctx.SyncDesc(&d19)
-			if d19.Loc == scm.LocReg {
+			if d19.Loc == scm.LocReg || d19.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d19.Reg)
 			} else if d19.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d19.Reg)
@@ -91817,40 +91817,40 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			} else {
 				ctx.EmitStoreToStack(d794, int32(bbs[5].PhiBase)+int32(32))
 			}
-			if d17.Loc == scm.LocReg {
+			if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d17.Reg)
 			} else if d17.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d17.Reg)
 				ctx.UnprotectReg(d17.Reg2)
 			}
-			if d18.Loc == scm.LocReg {
+			if d18.Loc == scm.LocReg || d18.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d18.Reg)
 			} else if d18.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d18.Reg)
 				ctx.UnprotectReg(d18.Reg2)
 			}
-			if d19.Loc == scm.LocReg {
+			if d19.Loc == scm.LocReg || d19.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d19.Reg)
 			} else if d19.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d19.Reg)
 				ctx.UnprotectReg(d19.Reg2)
 			}
 			ctx.SyncDesc(&d20)
-			if d20.Loc == scm.LocReg {
+			if d20.Loc == scm.LocReg || d20.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d20.Reg)
 			} else if d20.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d20.Reg)
 				ctx.ProtectReg(d20.Reg2)
 			}
 			ctx.SyncDesc(&d22)
-			if d22.Loc == scm.LocReg {
+			if d22.Loc == scm.LocReg || d22.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d22.Reg)
 			} else if d22.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d22.Reg)
 				ctx.ProtectReg(d22.Reg2)
 			}
 			ctx.SyncDesc(&d789)
-			if d789.Loc == scm.LocReg {
+			if d789.Loc == scm.LocReg || d789.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d789.Reg)
 			} else if d789.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d789.Reg)
@@ -91886,26 +91886,26 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			} else {
 				ctx.EmitStoreToStack(d797, int32(bbs[5].PhiBase)+int32(80))
 			}
-			if d20.Loc == scm.LocReg {
+			if d20.Loc == scm.LocReg || d20.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d20.Reg)
 			} else if d20.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d20.Reg)
 				ctx.UnprotectReg(d20.Reg2)
 			}
-			if d22.Loc == scm.LocReg {
+			if d22.Loc == scm.LocReg || d22.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d22.Reg)
 			} else if d22.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d22.Reg)
 				ctx.UnprotectReg(d22.Reg2)
 			}
-			if d789.Loc == scm.LocReg {
+			if d789.Loc == scm.LocReg || d789.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d789.Reg)
 			} else if d789.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d789.Reg)
 				ctx.UnprotectReg(d789.Reg2)
 			}
 			ctx.SyncDesc(&d790)
-			if d790.Loc == scm.LocReg {
+			if d790.Loc == scm.LocReg || d790.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d790.Reg)
 			} else if d790.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d790.Reg)
@@ -91921,7 +91921,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 			} else {
 				ctx.EmitStoreToStack(d798, int32(bbs[5].PhiBase)+int32(96))
 			}
-			if d790.Loc == scm.LocReg {
+			if d790.Loc == scm.LocReg || d790.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d790.Reg)
 			} else if d790.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d790.Reg)
@@ -92577,7 +92577,8 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 		if d21.Loc == scm.LocImm {
 			d807 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagFloat, Imm: scm.NewFloat(float64(d21.Imm.Int()))}
 		} else {
-			r30 := ctx.AllocRegExcept(d21.Reg)
+			var r30 scm.Reg
+			r30 = ctx.AllocRegExcept(d21.Reg)
 			ctx.EmitMovRegReg(r30, d21.Reg)
 			ctx.EmitCvtInt64ToFloat64(scm.RegX0, r30)
 			d807 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: r30}
@@ -97881,7 +97882,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		}
 		if ps.General {
 			ctx.SyncDesc(&d462)
-			if d462.Loc == scm.LocReg {
+			if d462.Loc == scm.LocReg || d462.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d462.Reg)
 			} else if d462.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d462.Reg)
@@ -97897,7 +97898,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d463, int32(bbs[5].PhiBase)+int32(0))
 			}
-			if d462.Loc == scm.LocReg {
+			if d462.Loc == scm.LocReg || d462.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d462.Reg)
 			} else if d462.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d462.Reg)
@@ -98275,14 +98276,14 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		ctx.StabilizeDescForControlFlow(&d474)
 		if ps.General {
 			ctx.SyncDesc(&d468)
-			if d468.Loc == scm.LocReg {
+			if d468.Loc == scm.LocReg || d468.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d468.Reg)
 			} else if d468.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d468.Reg)
 				ctx.ProtectReg(d468.Reg2)
 			}
 			ctx.SyncDesc(&d470)
-			if d470.Loc == scm.LocReg {
+			if d470.Loc == scm.LocReg || d470.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d470.Reg)
 			} else if d470.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d470.Reg)
@@ -98320,34 +98321,34 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d477, int32(bbs[12].PhiBase)+int32(32))
 			}
-			if d468.Loc == scm.LocReg {
+			if d468.Loc == scm.LocReg || d468.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d468.Reg)
 			} else if d468.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d468.Reg)
 				ctx.UnprotectReg(d468.Reg2)
 			}
-			if d470.Loc == scm.LocReg {
+			if d470.Loc == scm.LocReg || d470.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d470.Reg)
 			} else if d470.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d470.Reg)
 				ctx.UnprotectReg(d470.Reg2)
 			}
 			ctx.SyncDesc(&d471)
-			if d471.Loc == scm.LocReg {
+			if d471.Loc == scm.LocReg || d471.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d471.Reg)
 			} else if d471.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d471.Reg)
 				ctx.ProtectReg(d471.Reg2)
 			}
 			ctx.SyncDesc(&d472)
-			if d472.Loc == scm.LocReg {
+			if d472.Loc == scm.LocReg || d472.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d472.Reg)
 			} else if d472.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d472.Reg)
 				ctx.ProtectReg(d472.Reg2)
 			}
 			ctx.SyncDesc(&d473)
-			if d473.Loc == scm.LocReg {
+			if d473.Loc == scm.LocReg || d473.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d473.Reg)
 			} else if d473.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d473.Reg)
@@ -98383,26 +98384,26 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d480, int32(bbs[12].PhiBase)+int32(80))
 			}
-			if d471.Loc == scm.LocReg {
+			if d471.Loc == scm.LocReg || d471.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d471.Reg)
 			} else if d471.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d471.Reg)
 				ctx.UnprotectReg(d471.Reg2)
 			}
-			if d472.Loc == scm.LocReg {
+			if d472.Loc == scm.LocReg || d472.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d472.Reg)
 			} else if d472.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d472.Reg)
 				ctx.UnprotectReg(d472.Reg2)
 			}
-			if d473.Loc == scm.LocReg {
+			if d473.Loc == scm.LocReg || d473.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d473.Reg)
 			} else if d473.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d473.Reg)
 				ctx.UnprotectReg(d473.Reg2)
 			}
 			ctx.SyncDesc(&d474)
-			if d474.Loc == scm.LocReg {
+			if d474.Loc == scm.LocReg || d474.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d474.Reg)
 			} else if d474.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d474.Reg)
@@ -98423,7 +98424,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}, int32(bbs[12].PhiBase)+int32(112))
 			}
-			if d474.Loc == scm.LocReg {
+			if d474.Loc == scm.LocReg || d474.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d474.Reg)
 			} else if d474.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d474.Reg)
@@ -100791,21 +100792,21 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		ctx.StabilizeDescForControlFlow(&d704)
 		if ps.General {
 			ctx.SyncDesc(&d23)
-			if d23.Loc == scm.LocReg {
+			if d23.Loc == scm.LocReg || d23.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d23.Reg)
 			} else if d23.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d23.Reg)
 				ctx.ProtectReg(d23.Reg2)
 			}
 			ctx.SyncDesc(&d24)
-			if d24.Loc == scm.LocReg {
+			if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d24.Reg)
 			} else if d24.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d24.Reg)
 				ctx.ProtectReg(d24.Reg2)
 			}
 			ctx.SyncDesc(&d25)
-			if d25.Loc == scm.LocReg {
+			if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d25.Reg)
 			} else if d25.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d25.Reg)
@@ -100848,40 +100849,40 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d709, int32(bbs[17].PhiBase)+int32(32))
 			}
-			if d23.Loc == scm.LocReg {
+			if d23.Loc == scm.LocReg || d23.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d23.Reg)
 			} else if d23.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d23.Reg)
 				ctx.UnprotectReg(d23.Reg2)
 			}
-			if d24.Loc == scm.LocReg {
+			if d24.Loc == scm.LocReg || d24.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d24.Reg)
 			} else if d24.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d24.Reg)
 				ctx.UnprotectReg(d24.Reg2)
 			}
-			if d25.Loc == scm.LocReg {
+			if d25.Loc == scm.LocReg || d25.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d25.Reg)
 			} else if d25.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d25.Reg)
 				ctx.UnprotectReg(d25.Reg2)
 			}
 			ctx.SyncDesc(&d26)
-			if d26.Loc == scm.LocReg {
+			if d26.Loc == scm.LocReg || d26.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d26.Reg)
 			} else if d26.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d26.Reg)
 				ctx.ProtectReg(d26.Reg2)
 			}
 			ctx.SyncDesc(&d27)
-			if d27.Loc == scm.LocReg {
+			if d27.Loc == scm.LocReg || d27.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d27.Reg)
 			} else if d27.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d27.Reg)
 				ctx.ProtectReg(d27.Reg2)
 			}
 			ctx.SyncDesc(&d28)
-			if d28.Loc == scm.LocReg {
+			if d28.Loc == scm.LocReg || d28.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d28.Reg)
 			} else if d28.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d28.Reg)
@@ -100917,19 +100918,19 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d712, int32(bbs[17].PhiBase)+int32(80))
 			}
-			if d26.Loc == scm.LocReg {
+			if d26.Loc == scm.LocReg || d26.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d26.Reg)
 			} else if d26.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d26.Reg)
 				ctx.UnprotectReg(d26.Reg2)
 			}
-			if d27.Loc == scm.LocReg {
+			if d27.Loc == scm.LocReg || d27.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d27.Reg)
 			} else if d27.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d27.Reg)
 				ctx.UnprotectReg(d27.Reg2)
 			}
-			if d28.Loc == scm.LocReg {
+			if d28.Loc == scm.LocReg || d28.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d28.Reg)
 			} else if d28.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d28.Reg)
@@ -101987,21 +101988,21 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		ctx.StabilizeDescForControlFlow(&d726)
 		if ps.General {
 			ctx.SyncDesc(&d720)
-			if d720.Loc == scm.LocReg {
+			if d720.Loc == scm.LocReg || d720.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d720.Reg)
 			} else if d720.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d720.Reg)
 				ctx.ProtectReg(d720.Reg2)
 			}
 			ctx.SyncDesc(&d722)
-			if d722.Loc == scm.LocReg {
+			if d722.Loc == scm.LocReg || d722.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d722.Reg)
 			} else if d722.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d722.Reg)
 				ctx.ProtectReg(d722.Reg2)
 			}
 			ctx.SyncDesc(&d723)
-			if d723.Loc == scm.LocReg {
+			if d723.Loc == scm.LocReg || d723.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d723.Reg)
 			} else if d723.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d723.Reg)
@@ -102037,40 +102038,40 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d729, int32(bbs[17].PhiBase)+int32(32))
 			}
-			if d720.Loc == scm.LocReg {
+			if d720.Loc == scm.LocReg || d720.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d720.Reg)
 			} else if d720.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d720.Reg)
 				ctx.UnprotectReg(d720.Reg2)
 			}
-			if d722.Loc == scm.LocReg {
+			if d722.Loc == scm.LocReg || d722.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d722.Reg)
 			} else if d722.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d722.Reg)
 				ctx.UnprotectReg(d722.Reg2)
 			}
-			if d723.Loc == scm.LocReg {
+			if d723.Loc == scm.LocReg || d723.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d723.Reg)
 			} else if d723.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d723.Reg)
 				ctx.UnprotectReg(d723.Reg2)
 			}
 			ctx.SyncDesc(&d724)
-			if d724.Loc == scm.LocReg {
+			if d724.Loc == scm.LocReg || d724.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d724.Reg)
 			} else if d724.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d724.Reg)
 				ctx.ProtectReg(d724.Reg2)
 			}
 			ctx.SyncDesc(&d725)
-			if d725.Loc == scm.LocReg {
+			if d725.Loc == scm.LocReg || d725.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d725.Reg)
 			} else if d725.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d725.Reg)
 				ctx.ProtectReg(d725.Reg2)
 			}
 			ctx.SyncDesc(&d726)
-			if d726.Loc == scm.LocReg {
+			if d726.Loc == scm.LocReg || d726.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d726.Reg)
 			} else if d726.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d726.Reg)
@@ -102106,19 +102107,19 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d732, int32(bbs[17].PhiBase)+int32(80))
 			}
-			if d724.Loc == scm.LocReg {
+			if d724.Loc == scm.LocReg || d724.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d724.Reg)
 			} else if d724.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d724.Reg)
 				ctx.UnprotectReg(d724.Reg2)
 			}
-			if d725.Loc == scm.LocReg {
+			if d725.Loc == scm.LocReg || d725.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d725.Reg)
 			} else if d725.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d725.Reg)
 				ctx.UnprotectReg(d725.Reg2)
 			}
-			if d726.Loc == scm.LocReg {
+			if d726.Loc == scm.LocReg || d726.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d726.Reg)
 			} else if d726.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d726.Reg)
@@ -107258,21 +107259,21 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		}
 		if ps.General {
 			ctx.SyncDesc(&d30)
-			if d30.Loc == scm.LocReg {
+			if d30.Loc == scm.LocReg || d30.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d30.Reg)
 			} else if d30.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d30.Reg)
 				ctx.ProtectReg(d30.Reg2)
 			}
 			ctx.SyncDesc(&d31)
-			if d31.Loc == scm.LocReg {
+			if d31.Loc == scm.LocReg || d31.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d31.Reg)
 			} else if d31.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d31.Reg)
 				ctx.ProtectReg(d31.Reg2)
 			}
 			ctx.SyncDesc(&d1307)
-			if d1307.Loc == scm.LocReg {
+			if d1307.Loc == scm.LocReg || d1307.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1307.Reg)
 			} else if d1307.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1307.Reg)
@@ -107315,40 +107316,40 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d1312, int32(bbs[12].PhiBase)+int32(32))
 			}
-			if d30.Loc == scm.LocReg {
+			if d30.Loc == scm.LocReg || d30.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d30.Reg)
 			} else if d30.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d30.Reg)
 				ctx.UnprotectReg(d30.Reg2)
 			}
-			if d31.Loc == scm.LocReg {
+			if d31.Loc == scm.LocReg || d31.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d31.Reg)
 			} else if d31.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d31.Reg)
 				ctx.UnprotectReg(d31.Reg2)
 			}
-			if d1307.Loc == scm.LocReg {
+			if d1307.Loc == scm.LocReg || d1307.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1307.Reg)
 			} else if d1307.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1307.Reg)
 				ctx.UnprotectReg(d1307.Reg2)
 			}
 			ctx.SyncDesc(&d32)
-			if d32.Loc == scm.LocReg {
+			if d32.Loc == scm.LocReg || d32.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d32.Reg)
 			} else if d32.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d32.Reg)
 				ctx.ProtectReg(d32.Reg2)
 			}
 			ctx.SyncDesc(&d33)
-			if d33.Loc == scm.LocReg {
+			if d33.Loc == scm.LocReg || d33.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d33.Reg)
 			} else if d33.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d33.Reg)
 				ctx.ProtectReg(d33.Reg2)
 			}
 			ctx.SyncDesc(&d34)
-			if d34.Loc == scm.LocReg {
+			if d34.Loc == scm.LocReg || d34.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d34.Reg)
 			} else if d34.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d34.Reg)
@@ -107384,33 +107385,33 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d1315, int32(bbs[12].PhiBase)+int32(80))
 			}
-			if d32.Loc == scm.LocReg {
+			if d32.Loc == scm.LocReg || d32.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d32.Reg)
 			} else if d32.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d32.Reg)
 				ctx.UnprotectReg(d32.Reg2)
 			}
-			if d33.Loc == scm.LocReg {
+			if d33.Loc == scm.LocReg || d33.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d33.Reg)
 			} else if d33.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d33.Reg)
 				ctx.UnprotectReg(d33.Reg2)
 			}
-			if d34.Loc == scm.LocReg {
+			if d34.Loc == scm.LocReg || d34.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d34.Reg)
 			} else if d34.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d34.Reg)
 				ctx.UnprotectReg(d34.Reg2)
 			}
 			ctx.SyncDesc(&d35)
-			if d35.Loc == scm.LocReg {
+			if d35.Loc == scm.LocReg || d35.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d35.Reg)
 			} else if d35.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d35.Reg)
 				ctx.ProtectReg(d35.Reg2)
 			}
 			ctx.SyncDesc(&d1308)
-			if d1308.Loc == scm.LocReg {
+			if d1308.Loc == scm.LocReg || d1308.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1308.Reg)
 			} else if d1308.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1308.Reg)
@@ -107436,13 +107437,13 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d1317, int32(bbs[12].PhiBase)+int32(112))
 			}
-			if d35.Loc == scm.LocReg {
+			if d35.Loc == scm.LocReg || d35.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d35.Reg)
 			} else if d35.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d35.Reg)
 				ctx.UnprotectReg(d35.Reg2)
 			}
-			if d1308.Loc == scm.LocReg {
+			if d1308.Loc == scm.LocReg || d1308.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1308.Reg)
 			} else if d1308.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1308.Reg)
@@ -108353,8 +108354,9 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		if d1329.Loc == scm.LocImm {
 			d1330 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagFloat, Imm: scm.NewFloat(float64(d1329.Imm.Int()))}
 		} else {
-			r38 := ctx.AllocRegExcept(d1329.Reg)
-			ctx.EmitMovRegReg(r38, d1329.Reg)
+			var r38 scm.Reg
+			r38 = d1329.Reg
+			d1329.Loc = scm.LocNone
 			ctx.EmitCvtInt64ToFloat64(scm.RegX0, r38)
 			d1330 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: r38}
 			ctx.BindReg(r38, &d1330)
@@ -115501,14 +115503,14 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		}
 		if ps.General {
 			ctx.SyncDesc(&d2078)
-			if d2078.Loc == scm.LocReg {
+			if d2078.Loc == scm.LocReg || d2078.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d2078.Reg)
 			} else if d2078.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d2078.Reg)
 				ctx.ProtectReg(d2078.Reg2)
 			}
 			ctx.SyncDesc(&d2079)
-			if d2079.Loc == scm.LocReg {
+			if d2079.Loc == scm.LocReg || d2079.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d2079.Reg)
 			} else if d2079.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d2079.Reg)
@@ -115534,13 +115536,13 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 			} else {
 				ctx.EmitStoreToStack(d2081, int32(bbs[21].PhiBase)+int32(16))
 			}
-			if d2078.Loc == scm.LocReg {
+			if d2078.Loc == scm.LocReg || d2078.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d2078.Reg)
 			} else if d2078.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d2078.Reg)
 				ctx.UnprotectReg(d2078.Reg2)
 			}
-			if d2079.Loc == scm.LocReg {
+			if d2079.Loc == scm.LocReg || d2079.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d2079.Reg)
 			} else if d2079.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d2079.Reg)
@@ -116558,8 +116560,9 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 		if d2088.Loc == scm.LocImm {
 			d2089 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagFloat, Imm: scm.NewFloat(float64(d2088.Imm.Int()))}
 		} else {
-			r49 := ctx.AllocRegExcept(d2088.Reg)
-			ctx.EmitMovRegReg(r49, d2088.Reg)
+			var r49 scm.Reg
+			r49 = d2088.Reg
+			d2088.Loc = scm.LocNone
 			ctx.EmitCvtInt64ToFloat64(scm.RegX0, r49)
 			d2089 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: r49}
 			ctx.BindReg(r49, &d2089)
@@ -117981,14 +117984,14 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 		}
 		if ps.General {
 			ctx.SyncDesc(&d99)
-			if d99.Loc == scm.LocReg {
+			if d99.Loc == scm.LocReg || d99.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d99.Reg)
 			} else if d99.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d99.Reg)
 				ctx.ProtectReg(d99.Reg2)
 			}
 			ctx.SyncDesc(&d100)
-			if d100.Loc == scm.LocReg {
+			if d100.Loc == scm.LocReg || d100.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d100.Reg)
 			} else if d100.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d100.Reg)
@@ -118014,13 +118017,13 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 			} else {
 				ctx.EmitStoreToStack(d102, int32(bbs[3].PhiBase)+int32(16))
 			}
-			if d99.Loc == scm.LocReg {
+			if d99.Loc == scm.LocReg || d99.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d99.Reg)
 			} else if d99.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d99.Reg)
 				ctx.UnprotectReg(d99.Reg2)
 			}
-			if d100.Loc == scm.LocReg {
+			if d100.Loc == scm.LocReg || d100.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d100.Reg)
 			} else if d100.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d100.Reg)
@@ -119411,14 +119414,14 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 		}
 		if ps.General {
 			ctx.SyncDesc(&d45)
-			if d45.Loc == scm.LocReg {
+			if d45.Loc == scm.LocReg || d45.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d45.Reg)
 			} else if d45.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d45.Reg)
 				ctx.ProtectReg(d45.Reg2)
 			}
 			ctx.SyncDesc(&d105)
-			if d105.Loc == scm.LocReg {
+			if d105.Loc == scm.LocReg || d105.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d105.Reg)
 			} else if d105.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d105.Reg)
@@ -119444,13 +119447,13 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 			} else {
 				ctx.EmitStoreToStack(d107, int32(bbs[3].PhiBase)+int32(16))
 			}
-			if d45.Loc == scm.LocReg {
+			if d45.Loc == scm.LocReg || d45.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d45.Reg)
 			} else if d45.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d45.Reg)
 				ctx.UnprotectReg(d45.Reg2)
 			}
-			if d105.Loc == scm.LocReg {
+			if d105.Loc == scm.LocReg || d105.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d105.Reg)
 			} else if d105.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d105.Reg)

--- a/storage/storage-decimal.go
+++ b/storage/storage-decimal.go
@@ -282,8 +282,6 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 	_ = d214
 	var d215 scm.JITValueDesc
 	_ = d215
-	var d216 scm.JITValueDesc
-	_ = d216
 	var d217 scm.JITValueDesc
 	_ = d217
 	var d218 scm.JITValueDesc
@@ -298,8 +296,10 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 	_ = d222
 	var d223 scm.JITValueDesc
 	_ = d223
-	var d224 scm.JITValueDesc
-	_ = d224
+	var d225 scm.JITValueDesc
+	_ = d225
+	var d226 scm.JITValueDesc
+	_ = d226
 	/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 	ctx.TrackPointer(unsafe.Pointer(s))
 	thisptr := scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uintptr(unsafe.Pointer(s)))), NoHeapPointer: true}
@@ -2259,19 +2259,33 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 		ctx.BindReg(r35, &d215)
 		ctx.FreeDesc(&d214)
 		ctx.EnsureDesc(&d73)
+		resultTarget216 := false
+		_ = resultTarget216
 		ctx.EnsureDesc(&d215)
 		ctx.EnsureDescsTogether(&d73, &d215)
-		var d216 scm.JITValueDesc
+		var d217 scm.JITValueDesc
 		if d73.Loc == scm.LocImm && d215.Loc == scm.LocImm {
-			d216 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d73.Imm.Int() * d215.Imm.Int())}
+			d217 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d73.Imm.Int() * d215.Imm.Int())}
 		} else if d73.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d215.Reg)
+			var scratch scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d215.Reg {
+				scratch = result.Reg2
+				resultTarget216 = true
+			} else {
+				scratch = ctx.AllocRegExcept(d215.Reg)
+			}
 			ctx.EmitMovRegImm64(scratch, uint64(d73.Imm.Int()))
 			ctx.EmitImulInt64(scratch, d215.Reg)
-			d216 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d216)
+			d217 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d217)
 		} else if d215.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d73.Reg)
+			var scratch scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d73.Reg {
+				scratch = result.Reg2
+				resultTarget216 = true
+			} else {
+				scratch = ctx.AllocRegExcept(d73.Reg)
+			}
 			ctx.EmitMovRegReg(scratch, d73.Reg)
 			if d215.Imm.Int() >= -2147483648 && d215.Imm.Int() <= 2147483647 {
 				ctx.EmitImulRegImm32(scratch, int32(d215.Imm.Int()))
@@ -2279,26 +2293,35 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 				ctx.EmitMovRegImm64(scm.RegR11, uint64(d215.Imm.Int()))
 				ctx.EmitImulInt64(scratch, scm.RegR11)
 			}
-			d216 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d216)
+			d217 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d217)
 		} else {
-			r36 := ctx.AllocRegExcept(d73.Reg, d215.Reg)
+			var r36 scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d73.Reg && result.Reg2 != d215.Reg {
+				r36 = result.Reg2
+				resultTarget216 = true
+			} else {
+				r36 = ctx.AllocRegExcept(d73.Reg, d215.Reg)
+			}
 			ctx.EmitMovRegReg(r36, d73.Reg)
 			ctx.EmitImulInt64(r36, d215.Reg)
-			d216 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r36}
-			ctx.BindReg(r36, &d216)
+			d217 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r36}
+			ctx.BindReg(r36, &d217)
 		}
-		if d216.Loc == scm.LocReg && d73.Loc == scm.LocReg && d216.Reg == d73.Reg {
+		if d217.Loc == scm.LocReg && d73.Loc == scm.LocReg && d217.Reg == d73.Reg {
 			ctx.TransferReg(d73.Reg)
 			d73.Loc = scm.LocNone
 		}
+		if resultTarget216 && d217.Loc == scm.LocReg {
+			ctx.BindReg(result.Reg2, &result)
+		}
 		ctx.FreeDesc(&d215)
-		ctx.EnsureDesc(&d216)
-		d217 = result
-		ctx.EnsureDesc(&d216)
-		ctx.EmitMakeInt(d217, d216)
-		if d216.Loc == scm.LocReg {
-			ctx.FreeReg(d216.Reg)
+		ctx.EnsureDesc(&d217)
+		d218 = result
+		ctx.EnsureDesc(&d217)
+		ctx.EmitMakeInt(d218, d217)
+		if d217.Loc == scm.LocReg {
+			ctx.FreeReg(d217.Reg)
 		}
 		ctx.EmitJmp(lbl0)
 		return result
@@ -2424,76 +2447,77 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 		if len(ps.OverlayValues) > 215 && ps.OverlayValues[215].Loc != scm.LocNone {
 			d215 = ps.OverlayValues[215]
 		}
-		if len(ps.OverlayValues) > 216 && ps.OverlayValues[216].Loc != scm.LocNone {
-			d216 = ps.OverlayValues[216]
-		}
 		if len(ps.OverlayValues) > 217 && ps.OverlayValues[217].Loc != scm.LocNone {
 			d217 = ps.OverlayValues[217]
+		}
+		if len(ps.OverlayValues) > 218 && ps.OverlayValues[218].Loc != scm.LocNone {
+			d218 = ps.OverlayValues[218]
 		}
 		ctx.ReclaimUntrackedRegs()
 		ctx.EnsureDesc(&d73)
 		ctx.EnsureDesc(&d73)
-		var d218 scm.JITValueDesc
+		var d219 scm.JITValueDesc
 		if d73.Loc == scm.LocImm {
-			d218 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagFloat, Imm: scm.NewFloat(float64(d73.Imm.Int()))}
+			d219 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagFloat, Imm: scm.NewFloat(float64(d73.Imm.Int()))}
 		} else {
-			r37 := ctx.AllocRegExcept(d73.Reg)
+			var r37 scm.Reg
+			r37 = ctx.AllocRegExcept(d73.Reg)
 			ctx.EmitMovRegReg(r37, d73.Reg)
 			ctx.EmitCvtInt64ToFloat64(scm.RegX0, r37)
-			d218 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: r37}
-			ctx.BindReg(r37, &d218)
+			d219 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: r37}
+			ctx.BindReg(r37, &d219)
 		}
-		var d219 scm.JITValueDesc
+		var d220 scm.JITValueDesc
 		if thisptr.Loc == scm.LocImm {
 			fieldAddr := uintptr(thisptr.Imm.Int()) + unsafe.Offsetof((*StorageDecimal)(nil).scaleExp)
 			val := *(*int8)(unsafe.Pointer(fieldAddr))
-			d219 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(val))}
+			d220 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(val))}
 		} else {
 			off := int32(unsafe.Offsetof((*StorageDecimal)(nil).scaleExp))
 			r38 := ctx.AllocReg()
 			ctx.EmitMovRegMemB(r38, thisptr.Reg, off)
-			d219 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r38}
-			ctx.BindReg(r38, &d219)
+			d220 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r38}
+			ctx.BindReg(r38, &d220)
 		}
-		ctx.EnsureDesc(&d219)
-		ctx.EnsureDesc(&d219)
-		var d220 scm.JITValueDesc
-		if d219.Loc == scm.LocImm {
-			d220 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(int64(int8(d219.Imm.Int()))))}
-		} else {
-			r39 := ctx.AllocReg()
-			ctx.EmitMovRegReg(r39, d219.Reg)
-			ctx.EmitShlRegImm8(r39, 56)
-			ctx.EmitSarRegImm8(r39, 56)
-			d220 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r39}
-			ctx.BindReg(r39, &d220)
-		}
-		ctx.FreeDesc(&d219)
 		ctx.EnsureDesc(&d220)
 		ctx.EnsureDesc(&d220)
 		var d221 scm.JITValueDesc
 		if d220.Loc == scm.LocImm {
-			d221 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d220.Imm.Int() + 15)}
+			d221 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(int64(int8(d220.Imm.Int()))))}
 		} else {
-			scratch := ctx.AllocRegExcept(d220.Reg)
-			ctx.EmitMovRegReg(scratch, d220.Reg)
-			ctx.EmitAddRegImm32(scratch, int32(15))
-			d221 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d221)
-		}
-		if d221.Loc == scm.LocReg && d220.Loc == scm.LocReg && d221.Reg == d220.Reg {
-			ctx.TransferReg(d220.Reg)
-			d220.Loc = scm.LocNone
+			r39 := ctx.AllocReg()
+			ctx.EmitMovRegReg(r39, d220.Reg)
+			ctx.EmitShlRegImm8(r39, 56)
+			ctx.EmitSarRegImm8(r39, 56)
+			d221 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r39}
+			ctx.BindReg(r39, &d221)
 		}
 		ctx.FreeDesc(&d220)
 		ctx.EnsureDesc(&d221)
+		ctx.EnsureDesc(&d221)
+		var d222 scm.JITValueDesc
+		if d221.Loc == scm.LocImm {
+			d222 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d221.Imm.Int() + 15)}
+		} else {
+			scratch := ctx.AllocRegExcept(d221.Reg)
+			ctx.EmitMovRegReg(scratch, d221.Reg)
+			ctx.EmitAddRegImm32(scratch, int32(15))
+			d222 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d222)
+		}
+		if d222.Loc == scm.LocReg && d221.Loc == scm.LocReg && d222.Reg == d221.Reg {
+			ctx.TransferReg(d221.Reg)
+			d221.Loc = scm.LocNone
+		}
+		ctx.FreeDesc(&d221)
+		ctx.EnsureDesc(&d222)
 		r40 := ctx.AllocReg()
 		ctx.EmitMovRegImm64(r40, uint64(uintptr(unsafe.Pointer(&pow10f[0]))))
 		r41 := ctx.AllocReg()
-		if d221.Loc == scm.LocImm {
-			ctx.EmitMovRegImm64(r41, uint64(d221.Imm.Int())*8)
+		if d222.Loc == scm.LocImm {
+			ctx.EmitMovRegImm64(r41, uint64(d222.Imm.Int())*8)
 		} else {
-			ctx.EmitMovRegReg(r41, d221.Reg)
+			ctx.EmitMovRegReg(r41, d222.Reg)
 			ctx.EmitShlRegImm8(r41, 3)
 		}
 		ctx.EmitAddInt64(r40, r41)
@@ -2501,55 +2525,78 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 		r42 := ctx.AllocRegExcept(r40)
 		ctx.EmitMovRegMem(r42, r40, 0)
 		ctx.FreeReg(r40)
-		d222 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r42}
-		ctx.BindReg(r42, &d222)
-		ctx.FreeDesc(&d221)
-		ctx.EnsureDesc(&d218)
-		ctx.EnsureDesc(&d222)
-		ctx.EnsureDescsTogether(&d218, &d222)
-		var d223 scm.JITValueDesc
-		if d218.Loc == scm.LocImm && d222.Loc == scm.LocImm {
-			d223 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagFloat, Imm: scm.NewFloat(d218.Imm.Float() * d222.Imm.Float())}
-		} else if d218.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d222.Reg)
-			_, xBits := d218.Imm.RawWords()
+		d223 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r42}
+		ctx.BindReg(r42, &d223)
+		ctx.FreeDesc(&d222)
+		ctx.EnsureDesc(&d219)
+		resultTarget224 := false
+		_ = resultTarget224
+		ctx.EnsureDesc(&d223)
+		ctx.EnsureDescsTogether(&d219, &d223)
+		var d225 scm.JITValueDesc
+		if d219.Loc == scm.LocImm && d223.Loc == scm.LocImm {
+			d225 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagFloat, Imm: scm.NewFloat(d219.Imm.Float() * d223.Imm.Float())}
+		} else if d219.Loc == scm.LocImm {
+			var scratch scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d223.Reg {
+				scratch = result.Reg2
+				resultTarget224 = true
+			} else {
+				scratch = ctx.AllocRegExcept(d223.Reg)
+			}
+			_, xBits := d219.Imm.RawWords()
 			ctx.EmitMovRegImm64(scratch, xBits)
-			ctx.EmitMulFloat64(scratch, d222.Reg)
-			d223 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: scratch}
-			ctx.BindReg(scratch, &d223)
-		} else if d222.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d218.Reg)
-			ctx.EmitMovRegReg(scratch, d218.Reg)
-			_, yBits := d222.Imm.RawWords()
+			ctx.EmitMulFloat64(scratch, d223.Reg)
+			d225 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: scratch}
+			ctx.BindReg(scratch, &d225)
+		} else if d223.Loc == scm.LocImm {
+			var scratch scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d219.Reg {
+				scratch = result.Reg2
+				resultTarget224 = true
+			} else {
+				scratch = ctx.AllocRegExcept(d219.Reg)
+			}
+			ctx.EmitMovRegReg(scratch, d219.Reg)
+			_, yBits := d223.Imm.RawWords()
 			ctx.EmitMovRegImm64(scm.RegR11, yBits)
 			ctx.EmitMulFloat64(scratch, scm.RegR11)
-			d223 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: scratch}
-			ctx.BindReg(scratch, &d223)
+			d225 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: scratch}
+			ctx.BindReg(scratch, &d225)
 		} else {
-			r43 := ctx.AllocRegExcept(d218.Reg, d222.Reg)
-			ctx.EmitMovRegReg(r43, d218.Reg)
-			ctx.EmitMulFloat64(r43, d222.Reg)
-			d223 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: r43}
-			ctx.BindReg(r43, &d223)
+			var r43 scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d219.Reg && result.Reg2 != d223.Reg {
+				r43 = result.Reg2
+				resultTarget224 = true
+			} else {
+				r43 = ctx.AllocRegExcept(d219.Reg, d223.Reg)
+			}
+			ctx.EmitMovRegReg(r43, d219.Reg)
+			ctx.EmitMulFloat64(r43, d223.Reg)
+			d225 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: r43}
+			ctx.BindReg(r43, &d225)
 		}
-		if d223.Loc == scm.LocReg && d218.Loc == scm.LocReg && d223.Reg == d218.Reg {
-			ctx.TransferReg(d218.Reg)
-			d218.Loc = scm.LocNone
+		if d225.Loc == scm.LocReg && d219.Loc == scm.LocReg && d225.Reg == d219.Reg {
+			ctx.TransferReg(d219.Reg)
+			d219.Loc = scm.LocNone
 		}
-		ctx.FreeDesc(&d218)
-		ctx.FreeDesc(&d222)
-		ctx.EnsureDesc(&d223)
-		d224 = result
-		ctx.EnsureDesc(&d223)
-		ctx.EmitMakeFloat(d224, d223)
-		if d223.Loc == scm.LocReg {
-			ctx.FreeReg(d223.Reg)
+		if resultTarget224 && d225.Loc == scm.LocReg {
+			ctx.BindReg(result.Reg2, &result)
+		}
+		ctx.FreeDesc(&d219)
+		ctx.FreeDesc(&d223)
+		ctx.EnsureDesc(&d225)
+		d226 = result
+		ctx.EnsureDesc(&d225)
+		ctx.EmitMakeFloat(d226, d225)
+		if d225.Loc == scm.LocReg {
+			ctx.FreeReg(d225.Reg)
 		}
 		ctx.EmitJmp(lbl0)
 		return result
 	}
-	ps225 := scm.PhiState{General: false}
-	_ = bbs[0].RenderPS(ps225)
+	ps227 := scm.PhiState{General: false}
+	_ = bbs[0].RenderPS(ps227)
 	ctx.MarkLabel(lbl0)
 	ctx.ResolveFixups()
 	if resultRegsProtected {

--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -1994,7 +1994,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 		ctx.FreeDesc(&d135)
 		if ps.General {
 			ctx.SyncDesc(&d136)
-			if d136.Loc == scm.LocReg {
+			if d136.Loc == scm.LocReg || d136.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d136.Reg)
 			} else if d136.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d136.Reg)
@@ -2006,7 +2006,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 			}
 			ctx.EnsureDesc(&d137)
 			ctx.EmitStoreToStack(d137, int32(bbs[6].PhiBase)+int32(0))
-			if d136.Loc == scm.LocReg {
+			if d136.Loc == scm.LocReg || d136.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d136.Reg)
 			} else if d136.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d136.Reg)
@@ -2316,7 +2316,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 		ctx.FreeDesc(&d4)
 		if ps.General {
 			ctx.SyncDesc(&d145)
-			if d145.Loc == scm.LocReg {
+			if d145.Loc == scm.LocReg || d145.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d145.Reg)
 			} else if d145.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d145.Reg)
@@ -2339,7 +2339,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 			} else {
 				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}, int32(bbs[7].PhiBase)+int32(32))
 			}
-			if d145.Loc == scm.LocReg {
+			if d145.Loc == scm.LocReg || d145.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d145.Reg)
 			} else if d145.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d145.Reg)
@@ -3507,21 +3507,21 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 		}
 		if ps.General {
 			ctx.SyncDesc(&d262)
-			if d262.Loc == scm.LocReg {
+			if d262.Loc == scm.LocReg || d262.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d262.Reg)
 			} else if d262.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d262.Reg)
 				ctx.ProtectReg(d262.Reg2)
 			}
 			ctx.SyncDesc(&d268)
-			if d268.Loc == scm.LocReg {
+			if d268.Loc == scm.LocReg || d268.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d268.Reg)
 			} else if d268.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d268.Reg)
 				ctx.ProtectReg(d268.Reg2)
 			}
 			ctx.SyncDesc(&d269)
-			if d269.Loc == scm.LocReg {
+			if d269.Loc == scm.LocReg || d269.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d269.Reg)
 			} else if d269.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d269.Reg)
@@ -3564,19 +3564,19 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 			} else {
 				ctx.EmitStoreToStack(d272, int32(bbs[7].PhiBase)+int32(32))
 			}
-			if d262.Loc == scm.LocReg {
+			if d262.Loc == scm.LocReg || d262.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d262.Reg)
 			} else if d262.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d262.Reg)
 				ctx.UnprotectReg(d262.Reg2)
 			}
-			if d268.Loc == scm.LocReg {
+			if d268.Loc == scm.LocReg || d268.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d268.Reg)
 			} else if d268.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d268.Reg)
 				ctx.UnprotectReg(d268.Reg2)
 			}
-			if d269.Loc == scm.LocReg {
+			if d269.Loc == scm.LocReg || d269.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d269.Reg)
 			} else if d269.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d269.Reg)

--- a/storage/storage-int.go
+++ b/storage/storage-int.go
@@ -73,8 +73,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 	_ = d16
 	var d17 scm.JITValueDesc
 	_ = d17
-	var d18 scm.JITValueDesc
-	_ = d18
 	var d19 scm.JITValueDesc
 	_ = d19
 	var d20 scm.JITValueDesc
@@ -105,8 +103,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 	_ = d32
 	var d33 scm.JITValueDesc
 	_ = d33
-	var d34 scm.JITValueDesc
-	_ = d34
 	var d35 scm.JITValueDesc
 	_ = d35
 	var d36 scm.JITValueDesc
@@ -123,8 +119,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 	_ = d41
 	var d42 scm.JITValueDesc
 	_ = d42
-	var d43 scm.JITValueDesc
-	_ = d43
 	var d44 scm.JITValueDesc
 	_ = d44
 	var d45 scm.JITValueDesc
@@ -151,18 +145,24 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 	_ = d55
 	var d56 scm.JITValueDesc
 	_ = d56
-	var d157 scm.JITValueDesc
-	_ = d157
-	var d158 scm.JITValueDesc
-	_ = d158
-	var d159 scm.JITValueDesc
-	_ = d159
+	var d57 scm.JITValueDesc
+	_ = d57
+	var d58 scm.JITValueDesc
+	_ = d58
+	var d59 scm.JITValueDesc
+	_ = d59
 	var d160 scm.JITValueDesc
 	_ = d160
 	var d161 scm.JITValueDesc
 	_ = d161
 	var d162 scm.JITValueDesc
 	_ = d162
+	var d163 scm.JITValueDesc
+	_ = d163
+	var d165 scm.JITValueDesc
+	_ = d165
+	var d166 scm.JITValueDesc
+	_ = d166
 	/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 	ctx.TrackPointer(unsafe.Pointer(s))
 	thisptr := scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uintptr(unsafe.Pointer(s)))), NoHeapPointer: true}
@@ -435,30 +435,32 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		}
 		ctx.ReclaimUntrackedRegs()
 		ctx.EnsureDesc(&d16)
-		var d18 scm.JITValueDesc
+		resultTarget18 := false
+		_ = resultTarget18
+		var d19 scm.JITValueDesc
 		if d16.Loc == scm.LocImm {
-			d18 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d16.Imm.Int() % 64)}
+			d19 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d16.Imm.Int() % 64)}
 		} else {
 			r5 := ctx.AllocRegExcept(d16.Reg)
 			ctx.EmitMovRegReg(r5, d16.Reg)
 			ctx.EmitAndRegImm32(r5, 63)
-			d18 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r5}
-			ctx.BindReg(r5, &d18)
+			d19 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r5}
+			ctx.BindReg(r5, &d19)
 		}
-		if d18.Loc == scm.LocReg && d16.Loc == scm.LocReg && d18.Reg == d16.Reg {
+		if d19.Loc == scm.LocReg && d16.Loc == scm.LocReg && d19.Reg == d16.Reg {
 			ctx.TransferReg(d16.Reg)
 			d16.Loc = scm.LocNone
 		}
 		ctx.FreeDesc(&d16)
 		ctx.ReclaimUntrackedRegs()
 		ctx.ReclaimUntrackedRegs()
-		var d19 scm.JITValueDesc
+		var d20 scm.JITValueDesc
 		if thisptr.Loc == scm.LocImm {
 			fieldAddr := uintptr(thisptr.Imm.Int()) + unsafe.Offsetof((*StorageInt)(nil).chunk)
 			dataPtr := *(*uintptr)(unsafe.Pointer(fieldAddr))
 			sliceLen := *(*int)(unsafe.Pointer(fieldAddr + 8))
 			sliceCap := *(*int)(unsafe.Pointer(fieldAddr + 16))
-			d19 = scm.JITValueDesc{Loc: scm.LocMem, Type: scm.TagSlice, MemPtr: dataPtr, KnownSliceLen: int32(sliceLen), KnownSliceCap: int32(sliceCap), SliceSizeKnown: true, GoArray: true, RelocatablePointer: true, Rooted: true}
+			d20 = scm.JITValueDesc{Loc: scm.LocMem, Type: scm.TagSlice, MemPtr: dataPtr, KnownSliceLen: int32(sliceLen), KnownSliceCap: int32(sliceCap), SliceSizeKnown: true, GoArray: true, RelocatablePointer: true, Rooted: true}
 		} else {
 			r6 := ctx.AllocReg()
 			r7 := ctx.AllocRegExcept(r6)
@@ -467,364 +469,393 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 			ctx.EmitMovRegMem(r6, thisptr.Reg, off)
 			ctx.EmitMovRegMem(r7, thisptr.Reg, off+8)
 			ctx.EmitMovRegMem(r8, thisptr.Reg, off+16)
-			d19 = scm.JITValueDesc{Loc: scm.LocRegTriple, Type: scm.TagSlice, Reg: r6, Reg2: r7, Reg3: r8}
-			ctx.BindReg(r6, &d19)
-			ctx.BindReg(r7, &d19)
-			ctx.BindReg(r8, &d19)
-			ctx.BindReg(r6, &d19)
-			ctx.BindReg(r7, &d19)
-			ctx.BindReg(r8, &d19)
+			d20 = scm.JITValueDesc{Loc: scm.LocRegTriple, Type: scm.TagSlice, Reg: r6, Reg2: r7, Reg3: r8}
+			ctx.BindReg(r6, &d20)
+			ctx.BindReg(r7, &d20)
+			ctx.BindReg(r8, &d20)
+			ctx.BindReg(r6, &d20)
+			ctx.BindReg(r7, &d20)
+			ctx.BindReg(r8, &d20)
 		}
 		ctx.ReclaimUntrackedRegs()
 		ctx.EnsureDesc(&d17)
 		ctx.ReclaimUntrackedRegs()
-		d20 = ctx.EmitLoadScalarSliceElement(&d19, &d17, 8, scm.TagInt)
+		d21 = ctx.EmitLoadScalarSliceElement(&d20, &d17, 8, scm.TagInt)
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d20)
-		ctx.EnsureDesc(&d18)
-		ctx.EnsureDescsTogether(&d20, &d18)
-		var d21 scm.JITValueDesc
-		if d20.Loc == scm.LocImm && d18.Loc == scm.LocImm {
-			d21 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d20.Imm.Int()) << uint64(d18.Imm.Int())))}
-		} else if d18.Loc == scm.LocImm {
-			r9 := ctx.AllocRegExcept(d20.Reg)
-			ctx.EmitMovRegReg(r9, d20.Reg)
-			ctx.EmitShlRegImm8(r9, uint8(d18.Imm.Int()))
-			d21 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r9}
-			ctx.BindReg(r9, &d21)
+		ctx.EnsureDesc(&d21)
+		ctx.EnsureDesc(&d19)
+		ctx.EnsureDescsTogether(&d21, &d19)
+		var d22 scm.JITValueDesc
+		if d21.Loc == scm.LocImm && d19.Loc == scm.LocImm {
+			d22 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d21.Imm.Int()) << uint64(d19.Imm.Int())))}
+		} else if d19.Loc == scm.LocImm {
+			r9 := ctx.AllocRegExcept(d21.Reg)
+			ctx.EmitMovRegReg(r9, d21.Reg)
+			ctx.EmitShlRegImm8(r9, uint8(d19.Imm.Int()))
+			d22 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r9}
+			ctx.BindReg(r9, &d22)
 		} else {
 			{
-				shiftSrc := d20.Reg
-				r10 := ctx.AllocRegExcept(d20.Reg, d18.Reg)
-				ctx.EmitMovRegReg(r10, d20.Reg)
+				shiftSrc := d21.Reg
+				r10 := ctx.AllocRegExcept(d21.Reg, d19.Reg)
+				ctx.EmitMovRegReg(r10, d21.Reg)
 				shiftSrc = r10
-				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d18.Reg != scm.RegRCX
+				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d19.Reg != scm.RegRCX
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegR11, scm.RegRCX)
 				}
-				if d18.Reg != scm.RegRCX {
-					ctx.EmitMovRegReg(scm.RegRCX, d18.Reg)
+				if d19.Reg != scm.RegRCX {
+					ctx.EmitMovRegReg(scm.RegRCX, d19.Reg)
 				}
 				ctx.EmitShlRegCl(shiftSrc)
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegRCX, scm.RegR11)
 				}
-				d21 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
-				ctx.BindReg(shiftSrc, &d21)
+				d22 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
+				ctx.BindReg(shiftSrc, &d22)
 			}
 		}
-		if d21.Loc == scm.LocReg && d20.Loc == scm.LocReg && d21.Reg == d20.Reg {
-			ctx.TransferReg(d20.Reg)
-			d20.Loc = scm.LocNone
+		if d22.Loc == scm.LocReg && d21.Loc == scm.LocReg && d22.Reg == d21.Reg {
+			ctx.TransferReg(d21.Reg)
+			d21.Loc = scm.LocNone
 		}
-		ctx.FreeDesc(&d20)
+		ctx.FreeDesc(&d21)
 		ctx.ReclaimUntrackedRegs()
 		ctx.ReclaimUntrackedRegs()
 		ctx.ReclaimUntrackedRegs()
 		ctx.EnsureDesc(&d17)
 		ctx.EnsureDesc(&d17)
-		var d22 scm.JITValueDesc
+		var d23 scm.JITValueDesc
 		if d17.Loc == scm.LocImm {
-			d22 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d17.Imm.Int() + 1)}
+			d23 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d17.Imm.Int() + 1)}
 		} else {
 			scratch := ctx.AllocRegExcept(d17.Reg)
 			ctx.EmitMovRegReg(scratch, d17.Reg)
 			ctx.EmitAddRegImm32(scratch, int32(1))
-			d22 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d22)
+			d23 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d23)
 		}
-		if d22.Loc == scm.LocReg && d17.Loc == scm.LocReg && d22.Reg == d17.Reg {
+		if d23.Loc == scm.LocReg && d17.Loc == scm.LocReg && d23.Reg == d17.Reg {
 			ctx.TransferReg(d17.Reg)
 			d17.Loc = scm.LocNone
 		}
 		ctx.FreeDesc(&d17)
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d22)
+		ctx.EnsureDesc(&d23)
 		ctx.ReclaimUntrackedRegs()
-		d23 = ctx.EmitLoadScalarSliceElement(&d19, &d22, 8, scm.TagInt)
-		ctx.FreeDesc(&d22)
+		d24 = ctx.EmitLoadScalarSliceElement(&d20, &d23, 8, scm.TagInt)
+		ctx.FreeDesc(&d23)
 		ctx.ReclaimUntrackedRegs()
-		d24 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(64)}
-		ctx.EnsureDesc(&d18)
-		ctx.EnsureDescsTogether(&d24, &d18)
-		var d25 scm.JITValueDesc
-		if d24.Loc == scm.LocImm && d18.Loc == scm.LocImm {
-			d25 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d24.Imm.Int() - d18.Imm.Int())}
-		} else if d18.Loc == scm.LocImm && d18.Imm.Int() == 0 {
-			r11 := ctx.AllocRegExcept(d24.Reg)
-			ctx.EmitMovRegReg(r11, d24.Reg)
-			d25 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r11}
-			ctx.BindReg(r11, &d25)
-		} else if d24.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d18.Reg)
-			ctx.EmitMovRegImm64(scratch, uint64(d24.Imm.Int()))
-			ctx.EmitSubInt64(scratch, d18.Reg)
-			d25 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d25)
-		} else if d18.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d24.Reg)
-			ctx.EmitMovRegReg(scratch, d24.Reg)
-			if d18.Imm.Int() >= -2147483648 && d18.Imm.Int() <= 2147483647 {
-				ctx.EmitSubRegImm32(scratch, int32(d18.Imm.Int()))
+		d25 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(64)}
+		ctx.EnsureDesc(&d19)
+		ctx.EnsureDescsTogether(&d25, &d19)
+		var d26 scm.JITValueDesc
+		if d25.Loc == scm.LocImm && d19.Loc == scm.LocImm {
+			d26 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d25.Imm.Int() - d19.Imm.Int())}
+		} else if d19.Loc == scm.LocImm && d19.Imm.Int() == 0 {
+			r11 := ctx.AllocRegExcept(d25.Reg)
+			ctx.EmitMovRegReg(r11, d25.Reg)
+			d26 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r11}
+			ctx.BindReg(r11, &d26)
+		} else if d25.Loc == scm.LocImm {
+			scratch := ctx.AllocRegExcept(d19.Reg)
+			ctx.EmitMovRegImm64(scratch, uint64(d25.Imm.Int()))
+			ctx.EmitSubInt64(scratch, d19.Reg)
+			d26 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d26)
+		} else if d19.Loc == scm.LocImm {
+			scratch := ctx.AllocRegExcept(d25.Reg)
+			ctx.EmitMovRegReg(scratch, d25.Reg)
+			if d19.Imm.Int() >= -2147483648 && d19.Imm.Int() <= 2147483647 {
+				ctx.EmitSubRegImm32(scratch, int32(d19.Imm.Int()))
 			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d18.Imm.Int()))
+				ctx.EmitMovRegImm64(scm.RegR11, uint64(d19.Imm.Int()))
 				ctx.EmitSubInt64(scratch, scm.RegR11)
 			}
-			d25 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d25)
+			d26 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d26)
 		} else {
-			r12 := ctx.AllocRegExcept(d24.Reg, d18.Reg)
-			ctx.EmitMovRegReg(r12, d24.Reg)
-			ctx.EmitSubInt64(r12, d18.Reg)
-			d25 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r12}
-			ctx.BindReg(r12, &d25)
+			r12 := ctx.AllocRegExcept(d25.Reg, d19.Reg)
+			ctx.EmitMovRegReg(r12, d25.Reg)
+			ctx.EmitSubInt64(r12, d19.Reg)
+			d26 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r12}
+			ctx.BindReg(r12, &d26)
 		}
-		if d25.Loc == scm.LocReg && d24.Loc == scm.LocReg && d25.Reg == d24.Reg {
-			ctx.TransferReg(d24.Reg)
-			d24.Loc = scm.LocNone
+		if d26.Loc == scm.LocReg && d25.Loc == scm.LocReg && d26.Reg == d25.Reg {
+			ctx.TransferReg(d25.Reg)
+			d25.Loc = scm.LocNone
 		}
-		ctx.FreeDesc(&d18)
+		ctx.FreeDesc(&d19)
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d23)
-		ctx.EnsureDesc(&d25)
-		ctx.EnsureDescsTogether(&d23, &d25)
-		var d26 scm.JITValueDesc
-		if d23.Loc == scm.LocImm && d25.Loc == scm.LocImm {
-			d26 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d23.Imm.Int()) >> uint64(d25.Imm.Int())))}
-		} else if d25.Loc == scm.LocImm {
-			r13 := ctx.AllocRegExcept(d23.Reg)
-			ctx.EmitMovRegReg(r13, d23.Reg)
-			ctx.EmitShrRegImm8(r13, uint8(d25.Imm.Int()))
-			d26 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r13}
-			ctx.BindReg(r13, &d26)
+		ctx.EnsureDesc(&d24)
+		ctx.EnsureDesc(&d26)
+		ctx.EnsureDescsTogether(&d24, &d26)
+		var d27 scm.JITValueDesc
+		if d24.Loc == scm.LocImm && d26.Loc == scm.LocImm {
+			d27 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d24.Imm.Int()) >> uint64(d26.Imm.Int())))}
+		} else if d26.Loc == scm.LocImm {
+			r13 := ctx.AllocRegExcept(d24.Reg)
+			ctx.EmitMovRegReg(r13, d24.Reg)
+			ctx.EmitShrRegImm8(r13, uint8(d26.Imm.Int()))
+			d27 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r13}
+			ctx.BindReg(r13, &d27)
 		} else {
 			{
-				shiftSrc := d23.Reg
-				r14 := ctx.AllocRegExcept(d23.Reg, d25.Reg)
-				ctx.EmitMovRegReg(r14, d23.Reg)
+				shiftSrc := d24.Reg
+				r14 := ctx.AllocRegExcept(d24.Reg, d26.Reg)
+				ctx.EmitMovRegReg(r14, d24.Reg)
 				shiftSrc = r14
-				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d25.Reg != scm.RegRCX
+				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d26.Reg != scm.RegRCX
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegR11, scm.RegRCX)
 				}
-				if d25.Reg != scm.RegRCX {
-					ctx.EmitMovRegReg(scm.RegRCX, d25.Reg)
+				if d26.Reg != scm.RegRCX {
+					ctx.EmitMovRegReg(scm.RegRCX, d26.Reg)
 				}
 				ctx.EmitShrRegClGo64(shiftSrc)
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegRCX, scm.RegR11)
 				}
-				d26 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
-				ctx.BindReg(shiftSrc, &d26)
+				d27 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
+				ctx.BindReg(shiftSrc, &d27)
 			}
 		}
-		if d26.Loc == scm.LocReg && d23.Loc == scm.LocReg && d26.Reg == d23.Reg {
-			ctx.TransferReg(d23.Reg)
-			d23.Loc = scm.LocNone
+		if d27.Loc == scm.LocReg && d24.Loc == scm.LocReg && d27.Reg == d24.Reg {
+			ctx.TransferReg(d24.Reg)
+			d24.Loc = scm.LocNone
 		}
-		ctx.FreeDesc(&d23)
-		ctx.FreeDesc(&d25)
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d21)
-		ctx.EnsureDesc(&d26)
-		var d27 scm.JITValueDesc
-		if d21.Loc == scm.LocImm && d26.Loc == scm.LocImm {
-			d27 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d21.Imm.Int() | d26.Imm.Int())}
-		} else if d21.Loc == scm.LocImm && d21.Imm.Int() == 0 {
-			d27 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d26.Reg}
-			ctx.BindReg(d26.Reg, &d27)
-		} else if d26.Loc == scm.LocImm && d26.Imm.Int() == 0 {
-			r15 := ctx.AllocRegExcept(d21.Reg)
-			ctx.EmitMovRegReg(r15, d21.Reg)
-			d27 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r15}
-			ctx.BindReg(r15, &d27)
-		} else if d21.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d26.Reg)
-			ctx.EmitMovRegImm64(scratch, uint64(d21.Imm.Int()))
-			ctx.EmitOrInt64(scratch, d26.Reg)
-			d27 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d27)
-		} else if d26.Loc == scm.LocImm {
-			r16 := ctx.AllocRegExcept(d21.Reg)
-			ctx.EmitMovRegReg(r16, d21.Reg)
-			if d26.Imm.Int() >= -2147483648 && d26.Imm.Int() <= 2147483647 {
-				ctx.EmitOrRegImm32(r16, int32(d26.Imm.Int()))
-			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d26.Imm.Int()))
-				ctx.EmitOrInt64(r16, scm.RegR11)
-			}
-			d27 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r16}
-			ctx.BindReg(r16, &d27)
-		} else {
-			r17 := ctx.AllocRegExcept(d21.Reg, d26.Reg)
-			ctx.EmitMovRegReg(r17, d21.Reg)
-			ctx.EmitOrInt64(r17, d26.Reg)
-			d27 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r17}
-			ctx.BindReg(r17, &d27)
-		}
-		if d27.Loc == scm.LocReg && d21.Loc == scm.LocReg && d27.Reg == d21.Reg {
-			ctx.TransferReg(d21.Reg)
-			d21.Loc = scm.LocNone
-		}
-		ctx.FreeDesc(&d21)
+		ctx.FreeDesc(&d24)
 		ctx.FreeDesc(&d26)
 		ctx.ReclaimUntrackedRegs()
-		d28 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(64)}
+		ctx.EnsureDesc(&d22)
+		ctx.EnsureDesc(&d27)
+		var d28 scm.JITValueDesc
+		if d22.Loc == scm.LocImm && d27.Loc == scm.LocImm {
+			d28 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d22.Imm.Int() | d27.Imm.Int())}
+		} else if d22.Loc == scm.LocImm && d22.Imm.Int() == 0 {
+			d28 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d27.Reg}
+			ctx.BindReg(d27.Reg, &d28)
+		} else if d27.Loc == scm.LocImm && d27.Imm.Int() == 0 {
+			r15 := ctx.AllocRegExcept(d22.Reg)
+			ctx.EmitMovRegReg(r15, d22.Reg)
+			d28 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r15}
+			ctx.BindReg(r15, &d28)
+		} else if d22.Loc == scm.LocImm {
+			scratch := ctx.AllocRegExcept(d27.Reg)
+			ctx.EmitMovRegImm64(scratch, uint64(d22.Imm.Int()))
+			ctx.EmitOrInt64(scratch, d27.Reg)
+			d28 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d28)
+		} else if d27.Loc == scm.LocImm {
+			r16 := ctx.AllocRegExcept(d22.Reg)
+			ctx.EmitMovRegReg(r16, d22.Reg)
+			if d27.Imm.Int() >= -2147483648 && d27.Imm.Int() <= 2147483647 {
+				ctx.EmitOrRegImm32(r16, int32(d27.Imm.Int()))
+			} else {
+				ctx.EmitMovRegImm64(scm.RegR11, uint64(d27.Imm.Int()))
+				ctx.EmitOrInt64(r16, scm.RegR11)
+			}
+			d28 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r16}
+			ctx.BindReg(r16, &d28)
+		} else {
+			r17 := ctx.AllocRegExcept(d22.Reg, d27.Reg)
+			ctx.EmitMovRegReg(r17, d22.Reg)
+			ctx.EmitOrInt64(r17, d27.Reg)
+			d28 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r17}
+			ctx.BindReg(r17, &d28)
+		}
+		if d28.Loc == scm.LocReg && d22.Loc == scm.LocReg && d28.Reg == d22.Reg {
+			ctx.TransferReg(d22.Reg)
+			d22.Loc = scm.LocNone
+		}
+		ctx.FreeDesc(&d22)
+		ctx.FreeDesc(&d27)
+		ctx.ReclaimUntrackedRegs()
+		d29 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(64)}
 		ctx.EnsureDesc(&d14)
-		ctx.EnsureDescsTogether(&d28, &d14)
-		var d29 scm.JITValueDesc
-		if d28.Loc == scm.LocImm && d14.Loc == scm.LocImm {
-			d29 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d28.Imm.Int() - d14.Imm.Int())}
+		ctx.EnsureDescsTogether(&d29, &d14)
+		var d30 scm.JITValueDesc
+		if d29.Loc == scm.LocImm && d14.Loc == scm.LocImm {
+			d30 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d29.Imm.Int() - d14.Imm.Int())}
 		} else if d14.Loc == scm.LocImm && d14.Imm.Int() == 0 {
-			r18 := ctx.AllocRegExcept(d28.Reg)
-			ctx.EmitMovRegReg(r18, d28.Reg)
-			d29 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r18}
-			ctx.BindReg(r18, &d29)
-		} else if d28.Loc == scm.LocImm {
+			r18 := ctx.AllocRegExcept(d29.Reg)
+			ctx.EmitMovRegReg(r18, d29.Reg)
+			d30 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r18}
+			ctx.BindReg(r18, &d30)
+		} else if d29.Loc == scm.LocImm {
 			scratch := ctx.AllocRegExcept(d14.Reg)
-			ctx.EmitMovRegImm64(scratch, uint64(d28.Imm.Int()))
+			ctx.EmitMovRegImm64(scratch, uint64(d29.Imm.Int()))
 			ctx.EmitSubInt64(scratch, d14.Reg)
-			d29 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d29)
+			d30 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d30)
 		} else if d14.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d28.Reg)
-			ctx.EmitMovRegReg(scratch, d28.Reg)
+			scratch := ctx.AllocRegExcept(d29.Reg)
+			ctx.EmitMovRegReg(scratch, d29.Reg)
 			if d14.Imm.Int() >= -2147483648 && d14.Imm.Int() <= 2147483647 {
 				ctx.EmitSubRegImm32(scratch, int32(d14.Imm.Int()))
 			} else {
 				ctx.EmitMovRegImm64(scm.RegR11, uint64(d14.Imm.Int()))
 				ctx.EmitSubInt64(scratch, scm.RegR11)
 			}
-			d29 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d29)
+			d30 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d30)
 		} else {
-			r19 := ctx.AllocRegExcept(d28.Reg, d14.Reg)
-			ctx.EmitMovRegReg(r19, d28.Reg)
+			r19 := ctx.AllocRegExcept(d29.Reg, d14.Reg)
+			ctx.EmitMovRegReg(r19, d29.Reg)
 			ctx.EmitSubInt64(r19, d14.Reg)
-			d29 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r19}
-			ctx.BindReg(r19, &d29)
+			d30 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r19}
+			ctx.BindReg(r19, &d30)
 		}
-		if d29.Loc == scm.LocReg && d28.Loc == scm.LocReg && d29.Reg == d28.Reg {
-			ctx.TransferReg(d28.Reg)
-			d28.Loc = scm.LocNone
+		if d30.Loc == scm.LocReg && d29.Loc == scm.LocReg && d30.Reg == d29.Reg {
+			ctx.TransferReg(d29.Reg)
+			d29.Loc = scm.LocNone
 		}
 		ctx.FreeDesc(&d14)
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d27)
-		ctx.EnsureDesc(&d29)
-		ctx.EnsureDescsTogether(&d27, &d29)
-		var d30 scm.JITValueDesc
-		if d27.Loc == scm.LocImm && d29.Loc == scm.LocImm {
-			d30 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d27.Imm.Int()) >> uint64(d29.Imm.Int())))}
-		} else if d29.Loc == scm.LocImm {
-			r20 := ctx.AllocRegExcept(d27.Reg)
-			ctx.EmitMovRegReg(r20, d27.Reg)
-			ctx.EmitShrRegImm8(r20, uint8(d29.Imm.Int()))
-			d30 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r20}
-			ctx.BindReg(r20, &d30)
+		ctx.EnsureDesc(&d28)
+		ctx.EnsureDesc(&d30)
+		ctx.EnsureDescsTogether(&d28, &d30)
+		var d31 scm.JITValueDesc
+		if d28.Loc == scm.LocImm && d30.Loc == scm.LocImm {
+			d31 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d28.Imm.Int()) >> uint64(d30.Imm.Int())))}
+		} else if d30.Loc == scm.LocImm {
+			r20 := ctx.AllocRegExcept(d28.Reg)
+			ctx.EmitMovRegReg(r20, d28.Reg)
+			ctx.EmitShrRegImm8(r20, uint8(d30.Imm.Int()))
+			d31 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r20}
+			ctx.BindReg(r20, &d31)
 		} else {
 			{
-				shiftSrc := d27.Reg
-				r21 := ctx.AllocRegExcept(d27.Reg, d29.Reg)
-				ctx.EmitMovRegReg(r21, d27.Reg)
+				shiftSrc := d28.Reg
+				r21 := ctx.AllocRegExcept(d28.Reg, d30.Reg)
+				ctx.EmitMovRegReg(r21, d28.Reg)
 				shiftSrc = r21
-				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d29.Reg != scm.RegRCX
+				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d30.Reg != scm.RegRCX
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegR11, scm.RegRCX)
 				}
-				if d29.Reg != scm.RegRCX {
-					ctx.EmitMovRegReg(scm.RegRCX, d29.Reg)
+				if d30.Reg != scm.RegRCX {
+					ctx.EmitMovRegReg(scm.RegRCX, d30.Reg)
 				}
 				ctx.EmitShrRegClGo64(shiftSrc)
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegRCX, scm.RegR11)
 				}
-				d30 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
-				ctx.BindReg(shiftSrc, &d30)
+				d31 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
+				ctx.BindReg(shiftSrc, &d31)
 			}
 		}
-		if d30.Loc == scm.LocReg && d27.Loc == scm.LocReg && d30.Reg == d27.Reg {
-			ctx.TransferReg(d27.Reg)
-			d27.Loc = scm.LocNone
+		if d31.Loc == scm.LocReg && d28.Loc == scm.LocReg && d31.Reg == d28.Reg {
+			ctx.TransferReg(d28.Reg)
+			d28.Loc = scm.LocNone
 		}
-		ctx.FreeDesc(&d27)
-		ctx.FreeDesc(&d29)
+		ctx.FreeDesc(&d28)
+		ctx.FreeDesc(&d30)
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d30)
-		ctx.EnsureDesc(&d30)
-		ctx.EnsureDesc(&d30)
-		var d31 scm.JITValueDesc
-		if d30.Loc == scm.LocImm {
-			d31 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(int64(uint64(d30.Imm.Int()))))}
+		ctx.EnsureDesc(&d31)
+		ctx.EnsureDesc(&d31)
+		ctx.EnsureDesc(&d31)
+		var d32 scm.JITValueDesc
+		if d31.Loc == scm.LocImm {
+			d32 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(int64(uint64(d31.Imm.Int()))))}
 		} else {
 			r22 := ctx.AllocReg()
-			ctx.EmitMovRegReg(r22, d30.Reg)
-			d31 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r22}
-			ctx.BindReg(r22, &d31)
+			ctx.EmitMovRegReg(r22, d31.Reg)
+			d32 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r22}
+			ctx.BindReg(r22, &d32)
 		}
-		ctx.FreeDesc(&d30)
-		var d32 scm.JITValueDesc
+		ctx.FreeDesc(&d31)
+		var d33 scm.JITValueDesc
 		if thisptr.Loc == scm.LocImm {
 			fieldAddr := uintptr(thisptr.Imm.Int()) + unsafe.Offsetof((*StorageInt)(nil).offset)
 			val := *(*int64)(unsafe.Pointer(fieldAddr))
-			d32 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(val)}
+			d33 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(val)}
 		} else {
 			off := int32(unsafe.Offsetof((*StorageInt)(nil).offset))
 			r23 := ctx.AllocReg()
 			ctx.EmitMovRegMem(r23, thisptr.Reg, off)
-			d32 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r23}
-			ctx.BindReg(r23, &d32)
+			d33 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r23}
+			ctx.BindReg(r23, &d33)
 		}
-		ctx.EnsureDesc(&d31)
 		ctx.EnsureDesc(&d32)
-		ctx.EnsureDescsTogether(&d31, &d32)
-		var d33 scm.JITValueDesc
-		if d31.Loc == scm.LocImm && d32.Loc == scm.LocImm {
-			d33 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d31.Imm.Int() + d32.Imm.Int())}
-		} else if d32.Loc == scm.LocImm && d32.Imm.Int() == 0 {
-			r24 := ctx.AllocRegExcept(d31.Reg)
-			ctx.EmitMovRegReg(r24, d31.Reg)
-			d33 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r24}
-			ctx.BindReg(r24, &d33)
-		} else if d31.Loc == scm.LocImm && d31.Imm.Int() == 0 {
-			d33 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d32.Reg}
-			ctx.BindReg(d32.Reg, &d33)
-		} else if d31.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d32.Reg)
-			ctx.EmitMovRegImm64(scratch, uint64(d31.Imm.Int()))
-			ctx.EmitAddInt64(scratch, d32.Reg)
-			d33 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d33)
-		} else if d32.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d31.Reg)
-			ctx.EmitMovRegReg(scratch, d31.Reg)
-			if d32.Imm.Int() >= -2147483648 && d32.Imm.Int() <= 2147483647 {
-				ctx.EmitAddRegImm32(scratch, int32(d32.Imm.Int()))
+		resultTarget34 := false
+		_ = resultTarget34
+		ctx.EnsureDesc(&d33)
+		ctx.EnsureDescsTogether(&d32, &d33)
+		var d35 scm.JITValueDesc
+		if d32.Loc == scm.LocImm && d33.Loc == scm.LocImm {
+			d35 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d32.Imm.Int() + d33.Imm.Int())}
+		} else if d33.Loc == scm.LocImm && d33.Imm.Int() == 0 {
+			var r24 scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d32.Reg {
+				r24 = result.Reg2
+				resultTarget34 = true
 			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d32.Imm.Int()))
+				r24 = ctx.AllocRegExcept(d32.Reg)
+			}
+			ctx.EmitMovRegReg(r24, d32.Reg)
+			d35 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r24}
+			ctx.BindReg(r24, &d35)
+		} else if d32.Loc == scm.LocImm && d32.Imm.Int() == 0 {
+			d35 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d33.Reg}
+			ctx.BindReg(d33.Reg, &d35)
+		} else if d32.Loc == scm.LocImm {
+			var scratch scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d33.Reg {
+				scratch = result.Reg2
+				resultTarget34 = true
+			} else {
+				scratch = ctx.AllocRegExcept(d33.Reg)
+			}
+			ctx.EmitMovRegImm64(scratch, uint64(d32.Imm.Int()))
+			ctx.EmitAddInt64(scratch, d33.Reg)
+			d35 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d35)
+		} else if d33.Loc == scm.LocImm {
+			var scratch scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d32.Reg {
+				scratch = result.Reg2
+				resultTarget34 = true
+			} else {
+				scratch = ctx.AllocRegExcept(d32.Reg)
+			}
+			ctx.EmitMovRegReg(scratch, d32.Reg)
+			if d33.Imm.Int() >= -2147483648 && d33.Imm.Int() <= 2147483647 {
+				ctx.EmitAddRegImm32(scratch, int32(d33.Imm.Int()))
+			} else {
+				ctx.EmitMovRegImm64(scm.RegR11, uint64(d33.Imm.Int()))
 				ctx.EmitAddInt64(scratch, scm.RegR11)
 			}
-			d33 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d33)
+			d35 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d35)
 		} else {
-			r25 := ctx.AllocRegExcept(d31.Reg, d32.Reg)
-			ctx.EmitMovRegReg(r25, d31.Reg)
-			ctx.EmitAddInt64(r25, d32.Reg)
-			d33 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r25}
-			ctx.BindReg(r25, &d33)
+			var r25 scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d32.Reg && result.Reg2 != d33.Reg {
+				r25 = result.Reg2
+				resultTarget34 = true
+			} else {
+				r25 = ctx.AllocRegExcept(d32.Reg, d33.Reg)
+			}
+			ctx.EmitMovRegReg(r25, d32.Reg)
+			ctx.EmitAddInt64(r25, d33.Reg)
+			d35 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r25}
+			ctx.BindReg(r25, &d35)
 		}
-		if d33.Loc == scm.LocReg && d31.Loc == scm.LocReg && d33.Reg == d31.Reg {
-			ctx.TransferReg(d31.Reg)
-			d31.Loc = scm.LocNone
+		if d35.Loc == scm.LocReg && d32.Loc == scm.LocReg && d35.Reg == d32.Reg {
+			ctx.TransferReg(d32.Reg)
+			d32.Loc = scm.LocNone
 		}
-		ctx.FreeDesc(&d31)
+		if resultTarget34 && d35.Loc == scm.LocReg {
+			ctx.BindReg(result.Reg2, &result)
+		}
 		ctx.FreeDesc(&d32)
-		ctx.EnsureDesc(&d33)
-		d34 = result
-		ctx.EnsureDesc(&d33)
-		ctx.EmitMakeInt(d34, d33)
-		if d33.Loc == scm.LocReg {
-			ctx.FreeReg(d33.Reg)
+		ctx.FreeDesc(&d33)
+		ctx.EnsureDesc(&d35)
+		d36 = result
+		ctx.EnsureDesc(&d35)
+		ctx.EmitMakeInt(d36, d35)
+		if d35.Loc == scm.LocReg {
+			ctx.FreeReg(d35.Reg)
 		}
 		ctx.EmitJmp(lbl0)
 		return result
@@ -872,9 +903,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != scm.LocNone {
 			d17 = ps.OverlayValues[17]
 		}
-		if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != scm.LocNone {
-			d18 = ps.OverlayValues[18]
-		}
 		if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != scm.LocNone {
 			d19 = ps.OverlayValues[19]
 		}
@@ -920,14 +948,17 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != scm.LocNone {
 			d33 = ps.OverlayValues[33]
 		}
-		if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != scm.LocNone {
-			d34 = ps.OverlayValues[34]
+		if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != scm.LocNone {
+			d35 = ps.OverlayValues[35]
+		}
+		if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != scm.LocNone {
+			d36 = ps.OverlayValues[36]
 		}
 		ctx.ReclaimUntrackedRegs()
 		ctx.EnsureDesc(&thisptr)
 		ctx.EnsureDesc(&idxInt)
-		d35 = idxInt
-		_ = d35
+		d37 = idxInt
+		_ = d37
 		bbpos_2_0 := int32(-1)
 		_ = bbpos_2_0
 		lbl7 := ctx.ReserveLabel()
@@ -938,113 +969,115 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		ctx.ReclaimUntrackedRegs()
 		ctx.ReclaimUntrackedRegs()
 		ctx.ReclaimUntrackedRegs()
-		var d36 scm.JITValueDesc
+		var d38 scm.JITValueDesc
 		if thisptr.Loc == scm.LocImm {
 			fieldAddr := uintptr(thisptr.Imm.Int()) + unsafe.Offsetof((*StorageInt)(nil).bitsize)
 			val := *(*uint8)(unsafe.Pointer(fieldAddr))
-			d36 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(val))}
+			d38 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(val))}
 		} else {
 			off := int32(unsafe.Offsetof((*StorageInt)(nil).bitsize))
 			r26 := ctx.AllocReg()
 			ctx.EmitMovRegMemB(r26, thisptr.Reg, off)
-			d36 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r26}
-			ctx.BindReg(r26, &d36)
+			d38 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r26}
+			ctx.BindReg(r26, &d38)
 		}
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d36)
-		ctx.EnsureDesc(&d36)
-		var d37 scm.JITValueDesc
-		if d36.Loc == scm.LocImm {
-			d37 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(uint8(d36.Imm.Int()))))}
+		ctx.EnsureDesc(&d38)
+		ctx.EnsureDesc(&d38)
+		var d39 scm.JITValueDesc
+		if d38.Loc == scm.LocImm {
+			d39 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(uint8(d38.Imm.Int()))))}
 		} else {
 			r27 := ctx.AllocReg()
-			ctx.EmitMovRegReg(r27, d36.Reg)
+			ctx.EmitMovRegReg(r27, d38.Reg)
 			ctx.EmitShlRegImm8(r27, 56)
 			ctx.EmitShrRegImm8(r27, 56)
-			d37 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r27}
-			ctx.BindReg(r27, &d37)
+			d39 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r27}
+			ctx.BindReg(r27, &d39)
 		}
-		ctx.FreeDesc(&d36)
+		ctx.FreeDesc(&d38)
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d35)
-		ctx.EnsureDesc(&d35)
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d35)
 		ctx.EnsureDesc(&d37)
-		ctx.EnsureDescsTogether(&d35, &d37)
-		var d39 scm.JITValueDesc
-		if d35.Loc == scm.LocImm && d37.Loc == scm.LocImm {
-			d39 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d35.Imm.Int() * d37.Imm.Int())}
-		} else if d35.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d37.Reg)
-			ctx.EmitMovRegImm64(scratch, uint64(d35.Imm.Int()))
-			ctx.EmitImulInt64(scratch, d37.Reg)
-			d39 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d39)
+		ctx.EnsureDesc(&d37)
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d37)
+		ctx.EnsureDesc(&d39)
+		ctx.EnsureDescsTogether(&d37, &d39)
+		var d41 scm.JITValueDesc
+		if d37.Loc == scm.LocImm && d39.Loc == scm.LocImm {
+			d41 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d37.Imm.Int() * d39.Imm.Int())}
 		} else if d37.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d35.Reg)
-			ctx.EmitMovRegReg(scratch, d35.Reg)
-			if d37.Imm.Int() >= -2147483648 && d37.Imm.Int() <= 2147483647 {
-				ctx.EmitImulRegImm32(scratch, int32(d37.Imm.Int()))
+			scratch := ctx.AllocRegExcept(d39.Reg)
+			ctx.EmitMovRegImm64(scratch, uint64(d37.Imm.Int()))
+			ctx.EmitImulInt64(scratch, d39.Reg)
+			d41 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d41)
+		} else if d39.Loc == scm.LocImm {
+			scratch := ctx.AllocRegExcept(d37.Reg)
+			ctx.EmitMovRegReg(scratch, d37.Reg)
+			if d39.Imm.Int() >= -2147483648 && d39.Imm.Int() <= 2147483647 {
+				ctx.EmitImulRegImm32(scratch, int32(d39.Imm.Int()))
 			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d37.Imm.Int()))
+				ctx.EmitMovRegImm64(scm.RegR11, uint64(d39.Imm.Int()))
 				ctx.EmitImulInt64(scratch, scm.RegR11)
 			}
-			d39 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d39)
+			d41 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d41)
 		} else {
-			r28 := ctx.AllocRegExcept(d35.Reg, d37.Reg)
-			ctx.EmitMovRegReg(r28, d35.Reg)
-			ctx.EmitImulInt64(r28, d37.Reg)
-			d39 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r28}
-			ctx.BindReg(r28, &d39)
+			r28 := ctx.AllocRegExcept(d37.Reg, d39.Reg)
+			ctx.EmitMovRegReg(r28, d37.Reg)
+			ctx.EmitImulInt64(r28, d39.Reg)
+			d41 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r28}
+			ctx.BindReg(r28, &d41)
 		}
-		if d39.Loc == scm.LocReg && d35.Loc == scm.LocReg && d39.Reg == d35.Reg {
-			ctx.TransferReg(d35.Reg)
-			d35.Loc = scm.LocNone
-		}
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d39)
-		var d40 scm.JITValueDesc
-		if d39.Loc == scm.LocImm {
-			d40 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d39.Imm.Int() / 64)}
-		} else {
-			r29 := ctx.AllocRegExcept(d39.Reg)
-			ctx.EmitMovRegReg(r29, d39.Reg)
-			ctx.EmitShrRegImm8(r29, 6)
-			d40 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r29}
-			ctx.BindReg(r29, &d40)
-		}
-		if d40.Loc == scm.LocReg && d39.Loc == scm.LocReg && d40.Reg == d39.Reg {
-			ctx.TransferReg(d39.Reg)
-			d39.Loc = scm.LocNone
+		if d41.Loc == scm.LocReg && d37.Loc == scm.LocReg && d41.Reg == d37.Reg {
+			ctx.TransferReg(d37.Reg)
+			d37.Loc = scm.LocNone
 		}
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d39)
-		var d41 scm.JITValueDesc
-		if d39.Loc == scm.LocImm {
-			d41 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d39.Imm.Int() % 64)}
-		} else {
-			r30 := ctx.AllocRegExcept(d39.Reg)
-			ctx.EmitMovRegReg(r30, d39.Reg)
-			ctx.EmitAndRegImm32(r30, 63)
-			d41 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r30}
-			ctx.BindReg(r30, &d41)
-		}
-		if d41.Loc == scm.LocReg && d39.Loc == scm.LocReg && d41.Reg == d39.Reg {
-			ctx.TransferReg(d39.Reg)
-			d39.Loc = scm.LocNone
-		}
-		ctx.FreeDesc(&d39)
-		ctx.ReclaimUntrackedRegs()
-		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d41)
 		var d42 scm.JITValueDesc
+		if d41.Loc == scm.LocImm {
+			d42 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d41.Imm.Int() / 64)}
+		} else {
+			r29 := ctx.AllocRegExcept(d41.Reg)
+			ctx.EmitMovRegReg(r29, d41.Reg)
+			ctx.EmitShrRegImm8(r29, 6)
+			d42 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r29}
+			ctx.BindReg(r29, &d42)
+		}
+		if d42.Loc == scm.LocReg && d41.Loc == scm.LocReg && d42.Reg == d41.Reg {
+			ctx.TransferReg(d41.Reg)
+			d41.Loc = scm.LocNone
+		}
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d41)
+		resultTarget43 := false
+		_ = resultTarget43
+		var d44 scm.JITValueDesc
+		if d41.Loc == scm.LocImm {
+			d44 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d41.Imm.Int() % 64)}
+		} else {
+			r30 := ctx.AllocRegExcept(d41.Reg)
+			ctx.EmitMovRegReg(r30, d41.Reg)
+			ctx.EmitAndRegImm32(r30, 63)
+			d44 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r30}
+			ctx.BindReg(r30, &d44)
+		}
+		if d44.Loc == scm.LocReg && d41.Loc == scm.LocReg && d44.Reg == d41.Reg {
+			ctx.TransferReg(d41.Reg)
+			d41.Loc = scm.LocNone
+		}
+		ctx.FreeDesc(&d41)
+		ctx.ReclaimUntrackedRegs()
+		ctx.ReclaimUntrackedRegs()
+		var d45 scm.JITValueDesc
 		if thisptr.Loc == scm.LocImm {
 			fieldAddr := uintptr(thisptr.Imm.Int()) + unsafe.Offsetof((*StorageInt)(nil).chunk)
 			dataPtr := *(*uintptr)(unsafe.Pointer(fieldAddr))
 			sliceLen := *(*int)(unsafe.Pointer(fieldAddr + 8))
 			sliceCap := *(*int)(unsafe.Pointer(fieldAddr + 16))
-			d42 = scm.JITValueDesc{Loc: scm.LocMem, Type: scm.TagSlice, MemPtr: dataPtr, KnownSliceLen: int32(sliceLen), KnownSliceCap: int32(sliceCap), SliceSizeKnown: true, GoArray: true, RelocatablePointer: true, Rooted: true}
+			d45 = scm.JITValueDesc{Loc: scm.LocMem, Type: scm.TagSlice, MemPtr: dataPtr, KnownSliceLen: int32(sliceLen), KnownSliceCap: int32(sliceCap), SliceSizeKnown: true, GoArray: true, RelocatablePointer: true, Rooted: true}
 		} else {
 			r31 := ctx.AllocReg()
 			r32 := ctx.AllocRegExcept(r31)
@@ -1053,488 +1086,485 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 			ctx.EmitMovRegMem(r31, thisptr.Reg, off)
 			ctx.EmitMovRegMem(r32, thisptr.Reg, off+8)
 			ctx.EmitMovRegMem(r33, thisptr.Reg, off+16)
-			d42 = scm.JITValueDesc{Loc: scm.LocRegTriple, Type: scm.TagSlice, Reg: r31, Reg2: r32, Reg3: r33}
-			ctx.BindReg(r31, &d42)
-			ctx.BindReg(r32, &d42)
-			ctx.BindReg(r33, &d42)
-			ctx.BindReg(r31, &d42)
-			ctx.BindReg(r32, &d42)
-			ctx.BindReg(r33, &d42)
+			d45 = scm.JITValueDesc{Loc: scm.LocRegTriple, Type: scm.TagSlice, Reg: r31, Reg2: r32, Reg3: r33}
+			ctx.BindReg(r31, &d45)
+			ctx.BindReg(r32, &d45)
+			ctx.BindReg(r33, &d45)
+			ctx.BindReg(r31, &d45)
+			ctx.BindReg(r32, &d45)
+			ctx.BindReg(r33, &d45)
 		}
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d40)
+		ctx.EnsureDesc(&d42)
 		ctx.ReclaimUntrackedRegs()
-		d43 = ctx.EmitLoadScalarSliceElement(&d42, &d40, 8, scm.TagInt)
+		d46 = ctx.EmitLoadScalarSliceElement(&d45, &d42, 8, scm.TagInt)
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d43)
-		ctx.EnsureDesc(&d41)
-		ctx.EnsureDescsTogether(&d43, &d41)
-		var d44 scm.JITValueDesc
-		if d43.Loc == scm.LocImm && d41.Loc == scm.LocImm {
-			d44 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d43.Imm.Int()) << uint64(d41.Imm.Int())))}
-		} else if d41.Loc == scm.LocImm {
-			r34 := ctx.AllocRegExcept(d43.Reg)
-			ctx.EmitMovRegReg(r34, d43.Reg)
-			ctx.EmitShlRegImm8(r34, uint8(d41.Imm.Int()))
-			d44 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r34}
-			ctx.BindReg(r34, &d44)
+		ctx.EnsureDesc(&d46)
+		ctx.EnsureDesc(&d44)
+		ctx.EnsureDescsTogether(&d46, &d44)
+		var d47 scm.JITValueDesc
+		if d46.Loc == scm.LocImm && d44.Loc == scm.LocImm {
+			d47 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d46.Imm.Int()) << uint64(d44.Imm.Int())))}
+		} else if d44.Loc == scm.LocImm {
+			r34 := ctx.AllocRegExcept(d46.Reg)
+			ctx.EmitMovRegReg(r34, d46.Reg)
+			ctx.EmitShlRegImm8(r34, uint8(d44.Imm.Int()))
+			d47 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r34}
+			ctx.BindReg(r34, &d47)
 		} else {
 			{
-				shiftSrc := d43.Reg
-				r35 := ctx.AllocRegExcept(d43.Reg, d41.Reg)
-				ctx.EmitMovRegReg(r35, d43.Reg)
+				shiftSrc := d46.Reg
+				r35 := ctx.AllocRegExcept(d46.Reg, d44.Reg)
+				ctx.EmitMovRegReg(r35, d46.Reg)
 				shiftSrc = r35
-				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d41.Reg != scm.RegRCX
+				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d44.Reg != scm.RegRCX
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegR11, scm.RegRCX)
 				}
-				if d41.Reg != scm.RegRCX {
-					ctx.EmitMovRegReg(scm.RegRCX, d41.Reg)
+				if d44.Reg != scm.RegRCX {
+					ctx.EmitMovRegReg(scm.RegRCX, d44.Reg)
 				}
 				ctx.EmitShlRegCl(shiftSrc)
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegRCX, scm.RegR11)
 				}
-				d44 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
-				ctx.BindReg(shiftSrc, &d44)
+				d47 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
+				ctx.BindReg(shiftSrc, &d47)
 			}
 		}
-		if d44.Loc == scm.LocReg && d43.Loc == scm.LocReg && d44.Reg == d43.Reg {
-			ctx.TransferReg(d43.Reg)
-			d43.Loc = scm.LocNone
-		}
-		ctx.FreeDesc(&d43)
-		ctx.ReclaimUntrackedRegs()
-		ctx.ReclaimUntrackedRegs()
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d40)
-		ctx.EnsureDesc(&d40)
-		var d45 scm.JITValueDesc
-		if d40.Loc == scm.LocImm {
-			d45 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d40.Imm.Int() + 1)}
-		} else {
-			scratch := ctx.AllocRegExcept(d40.Reg)
-			ctx.EmitMovRegReg(scratch, d40.Reg)
-			ctx.EmitAddRegImm32(scratch, int32(1))
-			d45 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d45)
-		}
-		if d45.Loc == scm.LocReg && d40.Loc == scm.LocReg && d45.Reg == d40.Reg {
-			ctx.TransferReg(d40.Reg)
-			d40.Loc = scm.LocNone
-		}
-		ctx.FreeDesc(&d40)
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d45)
-		ctx.ReclaimUntrackedRegs()
-		d46 = ctx.EmitLoadScalarSliceElement(&d42, &d45, 8, scm.TagInt)
-		ctx.FreeDesc(&d45)
-		ctx.ReclaimUntrackedRegs()
-		d47 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(64)}
-		ctx.EnsureDesc(&d41)
-		ctx.EnsureDescsTogether(&d47, &d41)
-		var d48 scm.JITValueDesc
-		if d47.Loc == scm.LocImm && d41.Loc == scm.LocImm {
-			d48 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d47.Imm.Int() - d41.Imm.Int())}
-		} else if d41.Loc == scm.LocImm && d41.Imm.Int() == 0 {
-			r36 := ctx.AllocRegExcept(d47.Reg)
-			ctx.EmitMovRegReg(r36, d47.Reg)
-			d48 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r36}
-			ctx.BindReg(r36, &d48)
-		} else if d47.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d41.Reg)
-			ctx.EmitMovRegImm64(scratch, uint64(d47.Imm.Int()))
-			ctx.EmitSubInt64(scratch, d41.Reg)
-			d48 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d48)
-		} else if d41.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d47.Reg)
-			ctx.EmitMovRegReg(scratch, d47.Reg)
-			if d41.Imm.Int() >= -2147483648 && d41.Imm.Int() <= 2147483647 {
-				ctx.EmitSubRegImm32(scratch, int32(d41.Imm.Int()))
-			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d41.Imm.Int()))
-				ctx.EmitSubInt64(scratch, scm.RegR11)
-			}
-			d48 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d48)
-		} else {
-			r37 := ctx.AllocRegExcept(d47.Reg, d41.Reg)
-			ctx.EmitMovRegReg(r37, d47.Reg)
-			ctx.EmitSubInt64(r37, d41.Reg)
-			d48 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r37}
-			ctx.BindReg(r37, &d48)
-		}
-		if d48.Loc == scm.LocReg && d47.Loc == scm.LocReg && d48.Reg == d47.Reg {
-			ctx.TransferReg(d47.Reg)
-			d47.Loc = scm.LocNone
-		}
-		ctx.FreeDesc(&d41)
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d46)
-		ctx.EnsureDesc(&d48)
-		ctx.EnsureDescsTogether(&d46, &d48)
-		var d49 scm.JITValueDesc
-		if d46.Loc == scm.LocImm && d48.Loc == scm.LocImm {
-			d49 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d46.Imm.Int()) >> uint64(d48.Imm.Int())))}
-		} else if d48.Loc == scm.LocImm {
-			r38 := ctx.AllocRegExcept(d46.Reg)
-			ctx.EmitMovRegReg(r38, d46.Reg)
-			ctx.EmitShrRegImm8(r38, uint8(d48.Imm.Int()))
-			d49 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r38}
-			ctx.BindReg(r38, &d49)
-		} else {
-			{
-				shiftSrc := d46.Reg
-				r39 := ctx.AllocRegExcept(d46.Reg, d48.Reg)
-				ctx.EmitMovRegReg(r39, d46.Reg)
-				shiftSrc = r39
-				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d48.Reg != scm.RegRCX
-				if rcxUsed {
-					ctx.EmitMovRegReg(scm.RegR11, scm.RegRCX)
-				}
-				if d48.Reg != scm.RegRCX {
-					ctx.EmitMovRegReg(scm.RegRCX, d48.Reg)
-				}
-				ctx.EmitShrRegClGo64(shiftSrc)
-				if rcxUsed {
-					ctx.EmitMovRegReg(scm.RegRCX, scm.RegR11)
-				}
-				d49 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
-				ctx.BindReg(shiftSrc, &d49)
-			}
-		}
-		if d49.Loc == scm.LocReg && d46.Loc == scm.LocReg && d49.Reg == d46.Reg {
+		if d47.Loc == scm.LocReg && d46.Loc == scm.LocReg && d47.Reg == d46.Reg {
 			ctx.TransferReg(d46.Reg)
 			d46.Loc = scm.LocNone
 		}
 		ctx.FreeDesc(&d46)
+		ctx.ReclaimUntrackedRegs()
+		ctx.ReclaimUntrackedRegs()
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d42)
+		ctx.EnsureDesc(&d42)
+		var d48 scm.JITValueDesc
+		if d42.Loc == scm.LocImm {
+			d48 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d42.Imm.Int() + 1)}
+		} else {
+			scratch := ctx.AllocRegExcept(d42.Reg)
+			ctx.EmitMovRegReg(scratch, d42.Reg)
+			ctx.EmitAddRegImm32(scratch, int32(1))
+			d48 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d48)
+		}
+		if d48.Loc == scm.LocReg && d42.Loc == scm.LocReg && d48.Reg == d42.Reg {
+			ctx.TransferReg(d42.Reg)
+			d42.Loc = scm.LocNone
+		}
+		ctx.FreeDesc(&d42)
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d48)
+		ctx.ReclaimUntrackedRegs()
+		d49 = ctx.EmitLoadScalarSliceElement(&d45, &d48, 8, scm.TagInt)
 		ctx.FreeDesc(&d48)
 		ctx.ReclaimUntrackedRegs()
+		d50 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(64)}
 		ctx.EnsureDesc(&d44)
-		ctx.EnsureDesc(&d49)
-		var d50 scm.JITValueDesc
-		if d44.Loc == scm.LocImm && d49.Loc == scm.LocImm {
-			d50 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d44.Imm.Int() | d49.Imm.Int())}
+		ctx.EnsureDescsTogether(&d50, &d44)
+		var d51 scm.JITValueDesc
+		if d50.Loc == scm.LocImm && d44.Loc == scm.LocImm {
+			d51 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d50.Imm.Int() - d44.Imm.Int())}
 		} else if d44.Loc == scm.LocImm && d44.Imm.Int() == 0 {
-			d50 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d49.Reg}
-			ctx.BindReg(d49.Reg, &d50)
-		} else if d49.Loc == scm.LocImm && d49.Imm.Int() == 0 {
-			r40 := ctx.AllocRegExcept(d44.Reg)
-			ctx.EmitMovRegReg(r40, d44.Reg)
-			d50 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r40}
-			ctx.BindReg(r40, &d50)
+			r36 := ctx.AllocRegExcept(d50.Reg)
+			ctx.EmitMovRegReg(r36, d50.Reg)
+			d51 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r36}
+			ctx.BindReg(r36, &d51)
+		} else if d50.Loc == scm.LocImm {
+			scratch := ctx.AllocRegExcept(d44.Reg)
+			ctx.EmitMovRegImm64(scratch, uint64(d50.Imm.Int()))
+			ctx.EmitSubInt64(scratch, d44.Reg)
+			d51 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d51)
 		} else if d44.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d49.Reg)
-			ctx.EmitMovRegImm64(scratch, uint64(d44.Imm.Int()))
-			ctx.EmitOrInt64(scratch, d49.Reg)
-			d50 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d50)
-		} else if d49.Loc == scm.LocImm {
-			r41 := ctx.AllocRegExcept(d44.Reg)
-			ctx.EmitMovRegReg(r41, d44.Reg)
-			if d49.Imm.Int() >= -2147483648 && d49.Imm.Int() <= 2147483647 {
-				ctx.EmitOrRegImm32(r41, int32(d49.Imm.Int()))
+			scratch := ctx.AllocRegExcept(d50.Reg)
+			ctx.EmitMovRegReg(scratch, d50.Reg)
+			if d44.Imm.Int() >= -2147483648 && d44.Imm.Int() <= 2147483647 {
+				ctx.EmitSubRegImm32(scratch, int32(d44.Imm.Int()))
 			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d49.Imm.Int()))
-				ctx.EmitOrInt64(r41, scm.RegR11)
-			}
-			d50 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r41}
-			ctx.BindReg(r41, &d50)
-		} else {
-			r42 := ctx.AllocRegExcept(d44.Reg, d49.Reg)
-			ctx.EmitMovRegReg(r42, d44.Reg)
-			ctx.EmitOrInt64(r42, d49.Reg)
-			d50 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r42}
-			ctx.BindReg(r42, &d50)
-		}
-		if d50.Loc == scm.LocReg && d44.Loc == scm.LocReg && d50.Reg == d44.Reg {
-			ctx.TransferReg(d44.Reg)
-			d44.Loc = scm.LocNone
-		}
-		ctx.FreeDesc(&d44)
-		ctx.FreeDesc(&d49)
-		ctx.ReclaimUntrackedRegs()
-		d51 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(64)}
-		ctx.EnsureDesc(&d37)
-		ctx.EnsureDescsTogether(&d51, &d37)
-		var d52 scm.JITValueDesc
-		if d51.Loc == scm.LocImm && d37.Loc == scm.LocImm {
-			d52 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d51.Imm.Int() - d37.Imm.Int())}
-		} else if d37.Loc == scm.LocImm && d37.Imm.Int() == 0 {
-			r43 := ctx.AllocRegExcept(d51.Reg)
-			ctx.EmitMovRegReg(r43, d51.Reg)
-			d52 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r43}
-			ctx.BindReg(r43, &d52)
-		} else if d51.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d37.Reg)
-			ctx.EmitMovRegImm64(scratch, uint64(d51.Imm.Int()))
-			ctx.EmitSubInt64(scratch, d37.Reg)
-			d52 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d52)
-		} else if d37.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d51.Reg)
-			ctx.EmitMovRegReg(scratch, d51.Reg)
-			if d37.Imm.Int() >= -2147483648 && d37.Imm.Int() <= 2147483647 {
-				ctx.EmitSubRegImm32(scratch, int32(d37.Imm.Int()))
-			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d37.Imm.Int()))
+				ctx.EmitMovRegImm64(scm.RegR11, uint64(d44.Imm.Int()))
 				ctx.EmitSubInt64(scratch, scm.RegR11)
 			}
-			d52 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d52)
+			d51 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d51)
 		} else {
-			r44 := ctx.AllocRegExcept(d51.Reg, d37.Reg)
-			ctx.EmitMovRegReg(r44, d51.Reg)
-			ctx.EmitSubInt64(r44, d37.Reg)
-			d52 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r44}
-			ctx.BindReg(r44, &d52)
+			r37 := ctx.AllocRegExcept(d50.Reg, d44.Reg)
+			ctx.EmitMovRegReg(r37, d50.Reg)
+			ctx.EmitSubInt64(r37, d44.Reg)
+			d51 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r37}
+			ctx.BindReg(r37, &d51)
 		}
-		if d52.Loc == scm.LocReg && d51.Loc == scm.LocReg && d52.Reg == d51.Reg {
-			ctx.TransferReg(d51.Reg)
-			d51.Loc = scm.LocNone
+		if d51.Loc == scm.LocReg && d50.Loc == scm.LocReg && d51.Reg == d50.Reg {
+			ctx.TransferReg(d50.Reg)
+			d50.Loc = scm.LocNone
 		}
-		ctx.FreeDesc(&d37)
+		ctx.FreeDesc(&d44)
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d50)
-		ctx.EnsureDesc(&d52)
-		ctx.EnsureDescsTogether(&d50, &d52)
-		var d53 scm.JITValueDesc
-		if d50.Loc == scm.LocImm && d52.Loc == scm.LocImm {
-			d53 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d50.Imm.Int()) >> uint64(d52.Imm.Int())))}
-		} else if d52.Loc == scm.LocImm {
-			r45 := ctx.AllocRegExcept(d50.Reg)
-			ctx.EmitMovRegReg(r45, d50.Reg)
-			ctx.EmitShrRegImm8(r45, uint8(d52.Imm.Int()))
-			d53 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r45}
-			ctx.BindReg(r45, &d53)
+		ctx.EnsureDesc(&d49)
+		ctx.EnsureDesc(&d51)
+		ctx.EnsureDescsTogether(&d49, &d51)
+		var d52 scm.JITValueDesc
+		if d49.Loc == scm.LocImm && d51.Loc == scm.LocImm {
+			d52 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d49.Imm.Int()) >> uint64(d51.Imm.Int())))}
+		} else if d51.Loc == scm.LocImm {
+			r38 := ctx.AllocRegExcept(d49.Reg)
+			ctx.EmitMovRegReg(r38, d49.Reg)
+			ctx.EmitShrRegImm8(r38, uint8(d51.Imm.Int()))
+			d52 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r38}
+			ctx.BindReg(r38, &d52)
 		} else {
 			{
-				shiftSrc := d50.Reg
-				r46 := ctx.AllocRegExcept(d50.Reg, d52.Reg)
-				ctx.EmitMovRegReg(r46, d50.Reg)
-				shiftSrc = r46
-				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d52.Reg != scm.RegRCX
+				shiftSrc := d49.Reg
+				r39 := ctx.AllocRegExcept(d49.Reg, d51.Reg)
+				ctx.EmitMovRegReg(r39, d49.Reg)
+				shiftSrc = r39
+				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d51.Reg != scm.RegRCX
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegR11, scm.RegRCX)
 				}
-				if d52.Reg != scm.RegRCX {
-					ctx.EmitMovRegReg(scm.RegRCX, d52.Reg)
+				if d51.Reg != scm.RegRCX {
+					ctx.EmitMovRegReg(scm.RegRCX, d51.Reg)
 				}
 				ctx.EmitShrRegClGo64(shiftSrc)
 				if rcxUsed {
 					ctx.EmitMovRegReg(scm.RegRCX, scm.RegR11)
 				}
-				d53 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
-				ctx.BindReg(shiftSrc, &d53)
+				d52 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
+				ctx.BindReg(shiftSrc, &d52)
 			}
 		}
-		if d53.Loc == scm.LocReg && d50.Loc == scm.LocReg && d53.Reg == d50.Reg {
-			ctx.TransferReg(d50.Reg)
-			d50.Loc = scm.LocNone
+		if d52.Loc == scm.LocReg && d49.Loc == scm.LocReg && d52.Reg == d49.Reg {
+			ctx.TransferReg(d49.Reg)
+			d49.Loc = scm.LocNone
 		}
-		ctx.FreeDesc(&d50)
+		ctx.FreeDesc(&d49)
+		ctx.FreeDesc(&d51)
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d47)
+		ctx.EnsureDesc(&d52)
+		var d53 scm.JITValueDesc
+		if d47.Loc == scm.LocImm && d52.Loc == scm.LocImm {
+			d53 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d47.Imm.Int() | d52.Imm.Int())}
+		} else if d47.Loc == scm.LocImm && d47.Imm.Int() == 0 {
+			d53 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d52.Reg}
+			ctx.BindReg(d52.Reg, &d53)
+		} else if d52.Loc == scm.LocImm && d52.Imm.Int() == 0 {
+			r40 := ctx.AllocRegExcept(d47.Reg)
+			ctx.EmitMovRegReg(r40, d47.Reg)
+			d53 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r40}
+			ctx.BindReg(r40, &d53)
+		} else if d47.Loc == scm.LocImm {
+			scratch := ctx.AllocRegExcept(d52.Reg)
+			ctx.EmitMovRegImm64(scratch, uint64(d47.Imm.Int()))
+			ctx.EmitOrInt64(scratch, d52.Reg)
+			d53 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d53)
+		} else if d52.Loc == scm.LocImm {
+			r41 := ctx.AllocRegExcept(d47.Reg)
+			ctx.EmitMovRegReg(r41, d47.Reg)
+			if d52.Imm.Int() >= -2147483648 && d52.Imm.Int() <= 2147483647 {
+				ctx.EmitOrRegImm32(r41, int32(d52.Imm.Int()))
+			} else {
+				ctx.EmitMovRegImm64(scm.RegR11, uint64(d52.Imm.Int()))
+				ctx.EmitOrInt64(r41, scm.RegR11)
+			}
+			d53 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r41}
+			ctx.BindReg(r41, &d53)
+		} else {
+			r42 := ctx.AllocRegExcept(d47.Reg, d52.Reg)
+			ctx.EmitMovRegReg(r42, d47.Reg)
+			ctx.EmitOrInt64(r42, d52.Reg)
+			d53 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r42}
+			ctx.BindReg(r42, &d53)
+		}
+		if d53.Loc == scm.LocReg && d47.Loc == scm.LocReg && d53.Reg == d47.Reg {
+			ctx.TransferReg(d47.Reg)
+			d47.Loc = scm.LocNone
+		}
+		ctx.FreeDesc(&d47)
 		ctx.FreeDesc(&d52)
 		ctx.ReclaimUntrackedRegs()
+		d54 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(64)}
+		ctx.EnsureDesc(&d39)
+		ctx.EnsureDescsTogether(&d54, &d39)
+		var d55 scm.JITValueDesc
+		if d54.Loc == scm.LocImm && d39.Loc == scm.LocImm {
+			d55 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d54.Imm.Int() - d39.Imm.Int())}
+		} else if d39.Loc == scm.LocImm && d39.Imm.Int() == 0 {
+			r43 := ctx.AllocRegExcept(d54.Reg)
+			ctx.EmitMovRegReg(r43, d54.Reg)
+			d55 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r43}
+			ctx.BindReg(r43, &d55)
+		} else if d54.Loc == scm.LocImm {
+			scratch := ctx.AllocRegExcept(d39.Reg)
+			ctx.EmitMovRegImm64(scratch, uint64(d54.Imm.Int()))
+			ctx.EmitSubInt64(scratch, d39.Reg)
+			d55 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d55)
+		} else if d39.Loc == scm.LocImm {
+			scratch := ctx.AllocRegExcept(d54.Reg)
+			ctx.EmitMovRegReg(scratch, d54.Reg)
+			if d39.Imm.Int() >= -2147483648 && d39.Imm.Int() <= 2147483647 {
+				ctx.EmitSubRegImm32(scratch, int32(d39.Imm.Int()))
+			} else {
+				ctx.EmitMovRegImm64(scm.RegR11, uint64(d39.Imm.Int()))
+				ctx.EmitSubInt64(scratch, scm.RegR11)
+			}
+			d55 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d55)
+		} else {
+			r44 := ctx.AllocRegExcept(d54.Reg, d39.Reg)
+			ctx.EmitMovRegReg(r44, d54.Reg)
+			ctx.EmitSubInt64(r44, d39.Reg)
+			d55 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r44}
+			ctx.BindReg(r44, &d55)
+		}
+		if d55.Loc == scm.LocReg && d54.Loc == scm.LocReg && d55.Reg == d54.Reg {
+			ctx.TransferReg(d54.Reg)
+			d54.Loc = scm.LocNone
+		}
+		ctx.FreeDesc(&d39)
+		ctx.ReclaimUntrackedRegs()
 		ctx.EnsureDesc(&d53)
+		ctx.EnsureDesc(&d55)
+		ctx.EnsureDescsTogether(&d53, &d55)
+		var d56 scm.JITValueDesc
+		if d53.Loc == scm.LocImm && d55.Loc == scm.LocImm {
+			d56 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uint64(d53.Imm.Int()) >> uint64(d55.Imm.Int())))}
+		} else if d55.Loc == scm.LocImm {
+			r45 := ctx.AllocRegExcept(d53.Reg)
+			ctx.EmitMovRegReg(r45, d53.Reg)
+			ctx.EmitShrRegImm8(r45, uint8(d55.Imm.Int()))
+			d56 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r45}
+			ctx.BindReg(r45, &d56)
+		} else {
+			{
+				shiftSrc := d53.Reg
+				r46 := ctx.AllocRegExcept(d53.Reg, d55.Reg)
+				ctx.EmitMovRegReg(r46, d53.Reg)
+				shiftSrc = r46
+				rcxUsed := ctx.FreeRegs&(1<<uint(scm.RegRCX)) == 0 && d55.Reg != scm.RegRCX
+				if rcxUsed {
+					ctx.EmitMovRegReg(scm.RegR11, scm.RegRCX)
+				}
+				if d55.Reg != scm.RegRCX {
+					ctx.EmitMovRegReg(scm.RegRCX, d55.Reg)
+				}
+				ctx.EmitShrRegClGo64(shiftSrc)
+				if rcxUsed {
+					ctx.EmitMovRegReg(scm.RegRCX, scm.RegR11)
+				}
+				d56 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: shiftSrc}
+				ctx.BindReg(shiftSrc, &d56)
+			}
+		}
+		if d56.Loc == scm.LocReg && d53.Loc == scm.LocReg && d56.Reg == d53.Reg {
+			ctx.TransferReg(d53.Reg)
+			d53.Loc = scm.LocNone
+		}
+		ctx.FreeDesc(&d53)
+		ctx.FreeDesc(&d55)
+		ctx.ReclaimUntrackedRegs()
+		ctx.EnsureDesc(&d56)
 		ctx.FreeDesc(&idxInt)
-		var d54 scm.JITValueDesc
+		var d57 scm.JITValueDesc
 		if thisptr.Loc == scm.LocImm {
 			fieldAddr := uintptr(thisptr.Imm.Int()) + unsafe.Offsetof((*StorageInt)(nil).null)
 			val := *(*uint64)(unsafe.Pointer(fieldAddr))
-			d54 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(val))}
+			d57 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(val))}
 		} else {
 			off := int32(unsafe.Offsetof((*StorageInt)(nil).null))
 			r47 := ctx.AllocReg()
 			ctx.EmitMovRegMem(r47, thisptr.Reg, off)
-			d54 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r47}
-			ctx.BindReg(r47, &d54)
+			d57 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r47}
+			ctx.BindReg(r47, &d57)
 		}
-		ctx.EnsureDesc(&d53)
-		ctx.EnsureDesc(&d54)
-		ctx.EnsureDescsTogether(&d53, &d54)
-		var d55 scm.JITValueDesc
-		if d53.Loc == scm.LocImm && d54.Loc == scm.LocImm {
-			d55 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewBool(uint64(d53.Imm.Int()) == uint64(d54.Imm.Int()))}
-		} else if d54.Loc == scm.LocImm {
-			r48 := ctx.AllocRegExcept(d53.Reg)
-			if d54.Imm.Int() >= -2147483648 && d54.Imm.Int() <= 2147483647 {
-				ctx.EmitCmpRegImm32(d53.Reg, int32(d54.Imm.Int()))
-			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d54.Imm.Int()))
-				ctx.EmitCmpInt64(d53.Reg, scm.RegR11)
-			}
-			d55 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r48, Condition: scm.CondEqual}
-			ctx.BindReg(r48, &d55)
-		} else if d53.Loc == scm.LocImm {
-			r49 := ctx.AllocReg()
-			ctx.EmitMovRegImm64(scm.RegR11, uint64(d53.Imm.Int()))
-			ctx.EmitCmpInt64(scm.RegR11, d54.Reg)
-			d55 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r49, Condition: scm.CondEqual}
-			ctx.BindReg(r49, &d55)
-		} else {
-			r50 := ctx.AllocRegExcept(d53.Reg)
-			ctx.EmitCmpInt64(d53.Reg, d54.Reg)
-			d55 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r50, Condition: scm.CondEqual}
-			ctx.BindReg(r50, &d55)
-		}
-		ctx.FreeDesc(&d54)
-		d56 = d55
 		ctx.EnsureDesc(&d56)
-		if d56.Loc != scm.LocImm && d56.Loc != scm.LocFlags {
+		ctx.EnsureDesc(&d57)
+		ctx.EnsureDescsTogether(&d56, &d57)
+		var d58 scm.JITValueDesc
+		if d56.Loc == scm.LocImm && d57.Loc == scm.LocImm {
+			d58 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewBool(uint64(d56.Imm.Int()) == uint64(d57.Imm.Int()))}
+		} else if d57.Loc == scm.LocImm {
+			r48 := ctx.AllocRegExcept(d56.Reg)
+			if d57.Imm.Int() >= -2147483648 && d57.Imm.Int() <= 2147483647 {
+				ctx.EmitCmpRegImm32(d56.Reg, int32(d57.Imm.Int()))
+			} else {
+				ctx.EmitMovRegImm64(scm.RegR11, uint64(d57.Imm.Int()))
+				ctx.EmitCmpInt64(d56.Reg, scm.RegR11)
+			}
+			d58 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r48, Condition: scm.CondEqual}
+			ctx.BindReg(r48, &d58)
+		} else if d56.Loc == scm.LocImm {
+			r49 := ctx.AllocReg()
+			ctx.EmitMovRegImm64(scm.RegR11, uint64(d56.Imm.Int()))
+			ctx.EmitCmpInt64(scm.RegR11, d57.Reg)
+			d58 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r49, Condition: scm.CondEqual}
+			ctx.BindReg(r49, &d58)
+		} else {
+			r50 := ctx.AllocRegExcept(d56.Reg)
+			ctx.EmitCmpInt64(d56.Reg, d57.Reg)
+			d58 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r50, Condition: scm.CondEqual}
+			ctx.BindReg(r50, &d58)
+		}
+		ctx.FreeDesc(&d57)
+		d59 = d58
+		ctx.EnsureDesc(&d59)
+		if d59.Loc != scm.LocImm && d59.Loc != scm.LocFlags {
 			panic("jit: fused If condition is neither scm.LocImm nor scm.LocFlags")
 		}
-		if d56.Loc == scm.LocImm {
-			if d56.Imm.Bool() {
+		if d59.Loc == scm.LocImm {
+			if d59.Imm.Bool() {
 				if ps.General {
 				}
-				ps57 := scm.PhiState{General: ps.General}
-				ps57.OverlayValues = make([]scm.JITValueDesc, 57)
-				ps57.OverlayValues[0] = d0
-				ps57.OverlayValues[1] = d1
-				ps57.OverlayValues[12] = d12
-				ps57.OverlayValues[13] = d13
-				ps57.OverlayValues[14] = d14
-				ps57.OverlayValues[15] = d15
-				ps57.OverlayValues[16] = d16
-				ps57.OverlayValues[17] = d17
-				ps57.OverlayValues[18] = d18
-				ps57.OverlayValues[19] = d19
-				ps57.OverlayValues[20] = d20
-				ps57.OverlayValues[21] = d21
-				ps57.OverlayValues[22] = d22
-				ps57.OverlayValues[23] = d23
-				ps57.OverlayValues[24] = d24
-				ps57.OverlayValues[25] = d25
-				ps57.OverlayValues[26] = d26
-				ps57.OverlayValues[27] = d27
-				ps57.OverlayValues[28] = d28
-				ps57.OverlayValues[29] = d29
-				ps57.OverlayValues[30] = d30
-				ps57.OverlayValues[31] = d31
-				ps57.OverlayValues[32] = d32
-				ps57.OverlayValues[33] = d33
-				ps57.OverlayValues[34] = d34
-				ps57.OverlayValues[35] = d35
-				ps57.OverlayValues[36] = d36
-				ps57.OverlayValues[37] = d37
-				ps57.OverlayValues[38] = d38
-				ps57.OverlayValues[39] = d39
-				ps57.OverlayValues[40] = d40
-				ps57.OverlayValues[41] = d41
-				ps57.OverlayValues[42] = d42
-				ps57.OverlayValues[43] = d43
-				ps57.OverlayValues[44] = d44
-				ps57.OverlayValues[45] = d45
-				ps57.OverlayValues[46] = d46
-				ps57.OverlayValues[47] = d47
-				ps57.OverlayValues[48] = d48
-				ps57.OverlayValues[49] = d49
-				ps57.OverlayValues[50] = d50
-				ps57.OverlayValues[51] = d51
-				ps57.OverlayValues[52] = d52
-				ps57.OverlayValues[53] = d53
-				ps57.OverlayValues[54] = d54
-				ps57.OverlayValues[55] = d55
-				ps57.OverlayValues[56] = d56
-				return bbs[3].RenderPS(ps57)
+				ps60 := scm.PhiState{General: ps.General}
+				ps60.OverlayValues = make([]scm.JITValueDesc, 60)
+				ps60.OverlayValues[0] = d0
+				ps60.OverlayValues[1] = d1
+				ps60.OverlayValues[12] = d12
+				ps60.OverlayValues[13] = d13
+				ps60.OverlayValues[14] = d14
+				ps60.OverlayValues[15] = d15
+				ps60.OverlayValues[16] = d16
+				ps60.OverlayValues[17] = d17
+				ps60.OverlayValues[19] = d19
+				ps60.OverlayValues[20] = d20
+				ps60.OverlayValues[21] = d21
+				ps60.OverlayValues[22] = d22
+				ps60.OverlayValues[23] = d23
+				ps60.OverlayValues[24] = d24
+				ps60.OverlayValues[25] = d25
+				ps60.OverlayValues[26] = d26
+				ps60.OverlayValues[27] = d27
+				ps60.OverlayValues[28] = d28
+				ps60.OverlayValues[29] = d29
+				ps60.OverlayValues[30] = d30
+				ps60.OverlayValues[31] = d31
+				ps60.OverlayValues[32] = d32
+				ps60.OverlayValues[33] = d33
+				ps60.OverlayValues[35] = d35
+				ps60.OverlayValues[36] = d36
+				ps60.OverlayValues[37] = d37
+				ps60.OverlayValues[38] = d38
+				ps60.OverlayValues[39] = d39
+				ps60.OverlayValues[40] = d40
+				ps60.OverlayValues[41] = d41
+				ps60.OverlayValues[42] = d42
+				ps60.OverlayValues[44] = d44
+				ps60.OverlayValues[45] = d45
+				ps60.OverlayValues[46] = d46
+				ps60.OverlayValues[47] = d47
+				ps60.OverlayValues[48] = d48
+				ps60.OverlayValues[49] = d49
+				ps60.OverlayValues[50] = d50
+				ps60.OverlayValues[51] = d51
+				ps60.OverlayValues[52] = d52
+				ps60.OverlayValues[53] = d53
+				ps60.OverlayValues[54] = d54
+				ps60.OverlayValues[55] = d55
+				ps60.OverlayValues[56] = d56
+				ps60.OverlayValues[57] = d57
+				ps60.OverlayValues[58] = d58
+				ps60.OverlayValues[59] = d59
+				return bbs[3].RenderPS(ps60)
 			}
 			if ps.General {
 			}
-			ps58 := scm.PhiState{General: ps.General}
-			ps58.OverlayValues = make([]scm.JITValueDesc, 57)
-			ps58.OverlayValues[0] = d0
-			ps58.OverlayValues[1] = d1
-			ps58.OverlayValues[12] = d12
-			ps58.OverlayValues[13] = d13
-			ps58.OverlayValues[14] = d14
-			ps58.OverlayValues[15] = d15
-			ps58.OverlayValues[16] = d16
-			ps58.OverlayValues[17] = d17
-			ps58.OverlayValues[18] = d18
-			ps58.OverlayValues[19] = d19
-			ps58.OverlayValues[20] = d20
-			ps58.OverlayValues[21] = d21
-			ps58.OverlayValues[22] = d22
-			ps58.OverlayValues[23] = d23
-			ps58.OverlayValues[24] = d24
-			ps58.OverlayValues[25] = d25
-			ps58.OverlayValues[26] = d26
-			ps58.OverlayValues[27] = d27
-			ps58.OverlayValues[28] = d28
-			ps58.OverlayValues[29] = d29
-			ps58.OverlayValues[30] = d30
-			ps58.OverlayValues[31] = d31
-			ps58.OverlayValues[32] = d32
-			ps58.OverlayValues[33] = d33
-			ps58.OverlayValues[34] = d34
-			ps58.OverlayValues[35] = d35
-			ps58.OverlayValues[36] = d36
-			ps58.OverlayValues[37] = d37
-			ps58.OverlayValues[38] = d38
-			ps58.OverlayValues[39] = d39
-			ps58.OverlayValues[40] = d40
-			ps58.OverlayValues[41] = d41
-			ps58.OverlayValues[42] = d42
-			ps58.OverlayValues[43] = d43
-			ps58.OverlayValues[44] = d44
-			ps58.OverlayValues[45] = d45
-			ps58.OverlayValues[46] = d46
-			ps58.OverlayValues[47] = d47
-			ps58.OverlayValues[48] = d48
-			ps58.OverlayValues[49] = d49
-			ps58.OverlayValues[50] = d50
-			ps58.OverlayValues[51] = d51
-			ps58.OverlayValues[52] = d52
-			ps58.OverlayValues[53] = d53
-			ps58.OverlayValues[54] = d54
-			ps58.OverlayValues[55] = d55
-			ps58.OverlayValues[56] = d56
-			return bbs[4].RenderPS(ps58)
+			ps61 := scm.PhiState{General: ps.General}
+			ps61.OverlayValues = make([]scm.JITValueDesc, 60)
+			ps61.OverlayValues[0] = d0
+			ps61.OverlayValues[1] = d1
+			ps61.OverlayValues[12] = d12
+			ps61.OverlayValues[13] = d13
+			ps61.OverlayValues[14] = d14
+			ps61.OverlayValues[15] = d15
+			ps61.OverlayValues[16] = d16
+			ps61.OverlayValues[17] = d17
+			ps61.OverlayValues[19] = d19
+			ps61.OverlayValues[20] = d20
+			ps61.OverlayValues[21] = d21
+			ps61.OverlayValues[22] = d22
+			ps61.OverlayValues[23] = d23
+			ps61.OverlayValues[24] = d24
+			ps61.OverlayValues[25] = d25
+			ps61.OverlayValues[26] = d26
+			ps61.OverlayValues[27] = d27
+			ps61.OverlayValues[28] = d28
+			ps61.OverlayValues[29] = d29
+			ps61.OverlayValues[30] = d30
+			ps61.OverlayValues[31] = d31
+			ps61.OverlayValues[32] = d32
+			ps61.OverlayValues[33] = d33
+			ps61.OverlayValues[35] = d35
+			ps61.OverlayValues[36] = d36
+			ps61.OverlayValues[37] = d37
+			ps61.OverlayValues[38] = d38
+			ps61.OverlayValues[39] = d39
+			ps61.OverlayValues[40] = d40
+			ps61.OverlayValues[41] = d41
+			ps61.OverlayValues[42] = d42
+			ps61.OverlayValues[44] = d44
+			ps61.OverlayValues[45] = d45
+			ps61.OverlayValues[46] = d46
+			ps61.OverlayValues[47] = d47
+			ps61.OverlayValues[48] = d48
+			ps61.OverlayValues[49] = d49
+			ps61.OverlayValues[50] = d50
+			ps61.OverlayValues[51] = d51
+			ps61.OverlayValues[52] = d52
+			ps61.OverlayValues[53] = d53
+			ps61.OverlayValues[54] = d54
+			ps61.OverlayValues[55] = d55
+			ps61.OverlayValues[56] = d56
+			ps61.OverlayValues[57] = d57
+			ps61.OverlayValues[58] = d58
+			ps61.OverlayValues[59] = d59
+			return bbs[4].RenderPS(ps61)
 		}
 		if !ps.General {
 			ps.General = true
 			return bbs[2].RenderPS(ps)
 		}
-		ctx.EmitJump(d56.Condition, lbl4)
+		ctx.EmitJump(d59.Condition, lbl4)
 		if bbs[4].Rendered {
 			ctx.EmitJmp(lbl5)
 		}
-		ctx.FreeDesc(&d55)
-		snap59 := d0
-		snap60 := d1
-		snap61 := d12
-		snap62 := d13
-		snap63 := d14
-		snap64 := d15
-		snap65 := d16
-		snap66 := d17
-		snap67 := d18
-		snap68 := d19
-		snap69 := d20
-		snap70 := d21
-		snap71 := d22
-		snap72 := d23
-		snap73 := d24
-		snap74 := d25
-		snap75 := d26
-		snap76 := d27
-		snap77 := d28
-		snap78 := d29
-		snap79 := d30
-		snap80 := d31
-		snap81 := d32
-		snap82 := d33
-		snap83 := d34
-		snap84 := d35
-		snap85 := d36
-		snap86 := d37
-		snap87 := d38
-		snap88 := d39
-		snap89 := d40
-		snap90 := d41
-		snap91 := d42
-		snap92 := d43
+		ctx.FreeDesc(&d58)
+		snap62 := d0
+		snap63 := d1
+		snap64 := d12
+		snap65 := d13
+		snap66 := d14
+		snap67 := d15
+		snap68 := d16
+		snap69 := d17
+		snap70 := d19
+		snap71 := d20
+		snap72 := d21
+		snap73 := d22
+		snap74 := d23
+		snap75 := d24
+		snap76 := d25
+		snap77 := d26
+		snap78 := d27
+		snap79 := d28
+		snap80 := d29
+		snap81 := d30
+		snap82 := d31
+		snap83 := d32
+		snap84 := d33
+		snap85 := d35
+		snap86 := d36
+		snap87 := d37
+		snap88 := d38
+		snap89 := d39
+		snap90 := d40
+		snap91 := d41
+		snap92 := d42
 		snap93 := d44
 		snap94 := d45
 		snap95 := d46
@@ -1548,42 +1578,42 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		snap103 := d54
 		snap104 := d55
 		snap105 := d56
-		alloc106 := ctx.SnapshotAllocState()
-		ctx.RestoreAllocState(alloc106)
-		d0 = snap59
-		d1 = snap60
-		d12 = snap61
-		d13 = snap62
-		d14 = snap63
-		d15 = snap64
-		d16 = snap65
-		d17 = snap66
-		d18 = snap67
-		d19 = snap68
-		d20 = snap69
-		d21 = snap70
-		d22 = snap71
-		d23 = snap72
-		d24 = snap73
-		d25 = snap74
-		d26 = snap75
-		d27 = snap76
-		d28 = snap77
-		d29 = snap78
-		d30 = snap79
-		d31 = snap80
-		d32 = snap81
-		d33 = snap82
-		d34 = snap83
-		d35 = snap84
-		d36 = snap85
-		d37 = snap86
-		d38 = snap87
-		d39 = snap88
-		d40 = snap89
-		d41 = snap90
-		d42 = snap91
-		d43 = snap92
+		snap106 := d57
+		snap107 := d58
+		snap108 := d59
+		alloc109 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc109)
+		d0 = snap62
+		d1 = snap63
+		d12 = snap64
+		d13 = snap65
+		d14 = snap66
+		d15 = snap67
+		d16 = snap68
+		d17 = snap69
+		d19 = snap70
+		d20 = snap71
+		d21 = snap72
+		d22 = snap73
+		d23 = snap74
+		d24 = snap75
+		d25 = snap76
+		d26 = snap77
+		d27 = snap78
+		d28 = snap79
+		d29 = snap80
+		d30 = snap81
+		d31 = snap82
+		d32 = snap83
+		d33 = snap84
+		d35 = snap85
+		d36 = snap86
+		d37 = snap87
+		d38 = snap88
+		d39 = snap89
+		d40 = snap90
+		d41 = snap91
+		d42 = snap92
 		d44 = snap93
 		d45 = snap94
 		d46 = snap95
@@ -1597,41 +1627,41 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		d54 = snap103
 		d55 = snap104
 		d56 = snap105
-		ctx.RestoreAllocState(alloc106)
-		d0 = snap59
-		d1 = snap60
-		d12 = snap61
-		d13 = snap62
-		d14 = snap63
-		d15 = snap64
-		d16 = snap65
-		d17 = snap66
-		d18 = snap67
-		d19 = snap68
-		d20 = snap69
-		d21 = snap70
-		d22 = snap71
-		d23 = snap72
-		d24 = snap73
-		d25 = snap74
-		d26 = snap75
-		d27 = snap76
-		d28 = snap77
-		d29 = snap78
-		d30 = snap79
-		d31 = snap80
-		d32 = snap81
-		d33 = snap82
-		d34 = snap83
-		d35 = snap84
-		d36 = snap85
-		d37 = snap86
-		d38 = snap87
-		d39 = snap88
-		d40 = snap89
-		d41 = snap90
-		d42 = snap91
-		d43 = snap92
+		d57 = snap106
+		d58 = snap107
+		d59 = snap108
+		ctx.RestoreAllocState(alloc109)
+		d0 = snap62
+		d1 = snap63
+		d12 = snap64
+		d13 = snap65
+		d14 = snap66
+		d15 = snap67
+		d16 = snap68
+		d17 = snap69
+		d19 = snap70
+		d20 = snap71
+		d21 = snap72
+		d22 = snap73
+		d23 = snap74
+		d24 = snap75
+		d25 = snap76
+		d26 = snap77
+		d27 = snap78
+		d28 = snap79
+		d29 = snap80
+		d30 = snap81
+		d31 = snap82
+		d32 = snap83
+		d33 = snap84
+		d35 = snap85
+		d36 = snap86
+		d37 = snap87
+		d38 = snap88
+		d39 = snap89
+		d40 = snap90
+		d41 = snap91
+		d42 = snap92
 		d44 = snap93
 		d45 = snap94
 		d46 = snap95
@@ -1645,138 +1675,138 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		d54 = snap103
 		d55 = snap104
 		d56 = snap105
-		ps107 := scm.PhiState{General: true}
-		ps107.OverlayValues = make([]scm.JITValueDesc, 57)
-		ps107.OverlayValues[0] = d0
-		ps107.OverlayValues[1] = d1
-		ps107.OverlayValues[12] = d12
-		ps107.OverlayValues[13] = d13
-		ps107.OverlayValues[14] = d14
-		ps107.OverlayValues[15] = d15
-		ps107.OverlayValues[16] = d16
-		ps107.OverlayValues[17] = d17
-		ps107.OverlayValues[18] = d18
-		ps107.OverlayValues[19] = d19
-		ps107.OverlayValues[20] = d20
-		ps107.OverlayValues[21] = d21
-		ps107.OverlayValues[22] = d22
-		ps107.OverlayValues[23] = d23
-		ps107.OverlayValues[24] = d24
-		ps107.OverlayValues[25] = d25
-		ps107.OverlayValues[26] = d26
-		ps107.OverlayValues[27] = d27
-		ps107.OverlayValues[28] = d28
-		ps107.OverlayValues[29] = d29
-		ps107.OverlayValues[30] = d30
-		ps107.OverlayValues[31] = d31
-		ps107.OverlayValues[32] = d32
-		ps107.OverlayValues[33] = d33
-		ps107.OverlayValues[34] = d34
-		ps107.OverlayValues[35] = d35
-		ps107.OverlayValues[36] = d36
-		ps107.OverlayValues[37] = d37
-		ps107.OverlayValues[38] = d38
-		ps107.OverlayValues[39] = d39
-		ps107.OverlayValues[40] = d40
-		ps107.OverlayValues[41] = d41
-		ps107.OverlayValues[42] = d42
-		ps107.OverlayValues[43] = d43
-		ps107.OverlayValues[44] = d44
-		ps107.OverlayValues[45] = d45
-		ps107.OverlayValues[46] = d46
-		ps107.OverlayValues[47] = d47
-		ps107.OverlayValues[48] = d48
-		ps107.OverlayValues[49] = d49
-		ps107.OverlayValues[50] = d50
-		ps107.OverlayValues[51] = d51
-		ps107.OverlayValues[52] = d52
-		ps107.OverlayValues[53] = d53
-		ps107.OverlayValues[54] = d54
-		ps107.OverlayValues[55] = d55
-		ps107.OverlayValues[56] = d56
-		ps108 := scm.PhiState{General: true}
-		ps108.OverlayValues = make([]scm.JITValueDesc, 57)
-		ps108.OverlayValues[0] = d0
-		ps108.OverlayValues[1] = d1
-		ps108.OverlayValues[12] = d12
-		ps108.OverlayValues[13] = d13
-		ps108.OverlayValues[14] = d14
-		ps108.OverlayValues[15] = d15
-		ps108.OverlayValues[16] = d16
-		ps108.OverlayValues[17] = d17
-		ps108.OverlayValues[18] = d18
-		ps108.OverlayValues[19] = d19
-		ps108.OverlayValues[20] = d20
-		ps108.OverlayValues[21] = d21
-		ps108.OverlayValues[22] = d22
-		ps108.OverlayValues[23] = d23
-		ps108.OverlayValues[24] = d24
-		ps108.OverlayValues[25] = d25
-		ps108.OverlayValues[26] = d26
-		ps108.OverlayValues[27] = d27
-		ps108.OverlayValues[28] = d28
-		ps108.OverlayValues[29] = d29
-		ps108.OverlayValues[30] = d30
-		ps108.OverlayValues[31] = d31
-		ps108.OverlayValues[32] = d32
-		ps108.OverlayValues[33] = d33
-		ps108.OverlayValues[34] = d34
-		ps108.OverlayValues[35] = d35
-		ps108.OverlayValues[36] = d36
-		ps108.OverlayValues[37] = d37
-		ps108.OverlayValues[38] = d38
-		ps108.OverlayValues[39] = d39
-		ps108.OverlayValues[40] = d40
-		ps108.OverlayValues[41] = d41
-		ps108.OverlayValues[42] = d42
-		ps108.OverlayValues[43] = d43
-		ps108.OverlayValues[44] = d44
-		ps108.OverlayValues[45] = d45
-		ps108.OverlayValues[46] = d46
-		ps108.OverlayValues[47] = d47
-		ps108.OverlayValues[48] = d48
-		ps108.OverlayValues[49] = d49
-		ps108.OverlayValues[50] = d50
-		ps108.OverlayValues[51] = d51
-		ps108.OverlayValues[52] = d52
-		ps108.OverlayValues[53] = d53
-		ps108.OverlayValues[54] = d54
-		ps108.OverlayValues[55] = d55
-		ps108.OverlayValues[56] = d56
-		snap109 := d0
-		snap110 := d1
-		snap111 := d12
-		snap112 := d13
-		snap113 := d14
-		snap114 := d15
-		snap115 := d16
-		snap116 := d17
-		snap117 := d18
-		snap118 := d19
-		snap119 := d20
-		snap120 := d21
-		snap121 := d22
-		snap122 := d23
-		snap123 := d24
-		snap124 := d25
-		snap125 := d26
-		snap126 := d27
-		snap127 := d28
-		snap128 := d29
-		snap129 := d30
-		snap130 := d31
-		snap131 := d32
-		snap132 := d33
-		snap133 := d34
-		snap134 := d35
-		snap135 := d36
-		snap136 := d37
-		snap137 := d38
-		snap138 := d39
-		snap139 := d40
-		snap140 := d41
-		snap141 := d42
-		snap142 := d43
+		d57 = snap106
+		d58 = snap107
+		d59 = snap108
+		ps110 := scm.PhiState{General: true}
+		ps110.OverlayValues = make([]scm.JITValueDesc, 60)
+		ps110.OverlayValues[0] = d0
+		ps110.OverlayValues[1] = d1
+		ps110.OverlayValues[12] = d12
+		ps110.OverlayValues[13] = d13
+		ps110.OverlayValues[14] = d14
+		ps110.OverlayValues[15] = d15
+		ps110.OverlayValues[16] = d16
+		ps110.OverlayValues[17] = d17
+		ps110.OverlayValues[19] = d19
+		ps110.OverlayValues[20] = d20
+		ps110.OverlayValues[21] = d21
+		ps110.OverlayValues[22] = d22
+		ps110.OverlayValues[23] = d23
+		ps110.OverlayValues[24] = d24
+		ps110.OverlayValues[25] = d25
+		ps110.OverlayValues[26] = d26
+		ps110.OverlayValues[27] = d27
+		ps110.OverlayValues[28] = d28
+		ps110.OverlayValues[29] = d29
+		ps110.OverlayValues[30] = d30
+		ps110.OverlayValues[31] = d31
+		ps110.OverlayValues[32] = d32
+		ps110.OverlayValues[33] = d33
+		ps110.OverlayValues[35] = d35
+		ps110.OverlayValues[36] = d36
+		ps110.OverlayValues[37] = d37
+		ps110.OverlayValues[38] = d38
+		ps110.OverlayValues[39] = d39
+		ps110.OverlayValues[40] = d40
+		ps110.OverlayValues[41] = d41
+		ps110.OverlayValues[42] = d42
+		ps110.OverlayValues[44] = d44
+		ps110.OverlayValues[45] = d45
+		ps110.OverlayValues[46] = d46
+		ps110.OverlayValues[47] = d47
+		ps110.OverlayValues[48] = d48
+		ps110.OverlayValues[49] = d49
+		ps110.OverlayValues[50] = d50
+		ps110.OverlayValues[51] = d51
+		ps110.OverlayValues[52] = d52
+		ps110.OverlayValues[53] = d53
+		ps110.OverlayValues[54] = d54
+		ps110.OverlayValues[55] = d55
+		ps110.OverlayValues[56] = d56
+		ps110.OverlayValues[57] = d57
+		ps110.OverlayValues[58] = d58
+		ps110.OverlayValues[59] = d59
+		ps111 := scm.PhiState{General: true}
+		ps111.OverlayValues = make([]scm.JITValueDesc, 60)
+		ps111.OverlayValues[0] = d0
+		ps111.OverlayValues[1] = d1
+		ps111.OverlayValues[12] = d12
+		ps111.OverlayValues[13] = d13
+		ps111.OverlayValues[14] = d14
+		ps111.OverlayValues[15] = d15
+		ps111.OverlayValues[16] = d16
+		ps111.OverlayValues[17] = d17
+		ps111.OverlayValues[19] = d19
+		ps111.OverlayValues[20] = d20
+		ps111.OverlayValues[21] = d21
+		ps111.OverlayValues[22] = d22
+		ps111.OverlayValues[23] = d23
+		ps111.OverlayValues[24] = d24
+		ps111.OverlayValues[25] = d25
+		ps111.OverlayValues[26] = d26
+		ps111.OverlayValues[27] = d27
+		ps111.OverlayValues[28] = d28
+		ps111.OverlayValues[29] = d29
+		ps111.OverlayValues[30] = d30
+		ps111.OverlayValues[31] = d31
+		ps111.OverlayValues[32] = d32
+		ps111.OverlayValues[33] = d33
+		ps111.OverlayValues[35] = d35
+		ps111.OverlayValues[36] = d36
+		ps111.OverlayValues[37] = d37
+		ps111.OverlayValues[38] = d38
+		ps111.OverlayValues[39] = d39
+		ps111.OverlayValues[40] = d40
+		ps111.OverlayValues[41] = d41
+		ps111.OverlayValues[42] = d42
+		ps111.OverlayValues[44] = d44
+		ps111.OverlayValues[45] = d45
+		ps111.OverlayValues[46] = d46
+		ps111.OverlayValues[47] = d47
+		ps111.OverlayValues[48] = d48
+		ps111.OverlayValues[49] = d49
+		ps111.OverlayValues[50] = d50
+		ps111.OverlayValues[51] = d51
+		ps111.OverlayValues[52] = d52
+		ps111.OverlayValues[53] = d53
+		ps111.OverlayValues[54] = d54
+		ps111.OverlayValues[55] = d55
+		ps111.OverlayValues[56] = d56
+		ps111.OverlayValues[57] = d57
+		ps111.OverlayValues[58] = d58
+		ps111.OverlayValues[59] = d59
+		snap112 := d0
+		snap113 := d1
+		snap114 := d12
+		snap115 := d13
+		snap116 := d14
+		snap117 := d15
+		snap118 := d16
+		snap119 := d17
+		snap120 := d19
+		snap121 := d20
+		snap122 := d21
+		snap123 := d22
+		snap124 := d23
+		snap125 := d24
+		snap126 := d25
+		snap127 := d26
+		snap128 := d27
+		snap129 := d28
+		snap130 := d29
+		snap131 := d30
+		snap132 := d31
+		snap133 := d32
+		snap134 := d33
+		snap135 := d35
+		snap136 := d36
+		snap137 := d37
+		snap138 := d38
+		snap139 := d39
+		snap140 := d40
+		snap141 := d41
+		snap142 := d42
 		snap143 := d44
 		snap144 := d45
 		snap145 := d46
@@ -1790,45 +1820,45 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		snap153 := d54
 		snap154 := d55
 		snap155 := d56
-		alloc156 := ctx.SnapshotAllocState()
+		snap156 := d57
+		snap157 := d58
+		snap158 := d59
+		alloc159 := ctx.SnapshotAllocState()
 		if !bbs[4].Rendered {
-			bbs[4].RenderPS(ps108)
+			bbs[4].RenderPS(ps111)
 		}
-		ctx.RestoreAllocState(alloc156)
-		d0 = snap109
-		d1 = snap110
-		d12 = snap111
-		d13 = snap112
-		d14 = snap113
-		d15 = snap114
-		d16 = snap115
-		d17 = snap116
-		d18 = snap117
-		d19 = snap118
-		d20 = snap119
-		d21 = snap120
-		d22 = snap121
-		d23 = snap122
-		d24 = snap123
-		d25 = snap124
-		d26 = snap125
-		d27 = snap126
-		d28 = snap127
-		d29 = snap128
-		d30 = snap129
-		d31 = snap130
-		d32 = snap131
-		d33 = snap132
-		d34 = snap133
-		d35 = snap134
-		d36 = snap135
-		d37 = snap136
-		d38 = snap137
-		d39 = snap138
-		d40 = snap139
-		d41 = snap140
-		d42 = snap141
-		d43 = snap142
+		ctx.RestoreAllocState(alloc159)
+		d0 = snap112
+		d1 = snap113
+		d12 = snap114
+		d13 = snap115
+		d14 = snap116
+		d15 = snap117
+		d16 = snap118
+		d17 = snap119
+		d19 = snap120
+		d20 = snap121
+		d21 = snap122
+		d22 = snap123
+		d23 = snap124
+		d24 = snap125
+		d25 = snap126
+		d26 = snap127
+		d27 = snap128
+		d28 = snap129
+		d29 = snap130
+		d30 = snap131
+		d31 = snap132
+		d32 = snap133
+		d33 = snap134
+		d35 = snap135
+		d36 = snap136
+		d37 = snap137
+		d38 = snap138
+		d39 = snap139
+		d40 = snap140
+		d41 = snap141
+		d42 = snap142
 		d44 = snap143
 		d45 = snap144
 		d46 = snap145
@@ -1842,8 +1872,11 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		d54 = snap153
 		d55 = snap154
 		d56 = snap155
+		d57 = snap156
+		d58 = snap157
+		d59 = snap158
 		if !bbs[3].Rendered {
-			return bbs[3].RenderPS(ps107)
+			return bbs[3].RenderPS(ps110)
 		}
 		return result
 		return result
@@ -1891,9 +1924,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != scm.LocNone {
 			d17 = ps.OverlayValues[17]
 		}
-		if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != scm.LocNone {
-			d18 = ps.OverlayValues[18]
-		}
 		if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != scm.LocNone {
 			d19 = ps.OverlayValues[19]
 		}
@@ -1939,9 +1969,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != scm.LocNone {
 			d33 = ps.OverlayValues[33]
 		}
-		if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != scm.LocNone {
-			d34 = ps.OverlayValues[34]
-		}
 		if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != scm.LocNone {
 			d35 = ps.OverlayValues[35]
 		}
@@ -1965,9 +1992,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		}
 		if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != scm.LocNone {
 			d42 = ps.OverlayValues[42]
-		}
-		if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != scm.LocNone {
-			d43 = ps.OverlayValues[43]
 		}
 		if len(ps.OverlayValues) > 44 && ps.OverlayValues[44].Loc != scm.LocNone {
 			d44 = ps.OverlayValues[44]
@@ -2008,24 +2032,33 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		if len(ps.OverlayValues) > 56 && ps.OverlayValues[56].Loc != scm.LocNone {
 			d56 = ps.OverlayValues[56]
 		}
+		if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != scm.LocNone {
+			d57 = ps.OverlayValues[57]
+		}
+		if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != scm.LocNone {
+			d58 = ps.OverlayValues[58]
+		}
+		if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != scm.LocNone {
+			d59 = ps.OverlayValues[59]
+		}
 		ctx.ReclaimUntrackedRegs()
-		d157 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagNil, Imm: scm.NewNil()}
-		d158 = result
-		ctx.EnsureDesc(&d157)
-		if d157.Loc == scm.LocRegPair {
-			ctx.EmitMovPairToResult(&d157, &d158)
+		d160 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagNil, Imm: scm.NewNil()}
+		d161 = result
+		ctx.EnsureDesc(&d160)
+		if d160.Loc == scm.LocRegPair {
+			ctx.EmitMovPairToResult(&d160, &d161)
 		} else {
-			switch d157.Type {
+			switch d160.Type {
 			case scm.TagBool:
-				ctx.EmitMakeBool(d158, d157)
+				ctx.EmitMakeBool(d161, d160)
 			case scm.TagInt:
-				ctx.EmitMakeInt(d158, d157)
+				ctx.EmitMakeInt(d161, d160)
 			case scm.TagFloat:
-				ctx.EmitMakeFloat(d158, d157)
+				ctx.EmitMakeFloat(d161, d160)
 			case scm.TagNil:
-				ctx.EmitMakeNil(d158)
+				ctx.EmitMakeNil(d161)
 			default:
-				ctx.EmitMovPairToResult(&d157, &d158)
+				ctx.EmitMovPairToResult(&d160, &d161)
 			}
 		}
 		ctx.EmitJmp(lbl0)
@@ -2074,9 +2107,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != scm.LocNone {
 			d17 = ps.OverlayValues[17]
 		}
-		if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != scm.LocNone {
-			d18 = ps.OverlayValues[18]
-		}
 		if len(ps.OverlayValues) > 19 && ps.OverlayValues[19].Loc != scm.LocNone {
 			d19 = ps.OverlayValues[19]
 		}
@@ -2122,9 +2152,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != scm.LocNone {
 			d33 = ps.OverlayValues[33]
 		}
-		if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != scm.LocNone {
-			d34 = ps.OverlayValues[34]
-		}
 		if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != scm.LocNone {
 			d35 = ps.OverlayValues[35]
 		}
@@ -2148,9 +2175,6 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		}
 		if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != scm.LocNone {
 			d42 = ps.OverlayValues[42]
-		}
-		if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != scm.LocNone {
-			d43 = ps.OverlayValues[43]
 		}
 		if len(ps.OverlayValues) > 44 && ps.OverlayValues[44].Loc != scm.LocNone {
 			d44 = ps.OverlayValues[44]
@@ -2191,92 +2215,130 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		if len(ps.OverlayValues) > 56 && ps.OverlayValues[56].Loc != scm.LocNone {
 			d56 = ps.OverlayValues[56]
 		}
-		if len(ps.OverlayValues) > 157 && ps.OverlayValues[157].Loc != scm.LocNone {
-			d157 = ps.OverlayValues[157]
+		if len(ps.OverlayValues) > 57 && ps.OverlayValues[57].Loc != scm.LocNone {
+			d57 = ps.OverlayValues[57]
 		}
-		if len(ps.OverlayValues) > 158 && ps.OverlayValues[158].Loc != scm.LocNone {
-			d158 = ps.OverlayValues[158]
+		if len(ps.OverlayValues) > 58 && ps.OverlayValues[58].Loc != scm.LocNone {
+			d58 = ps.OverlayValues[58]
+		}
+		if len(ps.OverlayValues) > 59 && ps.OverlayValues[59].Loc != scm.LocNone {
+			d59 = ps.OverlayValues[59]
+		}
+		if len(ps.OverlayValues) > 160 && ps.OverlayValues[160].Loc != scm.LocNone {
+			d160 = ps.OverlayValues[160]
+		}
+		if len(ps.OverlayValues) > 161 && ps.OverlayValues[161].Loc != scm.LocNone {
+			d161 = ps.OverlayValues[161]
 		}
 		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d53)
-		ctx.EnsureDesc(&d53)
-		var d159 scm.JITValueDesc
-		if d53.Loc == scm.LocImm {
-			d159 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(int64(uint64(d53.Imm.Int()))))}
+		ctx.EnsureDesc(&d56)
+		ctx.EnsureDesc(&d56)
+		var d162 scm.JITValueDesc
+		if d56.Loc == scm.LocImm {
+			d162 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(int64(uint64(d56.Imm.Int()))))}
 		} else {
 			r51 := ctx.AllocReg()
-			ctx.EmitMovRegReg(r51, d53.Reg)
-			d159 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r51}
-			ctx.BindReg(r51, &d159)
+			ctx.EmitMovRegReg(r51, d56.Reg)
+			d162 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r51}
+			ctx.BindReg(r51, &d162)
 		}
-		var d160 scm.JITValueDesc
+		var d163 scm.JITValueDesc
 		if thisptr.Loc == scm.LocImm {
 			fieldAddr := uintptr(thisptr.Imm.Int()) + unsafe.Offsetof((*StorageInt)(nil).offset)
 			val := *(*int64)(unsafe.Pointer(fieldAddr))
-			d160 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(val)}
+			d163 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(val)}
 		} else {
 			off := int32(unsafe.Offsetof((*StorageInt)(nil).offset))
 			r52 := ctx.AllocReg()
 			ctx.EmitMovRegMem(r52, thisptr.Reg, off)
-			d160 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r52}
-			ctx.BindReg(r52, &d160)
+			d163 = scm.JITValueDesc{Loc: scm.LocReg, Reg: r52}
+			ctx.BindReg(r52, &d163)
 		}
-		ctx.EnsureDesc(&d159)
-		ctx.EnsureDesc(&d160)
-		ctx.EnsureDescsTogether(&d159, &d160)
-		var d161 scm.JITValueDesc
-		if d159.Loc == scm.LocImm && d160.Loc == scm.LocImm {
-			d161 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d159.Imm.Int() + d160.Imm.Int())}
-		} else if d160.Loc == scm.LocImm && d160.Imm.Int() == 0 {
-			r53 := ctx.AllocRegExcept(d159.Reg)
-			ctx.EmitMovRegReg(r53, d159.Reg)
-			d161 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r53}
-			ctx.BindReg(r53, &d161)
-		} else if d159.Loc == scm.LocImm && d159.Imm.Int() == 0 {
-			d161 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d160.Reg}
-			ctx.BindReg(d160.Reg, &d161)
-		} else if d159.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d160.Reg)
-			ctx.EmitMovRegImm64(scratch, uint64(d159.Imm.Int()))
-			ctx.EmitAddInt64(scratch, d160.Reg)
-			d161 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d161)
-		} else if d160.Loc == scm.LocImm {
-			scratch := ctx.AllocRegExcept(d159.Reg)
-			ctx.EmitMovRegReg(scratch, d159.Reg)
-			if d160.Imm.Int() >= -2147483648 && d160.Imm.Int() <= 2147483647 {
-				ctx.EmitAddRegImm32(scratch, int32(d160.Imm.Int()))
+		ctx.EnsureDesc(&d162)
+		resultTarget164 := false
+		_ = resultTarget164
+		ctx.EnsureDesc(&d163)
+		ctx.EnsureDescsTogether(&d162, &d163)
+		var d165 scm.JITValueDesc
+		if d162.Loc == scm.LocImm && d163.Loc == scm.LocImm {
+			d165 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d162.Imm.Int() + d163.Imm.Int())}
+		} else if d163.Loc == scm.LocImm && d163.Imm.Int() == 0 {
+			var r53 scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d162.Reg {
+				r53 = result.Reg2
+				resultTarget164 = true
 			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d160.Imm.Int()))
+				r53 = ctx.AllocRegExcept(d162.Reg)
+			}
+			ctx.EmitMovRegReg(r53, d162.Reg)
+			d165 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r53}
+			ctx.BindReg(r53, &d165)
+		} else if d162.Loc == scm.LocImm && d162.Imm.Int() == 0 {
+			d165 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d163.Reg}
+			ctx.BindReg(d163.Reg, &d165)
+		} else if d162.Loc == scm.LocImm {
+			var scratch scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d163.Reg {
+				scratch = result.Reg2
+				resultTarget164 = true
+			} else {
+				scratch = ctx.AllocRegExcept(d163.Reg)
+			}
+			ctx.EmitMovRegImm64(scratch, uint64(d162.Imm.Int()))
+			ctx.EmitAddInt64(scratch, d163.Reg)
+			d165 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d165)
+		} else if d163.Loc == scm.LocImm {
+			var scratch scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d162.Reg {
+				scratch = result.Reg2
+				resultTarget164 = true
+			} else {
+				scratch = ctx.AllocRegExcept(d162.Reg)
+			}
+			ctx.EmitMovRegReg(scratch, d162.Reg)
+			if d163.Imm.Int() >= -2147483648 && d163.Imm.Int() <= 2147483647 {
+				ctx.EmitAddRegImm32(scratch, int32(d163.Imm.Int()))
+			} else {
+				ctx.EmitMovRegImm64(scm.RegR11, uint64(d163.Imm.Int()))
 				ctx.EmitAddInt64(scratch, scm.RegR11)
 			}
-			d161 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d161)
+			d165 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
+			ctx.BindReg(scratch, &d165)
 		} else {
-			r54 := ctx.AllocRegExcept(d159.Reg, d160.Reg)
-			ctx.EmitMovRegReg(r54, d159.Reg)
-			ctx.EmitAddInt64(r54, d160.Reg)
-			d161 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r54}
-			ctx.BindReg(r54, &d161)
+			var r54 scm.Reg
+			if result.Loc == scm.LocRegPair && result.Reg2 != d162.Reg && result.Reg2 != d163.Reg {
+				r54 = result.Reg2
+				resultTarget164 = true
+			} else {
+				r54 = ctx.AllocRegExcept(d162.Reg, d163.Reg)
+			}
+			ctx.EmitMovRegReg(r54, d162.Reg)
+			ctx.EmitAddInt64(r54, d163.Reg)
+			d165 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r54}
+			ctx.BindReg(r54, &d165)
 		}
-		if d161.Loc == scm.LocReg && d159.Loc == scm.LocReg && d161.Reg == d159.Reg {
-			ctx.TransferReg(d159.Reg)
-			d159.Loc = scm.LocNone
+		if d165.Loc == scm.LocReg && d162.Loc == scm.LocReg && d165.Reg == d162.Reg {
+			ctx.TransferReg(d162.Reg)
+			d162.Loc = scm.LocNone
 		}
-		ctx.FreeDesc(&d159)
-		ctx.FreeDesc(&d160)
-		ctx.EnsureDesc(&d161)
-		d162 = result
-		ctx.EnsureDesc(&d161)
-		ctx.EmitMakeInt(d162, d161)
-		if d161.Loc == scm.LocReg {
-			ctx.FreeReg(d161.Reg)
+		if resultTarget164 && d165.Loc == scm.LocReg {
+			ctx.BindReg(result.Reg2, &result)
+		}
+		ctx.FreeDesc(&d162)
+		ctx.FreeDesc(&d163)
+		ctx.EnsureDesc(&d165)
+		d166 = result
+		ctx.EnsureDesc(&d165)
+		ctx.EmitMakeInt(d166, d165)
+		if d165.Loc == scm.LocReg {
+			ctx.FreeReg(d165.Reg)
 		}
 		ctx.EmitJmp(lbl0)
 		return result
 	}
-	ps163 := scm.PhiState{General: false}
-	_ = bbs[0].RenderPS(ps163)
+	ps167 := scm.PhiState{General: false}
+	_ = bbs[0].RenderPS(ps167)
 	ctx.MarkLabel(lbl0)
 	ctx.ResolveFixups()
 	if resultRegsProtected {

--- a/storage/storage-seq.go
+++ b/storage/storage-seq.go
@@ -759,14 +759,14 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		ctx.FreeDesc(&d16)
 		if ps.General {
 			ctx.SyncDesc(&d15)
-			if d15.Loc == scm.LocReg {
+			if d15.Loc == scm.LocReg || d15.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d15.Reg)
 			} else if d15.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d15.Reg)
 				ctx.ProtectReg(d15.Reg2)
 			}
 			ctx.SyncDesc(&d17)
-			if d17.Loc == scm.LocReg {
+			if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d17.Reg)
 			} else if d17.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d17.Reg)
@@ -797,13 +797,13 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 			} else {
 				ctx.EmitStoreToStack(d19, int32(bbs[1].PhiBase)+int32(32))
 			}
-			if d15.Loc == scm.LocReg {
+			if d15.Loc == scm.LocReg || d15.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d15.Reg)
 			} else if d15.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d15.Reg)
 				ctx.UnprotectReg(d15.Reg2)
 			}
-			if d17.Loc == scm.LocReg {
+			if d17.Loc == scm.LocReg || d17.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d17.Reg)
 			} else if d17.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d17.Reg)
@@ -3821,7 +3821,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		ctx.StabilizeDescForControlFlow(&d345)
 		if ps.General {
 			ctx.SyncDesc(&d6)
-			if d6.Loc == scm.LocReg {
+			if d6.Loc == scm.LocReg || d6.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d6.Reg)
 			} else if d6.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d6.Reg)
@@ -3840,7 +3840,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				ctx.EmitShrRegImm8(d347.Reg, 32)
 			}
 			ctx.EmitStoreToStack(d347, int32(bbs[4].PhiBase)+int32(16))
-			if d6.Loc == scm.LocReg {
+			if d6.Loc == scm.LocReg || d6.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d6.Reg)
 			} else if d6.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d6.Reg)
@@ -4296,7 +4296,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 			if d354.Imm.Bool() {
 				if ps.General {
 					ctx.SyncDesc(&d10)
-					if d10.Loc == scm.LocReg {
+					if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d10.Reg)
 					} else if d10.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d10.Reg)
@@ -4315,7 +4315,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 						ctx.EmitShrRegImm8(d356.Reg, 32)
 					}
 					ctx.EmitStoreToStack(d356, int32(bbs[2].PhiBase)+int32(0))
-					if d10.Loc == scm.LocReg {
+					if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d10.Reg)
 					} else if d10.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d10.Reg)
@@ -4630,7 +4630,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		alloc455 := ctx.SnapshotAllocState()
 		ctx.MarkLabel(lbl17)
 		ctx.SyncDesc(&d10)
-		if d10.Loc == scm.LocReg {
+		if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d10.Reg)
 		} else if d10.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d10.Reg)
@@ -4649,7 +4649,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 			ctx.EmitShrRegImm8(d457.Reg, 32)
 		}
 		ctx.EmitStoreToStack(d457, int32(bbs[2].PhiBase)+int32(0))
-		if d10.Loc == scm.LocReg {
+		if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d10.Reg)
 		} else if d10.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d10.Reg)
@@ -5586,14 +5586,14 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		ctx.StabilizeDescForControlFlow(&d557)
 		if ps.General {
 			ctx.SyncDesc(&d5)
-			if d5.Loc == scm.LocReg {
+			if d5.Loc == scm.LocReg || d5.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d5.Reg)
 			} else if d5.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d5.Reg)
 				ctx.ProtectReg(d5.Reg2)
 			}
 			ctx.SyncDesc(&d7)
-			if d7.Loc == scm.LocReg {
+			if d7.Loc == scm.LocReg || d7.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d7.Reg)
 			} else if d7.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d7.Reg)
@@ -5625,13 +5625,13 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				ctx.EmitShrRegImm8(d561.Reg, 32)
 			}
 			ctx.EmitStoreToStack(d561, int32(bbs[4].PhiBase)+int32(32))
-			if d5.Loc == scm.LocReg {
+			if d5.Loc == scm.LocReg || d5.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d5.Reg)
 			} else if d5.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d5.Reg)
 				ctx.UnprotectReg(d5.Reg2)
 			}
-			if d7.Loc == scm.LocReg {
+			if d7.Loc == scm.LocReg || d7.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d7.Reg)
 			} else if d7.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d7.Reg)
@@ -8267,7 +8267,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		ctx.StabilizeDescForControlFlow(&d850)
 		if ps.General {
 			ctx.SyncDesc(&d10)
-			if d10.Loc == scm.LocReg {
+			if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d10.Reg)
 			} else if d10.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d10.Reg)
@@ -8286,7 +8286,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				ctx.EmitShrRegImm8(d852.Reg, 32)
 			}
 			ctx.EmitStoreToStack(d852, int32(bbs[8].PhiBase)+int32(0))
-			if d10.Loc == scm.LocReg {
+			if d10.Loc == scm.LocReg || d10.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d10.Reg)
 			} else if d10.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d10.Reg)
@@ -8930,7 +8930,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 			if d858.Imm.Bool() {
 				if ps.General {
 					ctx.SyncDesc(&d12)
-					if d12.Loc == scm.LocReg {
+					if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 						ctx.ProtectReg(d12.Reg)
 					} else if d12.Loc == scm.LocRegPair {
 						ctx.ProtectReg(d12.Reg)
@@ -8949,7 +8949,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 						ctx.EmitShrRegImm8(d860.Reg, 32)
 					}
 					ctx.EmitStoreToStack(d860, int32(bbs[2].PhiBase)+int32(0))
-					if d12.Loc == scm.LocReg {
+					if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 						ctx.UnprotectReg(d12.Reg)
 					} else if d12.Loc == scm.LocRegPair {
 						ctx.UnprotectReg(d12.Reg)
@@ -9405,7 +9405,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		alloc1006 := ctx.SnapshotAllocState()
 		ctx.MarkLabel(lbl19)
 		ctx.SyncDesc(&d12)
-		if d12.Loc == scm.LocReg {
+		if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 			ctx.ProtectReg(d12.Reg)
 		} else if d12.Loc == scm.LocRegPair {
 			ctx.ProtectReg(d12.Reg)
@@ -9424,7 +9424,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 			ctx.EmitShrRegImm8(d1008.Reg, 32)
 		}
 		ctx.EmitStoreToStack(d1008, int32(bbs[2].PhiBase)+int32(0))
-		if d12.Loc == scm.LocReg {
+		if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 			ctx.UnprotectReg(d12.Reg)
 		} else if d12.Loc == scm.LocRegPair {
 			ctx.UnprotectReg(d12.Reg)
@@ -10774,14 +10774,14 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		ctx.ReclaimUntrackedRegs()
 		if ps.General {
 			ctx.SyncDesc(&d9)
-			if d9.Loc == scm.LocReg {
+			if d9.Loc == scm.LocReg || d9.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d9.Reg)
 			} else if d9.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d9.Reg)
 				ctx.ProtectReg(d9.Reg2)
 			}
 			ctx.SyncDesc(&d11)
-			if d11.Loc == scm.LocReg {
+			if d11.Loc == scm.LocReg || d11.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d11.Reg)
 			} else if d11.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d11.Reg)
@@ -10813,13 +10813,13 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				ctx.EmitShrRegImm8(d1159.Reg, 32)
 			}
 			ctx.EmitStoreToStack(d1159, int32(bbs[8].PhiBase)+int32(16))
-			if d9.Loc == scm.LocReg {
+			if d9.Loc == scm.LocReg || d9.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d9.Reg)
 			} else if d9.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d9.Reg)
 				ctx.UnprotectReg(d9.Reg2)
 			}
-			if d11.Loc == scm.LocReg {
+			if d11.Loc == scm.LocReg || d11.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d11.Reg)
 			} else if d11.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d11.Reg)
@@ -11541,21 +11541,21 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		ctx.FreeDesc(&d1163)
 		if ps.General {
 			ctx.SyncDesc(&d12)
-			if d12.Loc == scm.LocReg {
+			if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d12.Reg)
 			} else if d12.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d12.Reg)
 				ctx.ProtectReg(d12.Reg2)
 			}
 			ctx.SyncDesc(&d13)
-			if d13.Loc == scm.LocReg {
+			if d13.Loc == scm.LocReg || d13.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d13.Reg)
 			} else if d13.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d13.Reg)
 				ctx.ProtectReg(d13.Reg2)
 			}
 			ctx.SyncDesc(&d1164)
-			if d1164.Loc == scm.LocReg {
+			if d1164.Loc == scm.LocReg || d1164.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d1164.Reg)
 			} else if d1164.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d1164.Reg)
@@ -11612,19 +11612,19 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 			} else {
 				ctx.EmitStoreToStack(d1170, int32(bbs[1].PhiBase)+int32(32))
 			}
-			if d12.Loc == scm.LocReg {
+			if d12.Loc == scm.LocReg || d12.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d12.Reg)
 			} else if d12.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d12.Reg)
 				ctx.UnprotectReg(d12.Reg2)
 			}
-			if d13.Loc == scm.LocReg {
+			if d13.Loc == scm.LocReg || d13.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d13.Reg)
 			} else if d13.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d13.Reg)
 				ctx.UnprotectReg(d13.Reg2)
 			}
-			if d1164.Loc == scm.LocReg {
+			if d1164.Loc == scm.LocReg || d1164.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d1164.Reg)
 			} else if d1164.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d1164.Reg)
@@ -13987,8 +13987,9 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 		if d1224.Loc == scm.LocImm {
 			d1225 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagFloat, Imm: scm.NewFloat(float64(d1224.Imm.Int()))}
 		} else {
-			r160 := ctx.AllocRegExcept(d1224.Reg)
-			ctx.EmitMovRegReg(r160, d1224.Reg)
+			var r160 scm.Reg
+			r160 = d1224.Reg
+			d1224.Loc = scm.LocNone
 			ctx.EmitCvtInt64ToFloat64(scm.RegX0, r160)
 			d1225 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagFloat, Reg: r160}
 			ctx.BindReg(r160, &d1225)

--- a/storage/storage-sparse.go
+++ b/storage/storage-sparse.go
@@ -287,7 +287,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 		ctx.FreeDesc(&d3)
 		if ps.General {
 			ctx.SyncDesc(&d4)
-			if d4.Loc == scm.LocReg {
+			if d4.Loc == scm.LocReg || d4.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d4.Reg)
 			} else if d4.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d4.Reg)
@@ -300,7 +300,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 			}
 			ctx.EnsureDesc(&d5)
 			ctx.EmitStoreToStack(d5, int32(bbs[1].PhiBase)+int32(16))
-			if d4.Loc == scm.LocReg {
+			if d4.Loc == scm.LocReg || d4.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d4.Reg)
 			} else if d4.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d4.Reg)
@@ -3053,7 +3053,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 		ctx.ReclaimUntrackedRegs()
 		if ps.General {
 			ctx.SyncDesc(&d50)
-			if d50.Loc == scm.LocReg {
+			if d50.Loc == scm.LocReg || d50.Loc == scm.LocFPReg {
 				ctx.ProtectReg(d50.Reg)
 			} else if d50.Loc == scm.LocRegPair {
 				ctx.ProtectReg(d50.Reg)
@@ -3072,7 +3072,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				ctx.EmitShrRegImm8(d280.Reg, 32)
 			}
 			ctx.EmitStoreToStack(d280, int32(bbs[1].PhiBase)+int32(16))
-			if d50.Loc == scm.LocReg {
+			if d50.Loc == scm.LocReg || d50.Loc == scm.LocFPReg {
 				ctx.UnprotectReg(d50.Reg)
 			} else if d50.Loc == scm.LocRegPair {
 				ctx.UnprotectReg(d50.Reg)

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -199,6 +199,7 @@ func main() {
 
 	// Collect operators from AST (for patching byte offsets)
 	var ops []operatorInfo
+	var helpers []jitHelperInfo
 	var storageFiles []storageASTFile
 	for _, astFile := range pkg.Syntax {
 		fname := fset.Position(astFile.Pos()).Filename
@@ -207,6 +208,7 @@ func main() {
 			continue
 		}
 		ops = append(ops, collectOperators(fset, astFile, fname)...)
+		helpers = append(helpers, collectJITHelpers(astFile, fname)...)
 		storageFiles = append(storageFiles, storageASTFile{file: astFile, path: fname})
 	}
 	stInfos := collectStorageMethods(storageFiles)
@@ -226,6 +228,30 @@ func main() {
 
 	// Process each operator (pattern 1: Declare)
 	patches := map[string][]patchEntry{}
+	for _, helper := range helpers {
+		if policyOnly || (onlyOp != "" && helper.sourceName != onlyOp && helper.emitterName != onlyOp) {
+			continue
+		}
+		ssaFn := ssaFuncs[helper.sourcePos]
+		if ssaFn == nil {
+			fmt.Fprintf(os.Stderr, "  %s: %s — helper SSA function not found\n", helper.path, helper.sourceName)
+			continue
+		}
+		body, genErr := generateJITHelperBody(ssaFn)
+		if genErr != "" {
+			fmt.Fprintf(os.Stderr, "  %s: %s helper failed: %s\n", helper.path, helper.sourceName, genErr)
+			continue
+		}
+		fmt.Printf("  %s: %s HELPER OK\n", helper.path, helper.sourceName)
+		if doPatch {
+			start := fset.Position(helper.body.Lbrace).Offset + 1
+			end := fset.Position(helper.body.Rbrace).Offset
+			patches[helper.path] = append(patches[helper.path], patchEntry{
+				startOff: start, endOff: end, newText: "\n" + body + "\n",
+				opName: helper.emitterName,
+			})
+		}
+	}
 	for opIndex, op := range ops {
 		if onlyOp != "" && op.name != onlyOp {
 			continue
@@ -490,7 +516,7 @@ func generatedEmitterOverlay(pkgDir string) (map[string][]byte, map[string]map[i
 			return nil, nil, err
 		}
 		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, path, source, 0)
+		file, err := parser.ParseFile(fset, path, source, parser.ParseComments)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -542,6 +568,28 @@ func generatedEmitterOverlay(pkgDir string) (map[string][]byte, map[string]map[i
 			changed = true
 			return false
 		})
+		// Reusable helper emitters are ordinary functions rather than Declaration
+		// fields. Hide their generated bodies from SSA for the same reason: only
+		// the annotated semantic source function must participate in generation.
+		for _, helper := range collectJITHelpers(file, path) {
+			start := fset.Position(helper.body.Lbrace).Offset + 1
+			end := fset.Position(helper.body.Rbrace).Offset
+			if start < 0 || end > len(source) || start >= end || !bytes.Contains(source[start:end], []byte(generatedBanner)) {
+				continue
+			}
+			stubBody := "\n\t_ = ctx\n\t_ = args\n\t_ = result\n\tpanic(0)\n"
+			span := patched[start:end]
+			if len(stubBody) > len(span) {
+				continue
+			}
+			for index := range span {
+				if span[index] != '\n' && span[index] != '\r' {
+					span[index] = ' '
+				}
+			}
+			copy(span, stubBody)
+			changed = true
+		}
 		if changed {
 			overlay[path] = patched
 		}
@@ -728,6 +776,51 @@ type operatorInfo struct {
 	jitInsertPos           token.Pos
 	typeInsertPos          token.Pos
 	preservedEnd           int
+}
+
+type jitHelperInfo struct {
+	path        string
+	sourceName  string
+	emitterName string
+	sourcePos   token.Pos
+	body        *ast.BlockStmt
+}
+
+// collectJITHelpers pairs a normal Go implementation with the emitter named by
+// its //jitgen:emitter annotation. The source remains the semantic authority;
+// the target function contains only generated JITValueDesc code.
+func collectJITHelpers(file *ast.File, path string) []jitHelperInfo {
+	const prefix = "jitgen:emitter "
+	functions := make(map[string]*ast.FuncDecl)
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok && function.Recv == nil {
+			functions[function.Name.Name] = function
+		}
+	}
+
+	var helpers []jitHelperInfo
+	for _, source := range functions {
+		if source.Doc == nil {
+			continue
+		}
+		for _, comment := range source.Doc.List {
+			text := strings.TrimSpace(strings.TrimPrefix(comment.Text, "//"))
+			if !strings.HasPrefix(text, prefix) {
+				continue
+			}
+			emitterName := strings.TrimSpace(strings.TrimPrefix(text, prefix))
+			emitter := functions[emitterName]
+			if emitter == nil || emitter.Body == nil {
+				panic(fmt.Sprintf("jitgen: %s names missing emitter %s", source.Name.Name, emitterName))
+			}
+			helpers = append(helpers, jitHelperInfo{
+				path: path, sourceName: source.Name.Name, emitterName: emitterName,
+				sourcePos: source.Name.Pos(), body: emitter.Body,
+			})
+		}
+	}
+	return helpers
 }
 
 func keyedValue(comp *ast.CompositeLit, name string) ast.Expr {
@@ -1156,6 +1249,7 @@ type codeGen struct {
 	valueRewriter      ssaValueRewriter
 	inlineInstructions int
 	nativeFP           bool // declaration explicitly permits typed FP register lowering
+	rawReturn          bool // helper emitters return the Go scalar, not a boxed Scmer
 }
 
 type storageInputHome struct {
@@ -1479,6 +1573,13 @@ func (g *codeGen) emitProtectIncomingArgRegs() string {
 			g.emit("}")
 		}
 		return "storageInputsProtected"
+	}
+	// Reusable helper emitters receive caller-owned descriptor copies and append
+	// directly to the caller's machine-code stream. Caller liveness has already
+	// stabilized values needed afterwards; preserving every helper argument here
+	// would turn known scalar tags back into stack values before specialization.
+	if g.rawReturn {
+		return ""
 	}
 	// A generated callee may use every register in the shared allocator. Give
 	// incoming register values stable stack homes instead of reserving their
@@ -4279,6 +4380,35 @@ func functionCallsMultipleResults(fn *ssa.Function) bool {
 	return false
 }
 
+func functionJITEmitter(fn *ssa.Function) (string, bool) {
+	const prefix = "jitgen:emitter "
+	decl, ok := fn.Syntax().(*ast.FuncDecl)
+	if !ok || decl.Doc == nil {
+		return "", false
+	}
+	for _, comment := range decl.Doc.List {
+		text := strings.TrimSpace(strings.TrimPrefix(comment.Text, "//"))
+		if strings.HasPrefix(text, prefix) {
+			name := strings.TrimSpace(strings.TrimPrefix(text, prefix))
+			return name, name != ""
+		}
+	}
+	return "", false
+}
+
+func functionHasJITGenAnnotation(fn *ssa.Function, annotation string) bool {
+	declaration, ok := fn.Syntax().(*ast.FuncDecl)
+	if !ok || declaration.Doc == nil {
+		return false
+	}
+	for _, comment := range declaration.Doc.List {
+		if strings.TrimSpace(strings.TrimPrefix(comment.Text, "//")) == annotation {
+			return true
+		}
+	}
+	return false
+}
+
 func blockEndsInPanic(block *ssa.BasicBlock) bool {
 	return block != nil && len(block.Instrs) > 0 && func() bool {
 		_, ok := block.Instrs[len(block.Instrs)-1].(*ssa.Panic)
@@ -4291,6 +4421,9 @@ func blockEndsInPanic(block *ssa.BasicBlock) bool {
 // builtin. The cloned generator makes this rollback exact.
 func (g *codeGen) tryInlineCall(callee *ssa.Function, callArgs []ssa.Value) (result genVal, ok bool) {
 	if callee == nil || callee.Blocks == nil || callee.Signature.Results().Len() > 1 {
+		return genVal{}, false
+	}
+	if functionHasJITGenAnnotation(callee, "jitgen:noinline") {
 		return genVal{}, false
 	}
 	// Inline package-local helpers because they expose the builtin's own type and
@@ -4355,6 +4488,68 @@ func (g *codeGen) tryInlineCall(callee *ssa.Function, callArgs []ssa.Value) (res
 	g.w.WriteString(generated)
 	g.wDecl.WriteString(declarations)
 	return result, true
+}
+
+// tryEmitJITHelperCall invokes a generated emitter while the enclosing emitter
+// is producing machine code. This is not a machine-code call boundary: the
+// helper receives the concrete JITValueDesc arguments and can fold their tags
+// before appending instructions to the same JITContext.
+func (g *codeGen) tryEmitJITHelperCall(name string, callee *ssa.Function, callArgs []ssa.Value) bool {
+	emitter, annotated := functionJITEmitter(callee)
+	if !annotated || callee.Pkg == nil || callee.Pkg.Pkg == nil || callee.Pkg.Pkg.Path() != g.topLevelPkgPath {
+		return false
+	}
+	if callee.Signature.Results().Len() != 1 || goCallWordCount(callee.Signature.Results().At(0).Type()) != 1 || name == "" {
+		return false
+	}
+	if len(callArgs) != len(callee.Params) {
+		return false
+	}
+	arguments := make([]string, len(callArgs))
+	for index, argument := range callArgs {
+		if !isScmerType(callee.Params[index].Type()) {
+			return false
+		}
+		resolved := g.resolveValue(argument)
+		if !resolved.isDesc || resolved.goVar == "" {
+			return false
+		}
+		// A reusable helper may spill its private descriptor copies while emitting
+		// a CFG. Give caller values that remain live a canonical home first.
+		if ssaValueNeededAfterInstruction(g.currentInstr, argument) {
+			g.emit("ctx.StabilizeDescForControlFlow(&%s)", resolved.goVar)
+		}
+		arguments[index] = resolved.goVar
+	}
+	descriptor := g.allocDesc()
+	resultType := callee.Signature.Results().At(0).Type().Underlying()
+	resultTag := jitTagForSSAType(callee.Signature.Results().At(0).Type())
+	targetExpression := "JITValueDesc{Loc: LocAny}"
+	targetVar := ""
+	if g.directResultPayloads[name] != "" {
+		target := g.allocDesc()
+		targetVar = g.allocTemp("resultTarget")
+		g.emit("%s := JITValueDesc{Loc: LocAny}", target)
+		g.emit("%s := result.Loc == LocRegPair", targetVar)
+		g.emit("if %s { %s = JITValueDesc{Loc: LocReg, Type: %s, Reg: result.Reg2, ID: 0} }", targetVar, target, resultTag)
+		targetExpression = target
+	}
+	g.emit("%s := %s(ctx, []JITValueDesc{%s}, %s)", descriptor, emitter, strings.Join(arguments, ", "), targetExpression)
+	generated := genVal{goVar: descriptor, isDesc: true, resultTargetVar: targetVar}
+	if basic, ok := resultType.(*types.Basic); ok {
+		switch basic.Kind() {
+		case types.Bool:
+			g.emit("%s.Type = tagBool", descriptor)
+			generated.canonicalIntBits = 1
+		case types.Int, types.Int64:
+			generated.canonicalIntBits = 64
+			generated.canonicalIntSigned = true
+		case types.Uint, types.Uint64, types.Uintptr:
+			generated.canonicalIntBits = 64
+		}
+	}
+	g.vals[name] = generated
+	return true
 }
 
 func (g *codeGen) tryInlineClosure(closure genVal, callArgs []ssa.Value) (result genVal, ok bool) {
@@ -4630,18 +4825,29 @@ func (g *codeGen) emitBody(cfg emitBodyConfig) {
 
 	if g.multiBlock && !storageVoid {
 		g.emit("if result.Loc == LocAny {")
-		g.emit("\tresult = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}")
-		g.emit("\tctx.BindReg(result.Reg, &result)")
-		g.emit("\tctx.BindReg(result.Reg2, &result)")
+		if g.rawReturn {
+			g.emit("\tresult = JITValueDesc{Loc: LocReg, Type: JITTypeUnknown, Reg: ctx.AllocReg()}")
+			g.emit("\tctx.BindReg(result.Reg, &result)")
+		} else {
+			g.emit("\tresult = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}")
+			g.emit("\tctx.BindReg(result.Reg, &result)")
+			g.emit("\tctx.BindReg(result.Reg2, &result)")
+		}
 		g.emit("}")
 		// A multi-block emitter writes every return arm into the caller-selected
 		// pair. Reserve that pair for the complete CFG render: path-local register
 		// reclamation must never recycle an output register before the arm which
 		// actually produces the runtime result has been emitted.
-		g.emit("resultRegsProtected := result.Loc == LocRegPair")
+		if g.rawReturn {
+			g.emit("resultRegsProtected := result.Loc == LocReg")
+		} else {
+			g.emit("resultRegsProtected := result.Loc == LocRegPair")
+		}
 		g.emit("if resultRegsProtected {")
 		g.emit("\tctx.ProtectReg(result.Reg)")
-		g.emit("\tctx.ProtectReg(result.Reg2)")
+		if !g.rawReturn {
+			g.emit("\tctx.ProtectReg(result.Reg2)")
+		}
 		g.emit("}")
 		if cfg.useReturnPhiRegs {
 			g.returnPhiReg = g.allocReg()
@@ -4672,7 +4878,9 @@ func (g *codeGen) emitBody(cfg emitBodyConfig) {
 	}
 	if g.multiBlock && !storageVoid {
 		g.emit("if resultRegsProtected {")
-		g.emit("\tctx.UnprotectReg(result.Reg2)")
+		if !g.rawReturn {
+			g.emit("\tctx.UnprotectReg(result.Reg2)")
+		}
 		g.emit("\tctx.UnprotectReg(result.Reg)")
 		g.emit("}")
 	}
@@ -4776,6 +4984,54 @@ func generateClosureCost(opName string, fn *ssa.Function, rewrite ssaValueRewrit
 		cost = math.MaxUint16 - 1
 	}
 	return result, "", uint16(cost)
+}
+
+// generateJITHelperBody compiles a fixed-signature Go helper into a reusable
+// emitter. Unlike a Declaration emitter, its result is the Go scalar described
+// by the function signature; callers decide whether and how to box that value.
+func generateJITHelperBody(fn *ssa.Function) (code string, errMsg string) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			code = ""
+			errMsg = fmt.Sprintf("%v", recovered)
+		}
+	}()
+	if fn.Signature.Results().Len() != 1 || fn.Signature.Results().At(0).Type().String() != "bool" {
+		panic(fmt.Sprintf("jitgen helper %s must return bool", fn.Name()))
+	}
+
+	g := newCodeGen(fn, nil)
+	g.rawReturn = true
+	g.directResultPayloads = computeRawReturnPayloads(fn)
+	g.multiBlock = len(fn.Blocks) > 1
+	for index, parameter := range fn.Params {
+		if !isScmerType(parameter.Type()) {
+			panic(fmt.Sprintf("jitgen helper %s parameter %s is not Scmer", fn.Name(), parameter.Name()))
+		}
+		g.vals[parameter.Name()] = genVal{goVar: fmt.Sprintf("args[%d]", index), isDesc: true}
+	}
+	// Unknown tags would make the reusable CFG render every type arm into the
+	// caller. Keep that case behind one compact native boundary; any fully known
+	// tag combination enters the generated renderer and prunes unreachable arms.
+	fmt.Fprintln(&g.w, "\tfor i := range args {")
+	fmt.Fprintln(&g.w, "\t\tif args[i].Type != JITTypeUnknown { continue }")
+	nativeValues := make([]string, len(fn.Params))
+	for index := range nativeValues {
+		nativeValues[index] = fmt.Sprintf("args[%d]", index)
+	}
+	fmt.Fprintf(&g.w, "\t\tnativeArgs := [...]JITValueDesc{%s}\n", strings.Join(nativeValues, ", "))
+	fmt.Fprintln(&g.w, "\t\tfor j := range nativeArgs { nativeArgs[j] = JITPrepareScmerGoArg(ctx, nativeArgs[j]) }")
+	fmt.Fprintf(&g.w, "\t\tnative := ctx.EmitGoCallScalar(GoFuncAddr(%s), nativeArgs[:], 1)\n", fn.Name())
+	fmt.Fprintln(&g.w, "\t\tctx.EmitAndRegImm32(native.Reg, 1)")
+	fmt.Fprintln(&g.w, "\t\tnative.Type = tagBool")
+	fmt.Fprintln(&g.w, "\t\tif result.Loc == LocAny { return native }")
+	fmt.Fprintln(&g.w, "\t\tctx.EmitMovToReg(result.Reg, native)")
+	fmt.Fprintln(&g.w, "\t\tresult.Type = tagBool")
+	fmt.Fprintln(&g.w, "\t\treturn result")
+	fmt.Fprintln(&g.w, "\t}")
+	fmt.Fprintf(&g.w, "\t%s\n", generatedBanner)
+	g.emitBody(emitBodyConfig{entryGeneral: false})
+	return g.wDecl.String() + injectBindRegCalls(g.w.String()), ""
 }
 
 // generateStorageBody generates a JIT emitter from one GetValue variant's SSA.
@@ -4921,7 +5177,7 @@ func addScmPrefix(code string) string {
 		"Reg": true, "JITRegisterPlan": true, "JITRegisterSlot": true,
 		"BBDescriptor": true, "PhiState": true,
 		"LocNone": true, "LocReg": true, "LocRegPair": true, "LocRegTriple": true,
-		"LocStack": true, "LocStackPair": true, "LocStackTriple": true, "LocInputPair": true, "LocMem": true, "LocImm": true, "LocAny": true, "LocFlags": true,
+		"LocStack": true, "LocStackPair": true, "LocStackTriple": true, "LocInputPair": true, "LocMem": true, "LocImm": true, "LocAny": true, "LocFlags": true, "LocFPReg": true,
 		"NewInt": true, "NewFloat": true, "NewBool": true, "NewNil": true, "NewString": true,
 		"NewFastDict": true, "NewFastDictValue": true,
 		"Scmer": true, "GoFuncAddr": true, "JITBuildMergeClosure": true,
@@ -5019,32 +5275,54 @@ func computeDirectResultPayloads(fn *ssa.Function) map[string]string {
 	if fn == nil {
 		return result
 	}
-	for _, instr := range fn.Blocks[0].Instrs {
-		ret, ok := instr.(*ssa.Return)
-		if !ok || len(ret.Results) != 1 {
-			continue
+	// A Declaration body commonly has nil/error guards before its successful
+	// return. Inspect every block: restricting this analysis to entry block made
+	// precisely those wrappers lose the caller-selected result register.
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			ret, ok := instr.(*ssa.Return)
+			if !ok || len(ret.Results) != 1 {
+				continue
+			}
+			call, ok := ret.Results[0].(*ssa.Call)
+			if !ok || len(call.Call.Args) != 1 {
+				continue
+			}
+			callee := call.Call.StaticCallee()
+			if callee == nil {
+				continue
+			}
+			marker := ""
+			switch callee.Name() {
+			case "NewBool":
+				marker = "_newbool"
+			case "NewInt":
+				marker = "_newint"
+			case "NewFloat":
+				marker = "_newfloat"
+			}
+			if marker != "" {
+				producer, ok := call.Call.Args[0].(ssa.Instruction)
+				if ok && producer.Block() == ret.Block() {
+					result[call.Call.Args[0].Name()] = marker
+				}
+			}
 		}
-		call, ok := ret.Results[0].(*ssa.Call)
-		if !ok || len(call.Call.Args) != 1 {
-			continue
-		}
-		callee := call.Call.StaticCallee()
-		if callee == nil {
-			continue
-		}
-		marker := ""
-		switch callee.Name() {
-		case "NewBool":
-			marker = "_newbool"
-		case "NewInt":
-			marker = "_newint"
-		case "NewFloat":
-			marker = "_newfloat"
-		}
-		if marker != "" {
-			producer, ok := call.Call.Args[0].(ssa.Instruction)
-			if ok && producer.Block() == ret.Block() {
-				result[call.Call.Args[0].Name()] = marker
+	}
+	return result
+}
+
+func computeRawReturnPayloads(fn *ssa.Function) map[string]string {
+	result := make(map[string]string)
+	for _, block := range fn.Blocks {
+		for _, instruction := range block.Instrs {
+			returned, ok := instruction.(*ssa.Return)
+			if !ok || len(returned.Results) != 1 {
+				continue
+			}
+			producer, ok := returned.Results[0].(ssa.Instruction)
+			if ok && producer.Block() == returned.Block() {
+				result[returned.Results[0].Name()] = "_raw"
 			}
 		}
 	}
@@ -5087,6 +5365,30 @@ func (g *codeGen) emitAllocResultAwareReg(dstVar, targetVar, indent string, dire
 	} else {
 		g.emit("%s} else {", indent)
 	}
+	g.emit("%s\t%s = ctx.AllocRegExcept(%s)", indent, dstVar, strings.Join(excludes, ", "))
+	g.emit("%s}", indent)
+}
+
+func (g *codeGen) emitAllocBooleanResultReg(dstVar, targetVar, indent, directMarker string, excludes ...string) {
+	if directMarker == "" {
+		g.emit("%s%s := ctx.AllocRegExcept(%s)", indent, dstVar, strings.Join(excludes, ", "))
+		return
+	}
+	targetReg := "result.Reg2"
+	targetLoc := "LocRegPair"
+	if directMarker == "_raw" {
+		targetReg = "result.Reg"
+		targetLoc = "LocReg"
+	}
+	condition := "result.Loc == " + targetLoc
+	for _, exclude := range excludes {
+		condition += " && " + targetReg + " != " + exclude
+	}
+	g.emit("%svar %s %s", indent, dstVar, g.regTypeName())
+	g.emit("%sif %s {", indent, condition)
+	g.emit("%s\t%s = %s", indent, dstVar, targetReg)
+	g.emit("%s\t%s = true", indent, targetVar)
+	g.emit("%s} else {", indent)
 	g.emit("%s\t%s = ctx.AllocRegExcept(%s)", indent, dstVar, strings.Join(excludes, ", "))
 	g.emit("%s}", indent)
 }
@@ -7089,8 +7391,11 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			if !arg.isDesc {
 				panic("GetTag expects Scmer descriptor")
 			}
+			borrowed := g.allocDesc()
+			g.emit("%s := %s", borrowed, arg.goVar)
+			g.emit("%s.ID = 0", borrowed)
 			dv := g.allocDesc()
-			g.emit("%s := ctx.EmitGetTagDesc(&%s, JITValueDesc{Loc: LocAny})", dv, arg.goVar)
+			g.emit("%s := ctx.EmitGetTagDesc(&%s, JITValueDesc{Loc: LocAny})", dv, borrowed)
 			// EmitGetTagDesc already sets Type: tagInt on LocReg results
 			g.vals[name] = genVal{goVar: dv, isDesc: true}
 		case "IsNil":
@@ -7634,6 +7939,9 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				if g.emitNestedStorageGetter(name, v, callee) {
 					break
 				}
+				if g.tryEmitJITHelperCall(name, callee, v.Call.Args) {
+					break
+				}
 				if result, ok := g.tryInlineCall(callee, v.Call.Args); ok {
 					if name != "" {
 						g.vals[name] = result
@@ -7662,6 +7970,9 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				}
 				break
 			}
+			if g.tryEmitJITHelperCall(name, callee, v.Call.Args) {
+				break
+			}
 			if result, ok := g.tryInlineCall(callee, v.Call.Args); ok {
 				if name != "" {
 					if _, signature := v.Type().Underlying().(*types.Signature); signature {
@@ -7679,6 +7990,26 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 	case *ssa.BinOp:
 		// Check for string concatenation before integer path
 		if basic, ok := v.X.Type().Underlying().(*types.Basic); ok && basic.Kind() == types.String {
+			materializeString := func(value ssa.Value) genVal {
+				resolved := g.resolveValue(value)
+				if resolved.marker == "_gostring" {
+					return resolved
+				}
+				dv := g.allocDesc()
+				g.emit("var %s JITValueDesc", dv)
+				g.emit("if %s.Loc == LocImm {", resolved.goVar)
+				g.emit("\tctx.TrackImm(%s.Imm)", resolved.goVar)
+				g.emit("\tptrWord, _ := %s.Imm.RawWords()", resolved.goVar)
+				g.emit("\t%s = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}", dv)
+				g.emit("\tctx.EmitMovRegImm64(%s.Reg, uint64(ptrWord))", dv)
+				g.emit("\tctx.EmitMovRegImm64(%s.Reg2, uint64(len(%s.Imm.String())))", dv, resolved.goVar)
+				g.emit("\tctx.BindReg(%s.Reg, &%s)", dv, dv)
+				g.emit("\tctx.BindReg(%s.Reg2, &%s)", dv, dv)
+				g.emit("} else {")
+				g.emit("\t%s = %s", dv, resolved.goVar)
+				g.emit("}")
+				return genVal{goVar: dv, isDesc: true, marker: "_gostring"}
+			}
 			if v.Op == token.ADD {
 				// String concatenation: call runtime concat function
 				xVal := g.resolveValue(v.X)
@@ -7689,26 +8020,6 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				break
 			}
 			if v.Op == token.EQL || v.Op == token.NEQ {
-				materializeString := func(value ssa.Value) genVal {
-					resolved := g.resolveValue(value)
-					if resolved.marker == "_gostring" {
-						return resolved
-					}
-					dv := g.allocDesc()
-					g.emit("var %s JITValueDesc", dv)
-					g.emit("if %s.Loc == LocImm {", resolved.goVar)
-					g.emit("\tctx.TrackImm(%s.Imm)", resolved.goVar)
-					g.emit("\tptrWord, _ := %s.Imm.RawWords()", resolved.goVar)
-					g.emit("\t%s = JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}", dv)
-					g.emit("\tctx.EmitMovRegImm64(%s.Reg, uint64(ptrWord))", dv)
-					g.emit("\tctx.EmitMovRegImm64(%s.Reg2, uint64(len(%s.Imm.String())))", dv, resolved.goVar)
-					g.emit("\tctx.BindReg(%s.Reg, &%s)", dv, dv)
-					g.emit("\tctx.BindReg(%s.Reg2, &%s)", dv, dv)
-					g.emit("} else {")
-					g.emit("\t%s = %s", dv, resolved.goVar)
-					g.emit("}")
-					return genVal{goVar: dv, isDesc: true, marker: "_gostring"}
-				}
 				xVal := materializeString(v.X)
 				yVal := materializeString(v.Y)
 				dv := g.allocDesc()
@@ -7725,13 +8036,34 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			}
 		}
 		xVal := g.resolveValue(v.X)
+		_, _, resultIsInteger := intTypeInfo(v.Type())
+		_, _, leftIsInteger := intTypeInfo(v.X.Type())
+		if (v.Op == token.ADD || v.Op == token.SUB) && resultIsInteger && leftIsInteger {
+			if constantOperand, ok := v.Y.(*ssa.Const); ok {
+				if value, exact := constant.Int64Val(constantOperand.Value); exact && value == 0 {
+					sourceName := v.X.Name()
+					if _, sourceIsConstant := v.X.(*ssa.Const); !sourceIsConstant {
+						g.ssaAliases[name] = sourceName
+						g.refCounts[sourceName] += g.refCounts[name]
+						delete(g.refCounts, name)
+					}
+					g.vals[name] = xVal
+					break
+				}
+			}
+		}
 		plannedTarget := g.plannedPhiTarget(v)
 		directResultMarker := g.directResultPayloads[name]
 		directResult := directResultMarker == "_newint" || directResultMarker == "_newfloat"
+		directBoolResult := directResultMarker == "_newbool" || directResultMarker == "_raw"
 		resultTargetVar := ""
-		if directResult {
+		if directResult || directBoolResult {
 			resultTargetVar = g.allocTemp("resultTarget")
 			g.emit("%s := false", resultTargetVar)
+			// A multi-block helper can route this value through a Phi that does
+			// not retain the producer's placement marker. Raw-return lowering uses
+			// the marker when it survives; other arms still need valid Go output.
+			g.emit("_ = %s", resultTargetVar)
 		}
 		// Check if v.X has more remaining uses (excluding this one).
 		// If so, destructive operations must copy before modifying.
@@ -7869,12 +8201,12 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 					g.emit("\tctx.EnsureDesc(&%s)", xVal.goVar)
 					g.emit("\tif %s.Loc != LocReg && %s.Loc != LocRegPair && %s.Loc != LocRegTriple { panic(\"jit: nil comparison requires a register value\") }", xVal.goVar, xVal.goVar, xVal.goVar)
 					rv := g.allocReg()
-					g.emitAllocRegExcept(rv, "\t", xMultiUse, xVal)
+					g.emitAllocBooleanResultReg(rv, resultTargetVar, "\t", directResultMarker, xVal.goVar+".Reg")
 					g.emit("\tctx.EmitCmpRegImm32(%s.Reg, 0)", xVal.goVar)
 					g.emit("\tctx.EmitSetcc(%s, %s)", rv, cc)
 					g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv)
 					g.emit("}")
-					g.vals[name] = genVal{goVar: dv, isDesc: true}
+					g.vals[name] = genVal{goVar: dv, isDesc: true, resultTargetVar: resultTargetVar}
 					break
 				}
 			}
@@ -7888,14 +8220,14 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 							g.emit("\t%s = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(%s.Imm.String() %s \"\")}", dv, xVal.goVar, goOp)
 							g.emit("} else if %s.Loc == LocRegPair {", xVal.goVar)
 							rv := g.allocReg()
-							g.emitAllocRegExcept(rv, "\t", xMultiUse, xVal)
+							g.emitAllocBooleanResultReg(rv, resultTargetVar, "\t", directResultMarker, xVal.goVar+".Reg", xVal.goVar+".Reg2")
 							g.emit("\tctx.EmitCmpRegImm32(%s.Reg2, 0)", xVal.goVar)
 							g.emit("\tctx.EmitSetcc(%s, %s)", rv, cc)
 							g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv)
 							g.emit("} else {")
 							g.emit("\tpanic(\"jit: string compare expects LocRegPair or LocImm\")")
 							g.emit("}")
-							g.vals[name] = genVal{goVar: dv, isDesc: true}
+							g.vals[name] = genVal{goVar: dv, isDesc: true, resultTargetVar: resultTargetVar}
 							break
 						}
 					}
@@ -7906,7 +8238,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				if g.nativeFP {
 					yVal := g.resolveValue(v.Y)
 					g.emit("%s := ctx.EmitFloatCompare(&%s, &%s, %s)", dv, xVal.goVar, yVal.goVar, cc)
-					g.vals[name] = genVal{goVar: dv, isDesc: true}
+					g.vals[name] = genVal{goVar: dv, isDesc: true, resultTargetVar: resultTargetVar}
 					break
 				}
 				if c, ok := v.Y.(*ssa.Const); ok {
@@ -7920,7 +8252,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 					g.emit("\t%s = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(%s.Imm.Float() %s %g)}", dv, xVal.goVar, goOp, cmpVal)
 					g.emit("} else {")
 					rv := g.allocReg()
-					g.emitAllocRegExcept(rv, "\t", xMultiUse, xVal)
+					g.emitAllocBooleanResultReg(rv, resultTargetVar, "\t", directResultMarker, xVal.goVar+".Reg")
 					g.emit("\tctx.EmitMovRegImm64(RegR11, uint64(%d))", bits)
 					g.emit("\tctx.EmitCmpFloat64Setcc(%s, %s.Reg, RegR11, %s)", rv, xVal.goVar, cc)
 					g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv)
@@ -7933,26 +8265,26 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 					g.emit("\t%s = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(%s.Imm.Float() %s %s.Imm.Float())}", dv, xVal.goVar, goOp, yVal.goVar)
 					g.emit("} else if %s.Loc == LocImm {", yVal.goVar)
 					rv := g.allocReg()
-					g.emitAllocRegExcept(rv, "\t", xMultiUse, xVal)
+					g.emitAllocBooleanResultReg(rv, resultTargetVar, "\t", directResultMarker, xVal.goVar+".Reg")
 					g.emit("\t_, yBits := %s.Imm.RawWords()", yVal.goVar)
 					g.emit("\tctx.EmitMovRegImm64(RegR11, yBits)")
 					g.emit("\tctx.EmitCmpFloat64Setcc(%s, %s.Reg, RegR11, %s)", rv, xVal.goVar, cc)
 					g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv)
 					g.emit("} else if %s.Loc == LocImm {", xVal.goVar)
 					rv2 := g.allocReg()
-					g.emit("\t%s := ctx.AllocRegExcept(%s.Reg)", rv2, yVal.goVar)
+					g.emitAllocBooleanResultReg(rv2, resultTargetVar, "\t", directResultMarker, yVal.goVar+".Reg")
 					g.emit("\t_, xBits := %s.Imm.RawWords()", xVal.goVar)
 					g.emit("\tctx.EmitMovRegImm64(RegR11, xBits)")
 					g.emit("\tctx.EmitCmpFloat64Setcc(%s, RegR11, %s.Reg, %s)", rv2, yVal.goVar, cc)
 					g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv2)
 					g.emit("} else {")
 					rv3 := g.allocReg()
-					g.emit("\t%s := ctx.AllocRegExcept(%s.Reg, %s.Reg)", rv3, xVal.goVar, yVal.goVar)
+					g.emitAllocBooleanResultReg(rv3, resultTargetVar, "\t", directResultMarker, xVal.goVar+".Reg", yVal.goVar+".Reg")
 					g.emit("\tctx.EmitCmpFloat64Setcc(%s, %s.Reg, %s.Reg, %s)", rv3, xVal.goVar, yVal.goVar, cc)
 					g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv3)
 					g.emit("}")
 				}
-				g.vals[name] = genVal{goVar: dv, isDesc: true}
+				g.vals[name] = genVal{goVar: dv, isDesc: true, resultTargetVar: resultTargetVar}
 				break
 			}
 			if c, ok := v.Y.(*ssa.Const); ok {
@@ -7986,7 +8318,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				} else {
 					// CMP is non-destructive, but SETcc requires a fresh result register.
 					rv := g.allocReg()
-					g.emitAllocRegExcept(rv, "\t", xMultiUse, xVal)
+					g.emitAllocBooleanResultReg(rv, resultTargetVar, "\t", directResultMarker, xVal.goVar+".Reg")
 					g.emit("\tctx.EmitSetcc(%s, %s)", rv, cc)
 					g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv)
 				}
@@ -8018,7 +8350,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 					g.emit("\tctx.BindReg(%s, &%s)", flagsRegY, dv)
 				} else {
 					rv := g.allocReg()
-					g.emitAllocRegExcept(rv, "\t", xMultiUse, xVal)
+					g.emitAllocBooleanResultReg(rv, resultTargetVar, "\t", directResultMarker, xVal.goVar+".Reg")
 					g.emit("\tctx.EmitSetcc(%s, %s)", rv, cc)
 					g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv)
 				}
@@ -8036,7 +8368,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 					g.emit("\tctx.BindReg(%s, &%s)", flagsRegX, dv)
 				} else {
 					rv2 := g.allocReg()
-					g.emit("\t%s := ctx.AllocReg()", rv2)
+					g.emitAllocBooleanResultReg(rv2, resultTargetVar, "\t", directResultMarker, yVal.goVar+".Reg")
 					g.emit("\tctx.EmitSetcc(%s, %s)", rv2, cc)
 					g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv2)
 				}
@@ -8053,7 +8385,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				} else {
 					// Protect xVal.Reg when multi-use: SETcc must not clobber it.
 					rv3 := g.allocReg()
-					g.emitAllocRegExcept(rv3, "\t", xMultiUse, xVal)
+					g.emitAllocBooleanResultReg(rv3, resultTargetVar, "\t", directResultMarker, xVal.goVar+".Reg", yVal.goVar+".Reg")
 					g.emit("\tctx.EmitSetcc(%s, %s)", rv3, cc)
 					g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: %s}", dv, rv3)
 				}
@@ -8063,7 +8395,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			if flagsOnly {
 				marker = "_flags"
 			}
-			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: marker}
+			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: marker, resultTargetVar: resultTargetVar}
 		} else if aluOp := aluEmitFunc(v.Op); aluOp != "" {
 			// Arithmetic BinOp: ADD, SUB, MUL
 			dv := g.allocDesc()
@@ -8934,16 +9266,23 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			g.vals[name] = genVal{goVar: dv, isDesc: true,
 				canonicalIntBits: dstBits, canonicalIntSigned: dstSigned}
 		} else if srcOk && dstOk && isIntegerKind(srcBasic.Kind()) && dstBasic.Kind() == types.Float64 {
-			// int → float64: CVTSI2SD overwrites its GPR operand with the
-			// resulting IEEE-754 bits. Keep the SSA producer intact because it
-			// may still feed a loop phi or another consumer after this conversion.
+			// CVTSI2SD reads the integer before replacing the selected GPR with
+			// IEEE-754 bits. A last-use source can therefore transfer its register
+			// directly; only values live after this SSA instruction need a copy.
+			reuseSource := g.ssaValueUsesRemaining(v.X.Name()) == 1 && !g.crossBlockValues[v.X.Name()] && !g.usedByOutgoingPhi(v.X.Name())
 			g.emit("var %s JITValueDesc", dv)
 			g.emit("if %s.Loc == LocImm {", src.goVar)
 			g.emit("\t%s = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(float64(%s.Imm.Int()))}", dv, src.goVar)
 			g.emit("} else {")
 			tmpReg := g.allocReg()
-			g.emit("\t%s := ctx.AllocRegExcept(%s.Reg)", tmpReg, src.goVar)
-			g.emit("\tctx.EmitMovRegReg(%s, %s.Reg)", tmpReg, src.goVar)
+			g.emit("\tvar %s Reg", tmpReg)
+			if reuseSource {
+				g.emit("\t%s = %s.Reg", tmpReg, src.goVar)
+				g.emit("\t%s.Loc = LocNone", src.goVar)
+			} else {
+				g.emit("\t%s = ctx.AllocRegExcept(%s.Reg)", tmpReg, src.goVar)
+				g.emit("\tctx.EmitMovRegReg(%s, %s.Reg)", tmpReg, src.goVar)
+			}
 			g.emit("\tctx.EmitCvtInt64ToFloat64(RegX0, %s)", tmpReg)
 			g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: %s}", dv, tmpReg)
 			g.emit("}")
@@ -9726,6 +10065,24 @@ func (g *codeGen) emitReturnSingleBlock(v *ssa.Return) {
 		g.emit("return result")
 		return
 	}
+	if g.rawReturn {
+		res := g.resolveValue(v.Results[0])
+		if !res.isDesc {
+			panic(fmt.Sprintf("unsupported raw helper return for %s", v.Results[0]))
+		}
+		g.emit("if result.Loc == LocAny { return %s }", res.goVar)
+		if res.resultTargetVar != "" {
+			// A scalar producer may already have selected result.Reg as its home.
+			// Keep the final move structurally present only for paths where that
+			// placement was impossible (for example because an operand was live).
+			g.emit("if !%s { ctx.EmitMovToReg(result.Reg, %s) }", res.resultTargetVar, res.goVar)
+		} else {
+			g.emit("ctx.EmitMovToReg(result.Reg, %s)", res.goVar)
+		}
+		g.emit("result.Type = %s.Type", res.goVar)
+		g.emit("return result")
+		return
+	}
 	res := g.vals[v.Results[0].Name()]
 	switch res.marker {
 	case "_newargslice":
@@ -9854,6 +10211,19 @@ func (g *codeGen) emitReturnSingleBlock(v *ssa.Return) {
 // emitReturnMultiBlock handles Return for multi-block functions.
 // Emits machine code to construct the result + JMP to the shared epilogue.
 func (g *codeGen) emitReturnMultiBlock(v *ssa.Return) {
+	if g.rawReturn {
+		if len(v.Results) != 1 {
+			panic("raw helper must return exactly one value")
+		}
+		res := g.resolveValue(v.Results[0])
+		if !res.isDesc {
+			panic(fmt.Sprintf("unsupported raw helper return for %s", v.Results[0]))
+		}
+		g.emit("ctx.EmitMovToReg(result.Reg, %s)", res.goVar)
+		g.emit("result.Type = %s.Type", res.goVar)
+		g.emit("ctx.EmitJmp(%s)", g.endLabel)
+		return
+	}
 	if g.storageMode {
 		if len(v.Results) == 0 {
 			g.emit("ctx.EmitJmp(%s)", g.endLabel)

--- a/tools/jitgen/main_test.go
+++ b/tools/jitgen/main_test.go
@@ -17,12 +17,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package main
 
 import (
+	"bytes"
 	"go/ast"
 	"go/constant"
 	"go/importer"
 	"go/parser"
 	"go/token"
 	"go/types"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -30,10 +32,36 @@ import (
 	"golang.org/x/tools/go/ssa/ssautil"
 )
 
+func TestGeneratedEmitterOverlayHidesReusableHelperBodies(t *testing.T) {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, "../../scm/compare.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if helpers := collectJITHelpers(parsed, "../../scm/compare.go"); len(helpers) != 1 {
+		t.Fatalf("got %d reusable helpers", len(helpers))
+	}
+	overlay, _, err := generatedEmitterOverlay("../../scm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, err := filepath.Abs("../../scm/compare.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	generated := overlay[path]
+	if len(generated) == 0 {
+		t.Fatal("compare.go has no generated overlay")
+	}
+	if bytes.Contains(generated, []byte("*bson.RawValue")) {
+		t.Fatal("generated jitEmitLess body remained visible to SSA")
+	}
+}
+
 func buildTestSSAFunction(t *testing.T, source, name string) *ssa.Function {
 	t.Helper()
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "sample.go", source, 0)
+	file, err := parser.ParseFile(fset, "sample.go", source, parser.ParseComments)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,6 +75,33 @@ func buildTestSSAFunction(t *testing.T, source, name string) *ssa.Function {
 		t.Fatalf("SSA function %q not found", name)
 	}
 	return fn
+}
+
+func TestAnnotatedHelperCallInvokesEmitterInsteadOfNativeFunction(t *testing.T) {
+	fn := buildTestSSAFunction(t, `package sample
+type Scmer struct{}
+func NewBool(bool) Scmer
+func (Scmer) Int() int64
+//jitgen:emitter jitEmitLess
+func Less(a, b Scmer) bool { return a.Int() < b.Int() }
+func compare(a ...Scmer) Scmer {
+	if a[0].Int() == 0 { return NewBool(false) }
+	return NewBool(Less(a[0], a[1]))
+}
+`, "compare")
+	code, errMsg := generateClosure("compare", fn, nil)
+	if errMsg != "" {
+		t.Fatal(errMsg)
+	}
+	if !strings.Contains(code, "jitEmitLess(ctx, []JITValueDesc{") {
+		t.Fatalf("annotated helper did not invoke its generated emitter:\n%s", code)
+	}
+	if strings.Contains(code, "GoFuncAddr(Less)") {
+		t.Fatalf("annotated helper retained a native Less call boundary:\n%s", code)
+	}
+	if !strings.Contains(code, "result.Loc == LocRegPair") || !strings.Contains(code, "Reg: result.Reg2") {
+		t.Fatalf("guarded helper return did not inherit the caller's payload register:\n%s", code)
+	}
 }
 
 func TestFallbackClosureUsesGeneratedCallBoundary(t *testing.T) {


### PR DESCRIPTION
## Problem

JITGen could inline declared Scheme builtins, but ordinary Go helpers called by those builtins remained either expanded wholesale or emitted as native Go calls. In particular, `scm.Less` stayed behind a Go ABI boundary inside typed storage consumers. That boundary rebuilt two `Scmer` values, spilled them for the call, and prevented the known storage tag from pruning comparison branches.

Register placement at ABI, Phi, and result boundaries also used allocating slices and a fixed x86 scratch register. Sequential placement could retain redundant moves or destroy overlapping sources.

## Solution

- Add `//jitgen:emitter` helpers: JITGen reads the annotated Go implementation and generates a reusable descriptor emitter beside it.
- Generate `jitEmitLess` from `scm.Less`; known tags render only the reachable comparison path, while unknown tags retain the compact native-call boundary.
- Respect `//jitgen:noinline` for deliberately cold semantic helpers.
- Transport caller-selected result registers through guarded/multi-block wrappers, including boolean `SETcc` results.
- Reuse last-use registers for integer-to-float conversion and alias identity arithmetic such as `x + 0`.
- Replace allocating register-move slices with a fixed, architecture-neutral parallel-move batch. It removes identities, schedules dependencies, and resolves cycles with a backend-selected saved scratch register.
- Regenerate every affected builtin and storage emitter; `make jitgen` is byte-for-byte reproducible.

## Manual A/B measurement

Compared current `master` (`7df542f86`) with this branch using the same patched Go toolchain, fixture, CPU, warmup, and sample count:

```text
GOMAXPROCS=1 taskset -c 2 \
GOROOT=../go-jit/goroot GOEXPERIMENT=jit ../go-jit/goroot/bin/go test ./storage \
  -run '^$' -bench '^BenchmarkStorageIntTypedConsumer/Typed$' \
  -benchtime=2s -count=8 -benchmem

master median: 705,237 ns / 60,000 values
PR median:     358,525 ns / 60,000 values
change:        -49.2% latency (1.97x throughput)
allocations:   0 -> 0 allocs/op
```

The integrated typed-consumer machine code shrinks from 372 to 341 bytes (-8.3%). Disassembly confirms that the native `CALL scm.Less` and its Go call frame disappear. The specialized path emits the numeric conversion/comparison directly and `SETcc` writes into the final `Scmer` payload register.

## Validation

- `go test ./...`
- `GOROOT=../go-jit/goroot GOEXPERIMENT=jit ../go-jit/goroot/bin/go test ./...`
- `make jitgen`, followed by a byte-identical second generation
- Exact-byte tests for acyclic, identity, and cyclic parallel moves
- Known-integer `jitEmitLess` correctness test
- Generator regression test proving an annotated helper becomes an emitter call, not `GoFuncAddr(Less)`

## Follow-up

A broader lazy move graph can defer copies across nested emitter boundaries, but it should land only after architecture instruction APIs expose explicit register use/def masks. That is necessary to flush correctly around destructive operations, flags, control-flow edges, and safepoints. The present PR keeps that concern separate and applies deferred/simultaneous solving only at boundaries whose complete assignments are already known.
