### PR TITLE
Add configurable storage failure hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,26 @@ MemCP supports several storage engines, selectable per table via `CREATE TABLE .
 For production data, use `safe` unless you have explicitly accepted another
 engine's weaker durability contract.
 
+### Storage failure notifications
+
+Administrators can register one process-local Scheme callback for persistence
+failures. The callback runs asynchronously, so notification delivery cannot
+delay or rescue the failing storage operation:
+
+```scheme
+(register_storage_failure_hook 300 (lambda (failure)
+	(http_request "POST" "https://monitor.example/memcp"
+		(list "Content-Type" "text/plain") (serialize failure))))
+```
+
+The numeric argument is a per-fingerprint cooldown in seconds. A fingerprint
+consists of `class`, `backend`, `database`, and `operation`; the next delivered
+event reports intervening occurrences in `suppressed_count`. Events also contain
+`error`, `outcome_unknown`, and `timestamp`. Callback panics and storage errors
+caused by the callback are isolated and written directly to stderr instead of
+being logged through a MemCP table. `clear_storage_failure_hook` removes the
+registration. Registrations are not persisted across process restarts.
+
 ### Test coverage
 
 The repository currently contains more than 6,000 SQL/YAML cases across more

--- a/README.md
+++ b/README.md
@@ -206,23 +206,31 @@ engine's weaker durability contract.
 
 ### Storage failure notifications
 
-Administrators can register one process-local Scheme callback for persistence
-failures. The callback runs asynchronously, so notification delivery cannot
-delay or rescue the failing storage operation:
+Administrators can register named Scheme callbacks for persistence failures.
+The callback runs asynchronously, so notification delivery cannot delay or
+rescue the failing storage operation:
 
 ```scheme
-(register_storage_failure_hook 300 (lambda (failure)
+(register_storage_failure_hook "monitor" (list "*") 300 (lambda (failure)
 	(http_request "POST" "https://monitor.example/memcp"
 		(list "Content-Type" "text/plain") (serialize failure))))
 ```
 
 The numeric argument is a per-fingerprint cooldown in seconds. A fingerprint
-consists of `class`, `backend`, `database`, and `operation`; the next delivered
+consists of the hook name, `class`, `backend`, `database`, and `operation`; the next delivered
 event reports intervening occurrences in `suppressed_count`. Events also contain
-`error`, `outcome_unknown`, and `timestamp`. Callback panics and storage errors
+`error`, `outcome_unknown`, and `timestamp`. Named hooks can be replaced or
+removed independently. Callback panics and storage errors
 caused by the callback are isolated and written directly to stderr instead of
-being logged through a MemCP table. `clear_storage_failure_hook` removes the
-registration. Registrations are not persisted across process restarts.
+being logged through a MemCP table.
+
+The dashboard Settings page manages persistent definitions in
+`system.storage_failure_hooks`. Each row stores its enabled state, selected
+failure classes, cooldown, and Scheme source. Enabled definitions are compiled
+once during startup and published to the in-memory dispatcher; failure handling
+does not query the catalog. New installations include disabled templates for
+calling the system logger and opening a local outage HTML page. Direct runtime
+registrations are not persisted across process restarts.
 
 ### Test coverage
 

--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -98,6 +98,14 @@ header a:hover{opacity:1;text-decoration:underline}
 .settings-status{text-align:center;padding:8px;font-size:.8rem;color:#76b512;min-height:24px}
 .settings-group-header{grid-column:1/-1;font-size:.8rem;color:#888;text-transform:uppercase;letter-spacing:.5px;padding:12px 0 4px;border-bottom:1px solid #2a2a4a;margin-top:8px}
 .settings-group-header:first-child{margin-top:0}
+.hook-list{display:grid;gap:14px}
+.hook-card{background:#16213e;border:1px solid #2a2a4a;border-radius:6px;padding:16px 20px}
+.hook-fields{display:grid;grid-template-columns:minmax(150px,1fr) minmax(180px,1fr) 130px auto;gap:12px;align-items:end;margin-bottom:12px}
+.hook-field label{display:block;color:#888;font-size:.7rem;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
+.hook-field input[type="text"],.hook-field input[type="number"]{width:100%;background:#1a1a2e;border:1px solid #2a2a4a;color:#fff;padding:7px 9px;border-radius:4px}
+.hook-source{font-family:monospace;background:#1a1a2e;border:1px solid #2a2a4a;color:#e0e0e0;width:100%;min-height:100px;padding:10px;border-radius:4px;resize:vertical}
+.hook-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:10px}
+@media(max-width:800px){.hook-fields{grid-template-columns:1fr}}
 .btn-danger{background:#c0392b;color:#fff;border:none;padding:4px 10px;border-radius:3px;font-size:.75rem;cursor:pointer}
 .btn-danger:hover{background:#e74c3c}
 .btn-warn{background:#e67e22;color:#fff;border:none;padding:4px 10px;border-radius:3px;font-size:.75rem;cursor:pointer}
@@ -526,6 +534,13 @@ body{display:flex;flex-direction:column}
 </div>
 <div class="settings-status" id="settings-status"></div>
 <div class="settings-grid" id="settings-grid"></div>
+<div class="detail-section" style="margin-top:28px">
+<h3>Storage Failure Hooks</h3>
+<p style="color:#888;font-size:.78rem;margin-bottom:12px">Enabled hooks execute trusted Scheme code with server permissions. Classes are <code>io</code>, <code>cleanup</code>, <code>ambiguous_commit</code>, or <code>*</code>. Changes are persisted in <code>system.storage_failure_hooks</code>.</p>
+<button class="btn-warn" id="btn-add-storage-hook" style="margin-bottom:12px">Add Hook</button>
+<div class="settings-status" id="storage-hooks-status"></div>
+<div class="hook-list" id="storage-hooks-list"></div>
+</div>
 </div>
 </div>
 
@@ -611,6 +626,7 @@ if(bytes>=1024)return(bytes/1024).toFixed(0)+" KB";
 return bytes+" B";
 }
 function esc(s){var d=document.createElement("span");d.textContent=String(s);return d.innerHTML}
+function attr(s){return esc(s).replace(/'/g,"&#39;").replace(/\"/g,"&quot;")}
 function truncName(s,n){n=n||30;return s.length>n?s.substring(0,n)+"\u2026":s}
 
 /* ---- Error log ---- */
@@ -1272,6 +1288,71 @@ fetch(base+"/scm",{method:"POST",credentials:"same-origin",body:"(settings "+JSO
 .catch(function(e){window.alert("Error: "+e.message);});
 }
 
+var storageFailureHooks=[];
+function storageHooksStatus(message,isError){
+var el=document.getElementById("storage-hooks-status");
+if(!el)return;
+el.style.color=isError?"#e74c3c":"#76b512";
+el.textContent=message||"";
+}
+function loadStorageFailureHooks(){
+fetch(base+"/dashboard/api/storage-failure-hooks",{credentials:"same-origin"})
+.then(function(r){if(!r.ok)return r.text().then(function(t){throw new Error(t)});return r.json();})
+.then(function(rows){storageFailureHooks=Array.isArray(rows)?rows:[];renderStorageFailureHooks();})
+.catch(function(e){storageHooksStatus("Could not load hooks: "+e.message,true);});
+}
+function renderStorageFailureHooks(){
+var list=document.getElementById("storage-hooks-list");
+if(!list)return;
+var h="";
+for(var i=0;i<storageFailureHooks.length;i++){
+var hook=storageFailureHooks[i]||{};
+var classes=Array.isArray(hook.classes)?hook.classes.join(", "):String(hook.classes||"*").split(",").join(", ");
+h+="<div class='hook-card' data-hook-index='"+i+"'>";
+h+="<div class='hook-fields'>";
+h+="<div class='hook-field'><label>Name</label><input class='hook-name' type='text' value='"+attr(hook.name||"")+"'"+(hook.is_new?"":" readonly")+"></div>";
+h+="<div class='hook-field'><label>Failure classes</label><input class='hook-classes' type='text' value='"+attr(classes)+"'></div>";
+h+="<div class='hook-field'><label>Cooldown (seconds)</label><input class='hook-cooldown' type='number' min='0' value='"+Number(hook.cooldown_seconds||0)+"'></div>";
+h+="<div class='hook-field'><label>Enabled</label><label class='toggle'><input class='hook-enabled' type='checkbox'"+(hook.enabled?" checked":"")+"><span class='slider'></span></label></div>";
+h+="</div>";
+h+="<div class='hook-field'><label>Scheme source (must evaluate to a lambda accepting failure)</label><textarea class='hook-source'>"+esc(hook.source||"")+"</textarea></div>";
+h+="<div class='hook-actions'><button class='btn-danger hook-delete'>Delete</button><button class='btn-warn hook-save'>Save &amp; activate</button></div>";
+h+="</div>";
+}
+list.innerHTML=h||"<div style='color:#888;font-size:.85rem'>No storage failure hooks configured.</div>";
+list.querySelectorAll(".hook-save").forEach(function(button){button.addEventListener("click",function(){saveStorageFailureHook(button.closest(".hook-card"));});});
+list.querySelectorAll(".hook-delete").forEach(function(button){button.addEventListener("click",function(){deleteStorageFailureHook(button.closest(".hook-card"));});});
+}
+function saveStorageFailureHook(card){
+var classes=card.querySelector(".hook-classes").value.split(",").map(function(v){return v.trim();}).filter(Boolean);
+var payload={
+name:card.querySelector(".hook-name").value.trim(),
+enabled:card.querySelector(".hook-enabled").checked,
+classes:classes,
+cooldown_seconds:Number(card.querySelector(".hook-cooldown").value)||0,
+source:card.querySelector(".hook-source").value
+};
+storageHooksStatus("Saving "+(payload.name||"hook")+"...",false);
+fetch(base+"/dashboard/api/storage-failure-hooks/save",{method:"POST",credentials:"same-origin",headers:{"Content-Type":"application/json"},body:JSON.stringify(payload)})
+.then(function(r){if(!r.ok)return r.text().then(function(t){throw new Error(t)});return r.json();})
+.then(function(){storageHooksStatus(payload.name+" saved and runtime hooks updated",false);loadStorageFailureHooks();})
+.catch(function(e){storageHooksStatus("Hook was not saved: "+e.message,true);});
+}
+function deleteStorageFailureHook(card){
+var name=card.querySelector(".hook-name").value.trim();
+var index=Number(card.getAttribute("data-hook-index"));
+if(storageFailureHooks[index]&&storageFailureHooks[index].is_new){storageFailureHooks.splice(index,1);renderStorageFailureHooks();return;}
+if(!confirm("Delete storage failure hook "+name+"?"))return;
+fetch(base+"/dashboard/api/storage-failure-hooks/delete",{method:"POST",credentials:"same-origin",headers:{"Content-Type":"application/json"},body:JSON.stringify({name:name})})
+.then(function(r){if(!r.ok)return r.text().then(function(t){throw new Error(t)});return r.json();})
+.then(function(){storageHooksStatus(name+" deleted",false);loadStorageFailureHooks();})
+.catch(function(e){storageHooksStatus("Hook was not deleted: "+e.message,true);});
+}
+document.getElementById("btn-add-storage-hook").addEventListener("click",function(){
+storageFailureHooks.push({name:"",enabled:false,classes:["io"],cooldown_seconds:300,is_new:true,source:'(lambda (failure) (http_request "POST" "https://monitor.example/memcp" (list "Content-Type" "text/plain") (serialize failure)))'});
+renderStorageFailureHooks();
+});
+
 /* settings grouped by topic */
 var settingsGroups=[
 {group:"Memory",items:[
@@ -1414,6 +1495,7 @@ if(!isAdmin){location.hash="databases";return}
 showView("view-settings");
 document.getElementById("root-pw-warning").style.display=defaultPassword?"":"none";
 fetchSettings(renderSettings);
+loadStorageFailureHooks();
 scmFetch(SCM_SERVICES,renderServices);
 return;
 }

--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -161,6 +161,29 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(lambda (req res) (begin
 		(define session (req "__session"))
 		(match (req "path")
+			/* API: persistent storage failure hooks (admin only) */
+			"/dashboard/api/storage-failure-hooks/save" (begin
+				(if (dashboard_check_admin req) (begin
+					(define payload (json_decode ((req "body"))))
+					(storage_failure_hook_save
+						(payload "name") (payload "enabled") (payload "classes")
+						(payload "cooldown_seconds") (payload "source"))
+					(dashboard_send_json res "{\"ok\":true}")
+				) (dashboard_send_401 res))
+			)
+			"/dashboard/api/storage-failure-hooks/delete" (begin
+				(if (dashboard_check_admin req) (begin
+					(define payload (json_decode ((req "body"))))
+					(storage_failure_hook_delete (payload "name"))
+					(dashboard_send_json res "{\"ok\":true}")
+				) (dashboard_send_401 res))
+			)
+			"/dashboard/api/storage-failure-hooks" (begin
+				(if (dashboard_check_admin req)
+					(dashboard_send_json res (dashboard_json_array
+						(map (storage_failure_hook_rows) (lambda (row) (json_encode_assoc row)))))
+					(dashboard_send_401 res))
+			)
 			/* API: list databases (admin: all, non-admin: filtered by system.access) */
 			"/dashboard/api/databases" (begin
 				(define is_admin (dashboard_check_user req))

--- a/lib/main.scm
+++ b/lib/main.scm
@@ -47,6 +47,7 @@ own compiler under any language name. */
 		(scheme source (concat "trigger:" (context "schema") "." (context "table") ":" (context "name"))))))
 
 (import "sql.scm")
+(import "storage-failure-hooks.scm")
 (import "dashboard.scm")
 (import "rdf.scm")
 

--- a/lib/storage-failure-hooks.scm
+++ b/lib/storage-failure-hooks.scm
@@ -1,0 +1,117 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Persist source rather than runtime closures. Each enabled source must
+evaluate to a one-argument callback. Runtime dispatch never reads this table. */
+(if (has? (show "system") "storage_failure_hooks") true (begin
+	(print "creating table system.storage_failure_hooks")
+	(eval (parse_sql "system" "CREATE TABLE storage_failure_hooks(name text, enabled boolean, classes text, cooldown_seconds int, source text, UNIQUE KEY uniq_name (name)) ENGINE=SAFE" (lambda (schema tblname write) true)))
+	(insert (table "system" "storage_failure_hooks")
+		'("name" "enabled" "classes" "cooldown_seconds" "source")
+		(list
+			(list "syslog-process" false "*" 300
+				"(lambda (failure) (process_run \"logger\" (list \"-t\" \"memcp-storage\" (serialize failure))))")
+			(list "open-outage-page" false "ambiguous_commit,io" 300
+				"(lambda (failure) (process_run \"xdg-open\" (list \"file:///etc/memcp/storage-failure.html\")))")))
+))
+
+(define storage_failure_hook_rows (lambda ()
+	(scan nil (table "system" "storage_failure_hooks") '(369435906932736) '()
+		'() (lambda () true)
+		'("name" "enabled" "classes" "cooldown_seconds" "source")
+		(lambda (rows name enabled classes cooldown_seconds source)
+			(cons (list "name" name "enabled" enabled "classes" classes
+				"cooldown_seconds" cooldown_seconds "source" source) rows))
+		'() (lambda (a b) (merge (list a b)))))
+)
+
+(define storage_failure_hook_compile (lambda (name source)
+	(eval (scheme source (concat "storage-failure-hook:" name))))
+)
+
+(define storage_failure_hook_validate_classes (lambda (classes)
+	(match classes
+		nil true
+		(cons class rest) (begin
+			(if (or (equal? class "") (> (count (split class ",")) 1))
+				(error "storage failure hook classes must be non-empty names without commas")
+				true)
+			(storage_failure_hook_validate_classes rest)))
+))
+
+(define storage_failure_hook_activate (lambda (name enabled classes cooldown_seconds source) (begin
+	(if enabled
+		(register_storage_failure_hook name classes cooldown_seconds
+			(storage_failure_hook_compile name source))
+		(unregister_storage_failure_hook name))
+	true
+)))
+
+(define storage_failure_hook_activate_rows (lambda (rows)
+	(match rows
+		nil true
+		(cons row rest) (begin
+			(try (lambda ()
+				(storage_failure_hook_activate (row "name") (row "enabled")
+					(split (row "classes") ",") (row "cooldown_seconds") (row "source")))
+				(lambda (e) (print "storage failure hook " (row "name") " was not activated: " e)))
+			(storage_failure_hook_activate_rows rest)))
+))
+
+(define reload_storage_failure_hooks (lambda () (begin
+	(clear_storage_failure_hooks)
+	(storage_failure_hook_activate_rows (storage_failure_hook_rows))
+)))
+
+(define storage_failure_hook_save (lambda (name enabled classes cooldown_seconds source) (begin
+	(if (equal? name "") (error "storage failure hook name must not be empty") true)
+	(if (equal? (count classes) 0) (error "storage failure hook must select at least one class") true)
+	(storage_failure_hook_validate_classes classes)
+	(if (< cooldown_seconds 0) (error "storage failure hook cooldown must not be negative") true)
+	/* Compile and validate through the native registration before persisting so
+	an enabled broken hook never enters the startup catalog. */
+	(define callback (if enabled (storage_failure_hook_compile name source) nil))
+	(define classes_text (reduce classes (lambda (a b) (concat a "," b))))
+	(if enabled
+		(register_storage_failure_hook name classes cooldown_seconds callback)
+		true)
+	(define updated (scan nil (table "system" "storage_failure_hooks") '(369435906932736) '()
+		'("name") (lambda (existing_name) (equal? existing_name name))
+		'("$update") (lambda (count $update) (begin
+			($update (list "enabled" enabled "classes" classes_text
+				"cooldown_seconds" cooldown_seconds "source" source))
+			(+ count 1)))
+		0 +))
+	(if (equal? updated 0)
+		(insert (table "system" "storage_failure_hooks")
+			'("name" "enabled" "classes" "cooldown_seconds" "source")
+			(list (list name enabled classes_text cooldown_seconds source)))
+		true)
+	(if enabled true (unregister_storage_failure_hook name))
+	true
+)))
+
+(define storage_failure_hook_delete (lambda (name) (begin
+	(scan nil (table "system" "storage_failure_hooks") '(369435906932736) '()
+		'("name") (lambda (existing_name) (equal? existing_name name))
+		'("$update") (lambda (count $update) (begin ($update) (+ count 1)))
+		0 +)
+	(unregister_storage_failure_hook name)
+	true
+)))
+
+(reload_storage_failure_hooks)

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -1484,6 +1484,13 @@ func (ctx *JITContext) ReclaimUntrackedRegs() {
 		if (ctx.ProtectedRegs & bit) != 0 {
 			continue
 		}
+		// FreeReg deliberately keeps a dead register unavailable while a deferred
+		// destination still aliases its physical contents. Reclamation must honor
+		// that reservation; releaseUnusedDeferredSources returns it after the last
+		// alias has been materialized.
+		if ctx.DeferredRegMoves.held&uint32(bit) != 0 {
+			continue
+		}
 		owner := ctx.RegOwners[rr]
 		if owner == nil {
 			if rr >= RegX0 {

--- a/scm/jit_storage_abi_test.go
+++ b/scm/jit_storage_abi_test.go
@@ -154,6 +154,10 @@ func TestDeferredRegisterMovesCollapseAcrossEmitterBoundaries(t *testing.T) {
 	if ctx.FreeRegs&uint64(jitRegisterMask(RegRDI)) != 0 {
 		t.Fatal("aliased physical source returned to allocator before materialization")
 	}
+	ctx.ReclaimUntrackedRegs()
+	if ctx.FreeRegs&uint64(jitRegisterMask(RegRDI)) != 0 {
+		t.Fatal("reclamation returned an aliased physical source before materialization")
+	}
 	ctx.FlushRegisterMoves()
 	emitted := code[:uintptr(ctx.Ptr)-uintptr(ctx.Start)]
 	if want := []byte{0x48, 0x89, 0xfa}; !bytes.Equal(emitted, want) {

--- a/storage/persistence-errors.go
+++ b/storage/persistence-errors.go
@@ -83,15 +83,27 @@ func raisePersistenceFailure(backend string, database string, operation string, 
 	// This must never use MemCP tables: the statistics database may be the
 	// failing backend and recursive failure reporting would never terminate.
 	_, _ = fmt.Fprintf(os.Stderr, "CRITICAL: %s\n", failure.Error())
+	notifyPersistenceFailure(persistenceFailureEvent{
+		class: "io", backend: backend, database: database,
+		operation: operation, err: err,
+	})
 	panic(failure)
 }
 
 func reportPersistenceCleanupFailure(backend string, database string, operation string, err error) {
 	_, _ = fmt.Fprintf(os.Stderr, "CRITICAL: persistence %s failed for %s database %s: %v; committed data is intact but orphan cleanup is incomplete\n", operation, backend, database, err)
+	notifyPersistenceFailure(persistenceFailureEvent{
+		class: "cleanup", backend: backend, database: database,
+		operation: operation, err: err,
+	})
 }
 
 func reportPersistenceAmbiguousFailure(backend string, database string, operation string, err error) {
 	_, _ = fmt.Fprintf(os.Stderr, "CRITICAL: persistence %s failed for %s database %s: %v; publication completed but crash durability is unknown\n", operation, backend, database, err)
+	notifyPersistenceFailure(persistenceFailureEvent{
+		class: "ambiguous_commit", backend: backend, database: database,
+		operation: operation, err: err, outcomeUnknown: true,
+	})
 }
 
 func recoverPersistenceFailure(errp *error) {
@@ -117,6 +129,10 @@ func markCommitOutcomeUnknown(err error) error {
 	}
 	copy := *failure
 	copy.OutcomeUnknown = true
+	notifyPersistenceFailure(persistenceFailureEvent{
+		class: "ambiguous_commit", backend: copy.Backend, database: copy.Database,
+		operation: copy.Operation, err: copy.Err, outcomeUnknown: true,
+	})
 	return &copy
 }
 

--- a/storage/persistence-failure-hook.go
+++ b/storage/persistence-failure-hook.go
@@ -36,6 +36,7 @@ type persistenceFailureEvent struct {
 }
 
 type persistenceFailureFingerprint struct {
+	hook      string
 	class     string
 	backend   string
 	database  string
@@ -47,18 +48,28 @@ type persistenceFailureCooldownState struct {
 	suppressed int64
 }
 
-type persistenceFailureHookConfig struct {
+type persistenceFailureHookRule struct {
+	name     string
+	classes  map[string]struct{}
 	callback scm.Scmer
 	cooldown time.Duration
 }
 
+type persistenceFailureHookConfig struct {
+	rules []*persistenceFailureHookRule
+}
+
 type persistenceFailureHookTask struct {
-	config     *persistenceFailureHookConfig
+	rule       *persistenceFailureHookRule
 	event      persistenceFailureEvent
 	occurredAt time.Time
 	suppressed int64
 }
 
+// Published configs, rules, and class maps are immutable. The atomic config
+// pointer serves error reporters without locking when no hooks exist; mu owns
+// cooldown state and config replacement, while running guards callback-induced
+// failures across the single dispatcher goroutine.
 var persistenceFailureHooks struct {
 	config    atomic.Pointer[persistenceFailureHookConfig]
 	running   atomic.Bool
@@ -68,22 +79,84 @@ var persistenceFailureHooks struct {
 	queue     chan persistenceFailureHookTask
 }
 
-func registerPersistenceFailureHook(cooldown time.Duration, callback scm.Scmer) {
+func registerPersistenceFailureHook(name string, classes []string, cooldown time.Duration, callback scm.Scmer) {
+	if name == "" {
+		panic("storage failure hook name must not be empty")
+	}
+	if len(classes) == 0 {
+		panic("storage failure hook must select at least one failure class")
+	}
 	if cooldown < 0 {
 		panic("storage failure hook cooldown must not be negative")
 	}
-	config := &persistenceFailureHookConfig{callback: callback, cooldown: cooldown}
+	if !callback.IsProc() && !callback.IsNativeFunc() && !callback.IsJIT() {
+		panic("storage failure hook callback must be callable")
+	}
+	classSet := make(map[string]struct{}, len(classes))
+	for _, class := range classes {
+		if class == "" {
+			panic("storage failure hook class must not be empty")
+		}
+		classSet[class] = struct{}{}
+	}
+	rule := &persistenceFailureHookRule{
+		name: name, classes: classSet, callback: callback, cooldown: cooldown,
+	}
 	persistenceFailureHooks.mu.Lock()
-	persistenceFailureHooks.states = make(map[persistenceFailureFingerprint]*persistenceFailureCooldownState)
+	config := persistenceFailureHooks.config.Load()
+	rules := make([]*persistenceFailureHookRule, 0, 1)
+	if config != nil {
+		rules = make([]*persistenceFailureHookRule, 0, len(config.rules)+1)
+		for _, existing := range config.rules {
+			if existing.name != name {
+				rules = append(rules, existing)
+			}
+		}
+	}
+	rules = append(rules, rule)
+	for fingerprint := range persistenceFailureHooks.states {
+		if fingerprint.hook == name {
+			delete(persistenceFailureHooks.states, fingerprint)
+		}
+	}
 	if persistenceFailureHooks.queue == nil {
 		persistenceFailureHooks.queue = make(chan persistenceFailureHookTask, persistenceFailureHookQueueSize)
 	}
-	persistenceFailureHooks.config.Store(config)
+	if persistenceFailureHooks.states == nil {
+		persistenceFailureHooks.states = make(map[persistenceFailureFingerprint]*persistenceFailureCooldownState)
+	}
+	persistenceFailureHooks.config.Store(&persistenceFailureHookConfig{rules: rules})
 	persistenceFailureHooks.mu.Unlock()
 	persistenceFailureHooks.startOnce.Do(func() { go runPersistenceFailureHooks() })
 }
 
-func clearPersistenceFailureHook() {
+func unregisterPersistenceFailureHook(name string) {
+	persistenceFailureHooks.mu.Lock()
+	config := persistenceFailureHooks.config.Load()
+	if config == nil {
+		persistenceFailureHooks.mu.Unlock()
+		return
+	}
+	rules := make([]*persistenceFailureHookRule, 0, len(config.rules))
+	for _, rule := range config.rules {
+		if rule.name != name {
+			rules = append(rules, rule)
+		}
+	}
+	for fingerprint := range persistenceFailureHooks.states {
+		if fingerprint.hook == name {
+			delete(persistenceFailureHooks.states, fingerprint)
+		}
+	}
+	if len(rules) == 0 {
+		persistenceFailureHooks.config.Store(nil)
+	} else {
+		persistenceFailureHooks.config.Store(&persistenceFailureHookConfig{rules: rules})
+	}
+	persistenceFailureHooks.mu.Unlock()
+}
+
+func clearPersistenceFailureHooks() {
 	persistenceFailureHooks.config.Store(nil)
 	persistenceFailureHooks.mu.Lock()
 	persistenceFailureHooks.states = nil
@@ -99,57 +172,81 @@ func notifyPersistenceFailureAt(event persistenceFailureEvent, occurredAt time.T
 	if config == nil {
 		return
 	}
-	fingerprint := persistenceFailureFingerprint{
-		class: event.class, backend: event.backend,
-		database: event.database, operation: event.operation,
-	}
 	persistenceFailureHooks.mu.Lock()
 	if persistenceFailureHooks.config.Load() != config {
 		persistenceFailureHooks.mu.Unlock()
 		return
 	}
-	state := persistenceFailureHooks.states[fingerprint]
-	if state == nil {
-		state = new(persistenceFailureCooldownState)
-		persistenceFailureHooks.states[fingerprint] = state
-	}
-	if persistenceFailureHooks.running.Load() {
-		// Go has no goroutine-local storage with which to distinguish a hook's
-		// own storage call from an unrelated concurrent failure. Suppress both
-		// while the hook runs, but retain the count for the next notification.
-		// This prevents recursion without silently losing concurrent failures.
-		state.suppressed++
-		persistenceFailureHooks.mu.Unlock()
-		return
-	}
-	if occurredAt.Before(state.next) {
-		state.suppressed++
-		persistenceFailureHooks.mu.Unlock()
-		return
-	}
-	task := persistenceFailureHookTask{
-		config: config, event: event, occurredAt: occurredAt,
-		suppressed: state.suppressed,
-	}
-	state.suppressed = 0
-	state.next = occurredAt.Add(config.cooldown)
-	select {
-	case persistenceFailureHooks.queue <- task:
-	default:
-		// A blocked outage callback must never block storage error propagation.
-		// Fold the dropped notification into the next event for this fingerprint.
-		state.suppressed++
+	for _, rule := range config.rules {
+		if !persistenceFailureHookMatchesClass(rule, event.class) {
+			continue
+		}
+		fingerprint := persistenceFailureFingerprint{
+			hook: rule.name, class: event.class, backend: event.backend,
+			database: event.database, operation: event.operation,
+		}
+		state := persistenceFailureHooks.states[fingerprint]
+		if state == nil {
+			state = new(persistenceFailureCooldownState)
+			persistenceFailureHooks.states[fingerprint] = state
+		}
+		if persistenceFailureHooks.running.Load() {
+			// Go has no goroutine-local storage with which to distinguish a hook's
+			// own storage call from an unrelated concurrent failure. Suppress both
+			// while a hook runs, but retain the count for the next notification.
+			// This prevents both direct and cross-hook recursion.
+			state.suppressed++
+			continue
+		}
+		if occurredAt.Before(state.next) {
+			state.suppressed++
+			continue
+		}
+		task := persistenceFailureHookTask{
+			rule: rule, event: event, occurredAt: occurredAt,
+			suppressed: state.suppressed,
+		}
+		state.suppressed = 0
+		state.next = occurredAt.Add(rule.cooldown)
+		select {
+		case persistenceFailureHooks.queue <- task:
+		default:
+			// A blocked outage callback must never block storage error propagation.
+			// Fold the dropped notification into the next event for this fingerprint.
+			state.suppressed++
+		}
 	}
 	persistenceFailureHooks.mu.Unlock()
 }
 
+func persistenceFailureHookMatchesClass(rule *persistenceFailureHookRule, class string) bool {
+	if _, matches := rule.classes[class]; matches {
+		return true
+	}
+	_, matchesAll := rule.classes["*"]
+	return matchesAll
+}
+
 func runPersistenceFailureHooks() {
 	for task := range persistenceFailureHooks.queue {
-		if persistenceFailureHooks.config.Load() != task.config {
+		if !persistenceFailureHookIsCurrent(task.rule) {
 			continue
 		}
 		invokePersistenceFailureHook(task)
 	}
+}
+
+func persistenceFailureHookIsCurrent(wanted *persistenceFailureHookRule) bool {
+	config := persistenceFailureHooks.config.Load()
+	if config == nil {
+		return false
+	}
+	for _, rule := range config.rules {
+		if rule == wanted {
+			return true
+		}
+	}
+	return false
 }
 
 func invokePersistenceFailureHook(task persistenceFailureHookTask) {
@@ -166,7 +263,7 @@ func invokePersistenceFailureHook(task persistenceFailureHookTask) {
 	if task.event.err != nil {
 		errText = task.event.err.Error()
 	}
-	scm.Apply(task.config.callback, scm.NewSlice([]scm.Scmer{
+	scm.Apply(task.rule.callback, scm.NewSlice([]scm.Scmer{
 		scm.NewString("backend"), scm.NewString(task.event.backend),
 		scm.NewString("database"), scm.NewString(task.event.database),
 		scm.NewString("operation"), scm.NewString(task.event.operation),

--- a/storage/persistence-failure-hook.go
+++ b/storage/persistence-failure-hook.go
@@ -16,8 +16,8 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package storage
 
-import "fmt"
 import "os"
+import "fmt"
 import "sync"
 import "time"
 import "sync/atomic"

--- a/storage/persistence-failure-hook.go
+++ b/storage/persistence-failure-hook.go
@@ -1,0 +1,179 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "fmt"
+import "os"
+import "sync"
+import "time"
+import "sync/atomic"
+
+import "github.com/launix-de/memcp/scm"
+
+const persistenceFailureHookQueueSize = 64
+
+type persistenceFailureEvent struct {
+	class          string
+	backend        string
+	database       string
+	operation      string
+	err            error
+	outcomeUnknown bool
+}
+
+type persistenceFailureFingerprint struct {
+	class     string
+	backend   string
+	database  string
+	operation string
+}
+
+type persistenceFailureCooldownState struct {
+	next       time.Time
+	suppressed int64
+}
+
+type persistenceFailureHookConfig struct {
+	callback scm.Scmer
+	cooldown time.Duration
+}
+
+type persistenceFailureHookTask struct {
+	config     *persistenceFailureHookConfig
+	event      persistenceFailureEvent
+	occurredAt time.Time
+	suppressed int64
+}
+
+var persistenceFailureHooks struct {
+	config    atomic.Pointer[persistenceFailureHookConfig]
+	running   atomic.Bool
+	startOnce sync.Once
+	mu        sync.Mutex
+	states    map[persistenceFailureFingerprint]*persistenceFailureCooldownState
+	queue     chan persistenceFailureHookTask
+}
+
+func registerPersistenceFailureHook(cooldown time.Duration, callback scm.Scmer) {
+	if cooldown < 0 {
+		panic("storage failure hook cooldown must not be negative")
+	}
+	config := &persistenceFailureHookConfig{callback: callback, cooldown: cooldown}
+	persistenceFailureHooks.mu.Lock()
+	persistenceFailureHooks.states = make(map[persistenceFailureFingerprint]*persistenceFailureCooldownState)
+	if persistenceFailureHooks.queue == nil {
+		persistenceFailureHooks.queue = make(chan persistenceFailureHookTask, persistenceFailureHookQueueSize)
+	}
+	persistenceFailureHooks.config.Store(config)
+	persistenceFailureHooks.mu.Unlock()
+	persistenceFailureHooks.startOnce.Do(func() { go runPersistenceFailureHooks() })
+}
+
+func clearPersistenceFailureHook() {
+	persistenceFailureHooks.config.Store(nil)
+	persistenceFailureHooks.mu.Lock()
+	persistenceFailureHooks.states = nil
+	persistenceFailureHooks.mu.Unlock()
+}
+
+func notifyPersistenceFailure(event persistenceFailureEvent) {
+	notifyPersistenceFailureAt(event, time.Now())
+}
+
+func notifyPersistenceFailureAt(event persistenceFailureEvent, occurredAt time.Time) {
+	config := persistenceFailureHooks.config.Load()
+	if config == nil {
+		return
+	}
+	fingerprint := persistenceFailureFingerprint{
+		class: event.class, backend: event.backend,
+		database: event.database, operation: event.operation,
+	}
+	persistenceFailureHooks.mu.Lock()
+	if persistenceFailureHooks.config.Load() != config {
+		persistenceFailureHooks.mu.Unlock()
+		return
+	}
+	state := persistenceFailureHooks.states[fingerprint]
+	if state == nil {
+		state = new(persistenceFailureCooldownState)
+		persistenceFailureHooks.states[fingerprint] = state
+	}
+	if persistenceFailureHooks.running.Load() {
+		// Go has no goroutine-local storage with which to distinguish a hook's
+		// own storage call from an unrelated concurrent failure. Suppress both
+		// while the hook runs, but retain the count for the next notification.
+		// This prevents recursion without silently losing concurrent failures.
+		state.suppressed++
+		persistenceFailureHooks.mu.Unlock()
+		return
+	}
+	if occurredAt.Before(state.next) {
+		state.suppressed++
+		persistenceFailureHooks.mu.Unlock()
+		return
+	}
+	task := persistenceFailureHookTask{
+		config: config, event: event, occurredAt: occurredAt,
+		suppressed: state.suppressed,
+	}
+	state.suppressed = 0
+	state.next = occurredAt.Add(config.cooldown)
+	select {
+	case persistenceFailureHooks.queue <- task:
+	default:
+		// A blocked outage callback must never block storage error propagation.
+		// Fold the dropped notification into the next event for this fingerprint.
+		state.suppressed++
+	}
+	persistenceFailureHooks.mu.Unlock()
+}
+
+func runPersistenceFailureHooks() {
+	for task := range persistenceFailureHooks.queue {
+		if persistenceFailureHooks.config.Load() != task.config {
+			continue
+		}
+		invokePersistenceFailureHook(task)
+	}
+}
+
+func invokePersistenceFailureHook(task persistenceFailureHookTask) {
+	persistenceFailureHooks.running.Store(true)
+	defer persistenceFailureHooks.running.Store(false)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			// Never use MemCP-backed logging here. The hook may have failed because
+			// its own database operation reached the same unavailable storage.
+			_, _ = fmt.Fprintf(os.Stderr, "CRITICAL: storage failure hook panicked: %v\n", recovered)
+		}
+	}()
+	errText := ""
+	if task.event.err != nil {
+		errText = task.event.err.Error()
+	}
+	scm.Apply(task.config.callback, scm.NewSlice([]scm.Scmer{
+		scm.NewString("backend"), scm.NewString(task.event.backend),
+		scm.NewString("database"), scm.NewString(task.event.database),
+		scm.NewString("operation"), scm.NewString(task.event.operation),
+		scm.NewString("error"), scm.NewString(errText),
+		scm.NewString("class"), scm.NewString(task.event.class),
+		scm.NewString("outcome_unknown"), scm.NewBool(task.event.outcomeUnknown),
+		scm.NewString("suppressed_count"), scm.NewInt(task.suppressed),
+		scm.NewString("timestamp"), scm.NewFloat(float64(task.occurredAt.UnixNano()) / 1e9),
+	}))
+}

--- a/storage/persistence_failure_test.go
+++ b/storage/persistence_failure_test.go
@@ -57,10 +57,10 @@ func waitForPersistenceFailureHook(t *testing.T) {
 }
 
 func TestPersistenceFailureHookDeliversStructuredEvent(t *testing.T) {
-	clearPersistenceFailureHook()
-	t.Cleanup(clearPersistenceFailureHook)
+	clearPersistenceFailureHooks()
+	t.Cleanup(clearPersistenceFailureHooks)
 	received := make(chan scm.Scmer, 1)
-	registerPersistenceFailureHook(30*time.Second, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+	registerPersistenceFailureHook("structured", []string{"*"}, 30*time.Second, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
 		received <- args[0]
 		return scm.NewNil()
 	}))
@@ -100,10 +100,10 @@ func TestPersistenceFailureHookDeliversStructuredEvent(t *testing.T) {
 }
 
 func TestPersistenceFailureHookCooldownCoalescesFingerprint(t *testing.T) {
-	clearPersistenceFailureHook()
-	t.Cleanup(clearPersistenceFailureHook)
+	clearPersistenceFailureHooks()
+	t.Cleanup(clearPersistenceFailureHooks)
 	received := make(chan scm.Scmer, 2)
-	registerPersistenceFailureHook(10*time.Second, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+	registerPersistenceFailureHook("cooldown", []string{"io"}, 10*time.Second, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
 		received <- args[0]
 		return scm.NewNil()
 	}))
@@ -132,10 +132,10 @@ func TestPersistenceFailureHookCooldownCoalescesFingerprint(t *testing.T) {
 }
 
 func TestPersistenceFailureHookDoesNotReenter(t *testing.T) {
-	clearPersistenceFailureHook()
-	t.Cleanup(clearPersistenceFailureHook)
+	clearPersistenceFailureHooks()
+	t.Cleanup(clearPersistenceFailureHooks)
 	calls := make(chan struct{}, 2)
-	registerPersistenceFailureHook(0, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+	registerPersistenceFailureHook("reentrant", []string{"io"}, 0, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
 		calls <- struct{}{}
 		notifyPersistenceFailureAt(persistenceFailureEvent{
 			class: "io", backend: "filesystem", database: "hook",
@@ -170,6 +170,98 @@ func TestPersistenceFailureHookDoesNotReenter(t *testing.T) {
 		t.Fatal("hook panic disabled later notifications")
 	}
 	waitForPersistenceFailureHook(t)
+}
+
+func TestPersistenceFailureHooksFilterClassesAndDispatchMultipleRules(t *testing.T) {
+	clearPersistenceFailureHooks()
+	t.Cleanup(clearPersistenceFailureHooks)
+	ioCalls := make(chan scm.Scmer, 1)
+	cleanupCalls := make(chan scm.Scmer, 1)
+	registerPersistenceFailureHook("io-only", []string{"io"}, 0, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		ioCalls <- args[0]
+		return scm.NewNil()
+	}))
+	registerPersistenceFailureHook("cleanup-only", []string{"cleanup"}, 0, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		cleanupCalls <- args[0]
+		return scm.NewNil()
+	}))
+
+	notifyPersistenceFailure(persistenceFailureEvent{
+		class: "ambiguous_commit", backend: "filesystem", database: "db",
+		operation: "log.sync", err: syscall.EIO, outcomeUnknown: true,
+	})
+	select {
+	case <-ioCalls:
+		t.Fatal("io-only hook received an ambiguous commit event")
+	case <-cleanupCalls:
+		t.Fatal("cleanup-only hook received an ambiguous commit event")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	notifyPersistenceFailure(persistenceFailureEvent{
+		class: "io", backend: "filesystem", database: "db",
+		operation: "log.write", err: syscall.ENOSPC,
+	})
+	select {
+	case event := <-ioCalls:
+		if got := failureHookValue(t, event, "class").String(); got != "io" {
+			t.Fatalf("io hook class = %q, want io", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("io-only hook did not receive matching event")
+	}
+	waitForPersistenceFailureHook(t)
+
+	notifyPersistenceFailure(persistenceFailureEvent{
+		class: "cleanup", backend: "s3", database: "db",
+		operation: "log.swap.cleanup", err: syscall.EIO,
+	})
+	select {
+	case event := <-cleanupCalls:
+		if got := failureHookValue(t, event, "class").String(); got != "cleanup" {
+			t.Fatalf("cleanup hook class = %q, want cleanup", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cleanup-only hook did not receive matching event")
+	}
+	waitForPersistenceFailureHook(t)
+}
+
+func TestPersistenceFailureHookNameReplacesAndUnregistersRule(t *testing.T) {
+	clearPersistenceFailureHooks()
+	t.Cleanup(clearPersistenceFailureHooks)
+	oldCalls := make(chan struct{}, 1)
+	newCalls := make(chan struct{}, 1)
+	registerPersistenceFailureHook("replaceable", []string{"io"}, 0, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		oldCalls <- struct{}{}
+		return scm.NewNil()
+	}))
+	registerPersistenceFailureHook("replaceable", []string{"cleanup"}, 0, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		newCalls <- struct{}{}
+		return scm.NewNil()
+	}))
+	notifyPersistenceFailure(persistenceFailureEvent{class: "io", backend: "filesystem", database: "db", operation: "log.write"})
+	select {
+	case <-oldCalls:
+		t.Fatal("replaced hook callback was called")
+	case <-newCalls:
+		t.Fatal("replacement hook ignored its class mask")
+	case <-time.After(20 * time.Millisecond):
+	}
+	notifyPersistenceFailure(persistenceFailureEvent{class: "cleanup", backend: "filesystem", database: "db", operation: "log.swap.cleanup"})
+	select {
+	case <-newCalls:
+	case <-time.After(time.Second):
+		t.Fatal("replacement hook was not called")
+	}
+	waitForPersistenceFailureHook(t)
+	unregisterPersistenceFailureHook("replaceable")
+	notifyPersistenceFailure(persistenceFailureEvent{class: "cleanup", backend: "filesystem", database: "db", operation: "log.swap.cleanup"})
+	select {
+	case <-newCalls:
+		t.Fatal("unregistered hook was called")
+	case <-time.After(20 * time.Millisecond):
+	}
 }
 
 func (r failingPersistenceReader) Read([]byte) (int, error) { return 0, r.readErr }

--- a/storage/persistence_failure_test.go
+++ b/storage/persistence_failure_test.go
@@ -23,11 +23,153 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
+
+	"github.com/launix-de/memcp/scm"
 )
 
 type failingPersistenceReader struct {
 	readErr  error
 	closeErr error
+}
+
+func failureHookValue(t *testing.T, event scm.Scmer, key string) scm.Scmer {
+	t.Helper()
+	values := event.Slice()
+	for index := 0; index+1 < len(values); index += 2 {
+		if values[index].String() == key {
+			return values[index+1]
+		}
+	}
+	t.Fatalf("failure hook event has no %q: %s", key, event.String())
+	return scm.NewNil()
+}
+
+func waitForPersistenceFailureHook(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for persistenceFailureHooks.running.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("storage failure hook did not return")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestPersistenceFailureHookDeliversStructuredEvent(t *testing.T) {
+	clearPersistenceFailureHook()
+	t.Cleanup(clearPersistenceFailureHook)
+	received := make(chan scm.Scmer, 1)
+	registerPersistenceFailureHook(30*time.Second, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		received <- args[0]
+		return scm.NewNil()
+	}))
+
+	notifyPersistenceFailureAt(persistenceFailureEvent{
+		class: "io", backend: "s3", database: "bucket/prefix",
+		operation: "log.write", err: syscall.ENOSPC,
+	}, time.Unix(100, 0))
+
+	select {
+	case event := <-received:
+		if got := failureHookValue(t, event, "class").String(); got != "io" {
+			t.Fatalf("class = %q, want io", got)
+		}
+		if got := failureHookValue(t, event, "backend").String(); got != "s3" {
+			t.Fatalf("backend = %q, want s3", got)
+		}
+		if got := failureHookValue(t, event, "database").String(); got != "bucket/prefix" {
+			t.Fatalf("database = %q, want bucket/prefix", got)
+		}
+		if got := failureHookValue(t, event, "operation").String(); got != "log.write" {
+			t.Fatalf("operation = %q, want log.write", got)
+		}
+		if got := failureHookValue(t, event, "error").String(); got != syscall.ENOSPC.Error() {
+			t.Fatalf("error = %q, want %q", got, syscall.ENOSPC.Error())
+		}
+		if failureHookValue(t, event, "outcome_unknown").Bool() {
+			t.Fatal("ordinary I/O failure reported an unknown commit outcome")
+		}
+		if got := failureHookValue(t, event, "suppressed_count").Int(); got != 0 {
+			t.Fatalf("suppressed_count = %d, want 0", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("storage failure hook was not called")
+	}
+	waitForPersistenceFailureHook(t)
+}
+
+func TestPersistenceFailureHookCooldownCoalescesFingerprint(t *testing.T) {
+	clearPersistenceFailureHook()
+	t.Cleanup(clearPersistenceFailureHook)
+	received := make(chan scm.Scmer, 2)
+	registerPersistenceFailureHook(10*time.Second, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		received <- args[0]
+		return scm.NewNil()
+	}))
+	event := persistenceFailureEvent{class: "io", backend: "filesystem", database: "db", operation: "log.sync", err: syscall.EIO}
+	start := time.Unix(200, 0)
+	notifyPersistenceFailureAt(event, start)
+	first := <-received
+	waitForPersistenceFailureHook(t)
+	notifyPersistenceFailureAt(event, start.Add(time.Second))
+	notifyPersistenceFailureAt(event, start.Add(2*time.Second))
+	notifyPersistenceFailureAt(event, start.Add(11*time.Second))
+
+	second := <-received
+	if got := failureHookValue(t, first, "suppressed_count").Int(); got != 0 {
+		t.Fatalf("first suppressed_count = %d, want 0", got)
+	}
+	if got := failureHookValue(t, second, "suppressed_count").Int(); got != 2 {
+		t.Fatalf("second suppressed_count = %d, want 2", got)
+	}
+	waitForPersistenceFailureHook(t)
+	select {
+	case extra := <-received:
+		t.Fatalf("cooldown emitted an extra event: %s", extra.String())
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestPersistenceFailureHookDoesNotReenter(t *testing.T) {
+	clearPersistenceFailureHook()
+	t.Cleanup(clearPersistenceFailureHook)
+	calls := make(chan struct{}, 2)
+	registerPersistenceFailureHook(0, scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		calls <- struct{}{}
+		notifyPersistenceFailureAt(persistenceFailureEvent{
+			class: "io", backend: "filesystem", database: "hook",
+			operation: "log.write", err: syscall.ENOSPC,
+		}, time.Now())
+		panic("hook failed")
+	}))
+	notifyPersistenceFailureAt(persistenceFailureEvent{
+		class: "io", backend: "filesystem", database: "db",
+		operation: "schema.write", err: syscall.EIO,
+	}, time.Now())
+
+	select {
+	case <-calls:
+	case <-time.After(time.Second):
+		t.Fatal("storage failure hook was not called")
+	}
+	waitForPersistenceFailureHook(t)
+	select {
+	case <-calls:
+		t.Fatal("storage failure hook recursively invoked itself")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	notifyPersistenceFailureAt(persistenceFailureEvent{
+		class: "io", backend: "filesystem", database: "db",
+		operation: "schema.sync", err: syscall.EIO,
+	}, time.Now())
+	select {
+	case <-calls:
+	case <-time.After(time.Second):
+		t.Fatal("hook panic disabled later notifications")
+	}
+	waitForPersistenceFailureHook(t)
 }
 
 func (r failingPersistenceReader) Read([]byte) (int, error) { return 0, r.readErr }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -4051,16 +4051,23 @@ func Init(en scm.Env) {
 	scm.Declare(&en, &scm.Declaration{
 		Name: "register_storage_failure_hook",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			cooldownSeconds := int64(scm.ToInt(a[0]))
+			classValues := a[1].Slice()
+			classes := make([]string, len(classValues))
+			for index, class := range classValues {
+				classes[index] = scm.String(class)
+			}
+			cooldownSeconds := int64(scm.ToInt(a[2]))
 			if cooldownSeconds < 0 || cooldownSeconds > int64((1<<63-1)/time.Second) {
 				panic("storage failure hook cooldown is out of range")
 			}
-			registerPersistenceFailureHook(time.Duration(cooldownSeconds)*time.Second, a[1])
+			registerPersistenceFailureHook(scm.String(a[0]), classes, time.Duration(cooldownSeconds)*time.Second, a[3])
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{Kind: "func", Description: "registers a process-local asynchronous callback for persistence failures; repeated failures with the same class, backend, database, and operation are coalesced during the cooldown",
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "registers or replaces a named process-local asynchronous callback for selected persistence failure classes; repeated failures with the same hook, class, backend, database, and operation are coalesced during the cooldown",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
+				{Kind: "string", Label: "name", Description: "stable name used to replace this hook"},
+				{Kind: "list", Label: "classes", Description: "exact failure classes to receive; use * for every class", Element: &scm.TypeDescriptor{Kind: "string"}},
 				{Kind: "number", Label: "cooldown_seconds", Description: "minimum seconds between callbacks for one failure fingerprint"},
 				{Kind: "func", Label: "callback", Description: "called with an assoc containing class, backend, database, operation, error, outcome_unknown, suppressed_count, and timestamp", Params: []*scm.TypeDescriptor{{Kind: "assoc", Label: "failure"}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "ignored"}},
 			},
@@ -4068,12 +4075,23 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
-		Name: "clear_storage_failure_hook",
+		Name: "unregister_storage_failure_hook",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			clearPersistenceFailureHook()
+			unregisterPersistenceFailureHook(scm.String(a[0]))
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{Kind: "func", Description: "removes the process-local persistence failure callback", HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "removes one named process-local persistence failure callback", HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{{Kind: "string", Label: "name"}},
+			Return: &scm.TypeDescriptor{Kind: "bool"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
+		Name: "clear_storage_failure_hooks",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			clearPersistenceFailureHooks()
+			return scm.NewBool(true)
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "removes all process-local persistence failure callbacks", HasSideEffects: true,
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -4048,6 +4048,35 @@ func Init(en scm.Env) {
 			Return: &scm.TypeDescriptor{Kind: "any"},
 		},
 	})
+	scm.Declare(&en, &scm.Declaration{
+		Name: "register_storage_failure_hook",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			cooldownSeconds := int64(scm.ToInt(a[0]))
+			if cooldownSeconds < 0 || cooldownSeconds > int64((1<<63-1)/time.Second) {
+				panic("storage failure hook cooldown is out of range")
+			}
+			registerPersistenceFailureHook(time.Duration(cooldownSeconds)*time.Second, a[1])
+			return scm.NewBool(true)
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "registers a process-local asynchronous callback for persistence failures; repeated failures with the same class, backend, database, and operation are coalesced during the cooldown",
+			HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "number", Label: "cooldown_seconds", Description: "minimum seconds between callbacks for one failure fingerprint"},
+				{Kind: "func", Label: "callback", Description: "called with an assoc containing class, backend, database, operation, error, outcome_unknown, suppressed_count, and timestamp", Params: []*scm.TypeDescriptor{{Kind: "assoc", Label: "failure"}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "ignored"}},
+			},
+			Return: &scm.TypeDescriptor{Kind: "bool"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
+		Name: "clear_storage_failure_hook",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			clearPersistenceFailureHook()
+			return scm.NewBool(true)
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "removes the process-local persistence failure callback", HasSideEffects: true,
+			Return: &scm.TypeDescriptor{Kind: "bool"},
+		},
+	})
 
 	// Trigger management
 	scm.Declare(&en, &scm.Declaration{

--- a/tools/reliability-drill.md
+++ b/tools/reliability-drill.md
@@ -21,8 +21,9 @@ python3 tools/reliability_drill.py --mode all --workers 12 --operations 1000
 ```
 
 To inject a partial WAL write and a failed WAL sync, verify that both
-transactions fail, deliver the first failure through a registered Scheme HTTP
-webhook, retry the writes, and crash-recover the exact result:
+transactions fail, persist and reload a Scheme HTTP failure hook, reject an
+invalid hook, deliver the first failure through the reloaded callback, retry
+the writes, and crash-recover the exact result:
 
 ```sh
 python3 tools/reliability_drill.py --mode io-failures
@@ -106,8 +107,9 @@ The current drill covers:
 - rebuild publication raced against full schema serialization under Go's race
   detector, with concurrent reads and crash-recovery validation;
 - deterministic partial-write failures in autocommit and explicit transactions,
-  asynchronous Scheme failure-hook delivery, aborted-transaction enforcement,
-  sync failures, successful retries, and exact crash recovery;
+  persistent hook startup evaluation, class masking, asynchronous Scheme HTTP
+  delivery, aborted-transaction enforcement, sync failures, successful retries,
+  and exact crash recovery;
 - graceful offline snapshot, restore into a separate data directory, and
   checksum comparison.
 

--- a/tools/reliability-drill.md
+++ b/tools/reliability-drill.md
@@ -21,7 +21,8 @@ python3 tools/reliability_drill.py --mode all --workers 12 --operations 1000
 ```
 
 To inject a partial WAL write and a failed WAL sync, verify that both
-transactions fail, retry the writes, and crash-recover the exact result:
+transactions fail, deliver the first failure through a registered Scheme HTTP
+webhook, retry the writes, and crash-recover the exact result:
 
 ```sh
 python3 tools/reliability_drill.py --mode io-failures
@@ -88,8 +89,8 @@ The current drill covers:
 - a hard kill racing a rebuild and publication of its replacement shards;
 - concurrent disjoint writers and rebuilds followed by another hard kill;
 - deterministic partial-write failures in autocommit and explicit transactions,
-  aborted-transaction enforcement, sync failures, successful retries, and exact
-  crash recovery;
+  asynchronous Scheme failure-hook delivery, aborted-transaction enforcement,
+  sync failures, successful retries, and exact crash recovery;
 - graceful offline snapshot, restore into a separate data directory, and
   checksum comparison.
 

--- a/tools/reliability_drill.py
+++ b/tools/reliability_drill.py
@@ -149,9 +149,13 @@ class FailureWebhook:
 
 
 def register_failure_webhook(client: HttpClient, webhook: FailureWebhook) -> None:
+	source = (
+		'(lambda (failure) '
+		f'(http_request "POST" "{webhook.url}" (list) (serialize failure)))'
+	)
 	client.scm(
-		'(register_storage_failure_hook 60 (lambda (failure) '
-		f'(http_request "POST" "{webhook.url}" (list) (serialize failure))))'
+		'(storage_failure_hook_save "reliability-webhook" true (list "io") 60 '
+		+ json.dumps(source) + ')'
 	)
 
 
@@ -536,9 +540,27 @@ def run_io_failures(server: OwnedServer, rows: int, seed: int,
 	want_one = {"row_count": rows, "min_x": 1, "max_x": 1, "x_sum": rows}
 	want_two = {"row_count": rows, "min_x": 2, "max_x": 2, "x_sum": rows * 2}
 
+	client = server.client
+	assert client is not None
+	configured = json.loads(client.request("/dashboard/api/storage-failure-hooks", ""))
+	templates = {hook["name"]: hook for hook in configured}
+	for name in ("syslog-process", "open-outage-page"):
+		if name not in templates or templates[name]["enabled"]:
+			raise DrillFailure(f"missing disabled storage failure hook template: {name}")
+	try:
+		client.scm(
+			'(storage_failure_hook_save "invalid-hook" true (list "io") 60 "42")'
+		)
+	except DrillFailure:
+		pass
+	else:
+		raise DrillFailure("non-callable storage failure hook source was accepted")
+	configured = json.loads(client.request("/dashboard/api/storage-failure-hooks", ""))
+	if any(hook["name"] == "invalid-hook" for hook in configured):
+		raise DrillFailure("invalid storage failure hook was persisted")
+	register_failure_webhook(client, webhook)
 	server.stop()
 	client = server.start(io_fault_environment("log.write", "partial", seed))
-	register_failure_webhook(client, webhook)
 	session = "drill-explicit-write-failure"
 	client.sql("START ACID TRANSACTION", session=session)
 	expect_write_failure(

--- a/tools/reliability_drill.py
+++ b/tools/reliability_drill.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import http.server
 import json
 import os
 from pathlib import Path
@@ -96,6 +97,62 @@ class HttpClient:
 
 	def scm(self, expression: str, timeout: float | None = None) -> str:
 		return self.request("/scm", expression, timeout=timeout)
+
+
+class FailureWebhook:
+	def __init__(self, timeout: float) -> None:
+		self.timeout = timeout
+		self.payloads: list[str] = []
+		self.condition = threading.Condition()
+		owner = self
+
+		class Handler(http.server.BaseHTTPRequestHandler):
+			def do_POST(self) -> None:
+				length = int(self.headers.get("Content-Length", "0"))
+				payload = self.rfile.read(length).decode("utf-8", errors="replace")
+				with owner.condition:
+					owner.payloads.append(payload)
+					owner.condition.notify_all()
+				self.send_response(204)
+				self.end_headers()
+
+			def log_message(self, format: str, *args: object) -> None:
+				pass
+
+		self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+		self.thread = threading.Thread(
+			target=self.server.serve_forever,
+			name="reliability-failure-webhook", daemon=True,
+		)
+
+	@property
+	def url(self) -> str:
+		return f"http://127.0.0.1:{self.server.server_port}/storage-failure"
+
+	def start(self) -> None:
+		self.thread.start()
+
+	def close(self) -> None:
+		self.server.shutdown()
+		self.server.server_close()
+		self.thread.join(timeout=self.timeout)
+
+	def wait(self) -> str:
+		deadline = time.monotonic() + self.timeout
+		with self.condition:
+			while not self.payloads:
+				remaining = deadline - time.monotonic()
+				if remaining <= 0:
+					raise DrillFailure("storage failure hook did not call its HTTP webhook")
+				self.condition.wait(remaining)
+			return self.payloads[0]
+
+
+def register_failure_webhook(client: HttpClient, webhook: FailureWebhook) -> None:
+	client.scm(
+		'(register_storage_failure_hook 60 (lambda (failure) '
+		f'(http_request "POST" "{webhook.url}" (list) (serialize failure))))'
+	)
 
 
 class OwnedServer:
@@ -372,19 +429,27 @@ def expect_write_failure(client: HttpClient, statement: str,
 
 
 def run_io_failures(server: OwnedServer, rows: int, seed: int,
-		journal: list[dict]) -> None:
+		journal: list[dict], webhook: FailureWebhook) -> None:
 	want_zero = {"row_count": rows, "min_x": 0, "max_x": 0, "x_sum": 0}
 	want_one = {"row_count": rows, "min_x": 1, "max_x": 1, "x_sum": rows}
 	want_two = {"row_count": rows, "min_x": 2, "max_x": 2, "x_sum": rows * 2}
 
 	server.stop()
 	client = server.start(io_fault_environment("log.write", "partial", seed))
+	register_failure_webhook(client, webhook)
 	session = "drill-explicit-write-failure"
 	client.sql("START ACID TRANSACTION", session=session)
 	expect_write_failure(
 		client, "UPDATE drill_atomic SET x = x + 1", session,
 		"partially written explicit transaction",
 	)
+	hook_payload = webhook.wait()
+	for fragment in ('"class" "io"', '"operation" "log.write"',
+			f'"database" "{DATABASE}"', '"outcome_unknown" false'):
+		if fragment not in hook_payload:
+			raise DrillFailure(
+				f"storage failure webhook payload lacks {fragment}: {hook_payload}"
+			)
 	expect(atomic_signature(client), want_zero, "failed explicit transaction changed visible rows")
 	expect_write_failure(
 		client, "UPDATE drill_atomic SET x = x + 1", session,
@@ -400,6 +465,7 @@ def run_io_failures(server: OwnedServer, rows: int, seed: int,
 	journal.append({
 		"scenario": "explicit-partial-log-write-failure", "seed": seed,
 		"expected_after_failure": want_zero, "expected_after_retry": want_one,
+		"failure_hook_payload": hook_payload,
 	})
 
 	server.stop()
@@ -671,6 +737,7 @@ def main() -> int:
 	journal: list[dict] = []
 	server = OwnedServer(binary, app, data_dir, artifact_dir, args.timeout)
 	active_server = server
+	failure_webhook: FailureWebhook | None = None
 	manifest = artifact_dir / "manifest.json"
 	print(f"Reliability drill artifacts: {artifact_dir}")
 	print(f"Seed: {args.seed}")
@@ -684,7 +751,9 @@ def main() -> int:
 			return 0
 		if args.mode == "io-failures":
 			initialize_atomicity(client, args.io_failure_rows, backend_config)
-			run_io_failures(server, args.io_failure_rows, args.seed, journal)
+			failure_webhook = FailureWebhook(args.timeout)
+			failure_webhook.start()
+			run_io_failures(server, args.io_failure_rows, args.seed, journal, failure_webhook)
 			write_manifest(manifest, args.seed, "passed", journal)
 			print(f"PASS: {len(journal)} reliability scenarios; manifest: {manifest}")
 			return 0
@@ -710,6 +779,8 @@ def main() -> int:
 		return 1
 	finally:
 		active_server.cleanup()
+		if failure_webhook is not None:
+			failure_webhook.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add named, process-local storage failure callbacks with per-class masks and per-fingerprint cooldowns
- dispatch callbacks asynchronously through one bounded queue so alerting never blocks storage failure propagation
- coalesce repeated failures by hook/class/backend/database/operation and report the suppressed count
- isolate callback panics and callback-induced storage failures from MemCP-backed logging and recursive alert cascades
- persist enabled state, class masks, cooldowns, and Scheme source in `system.storage_failure_hooks`
- compile enabled definitions once at startup and publish immutable runtime rules; the failure path never reads the catalog
- add an admin-only dashboard editor for creating, enabling, editing, and deleting hooks
- seed new catalogs with disabled `logger` and `xdg-open` examples; no external action is enabled automatically
- cover ordinary I/O, cleanup, and unknown commit outcome notifications

The database does not enter a sticky failure mode. Every new write still retries the configured storage, allowing an administrator to fix capacity or availability without restarting MemCP.

## Event fields

`class`, `backend`, `database`, `operation`, `error`, `outcome_unknown`, `suppressed_count`, and `timestamp`.

Supported class masks currently include `io`, `cleanup`, `ambiguous_commit`, and `*`. Multiple matching hooks receive the same event serially through the dispatcher. Named runtime hooks can be replaced or removed independently.

## Failure-path behavior

Healthy storage operations do not consult or lock the hook registry. Reporting starts only after an existing persistence boundary has failed. The original failure is always written directly to stderr. A full queue, a callback panic, or a callback-induced storage failure cannot block the transaction or recursively write to `system_statistic`.

## Verification

- `python3 tools/lint_scm.py --path lib/storage-failure-hooks.scm --check`
- `python3 tools/lint_scm.py --path lib/dashboard.scm --check`
- extracted dashboard JavaScript parsed with Node.js `new Function`
- `python3 -m unittest tools/test_reliability_drill.py`
- `go test -race ./storage -run 'TestPersistenceFailureHook' -count=3`
- `go build -o memcp .`
- `python3 tools/reliability_drill.py --mode io-failures --io-failure-rows 201 --timeout 30`
- authenticated dashboard API smoke test for list/save/reload/delete and exact class-mask JSON

The final drill ran on current master (`618d97aa2`) and passed all three scenarios with seed `9208671449292596882`. It verified both disabled built-in templates, rejected and did not persist a non-callable hook, persisted a real HTTP callback, restarted MemCP, evaluated the callback at startup, applied its `io` class mask, observed the injected partial `log.write` failure through HTTP, rejected the failed write, accepted the next storage retry, and recovered the exact committed state after a hard restart.

This is an operational feature rather than a query-path optimization, so no performance A/B was run. The successful path is unchanged; the new registry is consulted only from existing failure-reporting branches. The full repository suite remains delegated to CI per repository policy.
