### PR TITLE
JIT: defer register moves across emitter boundaries

### DIFF
--- a/scm/alu.go
+++ b/scm/alu.go
@@ -244,6 +244,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -405,6 +406,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -490,6 +492,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -559,6 +562,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -1095,6 +1099,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -1153,6 +1158,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -1373,6 +1379,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -1630,6 +1637,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -1969,6 +1977,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -2171,6 +2180,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -2279,6 +2289,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -2470,6 +2481,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -2966,6 +2978,7 @@ func init_alu() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -3114,6 +3127,7 @@ func init_alu() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -3705,6 +3719,7 @@ func init_alu() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -3879,6 +3894,7 @@ func init_alu() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -4310,6 +4326,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -4419,6 +4436,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -4479,6 +4497,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -4648,6 +4667,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -4723,6 +4743,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -4952,6 +4973,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -5142,6 +5164,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -5334,6 +5357,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -6091,6 +6115,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -6169,6 +6194,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -6450,6 +6476,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -6830,6 +6857,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -7210,6 +7238,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -7342,6 +7371,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -7537,6 +7567,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -7752,6 +7783,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -8055,6 +8087,7 @@ func init_alu() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -8687,6 +8720,7 @@ func init_alu() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -9401,6 +9435,7 @@ func init_alu() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -10159,6 +10194,7 @@ func init_alu() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -10366,6 +10402,7 @@ func init_alu() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -10688,6 +10725,7 @@ func init_alu() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -11080,6 +11118,7 @@ func init_alu() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -11327,6 +11366,7 @@ func init_alu() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -12315,6 +12355,7 @@ func init_alu() {
 							return result
 						}
 						bbs[16].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_16 = bbs[16].Address
 						ctx.MarkLabel(lbl17)
@@ -13377,6 +13418,7 @@ func init_alu() {
 							return result
 						}
 						bbs[17].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_17 = bbs[17].Address
 						ctx.MarkLabel(lbl18)
@@ -13845,6 +13887,7 @@ func init_alu() {
 							return result
 						}
 						bbs[18].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_18 = bbs[18].Address
 						ctx.MarkLabel(lbl19)
@@ -14610,6 +14653,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -14683,6 +14727,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -14951,6 +14996,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -15318,6 +15364,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -15446,6 +15493,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -15568,6 +15616,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -16006,6 +16055,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -16481,6 +16531,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -17043,6 +17094,7 @@ func init_alu() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -17283,6 +17335,7 @@ func init_alu() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -17547,6 +17600,7 @@ func init_alu() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -18179,6 +18233,7 @@ func init_alu() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -18918,6 +18973,7 @@ func init_alu() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -19211,6 +19267,7 @@ func init_alu() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -19411,6 +19468,7 @@ func init_alu() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -19724,6 +19782,7 @@ func init_alu() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -20107,6 +20166,7 @@ func init_alu() {
 							return result
 						}
 						bbs[16].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_16 = bbs[16].Address
 						ctx.MarkLabel(lbl17)
@@ -20347,6 +20407,7 @@ func init_alu() {
 							return result
 						}
 						bbs[17].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_17 = bbs[17].Address
 						ctx.MarkLabel(lbl18)
@@ -21474,6 +21535,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -21532,6 +21594,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -21761,6 +21824,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -22089,6 +22153,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -22247,6 +22312,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -22379,6 +22445,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -22876,6 +22943,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -23150,6 +23218,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -23534,6 +23603,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -23643,6 +23713,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -23702,6 +23773,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -23871,6 +23943,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -24088,6 +24161,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -24377,6 +24451,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -24716,6 +24791,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -25077,6 +25153,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -25199,6 +25276,7 @@ func init_alu() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -25348,6 +25426,7 @@ func init_alu() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -25842,6 +25921,7 @@ func init_alu() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -26344,6 +26424,7 @@ func init_alu() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -26499,6 +26580,7 @@ func init_alu() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -27149,6 +27231,7 @@ func init_alu() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -27325,6 +27408,7 @@ func init_alu() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -27503,6 +27587,7 @@ func init_alu() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -28151,6 +28236,7 @@ func init_alu() {
 							return result
 						}
 						bbs[16].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_16 = bbs[16].Address
 						ctx.MarkLabel(lbl17)
@@ -29006,6 +29092,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -29115,6 +29202,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -29174,6 +29262,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -29343,6 +29432,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -29560,6 +29650,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -29849,6 +29940,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -30188,6 +30280,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -30549,6 +30642,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -30671,6 +30765,7 @@ func init_alu() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -30820,6 +30915,7 @@ func init_alu() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -30957,6 +31053,7 @@ func init_alu() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -31253,6 +31350,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -31362,6 +31460,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -31421,6 +31520,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -31506,6 +31606,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -31831,6 +31932,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -31940,6 +32042,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -31999,6 +32102,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -32064,6 +32168,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -32389,6 +32494,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -32498,6 +32604,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -32557,6 +32664,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -32622,6 +32730,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -32947,6 +33056,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -33056,6 +33166,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -33115,6 +33226,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -33200,6 +33312,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -33646,6 +33759,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -33755,6 +33869,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -33814,6 +33929,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -34095,6 +34211,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -34204,6 +34321,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -34263,6 +34381,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -34572,6 +34691,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -34885,6 +35005,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -35440,6 +35561,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -35599,6 +35721,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -36125,6 +36248,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -36675,6 +36799,7 @@ func init_alu() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -37249,6 +37374,7 @@ func init_alu() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -37469,6 +37595,7 @@ func init_alu() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -37740,6 +37867,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -37948,6 +38076,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -38027,6 +38156,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -38487,6 +38617,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -38549,6 +38680,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -38805,6 +38937,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -39095,6 +39228,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -39191,6 +39325,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -39344,6 +39479,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -39753,6 +39889,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -39950,6 +40087,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -40650,6 +40788,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -40712,6 +40851,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -40968,6 +41108,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -41258,6 +41399,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -41354,6 +41496,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -41507,6 +41650,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -41916,6 +42060,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -42113,6 +42258,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -43429,6 +43575,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -43538,6 +43685,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -43597,6 +43745,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -43825,6 +43974,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -43906,6 +44056,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -44188,6 +44339,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -44474,6 +44626,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -44576,6 +44729,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -47365,6 +47519,7 @@ func init_alu() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -50407,6 +50562,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -50529,6 +50685,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -50592,6 +50749,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -50866,6 +51024,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -51007,6 +51166,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -51447,6 +51607,7 @@ func init_alu() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -51572,6 +51733,7 @@ func init_alu() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -51692,6 +51854,7 @@ func init_alu() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -52292,6 +52455,7 @@ func init_alu() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -52401,6 +52565,7 @@ func init_alu() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -52460,6 +52625,7 @@ func init_alu() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -52655,6 +52821,7 @@ func init_alu() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -52729,6 +52896,7 @@ func init_alu() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)

--- a/scm/compare.go
+++ b/scm/compare.go
@@ -849,6 +849,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -987,6 +988,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -1031,6 +1033,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -1209,6 +1212,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -1411,6 +1415,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -1470,6 +1475,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -1708,6 +1714,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -1776,6 +1783,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -2050,6 +2058,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -2348,6 +2357,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[9].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_9 = bbs[9].Address
 			ctx.MarkLabel(lbl10)
@@ -2523,6 +2533,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[10].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_10 = bbs[10].Address
 			ctx.MarkLabel(lbl11)
@@ -2893,6 +2904,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[11].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_11 = bbs[11].Address
 			ctx.MarkLabel(lbl12)
@@ -3354,6 +3366,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[12].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_12 = bbs[12].Address
 			ctx.MarkLabel(lbl13)
@@ -3562,6 +3575,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[13].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_13 = bbs[13].Address
 			ctx.MarkLabel(lbl14)
@@ -4064,6 +4078,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[14].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_14 = bbs[14].Address
 			ctx.MarkLabel(lbl15)
@@ -4265,6 +4280,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[15].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_15 = bbs[15].Address
 			ctx.MarkLabel(lbl16)
@@ -4483,6 +4499,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[16].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_16 = bbs[16].Address
 			ctx.MarkLabel(lbl17)
@@ -5069,6 +5086,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[17].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_17 = bbs[17].Address
 			ctx.MarkLabel(lbl18)
@@ -5307,6 +5325,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[18].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_18 = bbs[18].Address
 			ctx.MarkLabel(lbl19)
@@ -5953,6 +5972,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 				return result
 			}
 			bbs[19].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_19 = bbs[19].Address
 			ctx.MarkLabel(lbl20)

--- a/scm/date.go
+++ b/scm/date.go
@@ -541,6 +541,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -690,6 +691,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -813,6 +815,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -1205,6 +1208,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -1357,6 +1361,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -1759,6 +1764,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -1868,6 +1874,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -1927,6 +1934,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -2115,6 +2123,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -2193,6 +2202,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -2434,6 +2444,7 @@ func init_date() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -2554,6 +2565,7 @@ func init_date() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -2943,6 +2955,7 @@ func init_date() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -3340,6 +3353,7 @@ func init_date() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -3478,6 +3492,7 @@ func init_date() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -3801,6 +3816,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -3936,6 +3952,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -4003,6 +4020,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -4203,6 +4221,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -4285,6 +4304,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -4554,6 +4574,7 @@ func init_date() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -4717,6 +4738,7 @@ func init_date() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -5229,6 +5251,7 @@ func init_date() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -5421,6 +5444,7 @@ func init_date() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -6084,6 +6108,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -6219,6 +6244,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -6286,6 +6312,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -6486,6 +6513,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -6568,6 +6596,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -6837,6 +6866,7 @@ func init_date() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -7000,6 +7030,7 @@ func init_date() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -7512,6 +7543,7 @@ func init_date() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -7704,6 +7736,7 @@ func init_date() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -8386,6 +8419,7 @@ func init_date() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -8571,6 +8605,7 @@ func init_date() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -8765,6 +8800,7 @@ func init_date() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -9512,6 +9548,7 @@ func init_date() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -9727,6 +9764,7 @@ func init_date() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -10558,6 +10596,7 @@ func init_date() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -10794,6 +10833,7 @@ func init_date() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -11709,6 +11749,7 @@ func init_date() {
 							return result
 						}
 						bbs[16].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_16 = bbs[16].Address
 						ctx.MarkLabel(lbl17)
@@ -11966,6 +12007,7 @@ func init_date() {
 							return result
 						}
 						bbs[17].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_17 = bbs[17].Address
 						ctx.MarkLabel(lbl18)
@@ -12965,6 +13007,7 @@ func init_date() {
 							return result
 						}
 						bbs[18].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_18 = bbs[18].Address
 						ctx.MarkLabel(lbl19)
@@ -13243,6 +13286,7 @@ func init_date() {
 							return result
 						}
 						bbs[19].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_19 = bbs[19].Address
 						ctx.MarkLabel(lbl20)
@@ -14326,6 +14370,7 @@ func init_date() {
 							return result
 						}
 						bbs[20].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[20].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_20 = bbs[20].Address
 						ctx.MarkLabel(lbl21)
@@ -14675,6 +14720,7 @@ func init_date() {
 							return result
 						}
 						bbs[21].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[21].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_21 = bbs[21].Address
 						ctx.MarkLabel(lbl22)
@@ -15878,6 +15924,7 @@ func init_date() {
 							return result
 						}
 						bbs[22].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[22].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_22 = bbs[22].Address
 						ctx.MarkLabel(lbl23)
@@ -16209,6 +16256,7 @@ func init_date() {
 							return result
 						}
 						bbs[23].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[23].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_23 = bbs[23].Address
 						ctx.MarkLabel(lbl24)
@@ -17508,6 +17556,7 @@ func init_date() {
 							return result
 						}
 						bbs[24].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[24].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_24 = bbs[24].Address
 						ctx.MarkLabel(lbl25)
@@ -17889,6 +17938,7 @@ func init_date() {
 							return result
 						}
 						bbs[25].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[25].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_25 = bbs[25].Address
 						ctx.MarkLabel(lbl26)
@@ -19284,6 +19334,7 @@ func init_date() {
 							return result
 						}
 						bbs[26].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[26].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_26 = bbs[26].Address
 						ctx.MarkLabel(lbl27)
@@ -19692,6 +19743,7 @@ func init_date() {
 							return result
 						}
 						bbs[27].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[27].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_27 = bbs[27].Address
 						ctx.MarkLabel(lbl28)
@@ -21195,6 +21247,7 @@ func init_date() {
 							return result
 						}
 						bbs[28].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[28].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_28 = bbs[28].Address
 						ctx.MarkLabel(lbl29)
@@ -21908,6 +21961,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -22030,6 +22084,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -22093,6 +22148,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -22280,6 +22336,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -22358,6 +22415,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -22754,6 +22812,7 @@ func init_date() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -22891,6 +22950,7 @@ func init_date() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -23092,6 +23152,7 @@ func init_date() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -23316,6 +23377,7 @@ func init_date() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -23858,6 +23920,7 @@ func init_date() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -24118,6 +24181,7 @@ func init_date() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -24768,6 +24832,7 @@ func init_date() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -25056,6 +25121,7 @@ func init_date() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -25814,6 +25880,7 @@ func init_date() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -26156,6 +26223,7 @@ func init_date() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -27034,6 +27102,7 @@ func init_date() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -27398,6 +27467,7 @@ func init_date() {
 							return result
 						}
 						bbs[16].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_16 = bbs[16].Address
 						ctx.MarkLabel(lbl17)
@@ -28384,6 +28454,7 @@ func init_date() {
 							return result
 						}
 						bbs[17].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_17 = bbs[17].Address
 						ctx.MarkLabel(lbl18)
@@ -28785,6 +28856,7 @@ func init_date() {
 							return result
 						}
 						bbs[18].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_18 = bbs[18].Address
 						ctx.MarkLabel(lbl19)
@@ -29879,6 +29951,7 @@ func init_date() {
 							return result
 						}
 						bbs[19].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_19 = bbs[19].Address
 						ctx.MarkLabel(lbl20)
@@ -30503,6 +30576,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -30625,6 +30699,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -30688,6 +30763,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -30875,6 +30951,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -30953,6 +31030,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -31349,6 +31427,7 @@ func init_date() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -31486,6 +31565,7 @@ func init_date() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -31712,6 +31792,7 @@ func init_date() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -31963,6 +32044,7 @@ func init_date() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -32529,6 +32611,7 @@ func init_date() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -32820,6 +32903,7 @@ func init_date() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -33506,6 +33590,7 @@ func init_date() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -33831,6 +33916,7 @@ func init_date() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -34637,6 +34723,7 @@ func init_date() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -35018,6 +35105,7 @@ func init_date() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -35956,6 +36044,7 @@ func init_date() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -36365,6 +36454,7 @@ func init_date() {
 							return result
 						}
 						bbs[16].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_16 = bbs[16].Address
 						ctx.MarkLabel(lbl17)
@@ -37423,6 +37513,7 @@ func init_date() {
 							return result
 						}
 						bbs[17].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_17 = bbs[17].Address
 						ctx.MarkLabel(lbl18)
@@ -37873,6 +37964,7 @@ func init_date() {
 							return result
 						}
 						bbs[18].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_18 = bbs[18].Address
 						ctx.MarkLabel(lbl19)
@@ -39051,6 +39143,7 @@ func init_date() {
 							return result
 						}
 						bbs[19].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_19 = bbs[19].Address
 						ctx.MarkLabel(lbl20)
@@ -39471,6 +39564,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -39580,6 +39674,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -39639,6 +39734,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -39813,6 +39909,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -39887,6 +39984,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -40735,6 +40833,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -40883,6 +40982,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -40954,6 +41054,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -41206,6 +41307,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -41498,6 +41600,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -41605,6 +41708,7 @@ func init_date() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -42056,6 +42160,7 @@ func init_date() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -42470,6 +42575,7 @@ func init_date() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -42638,6 +42744,7 @@ func init_date() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -42921,6 +43028,7 @@ func init_date() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -43537,6 +43645,7 @@ func init_date() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -43859,6 +43968,7 @@ func init_date() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -44631,6 +44741,7 @@ func init_date() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -44992,6 +45103,7 @@ func init_date() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -45920,6 +46032,7 @@ func init_date() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -46485,6 +46598,7 @@ func init_date() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -47797,6 +47911,7 @@ func init_date() {
 							return result
 						}
 						bbs[16].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_16 = bbs[16].Address
 						ctx.MarkLabel(lbl17)
@@ -48473,6 +48588,7 @@ func init_date() {
 							return result
 						}
 						bbs[17].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_17 = bbs[17].Address
 						ctx.MarkLabel(lbl18)
@@ -50181,6 +50297,7 @@ func init_date() {
 							return result
 						}
 						bbs[18].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_18 = bbs[18].Address
 						ctx.MarkLabel(lbl19)
@@ -52298,6 +52415,7 @@ func init_date() {
 							return result
 						}
 						bbs[19].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_19 = bbs[19].Address
 						ctx.MarkLabel(lbl20)
@@ -54270,6 +54388,7 @@ func init_date() {
 							return result
 						}
 						bbs[20].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[20].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_20 = bbs[20].Address
 						ctx.MarkLabel(lbl21)
@@ -56651,6 +56770,7 @@ func init_date() {
 							return result
 						}
 						bbs[21].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[21].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_21 = bbs[21].Address
 						ctx.MarkLabel(lbl22)
@@ -58887,6 +59007,7 @@ func init_date() {
 							return result
 						}
 						bbs[22].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[22].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_22 = bbs[22].Address
 						ctx.MarkLabel(lbl23)
@@ -59667,6 +59788,7 @@ func init_date() {
 							return result
 						}
 						bbs[23].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[23].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_23 = bbs[23].Address
 						ctx.MarkLabel(lbl24)
@@ -60254,6 +60376,7 @@ func init_date() {
 							return result
 						}
 						bbs[24].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[24].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_24 = bbs[24].Address
 						ctx.MarkLabel(lbl25)
@@ -62697,6 +62820,7 @@ func init_date() {
 							return result
 						}
 						bbs[25].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[25].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_25 = bbs[25].Address
 						ctx.MarkLabel(lbl26)
@@ -65113,6 +65237,7 @@ func init_date() {
 							return result
 						}
 						bbs[26].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[26].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_26 = bbs[26].Address
 						ctx.MarkLabel(lbl27)
@@ -65953,6 +66078,7 @@ func init_date() {
 							return result
 						}
 						bbs[27].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[27].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_27 = bbs[27].Address
 						ctx.MarkLabel(lbl28)
@@ -66603,6 +66729,7 @@ func init_date() {
 							return result
 						}
 						bbs[28].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[28].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_28 = bbs[28].Address
 						ctx.MarkLabel(lbl29)
@@ -67227,6 +67354,7 @@ func init_date() {
 							return result
 						}
 						bbs[29].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[29].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_29 = bbs[29].Address
 						ctx.MarkLabel(lbl30)
@@ -68083,6 +68211,7 @@ func init_date() {
 							return result
 						}
 						bbs[30].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[30].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_30 = bbs[30].Address
 						ctx.MarkLabel(lbl31)
@@ -68727,6 +68856,7 @@ func init_date() {
 							return result
 						}
 						bbs[31].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[31].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_31 = bbs[31].Address
 						ctx.MarkLabel(lbl32)
@@ -71368,6 +71498,7 @@ func init_date() {
 							return result
 						}
 						bbs[32].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[32].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_32 = bbs[32].Address
 						ctx.MarkLabel(lbl33)
@@ -74285,6 +74416,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -74394,6 +74526,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -74453,6 +74586,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -74666,6 +74800,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -74919,6 +75054,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -75014,6 +75150,7 @@ func init_date() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -75414,6 +75551,7 @@ func init_date() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -76145,6 +76283,7 @@ func init_date() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -76254,6 +76393,7 @@ func init_date() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -76313,6 +76453,7 @@ func init_date() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -76684,6 +76825,7 @@ func init_date() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -76795,6 +76937,7 @@ func init_date() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -803,6 +803,16 @@ type JITContext struct {
 	HasSelfLoop              bool
 	SelfParamCount           int
 	RegOwners                [32]*JITValueDesc // register → owner descriptor (nil = untracked)
+	// DeferredRegMoves is the physical half of descriptor-level lazy placement.
+	// A public register move changes the logical location immediately, but its
+	// bytes are held until a non-move instruction, control-flow boundary, or
+	// safepoint needs the value. Keeping this state in JITContext lets nested
+	// inline emitters collapse each other's hand-off moves.
+	DeferredRegMoves jitDeferredRegMoves
+	// registerInstructionDepth suppresses the conservative full barrier in the
+	// raw byte writer while an architecture emitter with an explicit use/def
+	// contract is encoding one instruction.
+	registerInstructionDepth uint8
 	// DynamicSP is the temporary distance below the static frame bottom. It
 	// covers pushed live registers, variadic arrays, and the Go call area.
 	DynamicSP    int32
@@ -1200,6 +1210,9 @@ type jitDescSpillSnapshot struct {
 }
 
 func (ctx *JITContext) SnapshotAllocState() jitAllocStateSnapshot {
+	// Sibling renderers rewind allocator metadata, not physical alias state.
+	// Materialize the fallthrough state before taking the branch snapshot.
+	ctx.FlushRegisterMoves()
 	s := jitAllocStateSnapshot{
 		freeRegs:            ctx.FreeRegs,
 		freeFPRegs:          ctx.FreeFPRegs,
@@ -1240,6 +1253,7 @@ func (ctx *JITContext) SnapshotAllocState() jitAllocStateSnapshot {
 }
 
 func (ctx *JITContext) RestoreAllocState(s jitAllocStateSnapshot) {
+	ctx.FlushRegisterMoves()
 	ctx.FreeRegs = s.freeRegs
 	ctx.FreeFPRegs = s.freeFPRegs
 	ctx.ProtectedRegs = s.protectedRegs
@@ -2031,6 +2045,7 @@ func (ctx *JITContext) EnsureDescsTogether(descs ...*JITValueDesc) {
 
 // FreeReg returns a register to the free pool.
 func (ctx *JITContext) FreeReg(r Reg) {
+	heldAsDeferredSource := ctx.releaseDeferredReg(r)
 	owner := ctx.RegOwners[r]
 	if owner != nil {
 		switch owner.Loc {
@@ -2069,10 +2084,12 @@ func (ctx *JITContext) FreeReg(r Reg) {
 			}
 		}
 	}
-	if r >= RegX0 {
-		ctx.FreeFPRegs |= 1 << uint(r)
-	} else {
-		ctx.FreeRegs |= 1 << uint(r)
+	if !heldAsDeferredSource {
+		if r >= RegX0 {
+			ctx.FreeFPRegs |= 1 << uint(r)
+		} else {
+			ctx.FreeRegs |= 1 << uint(r)
+		}
 	}
 	ctx.RegOwners[r] = nil
 }
@@ -3465,6 +3482,203 @@ type jitParallelRegMoveBatch struct {
 	count uint8
 }
 
+// jitDeferredRegMoves represents sequential register copies as aliases to the
+// physical register which still contains the requested value. Unlike a
+// parallel move batch, assigning a register is an ordering boundary for older
+// aliases which still depend on its previous contents.
+//
+// The fixed arrays make queuing and flushing allocation-free. Registers are
+// architecture identifiers supplied by the backend; the scheduler itself does
+// not know whether they spell RAX, X0, or a future RISC-V register.
+type jitDeferredRegMoves struct {
+	sources [32]Reg
+	active  uint32
+	// held marks physical source registers whose descriptor lifetime ended while
+	// a deferred destination still aliases their contents. Such registers remain
+	// unavailable to AllocReg until the final alias is emitted or discarded.
+	held     uint32
+	flushing bool
+}
+
+func (moves *jitDeferredRegMoves) source(reg Reg) Reg {
+	for depth := 0; depth < len(moves.sources); depth++ {
+		if moves.active&(uint32(1)<<uint(reg)) == 0 {
+			return reg
+		}
+		reg = moves.sources[reg]
+	}
+	panic("jit: cyclic deferred register moves")
+}
+
+// deferRegMove records the value currently visible through src as dst's new
+// logical value. If dst's old physical contents still feed another alias, that
+// dependent value must be materialized before dst can be redefined.
+func (ctx *JITContext) deferRegMove(dst, src Reg) {
+	if dst >= 32 || src >= 32 {
+		panic("jit: deferred move register outside scheduler range")
+	}
+	if dst == src {
+		return
+	}
+	var dependents uint32
+	for pending := ctx.DeferredRegMoves.active; pending != 0; pending &= pending - 1 {
+		candidate := Reg(bits.TrailingZeros32(pending))
+		bit := uint32(1) << uint(candidate)
+		if candidate != dst && ctx.DeferredRegMoves.source(candidate) == dst {
+			dependents |= bit
+		}
+	}
+	ctx.flushDeferredRegMoves(dependents)
+	source := ctx.DeferredRegMoves.source(src)
+	if source == dst {
+		ctx.DeferredRegMoves.active &^= uint32(1) << uint(dst)
+		return
+	}
+	ctx.DeferredRegMoves.sources[dst] = source
+	ctx.DeferredRegMoves.active |= uint32(1) << uint(dst)
+}
+
+// releaseDeferredReg drops a dead logical destination. Any other pending value
+// which still names the register's old physical contents is emitted first,
+// because the allocator may hand the register to a destructive producer next.
+func (ctx *JITContext) releaseDeferredReg(reg Reg) bool {
+	if reg >= 32 {
+		return false
+	}
+	regBit := uint32(1) << uint(reg)
+	if ctx.DeferredRegMoves.active&regBit != 0 {
+		source := ctx.DeferredRegMoves.source(reg)
+		representedElsewhere := false
+		for pending := ctx.DeferredRegMoves.active; pending != 0; pending &= pending - 1 {
+			candidate := Reg(bits.TrailingZeros32(pending))
+			if candidate != reg && ctx.DeferredRegMoves.source(candidate) == source {
+				representedElsewhere = true
+				break
+			}
+		}
+		if representedElsewhere {
+			ctx.DeferredRegMoves.active &^= regBit
+		} else {
+			// The final logical alias may still be read through a non-owning
+			// descriptor copy. Materialize it before returning its named register.
+			ctx.flushDeferredRegMoves(regBit)
+		}
+	}
+	hasDependents := false
+	for pending := ctx.DeferredRegMoves.active; pending != 0; pending &= pending - 1 {
+		candidate := Reg(bits.TrailingZeros32(pending))
+		if candidate != reg && ctx.DeferredRegMoves.source(candidate) == reg {
+			hasDependents = true
+			break
+		}
+	}
+	ctx.DeferredRegMoves.active &^= regBit
+	if hasDependents {
+		ctx.DeferredRegMoves.held |= uint32(1) << uint(reg)
+		return true
+	}
+	ctx.releaseUnusedDeferredSources()
+	return false
+}
+
+func (ctx *JITContext) releaseUnusedDeferredSources() {
+	moves := &ctx.DeferredRegMoves
+	for held := moves.held; held != 0; held &= held - 1 {
+		source := Reg(bits.TrailingZeros32(held))
+		bit := uint32(1) << uint(source)
+		used := false
+		for pending := moves.active; pending != 0; pending &= pending - 1 {
+			candidate := Reg(bits.TrailingZeros32(pending))
+			if moves.source(candidate) == source {
+				used = true
+				break
+			}
+		}
+		if used {
+			continue
+		}
+		moves.held &^= bit
+		if source >= RegX0 {
+			if ctx.AllFPRegs&uint64(bit) != 0 {
+				ctx.FreeFPRegs |= uint64(bit)
+			}
+		} else if ctx.AllRegs&uint64(bit) != 0 {
+			ctx.FreeRegs |= uint64(bit)
+		}
+	}
+}
+
+// flushDeferredRegMoves emits only the requested logical destinations. Their
+// canonical sources are physical registers because deferRegMove flattens every
+// alias chain. The parallel solver retains correct old-source semantics when
+// several destinations are materialized together.
+func (ctx *JITContext) flushDeferredRegMoves(mask uint32) {
+	moves := &ctx.DeferredRegMoves
+	mask &= moves.active
+	if mask == 0 || moves.flushing {
+		return
+	}
+	moves.flushing = true
+	defer func() { moves.flushing = false }()
+	var batch jitParallelRegMoveBatch
+	for pending := mask; pending != 0; pending &= pending - 1 {
+		dst := Reg(bits.TrailingZeros32(pending))
+		batch.add(dst, moves.source(dst))
+	}
+	ctx.emitParallelRegMoveBatch(&batch)
+	moves.active &^= mask
+	ctx.releaseUnusedDeferredSources()
+}
+
+// FlushRegisterMoves is a full materialization barrier for control-flow,
+// safepoint, stack-map, and raw-code-position boundaries.
+func (ctx *JITContext) FlushRegisterMoves() {
+	ctx.flushDeferredRegMoves(ctx.DeferredRegMoves.active)
+}
+
+func jitRegisterMask(regs ...Reg) uint32 {
+	var mask uint32
+	for _, reg := range regs {
+		if reg >= 32 {
+			panic("jit: register outside use/def mask")
+		}
+		mask |= uint32(1) << uint(reg)
+	}
+	return mask
+}
+
+// beginRegisterInstruction applies an architecture emitter's use/def contract.
+// Reads materialize only their requested logical values. Before a write, old
+// physical values still referenced by another alias are preserved; the written
+// destinations themselves become concrete outputs of this instruction.
+func (ctx *JITContext) beginRegisterInstruction(reads, writes uint32) {
+	if ctx.DeferredRegMoves.active == 0 {
+		ctx.registerInstructionDepth++
+		return
+	}
+	ctx.prepareDeferredRegisterInstruction(reads, writes)
+	ctx.registerInstructionDepth++
+}
+
+func (ctx *JITContext) prepareDeferredRegisterInstruction(reads, writes uint32) {
+	ctx.flushDeferredRegMoves(reads)
+	var oldValueDependents uint32
+	for pending := ctx.DeferredRegMoves.active &^ writes; pending != 0; pending &= pending - 1 {
+		candidate := Reg(bits.TrailingZeros32(pending))
+		bit := uint32(1) << uint(candidate)
+		source := ctx.DeferredRegMoves.source(candidate)
+		if writes&(uint32(1)<<uint(source)) != 0 {
+			oldValueDependents |= bit
+		}
+	}
+	ctx.flushDeferredRegMoves(oldValueDependents)
+	ctx.DeferredRegMoves.active &^= writes
+}
+
+func (ctx *JITContext) endRegisterInstruction() {
+	ctx.registerInstructionDepth--
+}
+
 func (batch *jitParallelRegMoveBatch) add(dst, src Reg) {
 	if dst == src {
 		return
@@ -4407,6 +4621,9 @@ func (ctx *JITContext) MarkLabel(id JITLabel) {
 	if int(id) >= len(ctx.Labels) {
 		panic("jit: invalid label")
 	}
+	// Fallthrough moves belong to the predecessor. A branch targeting this
+	// label must start after those bytes, never in front of them.
+	ctx.FlushRegisterMoves()
 	ctx.Labels[id] = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 }
 
@@ -4446,6 +4663,7 @@ func (ctx *JITContext) ResolveFixups() {
 
 // ResolveFixupsFinal patches all remaining fixups, panicking on undefined labels.
 func (ctx *JITContext) ResolveFixupsFinal() {
+	ctx.FlushRegisterMoves()
 	for i := range ctx.Fixups {
 		f := &ctx.Fixups[i]
 		targetPos := ctx.Labels[f.LabelID]
@@ -4647,6 +4865,7 @@ func init_jit() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -4821,6 +5040,7 @@ func init_jit() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -5082,6 +5302,7 @@ func init_jit() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -5173,6 +5394,7 @@ func init_jit() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -5328,6 +5550,7 @@ func init_jit() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -5480,6 +5703,7 @@ func init_jit() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -6138,6 +6362,7 @@ func init_jit() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -6325,6 +6550,7 @@ func init_jit() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -6587,6 +6813,7 @@ func init_jit() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -6687,6 +6914,7 @@ func init_jit() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -6835,6 +7063,7 @@ func init_jit() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -6980,6 +7209,7 @@ func init_jit() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -7392,6 +7622,7 @@ func init_jit() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -7954,6 +8185,7 @@ func init_jit() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -8114,6 +8346,7 @@ func init_jit() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -8636,6 +8869,7 @@ func init_jit() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -8884,6 +9118,7 @@ func init_jit() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -3007,6 +3007,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 	if expr.GetTag() == tagSourceInfo {
 		si := expr.SourceInfo()
 		if ctx.Arena != nil && si.source != "" {
+			ctx.FlushRegisterMoves()
 			codeOffset := int32(uintptr(ctx.Ptr) - uintptr(ctx.Arena.base))
 			ctx.Arena.addSourceEntry(jitSourceEntry{
 				offset: codeOffset,

--- a/scm/jit_storage_abi_test.go
+++ b/scm/jit_storage_abi_test.go
@@ -127,6 +127,66 @@ func TestParallelMoveBatchNeverUsesStackOrFrameRegisterAsScratch(t *testing.T) {
 	}
 }
 
+func TestDeferredRegisterMovesCollapseAcrossEmitterBoundaries(t *testing.T) {
+	code := make([]byte, 128)
+	ctx := &JITContext{
+		Start:        unsafe.Pointer(&code[0]),
+		Ptr:          unsafe.Pointer(&code[0]),
+		End:          unsafe.Pointer(&code[len(code)-1]),
+		SliceBase:    RegR12,
+		ScratchReg:   RegR11,
+		StackReg:     RegRSP,
+		RegisterBank: jitX86RegisterBank,
+	}
+
+	// Model two independent inline emitters handing the same value through an
+	// otherwise dead intermediate register. Ending the producer lifetime must
+	// reserve its physical register for the alias rather than forcing an early
+	// copy. The physical stream needs only the final RDI -> RDX move.
+	ctx.AllRegs = uint64(jitRegisterMask(RegRDI, RegRSI, RegRDX))
+	ctx.EmitMovRegReg(RegRSI, RegRDI)
+	ctx.FreeReg(RegRDI)
+	ctx.EmitMovRegReg(RegRDX, RegRSI)
+	ctx.FreeReg(RegRSI)
+	if ctx.Ptr != ctx.Start {
+		t.Fatal("deferred moves emitted before a materialization barrier")
+	}
+	if ctx.FreeRegs&uint64(jitRegisterMask(RegRDI)) != 0 {
+		t.Fatal("aliased physical source returned to allocator before materialization")
+	}
+	ctx.FlushRegisterMoves()
+	emitted := code[:uintptr(ctx.Ptr)-uintptr(ctx.Start)]
+	if want := []byte{0x48, 0x89, 0xfa}; !bytes.Equal(emitted, want) {
+		t.Fatalf("collapsed deferred chain = %x, want %x", emitted, want)
+	}
+	if ctx.FreeRegs&uint64(jitRegisterMask(RegRDI)) == 0 {
+		t.Fatal("physical source remained held after its final alias materialized")
+	}
+}
+
+func TestDeferredRegisterMovesPreserveOldSourceBeforeOverwrite(t *testing.T) {
+	code := make([]byte, 128)
+	ctx := &JITContext{
+		Start:        unsafe.Pointer(&code[0]),
+		Ptr:          unsafe.Pointer(&code[0]),
+		End:          unsafe.Pointer(&code[len(code)-1]),
+		SliceBase:    RegR12,
+		ScratchReg:   RegR11,
+		StackReg:     RegRSP,
+		RegisterBank: jitX86RegisterBank,
+	}
+
+	ctx.EmitMovRegReg(RegRSI, RegRDI)
+	ctx.EmitMovRegReg(RegRDI, RegRAX)
+	ctx.FlushRegisterMoves()
+	// RSI must receive the old RDI before the later RAX -> RDI assignment.
+	emitted := code[:uintptr(ctx.Ptr)-uintptr(ctx.Start)]
+	want := []byte{0x48, 0x89, 0xfe, 0x48, 0x89, 0xc7}
+	if !bytes.Equal(emitted, want) {
+		t.Fatalf("overwrite-preserving deferred moves = %x, want %x", emitted, want)
+	}
+}
+
 func jitFourScalarResults(seed uint32) (int64, bool, int64, int64) {
 	return int64(seed) + 1, seed&1 != 0, int64(seed) + 3, int64(seed) + 5
 }

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -512,6 +512,9 @@ func (ctx *JITContext) ensureSpace(n uintptr) {
 }
 
 func (ctx *JITContext) emitByte(b byte) {
+	if ctx.registerInstructionDepth == 0 && ctx.DeferredRegMoves.active != 0 {
+		ctx.FlushRegisterMoves()
+	}
 	ctx.ensureSpace(1)
 	*(*byte)(ctx.Ptr) = b
 	ctx.Ptr = unsafe.Add(ctx.Ptr, 1)
@@ -519,6 +522,9 @@ func (ctx *JITContext) emitByte(b byte) {
 
 // emitBytes appends raw bytes to the writer.
 func (ctx *JITContext) emitBytes(bs ...byte) {
+	if ctx.registerInstructionDepth == 0 && ctx.DeferredRegMoves.active != 0 {
+		ctx.FlushRegisterMoves()
+	}
 	ctx.ensureSpace(uintptr(len(bs)))
 	for _, b := range bs {
 		*(*byte)(ctx.Ptr) = b
@@ -528,6 +534,9 @@ func (ctx *JITContext) emitBytes(bs ...byte) {
 
 // emitU32 appends a little-endian uint32.
 func (ctx *JITContext) emitU32(v uint32) {
+	if ctx.registerInstructionDepth == 0 && ctx.DeferredRegMoves.active != 0 {
+		ctx.FlushRegisterMoves()
+	}
 	ctx.ensureSpace(4)
 	*(*uint32)(ctx.Ptr) = v
 	ctx.Ptr = unsafe.Add(ctx.Ptr, 4)
@@ -535,6 +544,9 @@ func (ctx *JITContext) emitU32(v uint32) {
 
 // emitU64 appends a little-endian uint64.
 func (ctx *JITContext) emitU64(v uint64) {
+	if ctx.registerInstructionDepth == 0 && ctx.DeferredRegMoves.active != 0 {
+		ctx.FlushRegisterMoves()
+	}
 	ctx.ensureSpace(8)
 	*(*uint64)(ctx.Ptr) = v
 	ctx.Ptr = unsafe.Add(ctx.Ptr, 8)
@@ -730,11 +742,15 @@ func (ctx *JITContext) emitOrRegReg(dst, src Reg) {
 
 // EmitAddInt64 emits: ADD dst, src (GPR += GPR)
 func (ctx *JITContext) EmitAddInt64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitAluRegReg(0x01, dst, src) // ADD r/m64, r64
 }
 
 // EmitSubInt64 emits: SUB dst, src (GPR -= GPR)
 func (ctx *JITContext) EmitSubInt64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitAluRegReg(0x29, dst, src) // SUB r/m64, r64
 }
 
@@ -742,16 +758,22 @@ func (ctx *JITContext) EmitSubInt64(dst, src Reg) {
 // on amd64, so uint32 SSA values become canonical without a following mask or
 // shift pair.
 func (ctx *JITContext) EmitAddInt32(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitAluRegRegWidth(0x01, dst, src, false)
 }
 
 // EmitSubInt32 is the subtraction counterpart of EmitAddInt32.
 func (ctx *JITContext) EmitSubInt32(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitAluRegRegWidth(0x29, dst, src, false)
 }
 
 // EmitImulInt64 emits: IMUL dst, src (GPR *= GPR, signed)
 func (ctx *JITContext) EmitImulInt64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	// IMUL dst, src: REX.W + 0F AF /r (dst = dst * src)
 	rex := byte(0x48)
 	if dst >= 8 {
@@ -766,6 +788,8 @@ func (ctx *JITContext) EmitImulInt64(dst, src Reg) {
 
 // EmitAddFloat64 emits: ADDSD dst, src (XMM += XMM)
 func (ctx *JITContext) EmitAddFloat64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst, RegX0, RegX1))
+	defer ctx.endRegisterInstruction()
 	ctx.emitMovqGprToXmm(RegX0, dst)
 	ctx.emitMovqGprToXmm(RegX1, src)
 	ctx.emitSseOp(0x58, RegX0, RegX1)
@@ -774,6 +798,8 @@ func (ctx *JITContext) EmitAddFloat64(dst, src Reg) {
 
 // EmitSubFloat64 emits: SUBSD dst, src (XMM -= XMM)
 func (ctx *JITContext) EmitSubFloat64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst, RegX0, RegX1))
+	defer ctx.endRegisterInstruction()
 	ctx.emitMovqGprToXmm(RegX0, dst)
 	ctx.emitMovqGprToXmm(RegX1, src)
 	ctx.emitSseOp(0x5C, RegX0, RegX1)
@@ -782,6 +808,8 @@ func (ctx *JITContext) EmitSubFloat64(dst, src Reg) {
 
 // EmitMulFloat64 emits: MULSD dst, src (XMM *= XMM)
 func (ctx *JITContext) EmitMulFloat64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst, RegX0, RegX1))
+	defer ctx.endRegisterInstruction()
 	ctx.emitMovqGprToXmm(RegX0, dst)
 	ctx.emitMovqGprToXmm(RegX1, src)
 	ctx.emitSseOp(0x59, RegX0, RegX1)
@@ -790,6 +818,8 @@ func (ctx *JITContext) EmitMulFloat64(dst, src Reg) {
 
 // EmitDivFloat64 emits: DIVSD dst, src (XMM /= XMM)
 func (ctx *JITContext) EmitDivFloat64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst, RegX0, RegX1))
+	defer ctx.endRegisterInstruction()
 	ctx.emitMovqGprToXmm(RegX0, dst)
 	ctx.emitMovqGprToXmm(RegX1, src)
 	ctx.emitSseOp(0x5E, RegX0, RegX1)
@@ -799,6 +829,8 @@ func (ctx *JITContext) EmitDivFloat64(dst, src Reg) {
 // EmitCmpFloat64 compares two float64 bit-patterns from GPRs and leaves the
 // UCOMISD result in machine flags for an immediately following consumer.
 func (ctx *JITContext) EmitCmpFloat64(left, right Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(left, right), jitRegisterMask(RegX0, RegX1))
+	defer ctx.endRegisterInstruction()
 	ctx.emitMovqGprToXmm(RegX0, left)
 	if left == right {
 		ctx.emitBytes(0x66, 0x0F, 0x2E, 0xC0) // UCOMISD XMM0, XMM0
@@ -811,6 +843,8 @@ func (ctx *JITContext) EmitCmpFloat64(left, right Reg) {
 // EmitCmpFloat64Setcc compares two float64 bit-patterns from GPRs and writes
 // 0/1 into dst using SETcc on the floating-point flags.
 func (ctx *JITContext) EmitCmpFloat64Setcc(dst, left, right Reg, cc JITCondition) {
+	ctx.beginRegisterInstruction(jitRegisterMask(left, right), jitRegisterMask(dst, RegR11, RegX0, RegX1))
+	defer ctx.endRegisterInstruction()
 	// UCOMISD sets CF/ZF/PF semantics; map signed integer CCs used by generic
 	// lowering to their unordered/unsigned floating-point equivalents.
 	switch cc {
@@ -841,12 +875,33 @@ func (ctx *JITContext) EmitCmpFloat64Setcc(dst, left, right Reg, cc JITCondition
 	}
 }
 
-func (ctx *JITContext) EmitAddFP64(dst, src Reg) { ctx.emitSseOp(0x58, dst, src) }
-func (ctx *JITContext) EmitSubFP64(dst, src Reg) { ctx.emitSseOp(0x5C, dst, src) }
-func (ctx *JITContext) EmitMulFP64(dst, src Reg) { ctx.emitSseOp(0x59, dst, src) }
-func (ctx *JITContext) EmitDivFP64(dst, src Reg) { ctx.emitSseOp(0x5E, dst, src) }
+func (ctx *JITContext) EmitAddFP64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
+	ctx.emitSseOp(0x58, dst, src)
+}
+
+func (ctx *JITContext) EmitSubFP64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
+	ctx.emitSseOp(0x5C, dst, src)
+}
+
+func (ctx *JITContext) EmitMulFP64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
+	ctx.emitSseOp(0x59, dst, src)
+}
+
+func (ctx *JITContext) EmitDivFP64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
+	ctx.emitSseOp(0x5E, dst, src)
+}
 
 func (ctx *JITContext) EmitCmpFP64Setcc(dst, left, right Reg, cc JITCondition) {
+	ctx.beginRegisterInstruction(jitRegisterMask(left, right), jitRegisterMask(dst, ctx.ScratchReg))
+	defer ctx.endRegisterInstruction()
 	switch cc {
 	case CcL:
 		cc = CcB
@@ -897,14 +952,32 @@ func (ctx *JITContext) emitUcomisd(left, right Reg) {
 	}
 }
 
-func (ctx *JITContext) EmitMovGPRToFP(dst, src Reg) { ctx.emitMovqGprToXmm(dst, src) }
-func (ctx *JITContext) EmitMovFPToGPR(dst, src Reg) { ctx.emitMovqXmmToGpr(dst, src) }
-func (ctx *JITContext) EmitMovFPReg(dst, src Reg)   { ctx.emitSseOp(0x10, dst, src) }
+func (ctx *JITContext) EmitMovGPRToFP(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
+	ctx.emitMovqGprToXmm(dst, src)
+}
+
+func (ctx *JITContext) EmitMovFPToGPR(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
+	ctx.emitMovqXmmToGpr(dst, src)
+}
+
+func (ctx *JITContext) EmitMovFPReg(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
+	ctx.emitSseOp(0x10, dst, src)
+}
 func (ctx *JITContext) EmitLoadFPRegMem(dst, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(base), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitMovqMemToXmm(dst, base, disp)
 }
 
 func (ctx *JITContext) EmitStoreFPRegMem(src, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(src, base), 0)
+	defer ctx.endRegisterInstruction()
 	x := src - 16
 	rex := byte(0)
 	if x >= 8 || base >= 8 {
@@ -944,6 +1017,8 @@ func (ctx *JITContext) EmitStoreFPRegMem(src, base Reg, disp int32) {
 //	CVTSI2SDQ xmm(gprSrc), gprSrc   — int64 → float64 in XMM
 //	MOVQ      gprSrc, xmm(gprSrc)   — extract float64 bits back to GPR
 func (ctx *JITContext) EmitCvtInt64ToFloat64(xmmDst, gprSrc Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(gprSrc), jitRegisterMask(xmmDst, gprSrc))
+	defer ctx.endRegisterInstruction()
 	xmm := xmmDst - 16 // convert to XMM index (unsigned underflow is fine)
 	rex := byte(0x48)
 	if xmm >= 8 {
@@ -965,6 +1040,8 @@ func (ctx *JITContext) EmitCvtInt64ToFloat64(xmmDst, gprSrc Reg) {
 //	MOVQ XMM0, gprSrc
 //	CVTTSD2SI dst, XMM0
 func (ctx *JITContext) EmitCvtFloatBitsToInt64(dst, gprSrc Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(gprSrc), jitRegisterMask(dst, RegX0))
+	defer ctx.endRegisterInstruction()
 	ctx.emitMovqGprToXmm(RegX0, gprSrc)
 	xmm := RegX0 - 16
 	rex := byte(0x48)
@@ -980,6 +1057,8 @@ func (ctx *JITContext) EmitCvtFloatBitsToInt64(dst, gprSrc Reg) {
 
 // EmitXorpdReg emits: XORPD xmm, xmm (zero a float register)
 func (ctx *JITContext) EmitXorpdReg(xmm Reg) {
+	ctx.beginRegisterInstruction(0, jitRegisterMask(xmm))
+	defer ctx.endRegisterInstruction()
 	r := xmm - 16
 	modrm := byte(0xC0) | (byte(r&7) << 3) | byte(r&7)
 	if r >= 8 {
@@ -996,6 +1075,8 @@ func (ctx *JITContext) EmitXorpdReg(xmm Reg) {
 // Loads a[idx].aux (which IS the raw int64) into dstReg.
 // sliceBase is the GPR holding the slice pointer.
 func (ctx *JITContext) EmitLoadArgInt64(dst, sliceBase Reg, idx int) {
+	ctx.beginRegisterInstruction(jitRegisterMask(sliceBase), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	// MOV dst, [sliceBase + idx*16 + 8]  (aux field)
 	ctx.emitMovRegMem(dst, sliceBase, int32(idx*16+8))
 }
@@ -1004,12 +1085,16 @@ func (ctx *JITContext) EmitLoadArgInt64(dst, sliceBase Reg, idx int) {
 // Only valid when JIT type = float64.
 // Loads a[idx].aux bits into xmmDst via MOVQ.
 func (ctx *JITContext) EmitLoadArgFloat64(xmmDst, sliceBase Reg, idx int) {
+	ctx.beginRegisterInstruction(jitRegisterMask(sliceBase), jitRegisterMask(xmmDst))
+	defer ctx.endRegisterInstruction()
 	// MOVQ xmm, [sliceBase + idx*16 + 8]
 	ctx.emitMovqMemToXmm(xmmDst, sliceBase, int32(idx*16+8))
 }
 
 // EmitLoadArgPair loads the idx-th Scmer (ptr+aux pair) from the args slice.
 func (ctx *JITContext) EmitLoadArgPair(dstPtr, dstAux, sliceBase Reg, idx int) {
+	ctx.beginRegisterInstruction(jitRegisterMask(sliceBase), jitRegisterMask(dstPtr, dstAux))
+	defer ctx.endRegisterInstruction()
 	ctx.emitMovRegMem(dstPtr, sliceBase, int32(idx*16))   // ptr field
 	ctx.emitMovRegMem(dstAux, sliceBase, int32(idx*16+8)) // aux field
 }
@@ -1023,6 +1108,8 @@ func (ctx *JITContext) EmitByte(b byte) {
 
 // EmitCmpInt64 emits: CMP reg1, reg2
 func (ctx *JITContext) EmitCmpInt64(a, b Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(a, b), 0)
+	defer ctx.endRegisterInstruction()
 	ctx.emitAluRegReg(0x39, a, b) // CMP r/m64, r64
 }
 
@@ -1118,13 +1205,14 @@ func x86ConditionCode(cc JITCondition) byte {
 
 // --- MOV helpers ---
 
-// emitMovRegReg emits MOV dst, src (64-bit GPR to GPR)
-// EmitMovRegReg emits MOV r64, r64 (no-op if dst == src)
+// emitMovRegReg emits MOV dst, src immediately. It is reserved for the move
+// scheduler and fixed prologue/epilogue sequences.
+//
+// EmitMovRegReg changes the logical register value now, but defers machine-code
+// emission until another instruction needs concrete register contents. This
+// allows adjacent moves produced by nested inline emitters to collapse.
 func (ctx *JITContext) EmitMovRegReg(dst, src Reg) {
-	if dst == src {
-		return
-	}
-	ctx.emitMovRegReg(dst, src)
+	ctx.deferRegMove(dst, src)
 }
 
 func (ctx *JITContext) emitMovRegReg(dst, src Reg) {
@@ -1143,6 +1231,8 @@ func (ctx *JITContext) emitMovRegReg(dst, src Reg) {
 // shortest encoding: XOR reg,reg (2-3 B) for 0, MOV r32,imm32 (5-6 B)
 // for values ≤ 0xFFFFFFFF, or full MOV r64,imm64 (10 B) otherwise.
 func (ctx *JITContext) EmitMovRegImm64(dst Reg, imm uint64) {
+	ctx.beginRegisterInstruction(0, jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	dstEnc := byte(dst & 7)
 	if imm == 0 {
 		// XOR r32, r32 — zero-extends to 64 bits (2 or 3 bytes)
@@ -1215,33 +1305,45 @@ func (ctx *JITContext) emitMovRegMem(dst, base Reg, disp int32) {
 
 // EmitMovRegMem emits MOV dst, [base + disp32] (load 64-bit from memory) — exported wrapper.
 func (ctx *JITContext) EmitMovRegMem(dst, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(base), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitMovRegMem(dst, base, disp)
 }
 
 // EmitOrRegMem emits OR dst, [base+disp]. Common lowering uses this to combine
 // words directly from spill slots without reserving another general register.
 func (ctx *JITContext) EmitOrRegMem(dst, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, base), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitRegMemOp(0x0B, dst, base, disp)
 }
 
 // EmitMovRegMemB emits MOVZX dst, byte [base + disp32] (8-bit zero-extended load).
 func (ctx *JITContext) EmitMovRegMemB(dst, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(base), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitRegMemOp2(0x0F, 0xB6, dst, base, disp)
 }
 
 // EmitMovRegMemW emits MOVZX dst, word [base + disp32] (16-bit zero-extended load).
 func (ctx *JITContext) EmitMovRegMemW(dst, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(base), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitRegMemOp2(0x0F, 0xB7, dst, base, disp)
 }
 
 // EmitMovRegMemL emits MOV r32, [base + disp32] (32-bit zero-extended load).
 func (ctx *JITContext) EmitMovRegMemL(dst, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(base), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitRegMemOp32(0x8B, dst, base, disp)
 }
 
 // EmitLeaRegMem emits LEA dst, [base + disp32] (compute address, no memory access)
 // For IndexAddr: LEA dst, [sliceBase + idx*16] computes &a[idx]
 func (ctx *JITContext) EmitLeaRegMem(dst, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(base), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitRegMemOp(0x8D, dst, base, disp)
 }
 
@@ -1249,6 +1351,8 @@ func (ctx *JITContext) EmitLeaRegMem(dst, base Reg, disp int32) {
 // addressing primitive in the architecture backend lets common lowering fuse
 // IndexAddr+Store without manufacturing an allocator-owned address value.
 func (ctx *JITContext) EmitLeaRegBaseIndex(dst, base, index Reg, scale uint8) {
+	ctx.beginRegisterInstruction(jitRegisterMask(base, index), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	var scaleBits byte
 	switch scale {
 	case 1:
@@ -1281,6 +1385,8 @@ func (ctx *JITContext) EmitLeaRegBaseIndex(dst, base, index Reg, scale uint8) {
 // semantic slice-element lowering lives in common code; only this SIB encoding
 // is architecture-specific.
 func (ctx *JITContext) EmitMovRegBaseIndex(dst, base, index Reg, scale uint8, width int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(base, index), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	var scaleBits byte
 	switch scale {
 	case 1:
@@ -1324,6 +1430,8 @@ func (ctx *JITContext) EmitMovRegBaseIndex(dst, base, index Reg, scale uint8, wi
 // EmitMovRegMem64 loads a 64-bit value from an absolute memory address into dst.
 // Uses dst itself as scratch for the address (avoids clobbering R11).
 func (ctx *JITContext) EmitMovRegMem64(dst Reg, addr uintptr) {
+	ctx.beginRegisterInstruction(0, jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.EmitMovRegImm64(dst, uint64(addr))
 	ctx.emitMovRegMem(dst, dst, 0)
 }
@@ -1331,6 +1439,8 @@ func (ctx *JITContext) EmitMovRegMem64(dst Reg, addr uintptr) {
 // EmitMovRegMem32 loads a 32-bit value (zero-extended to 64 bits) from an absolute address.
 // Uses dst itself as scratch for the address (avoids clobbering R11).
 func (ctx *JITContext) EmitMovRegMem32(dst Reg, addr uintptr) {
+	ctx.beginRegisterInstruction(0, jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.EmitMovRegImm64(dst, uint64(addr))
 	// MOV r32, [dst+0] — 32-bit load zero-extends to 64 bits (no REX.W)
 	ctx.emitRegMemOp32(0x8B, dst, dst, 0)
@@ -1339,6 +1449,8 @@ func (ctx *JITContext) EmitMovRegMem32(dst Reg, addr uintptr) {
 // EmitMovRegMem8 loads a byte (zero-extended to 64 bits) from an absolute address.
 // Uses dst itself as scratch for the address (avoids clobbering R11).
 func (ctx *JITContext) EmitMovRegMem8(dst Reg, addr uintptr) {
+	ctx.beginRegisterInstruction(0, jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.EmitMovRegImm64(dst, uint64(addr))
 	// MOVZX r64, byte [dst+0]
 	ctx.emitRegMemOp2(0x0F, 0xB6, dst, dst, 0)
@@ -1347,6 +1459,8 @@ func (ctx *JITContext) EmitMovRegMem8(dst Reg, addr uintptr) {
 // EmitMovRegMem16 loads a 16-bit value (zero-extended to 64 bits) from an absolute address.
 // Uses dst itself as scratch for the address (avoids clobbering R11).
 func (ctx *JITContext) EmitMovRegMem16(dst Reg, addr uintptr) {
+	ctx.beginRegisterInstruction(0, jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.EmitMovRegImm64(dst, uint64(addr))
 	// MOVZX r64, word [dst+0]
 	ctx.emitRegMemOp2(0x0F, 0xB7, dst, dst, 0)
@@ -1549,6 +1663,8 @@ func (ctx *JITContext) emitMovqMemToXmm(xmm, base Reg, disp int32) {
 
 // EmitCmpRegImm32 emits CMP r64, sign-extended imm32
 func (ctx *JITContext) EmitCmpRegImm32(dst Reg, imm int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), 0)
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1561,6 +1677,8 @@ func (ctx *JITContext) EmitCmpRegImm32(dst Reg, imm int32) {
 // EmitCmpRegImm8 emits CMP r8, imm8 on the low byte of the register.
 // This is used for compact Scmer tag checks where tags live in aux[7:0].
 func (ctx *JITContext) EmitCmpRegImm8(dst Reg, imm uint8) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), 0)
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x40) // force low-byte register encoding (incl. SIL/DIL/BPL/SPL)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1571,6 +1689,8 @@ func (ctx *JITContext) EmitCmpRegImm8(dst Reg, imm uint8) {
 
 // EmitAddRegImm32 emits ADD r64, sign-extended imm32.
 func (ctx *JITContext) EmitAddRegImm32(dst Reg, imm int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1583,6 +1703,8 @@ func (ctx *JITContext) EmitAddRegImm32(dst Reg, imm int32) {
 // EmitAddRegImm32Low emits ADD r32, imm32 and therefore canonicalizes a uint32
 // result as part of the arithmetic instruction itself.
 func (ctx *JITContext) EmitAddRegImm32Low(dst Reg, imm int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x40)
 	if dst >= 8 {
 		rex |= 0x01
@@ -1593,6 +1715,8 @@ func (ctx *JITContext) EmitAddRegImm32Low(dst Reg, imm int32) {
 
 // EmitSubRegImm32 emits SUB r64, sign-extended imm32.
 func (ctx *JITContext) EmitSubRegImm32(dst Reg, imm int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1604,6 +1728,8 @@ func (ctx *JITContext) EmitSubRegImm32(dst Reg, imm int32) {
 
 // EmitSubRegImm32Low emits SUB r32, imm32 and canonicalizes a uint32 result.
 func (ctx *JITContext) EmitSubRegImm32Low(dst Reg, imm int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x40)
 	if dst >= 8 {
 		rex |= 0x01
@@ -1614,6 +1740,8 @@ func (ctx *JITContext) EmitSubRegImm32Low(dst Reg, imm int32) {
 
 // EmitOrRegImm32 emits OR r64, sign-extended imm32.
 func (ctx *JITContext) EmitOrRegImm32(dst Reg, imm int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1625,6 +1753,8 @@ func (ctx *JITContext) EmitOrRegImm32(dst Reg, imm int32) {
 
 // EmitImulRegImm32 emits IMUL r64, r64, imm32.
 func (ctx *JITContext) EmitImulRegImm32(dst Reg, imm int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x05 // REX.R | REX.B (reg and r/m are both dst)
@@ -1700,6 +1830,8 @@ func (ctx *JITContext) EmitIremRegImm(dst Reg, imm int64) {
 
 // EmitSetcc emits SETcc r/m8 + MOVZX r32, r8 → zero-extended 0 or 1 in full 64-bit register
 func (ctx *JITContext) EmitSetcc(dst Reg, cc JITCondition) {
+	ctx.beginRegisterInstruction(0, jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	opcode := x86ConditionCode(cc)
 	dstEnc := byte(dst & 7)
 	// SETcc r/m8: 0F 9x /0
@@ -1725,6 +1857,8 @@ func (ctx *JITContext) EmitSetcc(dst Reg, cc JITCondition) {
 
 // EmitShlRegImm8 emits SHL r64, imm8 (logical shift left by immediate)
 func (ctx *JITContext) EmitShlRegImm8(dst Reg, imm uint8) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1735,6 +1869,8 @@ func (ctx *JITContext) EmitShlRegImm8(dst Reg, imm uint8) {
 
 // EmitShrRegImm8 emits SHR r64, imm8 (logical shift right by immediate)
 func (ctx *JITContext) EmitShrRegImm8(dst Reg, imm uint8) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1745,6 +1881,8 @@ func (ctx *JITContext) EmitShrRegImm8(dst Reg, imm uint8) {
 
 // EmitSarRegImm8 emits SAR r64, imm8 (arithmetic shift right by immediate)
 func (ctx *JITContext) EmitSarRegImm8(dst Reg, imm uint8) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1755,6 +1893,8 @@ func (ctx *JITContext) EmitSarRegImm8(dst Reg, imm uint8) {
 
 // EmitShlRegCl emits SHL r64, CL (shift left by variable amount in CL register)
 func (ctx *JITContext) EmitShlRegCl(dst Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, RegRCX), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1765,6 +1905,8 @@ func (ctx *JITContext) EmitShlRegCl(dst Reg) {
 
 // EmitShrRegCl emits SHR r64, CL (shift right by variable amount in CL register)
 func (ctx *JITContext) EmitShrRegCl(dst Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, RegRCX), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1797,6 +1939,8 @@ func (ctx *JITContext) EmitShrRegClGo64(dst Reg) {
 
 // EmitAndRegImm32 emits AND r64, imm32 (sign-extended)
 func (ctx *JITContext) EmitAndRegImm32(dst Reg, imm int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if dst >= 8 {
 		rex |= 0x01 // REX.B
@@ -1808,11 +1952,15 @@ func (ctx *JITContext) EmitAndRegImm32(dst Reg, imm int32) {
 
 // EmitOrInt64 emits OR dst, src (64-bit OR)
 func (ctx *JITContext) EmitOrInt64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitAluRegReg(0x09, dst, src) // OR r/m64, r64
 }
 
 // EmitAndInt64 emits AND dst, src (64-bit AND)
 func (ctx *JITContext) EmitAndInt64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitAluRegReg(0x21, dst, src) // AND r/m64, r64
 }
 
@@ -1822,6 +1970,8 @@ func (ctx *JITContext) EmitAndInt64(dst, src Reg) {
 // literal lowering uses it to compare an unaligned input word against a
 // compile-time literal before applying the byte significance mask.
 func (ctx *JITContext) EmitXorInt64(dst, src Reg) {
+	ctx.beginRegisterInstruction(jitRegisterMask(dst, src), jitRegisterMask(dst))
+	defer ctx.endRegisterInstruction()
 	ctx.emitAluRegReg(0x31, dst, src) // XOR r/m64, r64
 }
 
@@ -2252,6 +2402,9 @@ func (ctx *JITContext) regHoldsPointer(r Reg) bool {
 // their unwind marker and register spill space, while the compact Proc ABI has
 // no additional caller-owned frame.
 func (ctx *JITContext) recordSafepoint(transientRoots []int32, callAreaBytes int32) {
+	// Stack maps describe concrete machine locations. No logical register alias
+	// may cross this boundary without first becoming a real register value.
+	ctx.FlushRegisterMoves()
 	roots := make([]jitStackRoot, 0, len(ctx.StackRoots)+len(transientRoots))
 	for root := range ctx.StackRoots {
 		if root.base == jitStackRootFrameSP && root.offset < -ctx.DynamicSP {
@@ -2639,6 +2792,8 @@ func (ctx *JITContext) emitAluRegRegWidth(opcode byte, dst, src Reg, wide bool) 
 // EmitStoreRegMem is the exported version of emitStoreRegMem:
 // MOV [base+disp], src (64-bit store).
 func (ctx *JITContext) EmitStoreRegMem(src, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(src, base), 0)
+	defer ctx.endRegisterInstruction()
 	ctx.emitStoreRegMem(src, base, disp)
 }
 
@@ -2646,6 +2801,8 @@ func (ctx *JITContext) EmitStoreRegMem(src, base Reg, disp int32) {
 // memory word. x86-64 has no general imm64-to-memory encoding; constants that
 // fit this form avoid occupying a temporary register in tight generated loops.
 func (ctx *JITContext) EmitStoreImm32Mem(base Reg, disp int32, value int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(base), 0)
+	defer ctx.endRegisterInstruction()
 	rex := byte(0x48)
 	if base >= 8 {
 		rex |= 0x01
@@ -2705,17 +2862,23 @@ func (ctx *JITContext) emitStoreRegMemWidth(src, base Reg, disp int32, opcode by
 
 // EmitStoreRegMemB stores the low byte of src at [base+disp].
 func (ctx *JITContext) EmitStoreRegMemB(src, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(src, base), 0)
+	defer ctx.endRegisterInstruction()
 	ctx.emitStoreRegMemWidth(src, base, disp, 0x88, false)
 }
 
 // EmitStoreRegMemW stores the low word of src at [base+disp].
 func (ctx *JITContext) EmitStoreRegMemW(src, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(src, base), 0)
+	defer ctx.endRegisterInstruction()
 	ctx.emitBytes(0x66)
 	ctx.emitStoreRegMemWidth(src, base, disp, 0x89, false)
 }
 
 // EmitStoreRegMemL stores the low doubleword of src at [base+disp].
 func (ctx *JITContext) EmitStoreRegMemL(src, base Reg, disp int32) {
+	ctx.beginRegisterInstruction(jitRegisterMask(src, base), 0)
+	defer ctx.endRegisterInstruction()
 	ctx.emitStoreRegMemWidth(src, base, disp, 0x89, false)
 }
 

--- a/scm/list.go
+++ b/scm/list.go
@@ -1954,6 +1954,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -2082,6 +2083,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -2155,6 +2157,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -2403,6 +2406,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -2719,6 +2723,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -2800,6 +2805,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -2892,6 +2898,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -3133,6 +3140,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -3308,6 +3316,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -3353,6 +3362,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -3429,6 +3439,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -3778,6 +3789,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -3953,6 +3965,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -3998,6 +4011,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -4082,6 +4096,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -4540,6 +4555,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -4857,6 +4873,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -4963,6 +4980,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -5402,6 +5420,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -5586,6 +5605,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -6076,6 +6096,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -6242,6 +6263,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -6622,6 +6644,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -6711,6 +6734,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -6924,6 +6948,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -7104,6 +7129,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -7481,6 +7507,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -7574,6 +7601,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -7894,6 +7922,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -8059,6 +8088,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -8175,6 +8205,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -8596,6 +8627,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -9172,6 +9204,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -9515,6 +9548,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -9655,6 +9689,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -9742,6 +9777,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -9932,6 +9968,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -10084,6 +10121,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -10123,6 +10161,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -10289,6 +10328,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -10441,6 +10481,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -10521,6 +10562,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -10741,6 +10783,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -10893,6 +10936,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -10932,6 +10976,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -11246,6 +11291,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -11417,6 +11463,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -11537,6 +11584,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -11835,6 +11883,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -11954,6 +12003,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -12130,6 +12180,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -12597,6 +12648,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -12808,6 +12860,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -12969,6 +13022,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -13570,6 +13624,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -14252,6 +14307,7 @@ func init_list() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -14515,6 +14571,7 @@ func init_list() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -14695,6 +14752,7 @@ func init_list() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -15195,6 +15253,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -15392,6 +15451,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -15522,6 +15582,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -15658,6 +15719,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -16073,6 +16135,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -16320,6 +16383,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -16536,6 +16600,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -17182,6 +17247,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -17450,6 +17516,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -18018,6 +18085,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -18267,6 +18335,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -18417,6 +18486,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -18573,6 +18643,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -19040,6 +19111,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -19307,6 +19379,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -19543,6 +19616,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -20242,6 +20316,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -20552,6 +20627,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -20786,6 +20862,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -21811,6 +21888,7 @@ func init_list() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -22176,6 +22254,7 @@ func init_list() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -23269,6 +23348,7 @@ func init_list() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -24456,6 +24536,7 @@ func init_list() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -25717,6 +25798,7 @@ func init_list() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -26149,6 +26231,7 @@ func init_list() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -26762,6 +26845,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -26841,6 +26925,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -27068,6 +27153,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -27389,6 +27475,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -27482,6 +27569,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -27744,6 +27832,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -27890,6 +27979,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -28233,6 +28323,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -28721,6 +28812,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -28867,6 +28959,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -29242,6 +29335,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -29341,6 +29435,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -29592,6 +29687,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -29995,6 +30091,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -30401,6 +30498,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -30532,6 +30630,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -30665,6 +30764,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -30927,6 +31027,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -31055,6 +31156,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -31330,6 +31432,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -31504,6 +31607,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -31897,6 +32001,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -32025,6 +32130,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -32300,6 +32406,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -32482,6 +32589,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -32792,6 +32900,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -33001,6 +33110,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -33115,6 +33225,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -33509,6 +33620,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -33680,6 +33792,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -33898,6 +34011,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -34064,6 +34178,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -34844,6 +34959,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -35000,6 +35116,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -35145,6 +35262,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -35267,6 +35385,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -35959,6 +36078,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -36208,6 +36328,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -36299,6 +36420,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -36609,6 +36731,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -36743,6 +36866,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -36860,6 +36984,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -36990,6 +37115,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -37395,6 +37521,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -37874,6 +38001,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -38119,6 +38247,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -38742,6 +38871,7 @@ func init_list() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -39329,6 +39459,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -39578,6 +39709,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -39669,6 +39801,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -39997,6 +40130,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -40115,6 +40249,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -40540,6 +40675,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -40969,6 +41105,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -41472,6 +41609,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -41702,6 +41840,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -41872,6 +42011,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -42022,6 +42162,7 @@ func init_list() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -42295,6 +42436,7 @@ func init_list() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -43002,6 +43144,7 @@ func init_list() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -43316,6 +43459,7 @@ func init_list() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -43738,6 +43882,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -43847,6 +43992,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -43894,6 +44040,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -44071,6 +44218,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -44150,6 +44298,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -44377,6 +44526,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -44698,6 +44848,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -44791,6 +44942,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -45084,6 +45236,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -45250,6 +45403,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -45323,6 +45477,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -45428,6 +45583,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -45768,6 +45924,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -46151,6 +46308,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -46540,6 +46698,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -46707,6 +46866,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -47232,6 +47392,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -47380,6 +47541,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -47546,6 +47708,7 @@ func init_list() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -48101,6 +48264,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -48291,6 +48455,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -48355,6 +48520,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -48415,6 +48581,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -48658,6 +48825,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -48994,6 +49162,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -49357,6 +49526,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -49465,6 +49635,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -49622,6 +49793,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -49914,6 +50086,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -50104,6 +50277,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -50168,6 +50342,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -50370,6 +50545,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -50626,6 +50802,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -50974,6 +51151,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -51349,6 +51527,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -51497,6 +51676,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -51662,6 +51842,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -51796,6 +51977,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -51932,6 +52114,7 @@ func init_list() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -52275,6 +52458,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -52354,6 +52538,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -52581,6 +52766,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -52893,6 +53079,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -52999,6 +53186,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -53441,6 +53629,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -53899,6 +54088,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -54481,6 +54671,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -54660,6 +54851,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -55388,6 +55580,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -55502,6 +55695,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -55820,6 +56014,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -55972,6 +56167,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -56486,6 +56682,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -56696,6 +56893,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -56976,6 +57174,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -57710,6 +57909,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -58054,6 +58254,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -58303,6 +58504,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -59467,6 +59669,7 @@ func init_list() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -60550,6 +60753,7 @@ func init_list() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -60984,6 +61188,7 @@ func init_list() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -61621,6 +61826,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -61787,6 +61993,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -62154,6 +62361,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -62733,6 +62941,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -62897,6 +63106,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -63305,6 +63515,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -63451,6 +63662,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -63794,6 +64006,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -64285,6 +64498,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -64431,6 +64645,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -64863,6 +65078,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -65009,6 +65225,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -65337,6 +65554,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -65750,6 +65968,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -65879,6 +66098,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -66048,6 +66268,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -66507,6 +66728,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -67002,6 +67224,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -67288,6 +67511,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -67588,6 +67812,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -68508,6 +68733,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -68766,6 +68992,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -69250,6 +69477,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -69785,6 +70013,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -70307,6 +70536,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -70535,6 +70765,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -70817,6 +71048,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -71481,6 +71713,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -71690,6 +71923,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -72060,6 +72294,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -72175,6 +72410,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -72491,6 +72727,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -72892,6 +73129,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -73018,6 +73256,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -73183,6 +73422,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -73696,6 +73936,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -76964,6 +77205,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -77079,6 +77321,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -77395,6 +77638,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -77796,6 +78040,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -77922,6 +78167,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -78087,6 +78333,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -78603,6 +78850,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -78989,6 +79237,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -79088,6 +79337,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -79339,6 +79589,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -79759,6 +80010,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -79885,6 +80137,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -80194,6 +80447,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -80360,6 +80614,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -80727,6 +80982,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -81239,6 +81495,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -81391,6 +81648,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -81797,6 +82055,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -81945,6 +82204,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -82244,6 +82504,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -82461,6 +82722,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -82745,6 +83007,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -82887,6 +83150,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -83186,6 +83450,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -83404,6 +83669,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -83790,6 +84056,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -84177,6 +84444,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -84348,6 +84616,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -84593,6 +84862,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -85216,6 +85486,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -85895,6 +86166,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -86093,6 +86365,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -86384,6 +86657,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -86948,6 +87222,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -87335,6 +87610,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -87506,6 +87782,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -87751,6 +88028,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -88374,6 +88652,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -89141,6 +89420,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -89357,6 +89637,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -90097,6 +90378,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -90416,6 +90698,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -91090,6 +91373,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -91299,6 +91583,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -91364,6 +91649,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -91821,6 +92107,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -92019,6 +92306,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -92291,6 +92579,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -92989,6 +93278,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -93676,6 +93966,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -93997,6 +94288,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -94323,6 +94615,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -94684,6 +94977,7 @@ func init_list() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -95730,6 +96024,7 @@ func init_list() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -96765,6 +97060,7 @@ func init_list() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -97059,6 +97355,7 @@ func init_list() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -97477,6 +97774,7 @@ func init_list() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -98186,6 +98484,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -98609,6 +98908,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -98788,6 +99088,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -99041,6 +99342,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -99688,6 +99990,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -100546,6 +100849,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -100780,6 +101084,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -101592,6 +101897,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -101935,6 +102241,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -102568,6 +102875,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -102991,6 +103299,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -103170,6 +103479,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -103423,6 +103733,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -104070,6 +104381,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -104861,6 +105173,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -105083,6 +105396,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -105914,6 +106228,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -106257,6 +106572,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -106817,6 +107133,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -106983,6 +107300,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -107350,6 +107668,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -107862,6 +108181,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -108014,6 +108334,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -108241,6 +108562,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -109107,6 +109429,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -109270,6 +109593,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -109605,6 +109929,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -109818,6 +110143,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -110110,6 +110436,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -110330,6 +110657,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -110733,6 +111061,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -110952,6 +111281,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -111395,6 +111725,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -111486,6 +111817,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -111737,6 +112069,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -111902,6 +112235,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -112142,6 +112476,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -112233,6 +112568,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -112484,6 +112820,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -112657,6 +112994,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -112988,6 +113326,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -113092,6 +113431,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -113396,6 +113736,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -113849,6 +114190,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -114045,6 +114387,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -114398,6 +114741,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -114499,6 +114843,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -114753,6 +115098,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -114933,6 +115279,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -115472,6 +115819,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -115583,6 +115931,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -115890,6 +116239,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -116051,6 +116401,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -116164,6 +116515,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -116573,6 +116925,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -117137,6 +117490,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -118064,6 +118418,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -118377,6 +118732,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -118644,6 +119000,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -118979,6 +119336,7 @@ func init_list() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -119756,6 +120114,7 @@ func init_list() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -120097,6 +120456,7 @@ func init_list() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -120356,6 +120716,7 @@ func init_list() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -121460,6 +121821,7 @@ func init_list() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -121856,6 +122218,7 @@ func init_list() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -123028,6 +123391,7 @@ func init_list() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -124294,6 +124658,7 @@ func init_list() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -125634,6 +125999,7 @@ func init_list() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -126097,6 +126463,7 @@ func init_list() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -126626,6 +126993,7 @@ func init_list() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -128158,6 +128526,7 @@ func init_list() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -128710,6 +129079,7 @@ func init_list() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -129284,6 +129654,7 @@ func init_list() {
 							return result
 						}
 						bbs[16].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_16 = bbs[16].Address
 						ctx.MarkLabel(lbl17)
@@ -130984,6 +131355,7 @@ func init_list() {
 							return result
 						}
 						bbs[17].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_17 = bbs[17].Address
 						ctx.MarkLabel(lbl18)
@@ -132778,6 +133150,7 @@ func init_list() {
 							return result
 						}
 						bbs[18].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_18 = bbs[18].Address
 						ctx.MarkLabel(lbl19)
@@ -134646,6 +135019,7 @@ func init_list() {
 							return result
 						}
 						bbs[19].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_19 = bbs[19].Address
 						ctx.MarkLabel(lbl20)
@@ -135285,6 +135659,7 @@ func init_list() {
 							return result
 						}
 						bbs[20].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[20].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_20 = bbs[20].Address
 						ctx.MarkLabel(lbl21)
@@ -135990,6 +136365,7 @@ func init_list() {
 							return result
 						}
 						bbs[21].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[21].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_21 = bbs[21].Address
 						ctx.MarkLabel(lbl22)
@@ -138052,6 +138428,7 @@ func init_list() {
 							return result
 						}
 						bbs[22].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[22].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_22 = bbs[22].Address
 						ctx.MarkLabel(lbl23)
@@ -138842,6 +139219,7 @@ func init_list() {
 							return result
 						}
 						bbs[23].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[23].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_23 = bbs[23].Address
 						ctx.MarkLabel(lbl24)
@@ -139419,6 +139797,7 @@ func init_list() {
 							return result
 						}
 						bbs[24].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[24].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_24 = bbs[24].Address
 						ctx.MarkLabel(lbl25)
@@ -141795,6 +142174,7 @@ func init_list() {
 							return result
 						}
 						bbs[25].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[25].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_25 = bbs[25].Address
 						ctx.MarkLabel(lbl26)
@@ -142615,6 +142995,7 @@ func init_list() {
 							return result
 						}
 						bbs[26].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[26].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_26 = bbs[26].Address
 						ctx.MarkLabel(lbl27)
@@ -145059,6 +145440,7 @@ func init_list() {
 							return result
 						}
 						bbs[27].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[27].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_27 = bbs[27].Address
 						ctx.MarkLabel(lbl28)
@@ -147597,6 +147979,7 @@ func init_list() {
 							return result
 						}
 						bbs[28].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[28].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_28 = bbs[28].Address
 						ctx.MarkLabel(lbl29)
@@ -150209,6 +150592,7 @@ func init_list() {
 							return result
 						}
 						bbs[29].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[29].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_29 = bbs[29].Address
 						ctx.MarkLabel(lbl30)
@@ -151096,6 +151480,7 @@ func init_list() {
 							return result
 						}
 						bbs[30].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[30].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_30 = bbs[30].Address
 						ctx.MarkLabel(lbl31)
@@ -152135,6 +152520,7 @@ func init_list() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -152266,6 +152652,7 @@ func init_list() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -152343,6 +152730,7 @@ func init_list() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -165,6 +165,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -401,6 +402,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -760,6 +762,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -965,6 +968,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -1268,6 +1272,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -1504,6 +1509,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -1863,6 +1869,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -2099,6 +2106,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -2415,6 +2423,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -2651,6 +2660,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -3010,6 +3020,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -3252,6 +3263,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -3623,6 +3635,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -3839,6 +3852,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -4174,6 +4188,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -4359,6 +4374,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -4636,6 +4652,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -4852,6 +4869,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -5187,6 +5205,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -5378,6 +5397,7 @@ func init_list_assoc_extra() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -665,6 +665,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -827,6 +828,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -931,6 +933,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -1089,6 +1092,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -1486,6 +1490,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -1972,6 +1977,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -2116,6 +2122,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -2381,6 +2388,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -2823,6 +2831,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -3907,6 +3916,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -4012,6 +4022,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -4186,6 +4197,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -4245,6 +4257,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -4310,6 +4323,7 @@ func init_processlist() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)

--- a/scm/scheduler.go
+++ b/scm/scheduler.go
@@ -342,6 +342,7 @@ func init_scheduler() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -447,6 +448,7 @@ func init_scheduler() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -480,6 +482,7 @@ func init_scheduler() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -3143,6 +3143,7 @@ func init() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -3279,6 +3280,7 @@ func init() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -3380,6 +3382,7 @@ func init() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -3731,6 +3734,7 @@ func init() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -3849,6 +3853,7 @@ func init() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -3886,6 +3891,7 @@ func init() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -3950,6 +3956,7 @@ func init() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -4201,6 +4208,7 @@ func init() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -4395,6 +4403,7 @@ func init() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -5749,6 +5758,7 @@ func init() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -5854,6 +5864,7 @@ func init() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -6094,6 +6105,7 @@ func init() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -6195,6 +6207,7 @@ func init() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -6560,6 +6573,7 @@ func init() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -6726,6 +6740,7 @@ func init() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -7044,6 +7059,7 @@ func init() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -7167,6 +7183,7 @@ func init() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -7395,6 +7412,7 @@ func init() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -7493,6 +7511,7 @@ func init() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -7845,6 +7864,7 @@ func init() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -8007,6 +8027,7 @@ func init() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -13041,6 +13062,7 @@ Patterns can be any of:
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -13177,6 +13199,7 @@ Patterns can be any of:
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -13295,6 +13318,7 @@ Patterns can be any of:
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -43685,6 +43709,7 @@ Patterns can be any of:
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -43821,6 +43846,7 @@ Patterns can be any of:
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -43947,6 +43973,7 @@ Patterns can be any of:
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -679,6 +679,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -905,6 +906,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -1100,6 +1102,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -1500,6 +1503,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -1635,6 +1639,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -1702,6 +1707,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -2124,6 +2130,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -2254,6 +2261,7 @@ func init_strings() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -2672,6 +2680,7 @@ func init_strings() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -2782,6 +2791,7 @@ func init_strings() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -3237,6 +3247,7 @@ func init_strings() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -3927,6 +3938,7 @@ func init_strings() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -4149,6 +4161,7 @@ func init_strings() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -4427,6 +4440,7 @@ func init_strings() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -5151,6 +5165,7 @@ func init_strings() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -5342,6 +5357,7 @@ func init_strings() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -5972,6 +5988,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -6094,6 +6111,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -6157,6 +6175,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -6447,6 +6466,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -6761,6 +6781,7 @@ func init_strings() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -6971,6 +6992,7 @@ func init_strings() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -7280,6 +7302,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -7389,6 +7412,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -7448,6 +7472,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -7595,6 +7620,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -8622,6 +8648,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -8731,6 +8758,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -8790,6 +8818,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -8965,6 +8994,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -9074,6 +9104,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -9133,6 +9164,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -9337,6 +9369,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -9446,6 +9479,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -9505,6 +9539,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -9777,6 +9812,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -9926,6 +9962,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -10049,6 +10086,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -10278,6 +10316,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -10698,6 +10737,7 @@ func init_strings() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -10886,6 +10926,7 @@ func init_strings() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -11143,6 +11184,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -11252,6 +11294,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -11311,6 +11354,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -11539,6 +11583,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -11599,6 +11644,7 @@ func init_strings() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -12231,6 +12277,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -12429,6 +12476,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -12474,6 +12522,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -12601,6 +12650,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -12785,6 +12835,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -12827,6 +12878,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -13070,6 +13122,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -13179,6 +13232,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -13238,6 +13292,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -13601,6 +13656,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -13902,6 +13958,7 @@ func init_strings() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -13986,6 +14043,7 @@ func init_strings() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -14770,6 +14828,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -15009,6 +15068,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -15060,6 +15120,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -15260,6 +15321,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -15504,6 +15566,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -15555,6 +15618,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -15854,6 +15918,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -16067,6 +16132,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -16115,6 +16181,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -16324,6 +16391,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -16456,6 +16524,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -16734,6 +16803,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -17054,6 +17124,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -17355,6 +17426,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -17487,6 +17559,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -17765,6 +17838,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -18085,6 +18159,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -18314,6 +18389,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -18512,6 +18588,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -18557,6 +18634,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -18685,6 +18763,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -18810,6 +18889,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -18846,6 +18926,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -19037,6 +19118,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -19205,6 +19287,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -19247,6 +19330,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -19431,6 +19515,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -19669,6 +19754,7 @@ func init_strings() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -19741,6 +19827,7 @@ func init_strings() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -20070,6 +20157,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -20175,6 +20263,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -20208,6 +20297,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -20387,6 +20477,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -20588,6 +20679,7 @@ func init_strings() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -20694,6 +20786,7 @@ func init_strings() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -20792,6 +20885,7 @@ func init_strings() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -20907,6 +21001,7 @@ func init_strings() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -21867,6 +21962,7 @@ func init_strings() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -21976,6 +22072,7 @@ func init_strings() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -22035,6 +22132,7 @@ func init_strings() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -22293,6 +22391,7 @@ func init_strings() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -22546,6 +22645,7 @@ func init_strings() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -22618,6 +22718,7 @@ func init_strings() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -593,6 +593,7 @@ func init_sync() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -698,6 +699,7 @@ func init_sync() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -893,6 +895,7 @@ func init_sync() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -1277,6 +1280,7 @@ func init_sync() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -1376,6 +1380,7 @@ func init_sync() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -1843,6 +1848,7 @@ func init_sync() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -1948,6 +1954,7 @@ func init_sync() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -1981,6 +1988,7 @@ func init_sync() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -2175,6 +2183,7 @@ func init_sync() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)

--- a/scm/timezone.go
+++ b/scm/timezone.go
@@ -281,6 +281,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -386,6 +387,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -444,6 +446,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -625,6 +628,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -702,6 +706,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -948,6 +953,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -1040,6 +1046,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -1458,6 +1465,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -1580,6 +1588,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -1643,6 +1652,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -1914,6 +1924,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -2180,6 +2191,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -2494,6 +2506,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -2605,6 +2618,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -3068,6 +3082,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -3203,6 +3218,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -3697,6 +3713,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -3984,6 +4001,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -4397,6 +4415,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -5331,6 +5350,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -5586,6 +5606,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -6161,6 +6182,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -6296,6 +6318,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -6363,6 +6386,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -6611,6 +6635,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -6762,6 +6787,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -7238,6 +7264,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -7418,6 +7445,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -7937,6 +7965,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -8163,6 +8192,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -8354,6 +8384,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -9885,6 +9916,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -10020,6 +10052,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -10087,6 +10120,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -10371,6 +10405,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -10650,6 +10685,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -10753,6 +10789,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -11111,6 +11148,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -11538,6 +11576,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -12230,6 +12269,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -12516,6 +12556,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -12881,6 +12922,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -13676,6 +13718,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -13785,6 +13828,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -13844,6 +13888,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -14057,6 +14102,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -14310,6 +14356,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -14405,6 +14452,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -14840,6 +14888,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -15227,6 +15276,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -15478,6 +15528,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -15753,6 +15804,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -16390,6 +16442,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -16701,6 +16754,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -17482,6 +17536,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -17844,6 +17899,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -18781,6 +18837,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)
@@ -19182,6 +19239,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[15].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_15 = bbs[15].Address
 						ctx.MarkLabel(lbl16)
@@ -20275,6 +20333,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[16].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_16 = bbs[16].Address
 						ctx.MarkLabel(lbl17)
@@ -20734,6 +20793,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[17].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_17 = bbs[17].Address
 						ctx.MarkLabel(lbl18)
@@ -22019,6 +22079,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[18].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_18 = bbs[18].Address
 						ctx.MarkLabel(lbl19)
@@ -22424,6 +22485,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[19].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_19 = bbs[19].Address
 						ctx.MarkLabel(lbl20)
@@ -23865,6 +23927,7 @@ func init_timezone() {
 							return result
 						}
 						bbs[20].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[20].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_20 = bbs[20].Address
 						ctx.MarkLabel(lbl21)

--- a/scm/vector.go
+++ b/scm/vector.go
@@ -469,6 +469,7 @@ func init_vector() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -782,6 +783,7 @@ func init_vector() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -1007,6 +1009,7 @@ func init_vector() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -1485,6 +1488,7 @@ func init_vector() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -1702,6 +1706,7 @@ func init_vector() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -1877,6 +1882,7 @@ func init_vector() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -2135,6 +2141,7 @@ func init_vector() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -2898,6 +2905,7 @@ func init_vector() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -3403,6 +3411,7 @@ func init_vector() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -3791,6 +3800,7 @@ func init_vector() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -4892,6 +4902,7 @@ func init_vector() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -6079,6 +6090,7 @@ func init_vector() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -6662,6 +6674,7 @@ func init_vector() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -8114,6 +8127,7 @@ func init_vector() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -9605,6 +9619,7 @@ func init_vector() {
 							return result
 						}
 						bbs[14].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_14 = bbs[14].Address
 						ctx.MarkLabel(lbl15)

--- a/scm/window.go
+++ b/scm/window.go
@@ -565,6 +565,7 @@ func init_window() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -773,6 +774,7 @@ func init_window() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -825,6 +827,7 @@ func init_window() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -1375,6 +1378,7 @@ func init_window() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -1496,6 +1500,7 @@ func init_window() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -1890,6 +1895,7 @@ func init_window() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -2600,6 +2606,7 @@ func init_window() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -3339,6 +3346,7 @@ func init_window() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -4154,6 +4162,7 @@ func init_window() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -5002,6 +5011,7 @@ func init_window() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -5916,6 +5926,7 @@ func init_window() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -6274,6 +6285,7 @@ func init_window() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -6647,6 +6659,7 @@ func init_window() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)
@@ -6966,6 +6979,7 @@ func init_window() {
 							return result
 						}
 						bbs[13].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_13 = bbs[13].Address
 						ctx.MarkLabel(lbl14)
@@ -7542,6 +7556,7 @@ func init_window() {
 							return result
 						}
 						bbs[0].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_0 = bbs[0].Address
 						ctx.MarkLabel(lbl1)
@@ -7782,6 +7797,7 @@ func init_window() {
 							return result
 						}
 						bbs[1].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_1 = bbs[1].Address
 						ctx.MarkLabel(lbl2)
@@ -7841,6 +7857,7 @@ func init_window() {
 							return result
 						}
 						bbs[2].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_2 = bbs[2].Address
 						ctx.MarkLabel(lbl3)
@@ -8266,6 +8283,7 @@ func init_window() {
 							return result
 						}
 						bbs[3].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_3 = bbs[3].Address
 						ctx.MarkLabel(lbl4)
@@ -8364,6 +8382,7 @@ func init_window() {
 							return result
 						}
 						bbs[4].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_4 = bbs[4].Address
 						ctx.MarkLabel(lbl5)
@@ -8497,6 +8516,7 @@ func init_window() {
 							return result
 						}
 						bbs[5].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_5 = bbs[5].Address
 						ctx.MarkLabel(lbl6)
@@ -8943,6 +8963,7 @@ func init_window() {
 							return result
 						}
 						bbs[6].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_6 = bbs[6].Address
 						ctx.MarkLabel(lbl7)
@@ -9419,6 +9440,7 @@ func init_window() {
 							return result
 						}
 						bbs[7].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_7 = bbs[7].Address
 						ctx.MarkLabel(lbl8)
@@ -9946,6 +9968,7 @@ func init_window() {
 							return result
 						}
 						bbs[8].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_8 = bbs[8].Address
 						ctx.MarkLabel(lbl9)
@@ -10265,6 +10288,7 @@ func init_window() {
 							return result
 						}
 						bbs[9].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_9 = bbs[9].Address
 						ctx.MarkLabel(lbl10)
@@ -10451,6 +10475,7 @@ func init_window() {
 							return result
 						}
 						bbs[10].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_10 = bbs[10].Address
 						ctx.MarkLabel(lbl11)
@@ -11160,6 +11185,7 @@ func init_window() {
 							return result
 						}
 						bbs[11].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_11 = bbs[11].Address
 						ctx.MarkLabel(lbl12)
@@ -11432,6 +11458,7 @@ func init_window() {
 							return result
 						}
 						bbs[12].Rendered = true
+						ctx.FlushRegisterMoves()
 						bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 						bbpos_0_12 = bbs[12].Address
 						ctx.MarkLabel(lbl13)

--- a/storage/jit_getters.go
+++ b/storage/jit_getters.go
@@ -114,6 +114,7 @@ func (s *StoragePrefix) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -265,6 +266,7 @@ func (s *StoragePrefix) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -338,6 +340,7 @@ func (s *StoragePrefix) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -578,6 +581,7 @@ func (s *StoragePrefix) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -728,6 +732,7 @@ func (s *StoragePrefix) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -800,6 +805,7 @@ func (s *StoragePrefix) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -1396,6 +1402,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -1615,6 +1622,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -1724,6 +1732,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -2015,6 +2024,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -2111,6 +2121,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -2566,6 +2577,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -2733,6 +2745,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -3063,6 +3076,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -3590,6 +3604,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -4141,6 +4156,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[9].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_9 = bbs[9].Address
 			ctx.MarkLabel(lbl10)
@@ -4734,6 +4750,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[10].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_10 = bbs[10].Address
 			ctx.MarkLabel(lbl11)
@@ -5420,6 +5437,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[11].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_11 = bbs[11].Address
 			ctx.MarkLabel(lbl12)
@@ -6394,6 +6412,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[12].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_12 = bbs[12].Address
 			ctx.MarkLabel(lbl13)
@@ -6613,6 +6632,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[13].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_13 = bbs[13].Address
 			ctx.MarkLabel(lbl14)
@@ -6915,6 +6935,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[14].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_14 = bbs[14].Address
 			ctx.MarkLabel(lbl15)
@@ -7349,6 +7370,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[15].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_15 = bbs[15].Address
 			ctx.MarkLabel(lbl16)
@@ -7741,6 +7763,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[16].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_16 = bbs[16].Address
 			ctx.MarkLabel(lbl17)
@@ -8718,6 +8741,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[17].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_17 = bbs[17].Address
 			ctx.MarkLabel(lbl18)
@@ -10090,6 +10114,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[18].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_18 = bbs[18].Address
 			ctx.MarkLabel(lbl19)
@@ -10414,6 +10439,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[19].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_19 = bbs[19].Address
 			ctx.MarkLabel(lbl20)
@@ -11651,6 +11677,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[20].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[20].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_20 = bbs[20].Address
 			ctx.MarkLabel(lbl21)
@@ -12093,6 +12120,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[21].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[21].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_21 = bbs[21].Address
 			ctx.MarkLabel(lbl22)
@@ -12708,6 +12736,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[22].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[22].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_22 = bbs[22].Address
 			ctx.MarkLabel(lbl23)
@@ -13240,6 +13269,7 @@ func (s *StorageInt) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[23].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[23].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_23 = bbs[23].Address
 			ctx.MarkLabel(lbl24)
@@ -15046,6 +15076,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -15264,6 +15295,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -15372,6 +15404,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -15689,6 +15722,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -15787,6 +15821,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -16253,6 +16288,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -16442,6 +16478,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -16624,6 +16661,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -17102,6 +17140,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -17604,6 +17643,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[9].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_9 = bbs[9].Address
 			ctx.MarkLabel(lbl10)
@@ -18148,6 +18188,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[10].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_10 = bbs[10].Address
 			ctx.MarkLabel(lbl11)
@@ -18811,6 +18852,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[11].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_11 = bbs[11].Address
 			ctx.MarkLabel(lbl12)
@@ -19707,6 +19749,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[12].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_12 = bbs[12].Address
 			ctx.MarkLabel(lbl13)
@@ -19916,6 +19959,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[13].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_13 = bbs[13].Address
 			ctx.MarkLabel(lbl14)
@@ -20205,6 +20249,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[14].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_14 = bbs[14].Address
 			ctx.MarkLabel(lbl15)
@@ -20604,6 +20649,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[15].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_15 = bbs[15].Address
 			ctx.MarkLabel(lbl16)
@@ -20979,6 +21025,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[16].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_16 = bbs[16].Address
 			ctx.MarkLabel(lbl17)
@@ -21925,6 +21972,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[17].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_17 = bbs[17].Address
 			ctx.MarkLabel(lbl18)
@@ -22972,6 +23020,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[18].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_18 = bbs[18].Address
 			ctx.MarkLabel(lbl19)
@@ -24446,6 +24495,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[19].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_19 = bbs[19].Address
 			ctx.MarkLabel(lbl20)
@@ -24769,6 +24819,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[20].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[20].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_20 = bbs[20].Address
 			ctx.MarkLabel(lbl21)
@@ -25210,6 +25261,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[21].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[21].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_21 = bbs[21].Address
 			ctx.MarkLabel(lbl22)
@@ -25783,6 +25835,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[22].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[22].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_22 = bbs[22].Address
 			ctx.MarkLabel(lbl23)
@@ -26314,6 +26367,7 @@ func (s *StorageInt) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[23].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[23].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_23 = bbs[23].Address
 			ctx.MarkLabel(lbl24)
@@ -27896,6 +27950,7 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -28081,6 +28136,7 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -28172,6 +28228,7 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -28299,6 +28356,7 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -28651,6 +28709,7 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -29090,6 +29149,7 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -29200,6 +29260,7 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -29360,6 +29421,7 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -29652,6 +29714,7 @@ func (s *StorageFloat) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -30031,6 +30094,7 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -30215,6 +30279,7 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -30305,6 +30370,7 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -30431,6 +30497,7 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -30808,6 +30875,7 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -31217,6 +31285,7 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -31329,6 +31398,7 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -31492,6 +31562,7 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -31787,6 +31858,7 @@ func (s *StorageFloat) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -32162,6 +32234,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -32330,6 +32403,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -32412,6 +32486,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -32652,6 +32727,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -32724,6 +32800,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -32864,6 +32941,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -33239,6 +33317,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -33465,6 +33544,7 @@ func (s *StorageString) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -33817,6 +33897,7 @@ func (s *StorageString) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -33967,6 +34048,7 @@ func (s *StorageString) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -34039,6 +34121,7 @@ func (s *StorageString) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -34288,6 +34371,7 @@ func (s *StorageString) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -34354,6 +34438,7 @@ func (s *StorageString) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -34699,6 +34784,7 @@ func (s *StorageEnum) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -34884,6 +34970,7 @@ func (s *StorageEnum) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -34975,6 +35062,7 @@ func (s *StorageEnum) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -35106,6 +35194,7 @@ func (s *StorageEnum) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -35470,6 +35559,7 @@ func (s *StorageEnum) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -35813,6 +35903,7 @@ func (s *StorageEnum) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -36104,6 +36195,7 @@ func (s *StorageEnum) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -36288,6 +36380,7 @@ func (s *StorageEnum) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -36378,6 +36471,7 @@ func (s *StorageEnum) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -36527,6 +36621,7 @@ func (s *StorageEnum) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -36928,6 +37023,7 @@ func (s *StorageEnum) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -37215,6 +37311,7 @@ func (s *StorageEnum) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -37883,6 +37980,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -38222,6 +38320,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -38387,6 +38486,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -38798,6 +38898,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -38942,6 +39043,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -39268,6 +39370,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -40008,6 +40111,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -40412,6 +40516,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -40676,6 +40781,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -41734,6 +41840,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[9].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_9 = bbs[9].Address
 			ctx.MarkLabel(lbl10)
@@ -42778,6 +42885,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[10].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_10 = bbs[10].Address
 			ctx.MarkLabel(lbl11)
@@ -44035,6 +44143,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[11].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_11 = bbs[11].Address
 			ctx.MarkLabel(lbl12)
@@ -45475,6 +45584,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[12].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_12 = bbs[12].Address
 			ctx.MarkLabel(lbl13)
@@ -46514,6 +46624,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[13].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_13 = bbs[13].Address
 			ctx.MarkLabel(lbl14)
@@ -47200,6 +47311,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[14].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_14 = bbs[14].Address
 			ctx.MarkLabel(lbl15)
@@ -47875,6 +47987,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[15].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_15 = bbs[15].Address
 			ctx.MarkLabel(lbl16)
@@ -48751,6 +48864,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[16].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_16 = bbs[16].Address
 			ctx.MarkLabel(lbl17)
@@ -49469,6 +49583,7 @@ func (s *StorageSparse) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, 
 				return result
 			}
 			bbs[17].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_17 = bbs[17].Address
 			ctx.MarkLabel(lbl18)
@@ -52231,6 +52346,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -52633,6 +52749,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -52829,6 +52946,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -53330,6 +53448,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -53504,6 +53623,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -53732,6 +53852,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -54320,6 +54441,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -54983,6 +55105,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -55642,6 +55765,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -55917,6 +56041,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[9].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_9 = bbs[9].Address
 			ctx.MarkLabel(lbl10)
@@ -56241,6 +56366,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[10].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_10 = bbs[10].Address
 			ctx.MarkLabel(lbl11)
@@ -56562,6 +56688,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[11].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_11 = bbs[11].Address
 			ctx.MarkLabel(lbl12)
@@ -57008,6 +57135,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[12].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_12 = bbs[12].Address
 			ctx.MarkLabel(lbl13)
@@ -58047,6 +58175,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[13].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_13 = bbs[13].Address
 			ctx.MarkLabel(lbl14)
@@ -58579,6 +58708,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[14].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_14 = bbs[14].Address
 			ctx.MarkLabel(lbl15)
@@ -58954,6 +59084,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[15].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_15 = bbs[15].Address
 			ctx.MarkLabel(lbl16)
@@ -60299,6 +60430,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[16].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_16 = bbs[16].Address
 			ctx.MarkLabel(lbl17)
@@ -60869,6 +61001,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[17].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_17 = bbs[17].Address
 			ctx.MarkLabel(lbl18)
@@ -61292,6 +61425,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[18].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_18 = bbs[18].Address
 			ctx.MarkLabel(lbl19)
@@ -62941,6 +63075,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[19].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_19 = bbs[19].Address
 			ctx.MarkLabel(lbl20)
@@ -64576,6 +64711,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[20].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[20].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_20 = bbs[20].Address
 			ctx.MarkLabel(lbl21)
@@ -66424,6 +66560,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[21].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[21].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_21 = bbs[21].Address
 			ctx.MarkLabel(lbl22)
@@ -68455,6 +68592,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[22].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[22].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_22 = bbs[22].Address
 			ctx.MarkLabel(lbl23)
@@ -69701,6 +69839,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[23].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[23].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_23 = bbs[23].Address
 			ctx.MarkLabel(lbl24)
@@ -70594,6 +70733,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[24].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[24].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_24 = bbs[24].Address
 			ctx.MarkLabel(lbl25)
@@ -71476,6 +71616,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[25].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[25].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_25 = bbs[25].Address
 			ctx.MarkLabel(lbl26)
@@ -72537,6 +72678,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[26].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[26].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_26 = bbs[26].Address
 			ctx.MarkLabel(lbl27)
@@ -73458,6 +73600,7 @@ func (s *StorageSparse) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target
 				return result
 			}
 			bbs[27].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[27].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_27 = bbs[27].Address
 			ctx.MarkLabel(lbl28)
@@ -76247,6 +76390,7 @@ func (s *StorageConst) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -76431,6 +76575,7 @@ func (s *StorageConst) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -76521,6 +76666,7 @@ func (s *StorageConst) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -76647,6 +76793,7 @@ func (s *StorageConst) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -76998,6 +77145,7 @@ func (s *StorageConst) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -77291,6 +77439,7 @@ func (s *StorageConst) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -77568,6 +77717,7 @@ func (s *StorageConst) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -77752,6 +77902,7 @@ func (s *StorageConst) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -77842,6 +77993,7 @@ func (s *StorageConst) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -77987,6 +78139,7 @@ func (s *StorageConst) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -78375,6 +78528,7 @@ func (s *StorageConst) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -78654,6 +78808,7 @@ func (s *StorageConst) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -78992,6 +79147,7 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -79177,6 +79333,7 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -79268,6 +79425,7 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -79525,6 +79683,7 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -79796,6 +79955,7 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -80133,6 +80293,7 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -80775,6 +80936,7 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -81132,6 +81294,7 @@ func (s *StorageSCMER) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, t
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -81488,6 +81651,7 @@ func (s *StorageSCMER) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -81672,6 +81836,7 @@ func (s *StorageSCMER) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -81762,6 +81927,7 @@ func (s *StorageSCMER) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -81932,6 +82098,7 @@ func (s *StorageSCMER) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -82333,6 +82500,7 @@ func (s *StorageSCMER) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -82613,6 +82781,7 @@ func (s *StorageSCMER) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target,
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -82834,6 +83003,7 @@ func (s *StorageDecimal) JITEmitGetValueRange(ctx *scm.JITContext, recid, count,
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -82985,6 +83155,7 @@ func (s *StorageDecimal) JITEmitGetValueRange(ctx *scm.JITContext, recid, count,
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -83058,6 +83229,7 @@ func (s *StorageDecimal) JITEmitGetValueRange(ctx *scm.JITContext, recid, count,
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -83250,6 +83422,7 @@ func (s *StorageDecimal) JITEmitGetValueMulti(ctx *scm.JITContext, recids, targe
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -83400,6 +83573,7 @@ func (s *StorageDecimal) JITEmitGetValueMulti(ctx *scm.JITContext, recids, targe
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -83472,6 +83646,7 @@ func (s *StorageDecimal) JITEmitGetValueMulti(ctx *scm.JITContext, recids, targe
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -84075,6 +84250,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -84423,6 +84599,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -84589,6 +84766,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -85009,6 +85187,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -85153,6 +85332,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -85740,6 +85920,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -86713,6 +86894,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -88070,6 +88252,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -88412,6 +88595,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -89126,6 +89310,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[9].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_9 = bbs[9].Address
 			ctx.MarkLabel(lbl10)
@@ -90659,6 +90844,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[10].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_10 = bbs[10].Address
 			ctx.MarkLabel(lbl11)
@@ -91250,6 +91436,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[11].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_11 = bbs[11].Address
 			ctx.MarkLabel(lbl12)
@@ -92099,6 +92286,7 @@ func (s *StorageSeq) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, tar
 				return result
 			}
 			bbs[12].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_12 = bbs[12].Address
 			ctx.MarkLabel(lbl13)
@@ -93552,6 +93740,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -94004,6 +94193,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -94234,6 +94424,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -94785,6 +94976,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -94991,6 +95183,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -95253,6 +95446,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -95891,6 +96085,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -96604,6 +96799,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -97313,6 +97509,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -97622,6 +97819,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[9].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_9 = bbs[9].Address
 			ctx.MarkLabel(lbl10)
@@ -97980,6 +98178,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[10].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_10 = bbs[10].Address
 			ctx.MarkLabel(lbl11)
@@ -98536,6 +98735,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[11].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_11 = bbs[11].Address
 			ctx.MarkLabel(lbl12)
@@ -99036,6 +99236,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[12].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_12 = bbs[12].Address
 			ctx.MarkLabel(lbl13)
@@ -100410,6 +100611,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[13].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_13 = bbs[13].Address
 			ctx.MarkLabel(lbl14)
@@ -101075,6 +101277,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[14].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[14].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_14 = bbs[14].Address
 			ctx.MarkLabel(lbl15)
@@ -101512,6 +101715,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[15].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[15].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_15 = bbs[15].Address
 			ctx.MarkLabel(lbl16)
@@ -102282,6 +102486,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[16].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[16].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_16 = bbs[16].Address
 			ctx.MarkLabel(lbl17)
@@ -104013,6 +104218,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[17].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[17].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_17 = bbs[17].Address
 			ctx.MarkLabel(lbl18)
@@ -105943,6 +106149,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[18].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[18].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_18 = bbs[18].Address
 			ctx.MarkLabel(lbl19)
@@ -106646,6 +106853,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[19].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[19].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_19 = bbs[19].Address
 			ctx.MarkLabel(lbl20)
@@ -107645,6 +107853,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[20].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[20].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_20 = bbs[20].Address
 			ctx.MarkLabel(lbl21)
@@ -108588,6 +108797,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[21].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[21].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_21 = bbs[21].Address
 			ctx.MarkLabel(lbl22)
@@ -110886,6 +111096,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[22].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[22].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_22 = bbs[22].Address
 			ctx.MarkLabel(lbl23)
@@ -113241,6 +113452,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[23].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[23].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_23 = bbs[23].Address
 			ctx.MarkLabel(lbl24)
@@ -113900,6 +114112,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[24].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[24].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_24 = bbs[24].Address
 			ctx.MarkLabel(lbl25)
@@ -114767,6 +114980,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[25].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[25].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_25 = bbs[25].Address
 			ctx.MarkLabel(lbl26)
@@ -115766,6 +115980,7 @@ func (s *StorageSeq) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, s
 				return result
 			}
 			bbs[26].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[26].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_26 = bbs[26].Address
 			ctx.MarkLabel(lbl27)
@@ -116987,6 +117202,7 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -117172,6 +117388,7 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -117263,6 +117480,7 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -117420,6 +117638,7 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -117784,6 +118003,7 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -118087,6 +118307,7 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -118383,6 +118604,7 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -118567,6 +118789,7 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -118657,6 +118880,7 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -118830,6 +119054,7 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -119230,6 +119455,7 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -119518,6 +119744,7 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)

--- a/storage/storage-decimal.go
+++ b/storage/storage-decimal.go
@@ -370,6 +370,7 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -1052,6 +1053,7 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -1157,6 +1159,7 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -1644,6 +1647,7 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -2126,6 +2130,7 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -2340,6 +2345,7 @@ func (s *StorageDecimal) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resu
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)

--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -818,6 +818,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -1023,6 +1024,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -1101,6 +1103,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -1437,6 +1440,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -1539,6 +1543,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -1879,6 +1884,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -2069,6 +2075,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -2433,6 +2440,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -3096,6 +3104,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -3675,6 +3684,7 @@ func (s *StorageEnum) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result 
 				return result
 			}
 			bbs[9].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_9 = bbs[9].Address
 			ctx.MarkLabel(lbl10)

--- a/storage/storage-float.go
+++ b/storage/storage-float.go
@@ -132,6 +132,7 @@ func (s *StorageFloat) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -275,6 +276,7 @@ func (s *StorageFloat) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -329,6 +331,7 @@ func (s *StorageFloat) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)

--- a/storage/storage-int.go
+++ b/storage/storage-int.go
@@ -229,6 +229,7 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -326,6 +327,7 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -874,6 +876,7 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -1895,6 +1898,7 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -2078,6 +2082,7 @@ func (s *StorageInt) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)

--- a/storage/storage-int_jit_bench_test.go
+++ b/storage/storage-int_jit_bench_test.go
@@ -469,6 +469,9 @@ func BenchmarkStorageIntTypedConsumer(b *testing.B) {
 	if unknown == nil || typed == nil {
 		b.Fatal("failed to compile typed-consumer benchmark")
 	}
+	if !typed(0).Bool() || typed(1).Bool() {
+		b.Fatal("typed-consumer benchmark generated incorrect comparison code")
+	}
 
 	run := func(b *testing.B, fn scm.JITStorageGetValueFunc) {
 		var sum int64

--- a/storage/storage-prefix.go
+++ b/storage/storage-prefix.go
@@ -303,6 +303,7 @@ func (s *StoragePrefix) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -431,6 +432,7 @@ func (s *StoragePrefix) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -488,6 +490,7 @@ func (s *StoragePrefix) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -669,6 +672,7 @@ func (s *StoragePrefix) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -760,6 +764,7 @@ func (s *StoragePrefix) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -1757,6 +1762,7 @@ func (s *StoragePrefix) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -1932,6 +1938,7 @@ func (s *StoragePrefix) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -2131,6 +2138,7 @@ func (s *StoragePrefix) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)

--- a/storage/storage-seq.go
+++ b/storage/storage-seq.go
@@ -644,6 +644,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -882,6 +883,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -2053,6 +2055,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -3526,6 +3529,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -3968,6 +3972,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -5253,6 +5258,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -5766,6 +5772,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -7838,6 +7845,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)
@@ -8459,6 +8467,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[8].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[8].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_8 = bbs[8].Address
 			ctx.MarkLabel(lbl9)
@@ -10316,6 +10325,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[9].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[9].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_9 = bbs[9].Address
 			ctx.MarkLabel(lbl10)
@@ -11001,6 +11011,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[10].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[10].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_10 = bbs[10].Address
 			ctx.MarkLabel(lbl11)
@@ -11818,6 +11829,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[11].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[11].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_11 = bbs[11].Address
 			ctx.MarkLabel(lbl12)
@@ -12361,6 +12373,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[12].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[12].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_12 = bbs[12].Address
 			ctx.MarkLabel(lbl13)
@@ -14019,6 +14032,7 @@ func (s *StorageSeq) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, result s
 				return result
 			}
 			bbs[13].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[13].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_13 = bbs[13].Address
 			ctx.MarkLabel(lbl14)

--- a/storage/storage-sparse.go
+++ b/storage/storage-sparse.go
@@ -244,6 +244,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[0].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_0 = bbs[0].Address
 			ctx.MarkLabel(lbl1)
@@ -350,6 +351,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[1].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_1 = bbs[1].Address
 			ctx.MarkLabel(lbl2)
@@ -602,6 +604,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[2].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_2 = bbs[2].Address
 			ctx.MarkLabel(lbl3)
@@ -685,6 +688,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[3].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_3 = bbs[3].Address
 			ctx.MarkLabel(lbl4)
@@ -1764,6 +1768,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[4].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_4 = bbs[4].Address
 			ctx.MarkLabel(lbl5)
@@ -1965,6 +1970,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[5].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_5 = bbs[5].Address
 			ctx.MarkLabel(lbl6)
@@ -2643,6 +2649,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[6].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_6 = bbs[6].Address
 			ctx.MarkLabel(lbl7)
@@ -2893,6 +2900,7 @@ func (s *StorageSparse) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 				return result
 			}
 			bbs[7].Rendered = true
+			ctx.FlushRegisterMoves()
 			bbs[7].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 			bbpos_0_7 = bbs[7].Address
 			ctx.MarkLabel(lbl8)

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -4682,6 +4682,7 @@ func (g *codeGen) emitRecursiveBBRenderers() {
 		g.emit("\t\treturn result")
 		g.emit("\t}")
 		g.emit("\tbbs[%d].Rendered = true", bbIdx)
+		g.emit("\tctx.FlushRegisterMoves()")
 		g.emit("\tbbs[%d].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))", bbIdx)
 		g.emit("\t%s = bbs[%d].Address", posVar, bbIdx)
 		g.emit("\tctx.MarkLabel(%s)", lbl)


### PR DESCRIPTION
## Problem

Adjacent and nested JIT emitters currently materialize every register-to-register handoff immediately. That produces avoidable move chains and prevents an outer emitter from eliminating copies created inside an inlined builtin.

## Solution

Track register aliases in `JITContext` and materialize only the locations required by the next instruction. Control-flow boundaries, safepoints, stack-map boundaries, and raw code-position consumers remain full barriers. The scheduler is architecture-independent; x86 emitters provide explicit register use/def masks.

Physical source registers remain reserved while a deferred alias depends on them. Overwrites preserve old-source semantics through the existing parallel-move solver.

## Manual A/B measurements

Baseline: PR #814 head. Candidate: this branch. Both binaries used the patched Go toolchain with `GOEXPERIMENT=jit`, were pinned to the same Ryzen 9 7900X3D core, used identical fixtures, warmup, and repeated samples.

StorageInt typed GetValue consumer, 60,000 values:

- baseline median: 309.5 us
- candidate median: 295.9 us
- change: -4.4 percent, 1.05x faster
- allocations: 0 in both

Generated typed-consumer machine code:

- baseline: 341 bytes
- candidate: 335 bytes
- the `RDI -> RSI -> RDX` handoff collapses to one `RDI -> RDX` move

Loop builtin alternating fixed-core A/B:

- map: 2141 ns -> 2118 ns, 1.1 percent faster
- reduce: 1126 ns -> 1148 ns, 2.0 percent slower in the short sample
- filter_mut: 1816 ns -> 1820 ns, neutral

A longer fixed-iteration counter run shows effectively identical retired instructions for reduce (difference 0.003 percent). Its three JIT functions retain identical 250/348/567-byte sizes; only an independent move ordering changes. The latency delta is IPC/code-layout sensitivity between separately linked binaries, not extra generated work.

JIT compilation of the storage consumer remains allocation-neutral at 47 allocations and currently costs about 1 us more (22.4 us -> 23.4 us). The measured execution saving amortizes after roughly 4,500 values.

## Validation

- patched-Go `GOEXPERIMENT=jit go test ./scm ./storage ./tools/jitgen`
- vanilla `go test ./scm ./storage ./tools/jitgen`
- disassembly comparison for the typed storage consumer and all reduce-generated functions

Stacked on #814 until that PR is merged.