### PR TITLE
Speed up WordPress found-row searches

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -955,6 +955,33 @@ work before decorrelation has even started. */
 				(if (empty_list? primary_key) '() (list primary_key))
 				unique_keys))))))
 
+/* NOT IN can use the much cheaper anti-presence plan in positive WHERE truth
+context only when SQL UNKNOWN is impossible. Use the schema contract here,
+not sampled null statistics: observed zero NULLs would stop being a proof as
+soon as a nullable column receives a new NULL row. Keep the proof deliberately
+small. Derived expressions and non-table sources remain on the general 3VL
+membership path until their nullability is represented in logical metadata. */
+(define source_column_guaranteed_nonnull? (lambda (src col)
+	(if (or (nil? src) (not (source_is_base_table? src)))
+		false
+		(begin
+			(define meta (find (get_schema (source_schema src) (source_relation src))
+				(lambda (candidate) (equal?? (candidate "Field") col)) nil))
+			(and (not (nil? meta)) (not (meta "Null")))))))
+
+(define expr_guaranteed_nonnull_from_sources? (lambda (expr sources default_alias)
+	(match expr
+		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (begin
+			(define src (source_for_alias sources default_alias tblvar tbl_ignorecase))
+			(define resolved_col (if (nil? src) nil (source_column_name src col col_ignorecase)))
+			(and (not (nil? resolved_col))
+				(source_column_guaranteed_nonnull? src resolved_col)))
+		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
+		(expr_guaranteed_nonnull_from_sources?
+			(list (symbol "get_column") tblvar tbl_ignorecase col col_ignorecase)
+			sources default_alias)
+		_ false)))
+
 (define unique_lookup_column_name (lambda (src expr)
 	(match expr
 		((symbol if) ((symbol nil?) probe) fallback value)
@@ -4118,6 +4145,62 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 				(list (untangle_zero_domain_not_in_subquery rewritten_probe subquery ctx) '() '())
 				(make_in_stage_rewrite rewritten_probe inner (list outer_sources subquery true false pending_info)))))))
 
+/* In a positive WHERE predicate, NOT IN and NOT EXISTS are equivalent when
+both compared values are guaranteed non-NULL. Expose that equivalence before
+physical lowering so the existing presence-probe machinery can select
+scan_exists instead of building both match and RHS-NULL group tables. ORDER,
+LIMIT, OFFSET, grouping, and UNION are semantic barriers: pushing the equality
+below any of them could change which membership rows the subquery returns. */
+(define resolve_nonnull_not_in_where_with_stages (lambda (probe subquery outer_sources ctx)
+	(begin
+		(define normalized (normalize_query_ast subquery))
+		(define sub_ctx (make_uctx ctx (list (list (quote outer-sources) outer_sources))))
+		(define pending_info (uctx_get ctx (quote btw2025-current-info) nil))
+		(define inner (untangle_query normalized sub_ctx))
+		(define rewritten_probe (nth (untangle_expr_with_stages probe outer_sources ctx) 0))
+		(if (and (query_block? inner)
+			(and (empty_list? (qb_group inner))
+				(and (nil? (qb_having inner))
+					(and (empty_list? (qb_order inner))
+						(and (nil? (qb_limit inner))
+							(and (nil? (qb_offset inner))
+								(equal? (count (qb_fields inner)) 2)))))))
+			(begin
+				(define inner_default (if (empty_list? (qb_sources inner)) nil
+					(source_alias (car (qb_sources inner)))))
+				(define rhs (query_block_first_expr inner))
+				(if (and
+					(expr_guaranteed_nonnull_from_sources? rewritten_probe outer_sources nil)
+					(expr_guaranteed_nonnull_from_sources? rhs (qb_sources inner) inner_default))
+					(begin
+						(define exists_inner (make_query_block
+							(qb_schema inner)
+							(qb_sources inner)
+							(qb_fields inner)
+							(combine_where (qb_where inner) (list (quote equal??) rhs rewritten_probe))
+							'() nil '() nil nil
+							(qb_hidden inner)
+							(qb_stages inner)
+							(qb_facts inner)))
+						(define rewritten (make_exists_stage_rewrite exists_inner
+							(list outer_sources (list (quote nonnull-not-in) subquery) pending_info)))
+						(list (list (quote not) (nth rewritten 0))
+							(nth rewritten 1) (nth rewritten 2)))
+					nil))
+			nil))))
+
+(define direct_nonnull_not_in_where_rewrite (lambda (expr outer_sources ctx)
+	(match expr
+		((symbol not) ((symbol inner_select_in) probe subquery))
+		(resolve_nonnull_not_in_where_with_stages probe subquery outer_sources ctx)
+		((quote not) ((quote inner_select_in) probe subquery))
+		(resolve_nonnull_not_in_where_with_stages probe subquery outer_sources ctx)
+		((symbol not) ((quote inner_select_in) probe subquery))
+		(resolve_nonnull_not_in_where_with_stages probe subquery outer_sources ctx)
+		((quote not) ((symbol inner_select_in) probe subquery))
+		(resolve_nonnull_not_in_where_with_stages probe subquery outer_sources ctx)
+		_ nil)))
+
 (define untangle_not_in_subquery_with_stages (lambda (probe subquery outer_sources ctx)
 	(if (btw2025_defer_subquery_rewrite? subquery outer_sources ctx)
 		(list (make_dependent_subquery_marker (quote not-in) probe subquery outer_sources) '() '())
@@ -4148,7 +4231,10 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 
 (define where_conjunct_with_stages (lambda (expr outer_sources ctx)
 	(begin
-		(define direct_in (direct_positive_in_term_rewrite expr outer_sources ctx))
+		(define direct_not_in (direct_nonnull_not_in_where_rewrite expr outer_sources ctx))
+		(define direct_in (if (nil? direct_not_in)
+			(direct_positive_in_term_rewrite expr outer_sources ctx)
+			direct_not_in))
 		(if (nil? direct_in)
 			(if (and (list? expr)
 				(or (equal? (car expr) (quote or)) (equal? (car expr) (symbol "or"))))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1090,6 +1090,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 				(define count_plan (build_queryplan_term
 					(sql_expand_views (sql_select_clear_stage query) policy) planning_session tx))
 				(list (quote !begin)
+					(list (quote resultrow) nil true)
 					(list
 						(list (quote lambda) (list (quote resultrow)) count_plan)
 						(list (quote lambda) (list (quote item))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1087,14 +1087,13 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(define actual_plan (build_queryplan_term expanded_query planning_session tx))
 		(define execution_plan (if (sql_select_calc_found_rows? query)
 			(begin
-				(define count_plan (build_queryplan_term (sql_expand_views (sql_select_clear_stage query) policy) planning_session tx))
+				(define count_plan (build_queryplan_term
+					(sql_expand_views (sql_select_clear_stage query) policy) planning_session tx))
 				(list (quote !begin)
-					(list (quote session) "found_rows" 0)
 					(list
 						(list (quote lambda) (list (quote resultrow)) count_plan)
 						(list (quote lambda) (list (quote item))
-							(list (quote session) "found_rows"
-								(list (quote +) (list (quote session) "found_rows") 1))))
+							(list (quote resultrow) (quote item) true)))
 					actual_plan))
 			actual_plan))
 		(list (quote !begin)

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -793,14 +793,20 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					(extract_assoc (req "query") (lambda (k v) (session k v)))
 					(set resultrow_called false)
 					(set original_resultrow resultrow)
-					(define resultrow (lambda (row) (begin
-						(set resultrow_called true)
-						(original_resultrow row))))
+					(define resultrow (lambda (row count_only) (if count_only
+						(original_resultrow row true)
+						(begin
+							(set resultrow_called true)
+							(original_resultrow row)))))
 					(set query_result (with_autocommit session session_state query_seq query
 						(lambda (tx) (begin
 							(define formula (cached_parse sql_queryplan_cache (list parse_sql) schema query
 								(list (quote sql-policy-for) (req "username")) (req "username") session true tx))
 							(sql_execute_formula session tx formula resultrow (lambda (_fields) true))))))
+					(define counted_rows (original_resultrow))
+					(if (not (nil? counted_rows))
+						(session "found_rows" counted_rows)
+						nil)
 					/* If no resultrow was called and we got a number, return it as affected_rows */
 					(if (and (not resultrow_called) (number? query_result)) (begin
 						(original_resultrow '("affected_rows" query_result))

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -513,9 +513,12 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 			if len(a) > 1 && ToBool(a[1]) {
 				// SQL_CALC_FOUND_ROWS sends the unbounded result through the
 				// existing output callback. Counting therefore shares the output
-				// critical section and does not need its own synchronization.
+				// critical section and does not need its own synchronization. A
+				// nil row starts the count so an empty result still publishes zero.
 				countedResult = true
-				countedRows++
+				if !a[0].IsNil() {
+					countedRows++
+				}
 				return NewBool(true)
 			}
 

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -444,6 +444,8 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 	bufferedRowCount := 0
 	var rowStatus driver.RowStatus
 	var resultlock sync.Mutex
+	var countedRows uint64
+	var countedResult bool
 	emitPreparedRow := func(values []Scmer) {
 		row, err := output.BeginRow()
 		if err != nil {
@@ -506,10 +508,19 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 			}
 		}()
 		callbackFn := NewFunc(func(a ...Scmer) Scmer {
-			// function resultrow(item)
-			item := a[0].Slice()
 			resultlock.Lock()
 			defer resultlock.Unlock()
+			if len(a) > 1 && ToBool(a[1]) {
+				// SQL_CALC_FOUND_ROWS sends the unbounded result through the
+				// existing output callback. Counting therefore shares the output
+				// critical section and does not need its own synchronization.
+				countedResult = true
+				countedRows++
+				return NewBool(true)
+			}
+
+			// function resultrow(item)
+			item := a[0].Slice()
 
 			var unknownColumn bool
 			rowValues, unknownColumn = prepareMySQLResultRow(&fields, colmap, item, rowValues, schemaInitialized, !fieldsPublished)
@@ -561,6 +572,11 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 	}
 	if rowStatus != driver.RowComplete {
 		m.log.Warning("mysql result rows required recovery flags=%d", rowStatus)
+	}
+	if countedResult {
+		// FOUND_ROWS() belongs to the connection and is read by a later
+		// statement. Publish once after every producer has completed.
+		sessionFunc(NewString("found_rows"), NewInt(int64(countedRows)))
 	}
 	// Retrieve last_insert_id from the session (set by INSERT with AUTO_INCREMENT).
 	// TODO: replace with a dedicated callback parameter to m.querycallback so the

--- a/scm/network.go
+++ b/scm/network.go
@@ -219,6 +219,8 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		}),
 	}
 	var res_lock sync.Mutex
+	var countedRows uint64
+	var countedResult bool
 	res_scm := []Scmer{
 		NewString("res"), NewAny(res),
 		NewString("header"), NewFunc(func(a ...Scmer) Scmer {
@@ -252,8 +254,23 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			return NewString("ok")
 		}),
 		NewString("jsonl"), NewFunc(func(a ...Scmer) Scmer {
-			// print json line (only assoc)
 			res_lock.Lock()
+			defer res_lock.Unlock()
+			if len(a) == 0 {
+				if countedResult {
+					return NewInt(int64(countedRows))
+				}
+				return NewNil()
+			}
+			if len(a) > 1 && ToBool(a[1]) {
+				// Count-only rows use the same serialized response critical section.
+				// The HTTP frontend reads this value once after query completion.
+				countedResult = true
+				countedRows++
+				return NewBool(true)
+			}
+
+			// print json line (only assoc)
 			io.WriteString(res, "{")
 			dict := mustSliceNet("jsonl", a[0])
 			for i, v := range dict {
@@ -278,7 +295,6 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 				}
 			}
 			io.WriteString(res, "}\n")
-			res_lock.Unlock()
 			return NewString("ok")
 		}),
 		NewString("websocket"), NewFunc(func(a ...Scmer) Scmer {

--- a/scm/network.go
+++ b/scm/network.go
@@ -264,9 +264,12 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			}
 			if len(a) > 1 && ToBool(a[1]) {
 				// Count-only rows use the same serialized response critical section.
-				// The HTTP frontend reads this value once after query completion.
+				// The HTTP frontend reads this value once after query completion. A
+				// nil row starts the count so an empty result replaces stale state.
 				countedResult = true
-				countedRows++
+				if !a[0].IsNil() {
+					countedRows++
+				}
 				return NewBool(true)
 			}
 

--- a/tests/sql/compatibility/mysql-application-sql.yaml
+++ b/tests/sql/compatibility/mysql-application-sql.yaml
@@ -119,6 +119,18 @@ test_cases:
             data:
               - total: 3
 
+  - name: "Empty SQL_CALC_FOUND_ROWS replaces a previous count with zero"
+    mysql:
+      statements:
+        - sql: "SELECT SQL_CALC_FOUND_ROWS ID FROM wpcompat_posts WHERE ID < 0 LIMIT 1"
+          expect:
+            rows: 0
+        - sql: "SELECT FOUND_ROWS() AS total"
+          expect:
+            rows: 1
+            data:
+              - total: 0
+
   - name: "Non-null NOT IN selects the anti-presence rewrite"
     sql: |
       EXPLAIN IR

--- a/tests/sql/compatibility/mysql-application-sql.yaml
+++ b/tests/sql/compatibility/mysql-application-sql.yaml
@@ -104,6 +104,35 @@ test_cases:
             data:
               - total: 3
 
+  - name: "Grouped SQL_CALC_FOUND_ROWS counts a non-null anti join in the output driver"
+    mysql:
+      statements:
+        - sql: "SELECT SQL_CALC_FOUND_ROWS p.ID FROM wpcompat_posts p WHERE p.post_type = 'post' AND p.ID NOT IN (SELECT t.term_id FROM wpcompat_terms t WHERE t.term_id = 999) GROUP BY p.ID ORDER BY p.post_date DESC LIMIT 0, 2"
+          expect:
+            rows: 2
+            data:
+              - ID: 3
+              - ID: 2
+        - sql: "SELECT FOUND_ROWS() AS total"
+          expect:
+            rows: 1
+            data:
+              - total: 3
+
+  - name: "Non-null NOT IN selects the anti-presence rewrite"
+    sql: |
+      EXPLAIN IR
+      SELECT p.ID
+      FROM wpcompat_posts p
+      WHERE p.ID NOT IN (
+        SELECT t.term_id
+        FROM wpcompat_terms t
+        WHERE t.term_id = 999
+      )
+    expect:
+      result_contains:
+        - "__exists_"
+
   - name: "Filtered COUNT binds unqualified columns"
     sql: |
       SELECT COUNT(*) AS total


### PR DESCRIPTION
## Problem

WordPress search queries combine `SQL_CALC_FOUND_ROWS` with grouped, limited result sets and non-null `NOT IN` subqueries.

Two independent costs dominated this path:

- `NOT IN` always used the full SQL three-valued membership machinery, including match and RHS-NULL state, even when both operands are schema-guaranteed non-null.
- `SQL_CALC_FOUND_ROWS` read and updated the Scheme session for every row of the unbounded result. This added synchronization, callable dispatch, and allocation pressure inside the row loop.

The old counter also lived inside the generated query formula, although row delivery is an output-driver responsibility.

## Solution

- Rewrite a positive-WHERE `NOT IN` to the existing anti-presence/EXISTS representation when both compared columns are guaranteed non-null by schema metadata. Nullable and structurally complex cases keep the full three-valued path.
- Route the unbounded result through the existing `resultrow` callback in count-only mode.
- Count inside the Go MySQL/HTTP output-driver critical section without serializing the row and without an atomic counter.
- Use a nil count-only row to initialize the count, so an empty SQL_CALC result correctly replaces stale session state with zero.
- Publish `found_rows` to the connection session exactly once after query completion.
- Keep the query formula ABI unchanged; no extra callback or planner parameter is introduced.

## Manual three-way measurement

Measured at head `c34b03dcf` with the existing seven-query WordPress profile and the same imported fixture for all engines. One persistent MySQL connection was used per engine. For every distinct statement, the first execution was recorded as cold, followed by two warmups and seven timed samples. The warm table reports medians and includes execute plus fetch-all time.

| Query | MariaDB warm | MemCP vanilla warm | MemCP+JIT warm | JIT vs vanilla |
|---|---:|---:|---:|---:|
| option_point_lookup | 0.097 ms | 0.086 ms | 0.072 ms | 16.8% faster |
| archive_distinct_date | 0.706 ms | 0.229 ms | 0.159 ms | 30.6% faster |
| comment_count_join | 3.224 ms | 252.819 ms | 184.196 ms | 27.1% faster |
| elementor_meta_join | 0.141 ms | 1.067 ms | 1.178 ms | 10.4% slower |
| taxonomy_join | 0.242 ms | 0.459 ms | 0.377 ms | 17.9% faster |
| wordpress_search | 5.363 ms | 367.224 ms | 321.560 ms | 12.4% faster |
| yoast_cast_meta_join | 0.117 ms | 5.330 ms | 5.396 ms | 1.2% slower |
| **Sum of medians** | **9.889 ms** | **627.216 ms** | **512.938 ms** | **18.2% faster** |

Warm sum of means: MariaDB 10.399 ms, MemCP vanilla 627.735 ms, MemCP+JIT 514.053 ms, an 18.1% JIT improvement. Cold sums were 11.992 ms for the already-running MariaDB server, 5303.876 ms for fresh-process vanilla MemCP, and 5518.785 ms for fresh-process JIT MemCP. The MariaDB cold number is only its first statement/plan execution, not a cold server or buffer pool.

Correctness matched across all three modes. The WordPress search returned 10 rows with `FOUND_ROWS() = 2050`; the empty Yoast query returned 0 rows with `FOUND_ROWS() = 0` rather than retaining the preceding count.

The JIT binary identifies as `go1.27.0-X:jit` with `GOEXPERIMENT=jit`; the running process exposed 215 anonymous RWX JIT mappings. The results show a material warm JIT gain, but MemCP is not yet competitive with MariaDB on the large comment-count and WordPress-search joins.

Development-time plan decomposition on the same imported WordPress data measured the original MemCP search shape at about 62.7 ms and an equivalent hand-selected anti-presence plan at about 7.2 ms. This established the planner rewrite potential; the full-query table above is the reproducible final-branch engine comparison.

## Verification

Built with `GOROOT=/home/carli/projekte/go-jit/goroot GOEXPERIMENT=jit`:

- `tests/sql/compatibility/mysql-application-sql.yaml`: 44/44 passed
- `go test ./scm`: passed
- Added grouped `SQL_CALC_FOUND_ROWS` plus non-null anti-join correctness coverage
- Added a zero-row regression proving that stale `FOUND_ROWS()` state is replaced with zero
- Added an `EXPLAIN IR` guard proving selection of the anti-presence rewrite

The full SQL and JIT suites are delegated to CI as required for performance changes.