### PR TITLE
Lower recursive planner folds in the optimizer

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -922,10 +922,15 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 projection for every source; that turns read-model queries into O(N^2) planner
 work before decorrelation has even started. */
 (define query_expr_alias_set (lambda (default_alias expr aliases)
-	(reduce (tree_collect_tagged_nth_unique expr (quote get_column) 1)
-		(lambda (found tblvar)
-			(set_assoc found (resolve_column_alias tblvar default_alias) true))
-		aliases)))
+	(match expr
+		((symbol get_column) tblvar _ _ _)
+		(set_assoc aliases (resolve_column_alias tblvar default_alias) true)
+		((quote get_column) tblvar _ _ _)
+		(set_assoc aliases (resolve_column_alias tblvar default_alias) true)
+		(cons head tail) (reduce tail (lambda (found item)
+			(query_expr_alias_set default_alias item found))
+			(query_expr_alias_set default_alias head aliases))
+		_ aliases)))
 
 (define query_exprs_alias_set (lambda (default_alias exprs)
 	(reduce (coalesceNil exprs '()) (lambda (aliases expr)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3276,20 +3276,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	/* query_expr_alias_set is the planner JIT coverage target. Native compilation
 	is atomic, so a compiled descriptor means every expression in the function was
-	lowered without a whole-procedure fallback. The callback-free tree collector
-	deduplicates tagged leaves before Scheme builds the alias dictionary. */
+	lowered without a whole-procedure fallback. Its Scheme definition remains a
+	functional tree fold; the optimizer recognizes and lowers the complete shape. */
 	(set resolve_column_alias (jit resolve_column_alias))
 	(set query_expr_alias_set (jit query_expr_alias_set))
 	(assert (jit? resolve_column_alias) (jit-enabled?) "jit coverage: resolve_column_alias is 100% native")
 	(assert (jit? query_expr_alias_set) (jit-enabled?) "jit coverage: query_expr_alias_set is 100% native")
-	(assert (tree_collect_tagged_nth_unique
-		(list 'root
-			(list 'tag 'a)
-			(list 'nested (list 'tag 'b) (list 'tag 'a))
-			(list 'tag 'c (list 'tag 'payload-is-not-a-child)))
-		'tag 1)
-		(list 'a 'b 'c)
-		"tree collector preserves first-seen order, uniqueness, and tagged-leaf boundaries")
 	(assert (expr_collect_tagged_nth_unique
 		(list (list 'lambda (list 'row) (list 'tag 'operator-scope))
 			(list 'tag 'operand-scope))

--- a/scm/declare.go
+++ b/scm/declare.go
@@ -45,10 +45,14 @@ const (
 
 // Declaration describes a built-in or Scheme-defined function.
 type Declaration struct {
-	Name            string
-	Fn              func(...Scmer) Scmer
-	SpecialForm     SpecialForm
-	IsSpecialForm   bool
+	Name          string
+	Fn            func(...Scmer) Scmer
+	SpecialForm   SpecialForm
+	IsSpecialForm bool
+	// OptimizerOnly marks an implementation primitive that may be emitted by an
+	// optimizer rewrite, but is not part of the Scheme source language. It stays
+	// registered so optimized code can resolve, interpret, and JIT the call.
+	OptimizerOnly   bool
 	Type            *TypeDescriptor
 	RetainsCallArgs bool // native result or state may retain the variadic argument array
 	SyntaxKind      SyntaxKind
@@ -334,7 +338,7 @@ func DeclareTitle(title string) {
 var FreshAlloc = &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}
 
 func (d *Declaration) IsForbidden() bool {
-	return d.Type != nil && d.Type.Forbidden
+	return d.OptimizerOnly || d.Type != nil && d.Type.Forbidden
 }
 
 func (d *Declaration) IsFoldable() bool {
@@ -533,7 +537,7 @@ func WriteDocumentation(folder string) error {
 		}
 		// function name
 		def, ok := declarations[t]
-		if !ok {
+		if !ok || def.IsForbidden() {
 			// unknown entry — ignore gracefully
 			continue
 		}
@@ -758,6 +762,9 @@ func Validate(val Scmer, require string) string {
 		if len(slice) > 0 {
 			def := DeclarationForValue(slice[0])
 			if def != nil {
+				if def.OptimizerOnly {
+					panic(source_info.String() + ": optimizer-only function " + def.Name + " cannot be used in source code")
+				}
 				if len(slice)-1 < def.MinParams() {
 					panic(source_info.String() + ": function " + def.Name + " expects at least " + fmt.Sprintf("%d", def.MinParams()) + " parameters")
 				}
@@ -1062,7 +1069,7 @@ func Help(fn Scmer) string {
 		b.WriteString("\nget further information by typing (help \"functionname\") to get more info\n")
 	} else {
 		def := DeclarationForValue(fn)
-		if def != nil {
+		if def != nil && !def.IsForbidden() {
 			b.WriteString("Help for: " + def.Name + "\n===\n\n")
 			b.WriteString(def.Type.Description + "\n\n")
 			b.WriteString(fmt.Sprintf("Allowed nø of parameters: %d-%d\n\n", def.MinParams(), def.MaxParams()))

--- a/scm/declare_test.go
+++ b/scm/declare_test.go
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package scm
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -226,6 +227,76 @@ func TestDeclarationOwnsOptimizerHook(t *testing.T) {
 	}
 	if !optimized.IsInt() || optimized.Int() != 42 {
 		t.Fatalf("declaration optimizer hook returned %s, want 42", String(optimized))
+	}
+}
+
+func TestOptimizerOnlyDeclarationIsInternalToGeneratedCode(t *testing.T) {
+	oldTitles, oldDeclarations, oldFunctions := declaration_titles, declarations, declarationsByFunction
+	defer func() {
+		declaration_titles, declarations, declarationsByFunction = oldTitles, oldDeclarations, oldFunctions
+	}()
+	declaration_titles = nil
+	declarations = make(map[string]*Declaration)
+	declarationsByFunction = make(map[uintptr]*Declaration)
+
+	env := Env{Vars: make(Vars)}
+	DeclareTitle("Internal")
+	Declare(&env, &Declaration{
+		Name:          "optimizer_only_test",
+		Fn:            func(...Scmer) Scmer { return NewInt(42) },
+		OptimizerOnly: true,
+		Type: &TypeDescriptor{
+			Kind:        "func",
+			Description: "must not be user-visible",
+			Return:      &TypeDescriptor{Kind: "int"},
+		},
+	})
+
+	// Optimized output still resolves and executes the registered primitive.
+	call := NewSlice([]Scmer{NewSymbol("optimizer_only_test")})
+	if got := Eval(call, &env); !got.IsInt() || got.Int() != 42 {
+		t.Fatalf("optimizer-only generated call returned %s, want 42", String(got))
+	}
+
+	assertPanics := func(want string, fn func()) {
+		t.Helper()
+		defer func() {
+			recovered := recover()
+			if recovered == nil || !strings.Contains(fmt.Sprint(recovered), want) {
+				t.Fatalf("panic = %v, want text %q", recovered, want)
+			}
+		}()
+		fn()
+	}
+	assertPanics("optimizer-only function optimizer_only_test", func() {
+		EvalAll(t.Name(), "(optimizer_only_test)", &env)
+	})
+	if help := Help(NewNil()); strings.Contains(help, "optimizer_only_test") {
+		t.Fatalf("optimizer-only declaration appears in help index:\n%s", help)
+	}
+	assertPanics("function not found", func() {
+		Help(NewString("optimizer_only_test"))
+	})
+
+	folder := t.TempDir()
+	if err := WriteDocumentation(folder); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(folder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(folder, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(content), "optimizer_only_test") {
+			t.Fatalf("optimizer-only declaration appears in generated documentation %s", entry.Name())
+		}
 	}
 }
 

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -126,7 +126,8 @@ func groupAssocCapacity(inputLength int) int {
 
 func init_list_assoc_extra() {
 	Declare(&Globalenv, &Declaration{
-		Name: "tree_collect_tagged_nth_unique",
+		Name:          "optimizer_tree_collect_tagged_nth_unique",
+		OptimizerOnly: true,
 		Fn: func(a ...Scmer) Scmer {
 			return treeCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
 		},

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -2009,6 +2009,90 @@ func optimizerIsLambda(expr Scmer) bool {
 	return ok && len(items) >= 3 && scmerIsSymbol(items[0], "lambda")
 }
 
+// optimizeRecursiveTaggedAssocFold recognizes the complete functional tree
+// fold used by planner analyses. The source procedure remains an ordinary
+// recursive match/reduce rule; only the optimized body receives the native,
+// callback-friendly traversal. Matching the complete subtree keeps near-miss
+// procedures on their original semantics.
+func optimizeRecursiveTaggedAssocFold(name Symbol, expression Scmer) (Scmer, bool) {
+	lambda, ok := scmerSlice(expression)
+	if !ok || len(lambda) < 3 || !scmerIsSymbol(lambda[0], "lambda") {
+		return expression, false
+	}
+	params, ok := scmerSlice(lambda[1])
+	if !ok || len(params) != 3 {
+		return expression, false
+	}
+	root, rootOK := scmerSymbol(params[1])
+	accumulator, accumulatorOK := scmerSymbol(params[2])
+	body, ok := scmerSlice(lambda[2])
+	if !rootOK || !accumulatorOK || !ok || len(body) != 10 || !scmerIsSymbol(body[0], "match") || !scmerIsSymbol(body[1], string(root)) {
+		return expression, false
+	}
+
+	firstPattern, firstResultOK := scmerSlice(body[2])
+	firstResult := body[3]
+	secondPattern, secondResultOK := scmerSlice(body[4])
+	consPattern, consPatternOK := scmerSlice(body[6])
+	consResult, consResultOK := scmerSlice(body[7])
+	if !firstResultOK || !secondResultOK || !consPatternOK || !consResultOK ||
+		len(firstPattern) != 5 || len(secondPattern) != 5 || len(consPattern) != 3 || len(consResult) != 4 ||
+		!scmerIsSymbol(consPattern[0], "cons") || !scmerIsSymbol(consResult[0], "reduce") ||
+		!scmerIsSymbol(body[8], "_") || !scmerIsSymbol(body[9], string(accumulator)) {
+		return expression, false
+	}
+	firstHead, firstHeadOK := scmerSlice(firstPattern[0])
+	secondHead, secondHeadOK := scmerSlice(secondPattern[0])
+	if !firstHeadOK || !secondHeadOK || len(firstHead) != 2 || len(secondHead) != 2 ||
+		!scmerIsSymbol(firstHead[0], "symbol") || !scmerIsSymbol(secondHead[0], "quote") ||
+		!astStructuralEqual(firstHead[1], secondHead[1]) || !astStructuralEqual(firstResult, body[5]) {
+		return expression, false
+	}
+	leaf, leafOK := scmerSlice(firstResult)
+	leafValue, leafValueOK := scmerSymbol(firstPattern[1])
+	if !leafOK || !leafValueOK || len(leaf) != 4 || !scmerIsSymbol(leaf[0], "set_assoc") ||
+		!scmerIsSymbol(leaf[1], string(accumulator)) || !scmerIsSymbol(leaf[3], "true") {
+		return expression, false
+	}
+
+	head, headOK := scmerSymbol(consPattern[1])
+	tail, tailOK := scmerSymbol(consPattern[2])
+	reducer, reducerOK := scmerSlice(consResult[2])
+	initial, initialOK := scmerSlice(consResult[3])
+	if !headOK || !tailOK || !reducerOK || !initialOK || !scmerIsSymbol(consResult[1], string(tail)) ||
+		len(reducer) < 3 || !scmerIsSymbol(reducer[0], "lambda") {
+		return expression, false
+	}
+	reducerParams, reducerParamsOK := scmerSlice(reducer[1])
+	recursiveTail, recursiveTailOK := scmerSlice(reducer[2])
+	if !reducerParamsOK || len(reducerParams) != 2 || !recursiveTailOK || len(recursiveTail) != 4 || len(initial) != 4 ||
+		!scmerIsSymbol(recursiveTail[0], string(name)) || !scmerIsSymbol(initial[0], string(name)) ||
+		!astStructuralEqual(recursiveTail[1], params[0]) || !astStructuralEqual(initial[1], params[0]) ||
+		!astStructuralEqual(recursiveTail[2], reducerParams[1]) || !astStructuralEqual(recursiveTail[3], reducerParams[0]) ||
+		!scmerIsSymbol(initial[2], string(head)) || !scmerIsSymbol(initial[3], string(accumulator)) {
+		return expression, false
+	}
+
+	callback := NewSlice([]Scmer{
+		NewSymbol("lambda"),
+		NewSlice([]Scmer{NewSymbol(string(accumulator)), NewSymbol(string(leafValue))}),
+		firstResult,
+	})
+	rewritten := append([]Scmer(nil), lambda...)
+	rewritten[2] = NewSlice([]Scmer{
+		NewSymbol("reduce"),
+		NewSlice([]Scmer{
+			NewSymbol("optimizer_tree_collect_tagged_nth_unique"),
+			params[1],
+			NewSlice([]Scmer{NewSymbol("quote"), firstHead[1]}),
+			NewInt(1),
+		}),
+		callback,
+		params[2],
+	})
+	return NewSlice(rewritten), true
+}
+
 func optimizerProcSequenceForDefinition(name Symbol, expression Scmer) procSequenceKind {
 	if name != Symbol("split_and_terms") {
 		return procSequenceNone
@@ -2617,6 +2701,12 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		}
 		if v[1].IsNthLocalVar() {
 			v[0] = NewSymbol("setN")
+		}
+		if hasDefinedSym {
+			if rewritten, ok := optimizeRecursiveTaggedAssocFold(definedSym, v[2]); ok {
+				v[2] = rewritten
+				ome.rewrite.rewrites++
+			}
 		}
 		var returnType TypeInfo
 		v[2], returnType = OptimizeEx(v[2], env, ome, true)

--- a/scm/planner_fusion_optimizer_test.go
+++ b/scm/planner_fusion_optimizer_test.go
@@ -137,6 +137,64 @@ func TestOptimizeDoesNotFuseUnrecognizedSplitAndTerms(t *testing.T) {
 	}
 }
 
+const plannerTaggedAssocFoldSource = `(define planner_test_resolve_alias (lambda (value fallback)
+	(coalesceNil value fallback)))
+(define planner_test_tagged_assoc_fold (lambda (default_alias expr aliases)
+	(match expr
+		((symbol get_column) tblvar _ _ _) (set_assoc aliases (planner_test_resolve_alias tblvar default_alias) true)
+		((quote get_column) tblvar _ _ _) (set_assoc aliases (planner_test_resolve_alias tblvar default_alias) true)
+		(cons head tail) (reduce tail (lambda (found item)
+			(planner_test_tagged_assoc_fold default_alias item found))
+			(planner_test_tagged_assoc_fold default_alias head aliases))
+		_ aliases)))`
+
+func TestOptimizeRecognizesRecursiveTaggedAssocFold(t *testing.T) {
+	env := newOptimizerTestEnv()
+	definitionOffset := strings.Index(plannerTaggedAssocFoldSource, "(define planner_test_tagged_assoc_fold")
+	definition, ok := scmerSlice(Read(t.Name(), plannerTaggedAssocFoldSource[definitionOffset:]))
+	if !ok || len(definition) != 3 {
+		t.Fatal("could not parse recursive tagged assoc fold definition")
+	}
+	if _, recognized := optimizeRecursiveTaggedAssocFold(Symbol("planner_test_tagged_assoc_fold"), definition[2]); !recognized {
+		t.Fatalf("raw recursive tagged assoc fold was not recognized: %s", String(definition[2]))
+	}
+	EvalAll(t.Name(), plannerTaggedAssocFoldSource, env)
+	proc := env.Vars[Symbol("planner_test_tagged_assoc_fold")]
+	if !proc.IsProc() {
+		t.Fatal("tagged assoc fold was not defined")
+	}
+	serialized := serializedTestExpr(t, env, proc.Proc().Body)
+	if !strings.Contains(serialized, "optimizer_tree_collect_tagged_nth_unique") || strings.Contains(serialized, "(match ") {
+		t.Fatalf("recursive tagged assoc fold was not lowered after full-shape recognition: %s", serialized)
+	}
+	got := Apply(proc,
+		NewSymbol("default"),
+		NewSlice([]Scmer{
+			NewSymbol("root"),
+			NewSlice([]Scmer{NewSymbol("get_column"), NewSymbol("a"), NewNil(), NewNil(), NewNil()}),
+			NewSlice([]Scmer{NewSymbol("nested"), NewSlice([]Scmer{NewSymbol("get_column"), NewNil(), NewNil(), NewNil(), NewNil()})}),
+		}),
+		NewSlice(nil),
+	)
+	want := NewSlice([]Scmer{NewSymbol("a"), NewBool(true), NewSymbol("default"), NewBool(true)})
+	if !Equal(got, want) {
+		t.Fatalf("lowered tagged assoc fold returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeRejectsPartialTaggedAssocFoldShape(t *testing.T) {
+	env := newOptimizerTestEnv()
+	source := strings.Replace(plannerTaggedAssocFoldSource, "\t\t_ aliases)))", "\t\t_ (list))))", 1)
+	EvalAll(t.Name(), source, env)
+	proc := env.Vars[Symbol("planner_test_tagged_assoc_fold")]
+	if !proc.IsProc() {
+		t.Fatal("near-miss tagged assoc fold was not defined")
+	}
+	if serialized := serializedTestExpr(t, env, proc.Proc().Body); strings.Contains(serialized, "optimizer_tree_collect_tagged_nth_unique") {
+		t.Fatalf("partial tagged assoc fold shape was lowered: %s", serialized)
+	}
+}
+
 func plannerFusionAndTree(depth int, next *int64) Scmer {
 	if depth == 0 {
 		value := NewInt(*next)


### PR DESCRIPTION
## What

- restore `query_expr_alias_set` as the functional recursive `match`/`reduce` rule
- recognize the complete tagged-tree assoc-fold shape in `scm/optimizer.go`
- lower only an exact structural match to the stack-buffered physical tree walker
- keep that physical primitive optimizer-only: it cannot be called from Scheme source, does not appear in help, and is not documented
- leave partial or semantically different recursive folds untouched

This replaces the rejected direct planner call with an optimizer decision. It also corrects the stacked implementation that reached `master` through #825.

## Manual A/B measurement

Current `master` (`967538ea7`) versus this PR, normal Go build, fresh process and data directory per variant, identical 138-independent-subquery query from `tests/performance/traced-planner-scaling.yaml`, 5 warmups and 30 cache-busted `EXPLAIN COMPILE` samples:

| Metric (p50) | master | PR | Change |
|---|---:|---:|---:|
| HTTP wall | 572.670 ms | 568.911 ms | **-3.759 ms (-0.7%)** |
| compile total | 551.764 ms | 547.510 ms | **-4.254 ms (-0.8%)** |
| planner total | 245.113 ms | 241.511 ms | **-3.602 ms (-1.5%)** |
| untangle | 100.338 ms | 97.686 ms | **-2.652 ms (-2.6%)** |
| recipe emit | 142.384 ms | 139.412 ms | **-2.972 ms (-2.1%)** |

The parser phase was noise-positive (298.642 ms → 301.480 ms); it is outside this rewrite. Reorder was effectively neutral (2.554 ms → 2.643 ms).

## Verification

- optimizer exact-match and rejection tests
- optimizer-only source/help/documentation boundary test
- Scheme startup suite: 1280/1280
- SPARQL algebra: 21/21, including both MINUS cases
- decorrelated join reordering: 8/8
- compound ACL planning: 35/35
- Scheme lint for touched files
- normal build and `git diff --check`

The full SQL and JIT suites are left to CI as requested.