### PR TITLE
Fuse planner alias membership walks

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -897,12 +897,13 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 	(filter (coalesceNil sources '()) (lambda (src)
 		(and (not (source_outer? src)) (source_is_base_table? src))))))
 
+(define expr_referenced_aliases (lambda (default_alias expr)
+	(map (expr_collect_tagged_nth_unique expr (quote get_column) 1)
+		(lambda (tblvar) (resolve_column_alias tblvar default_alias)))))
+
 (define expr_refs_alias? (lambda (default_alias alias expr)
-	(match expr
-		((symbol get_column) tblvar _ _ _) (equal?? (resolve_column_alias tblvar default_alias) alias)
-		((quote get_column) tblvar _ _ _) (equal?? (resolve_column_alias tblvar default_alias) alias)
-		(cons _head tail) (reduce tail (lambda (found item) (or found (expr_refs_alias? default_alias alias item))) false)
-		_ false)))
+	(reduce (expr_referenced_aliases default_alias expr) (lambda (found referenced_alias)
+		(or found (equal?? referenced_alias alias))) false)))
 
 (define expr_only_refs_alias? (lambda (default_alias alias expr)
 	(match expr
@@ -912,8 +913,14 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 		_ true)))
 
 (define expr_refs_any_alias? (lambda (default_alias aliases expr)
-	(reduce (coalesceNil aliases '()) (lambda (found alias)
-		(or found (expr_refs_alias? default_alias alias expr))) false)))
+	(begin
+		/* Collect once: testing N aliases must not recursively traverse the same
+		expression N times. This predicate is used throughout logical optimization
+		and physical lowering, so keeping that complexity linear is important. */
+		(define referenced_aliases (expr_referenced_aliases default_alias expr))
+		(reduce (coalesceNil aliases '()) (lambda (found alias)
+			(or found (reduce referenced_aliases (lambda (matched referenced_alias)
+				(or matched (equal?? referenced_alias alias))) false))) false))))
 
 /* Collect bound source aliases once. Join pruning must not rescan a wide
 projection for every source; that turns read-model queries into O(N^2) planner

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4355,15 +4355,26 @@ that touch the current nullable source run in its map callback, after scan has
 either bound a real row or supplied the synthetic NULL row. */
 (define physical_partition_condition_terms (lambda (default_alias current_source future_sources terms scan_ready post_outer pending)
 	(match (coalesceNil terms '())
-		(cons term rest) (if (or
-			(expr_contains_orc_column? term)
-			(expr_refs_any_alias? default_alias (source_aliases future_sources) term))
+		(cons term rest) (if (expr_contains_orc_column? term)
 			(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready post_outer (cons term pending))
-			(if (and
-				(source_outer? current_source)
-				(expr_refs_alias? default_alias (source_alias current_source) term))
-				(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready (cons term post_outer) pending)
-				(physical_partition_condition_terms default_alias current_source future_sources rest (cons term scan_ready) post_outer pending)))
+			(begin
+				/* Classify the term from one alias walk. The former nested
+				expr_refs_any_alias? call rescanned it for every future source and
+				expr_refs_alias? scanned it again for nullable current sources. */
+				(define referenced_aliases (map
+					(expr_collect_tagged_nth_unique term (quote get_column) 1)
+					(lambda (tblvar) (resolve_column_alias tblvar default_alias))))
+				(define references_future (reduce future_sources (lambda (found src)
+					(or found (reduce referenced_aliases (lambda (matched referenced_alias)
+						(or matched (equal?? referenced_alias (source_alias src)))) false))) false))
+				(if references_future
+					(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready post_outer (cons term pending))
+					(if (and
+						(source_outer? current_source)
+						(reduce referenced_aliases (lambda (matched referenced_alias)
+							(or matched (equal?? referenced_alias (source_alias current_source)))) false))
+						(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready (cons term post_outer) pending)
+						(physical_partition_condition_terms default_alias current_source future_sources rest (cons term scan_ready) post_outer pending)))))
 		_ (list
 			(combine_where_terms (reverse scan_ready) true)
 			(combine_where_terms (reverse post_outer) true)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3290,6 +3290,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		'tag 1)
 		(list 'a 'b 'c)
 		"tree collector preserves first-seen order, uniqueness, and tagged-leaf boundaries")
+	(assert (expr_collect_tagged_nth_unique
+		(list (list 'lambda (list 'row) (list 'tag 'operator-scope))
+			(list 'tag 'operand-scope))
+		'tag 1)
+		(list 'operand-scope)
+		"expression collector excludes references embedded in operator heads")
 	(assert (query_expr_alias_set 'default (list 'get_column 'a 'x nil nil) '()) (list 'a true)
 		"jit coverage: symbol get_column match")
 	(assert (query_expr_alias_set 'default

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -17,8 +17,16 @@ Copyright (C) 2026  Carl-Philip Hänsch
 package scm
 
 func treeCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
+	return collectTaggedNthUnique(root, tag, position, true)
+}
+
+func exprCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
+	return collectTaggedNthUnique(root, tag, position, false)
+}
+
+func collectTaggedNthUnique(root, tag Scmer, position int, traverseHeads bool) Scmer {
 	if position < 0 {
-		panic("tree_collect_tagged_nth_unique expects a non-negative position")
+		panic("tagged nth collector expects a non-negative position")
 	}
 
 	// Compiler trees are normally shallow and aliases are few. Keep traversal
@@ -56,7 +64,11 @@ func treeCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
 			// data, not another expression to inspect for the same tag.
 			continue
 		}
-		for index := len(items) - 1; index >= 0; index-- {
+		firstChild := 0
+		if !traverseHeads {
+			firstChild = 1
+		}
+		for index := len(items) - 1; index >= firstChild; index-- {
 			pending = append(pending, items[index])
 		}
 	}
@@ -83,6 +95,21 @@ func init_list_assoc_extra() {
 		Type: &TypeDescriptor{Kind: "func", Description: "collects the unique zero-based nth values of tagged nodes in a nested list tree",
 			Params: []*TypeDescriptor{
 				{Kind: "any", Label: "tree", NoEscape: true},
+				{Kind: "any", Label: "tag", NoEscape: true},
+				{Kind: "number", Label: "position"},
+			},
+			Return: FreshAlloc,
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "expr_collect_tagged_nth_unique",
+		Fn: func(a ...Scmer) Scmer {
+			return exprCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "collects unique zero-based nth values of tagged operand expressions without traversing operator heads",
+			Params: []*TypeDescriptor{
+				{Kind: "any", Label: "expression", NoEscape: true},
 				{Kind: "any", Label: "tag", NoEscape: true},
 				{Kind: "number", Label: "position"},
 			},


### PR DESCRIPTION
## What

- add an operand-only tagged-node collector alongside the full-tree collector from #819
- lower `expr_refs_alias?` through that callback-free traversal
- make `expr_refs_any_alias?` collect expression aliases once instead of recursively rescanning once per candidate alias
- reuse the collected alias set while partitioning physical WHERE terms, including nullable-source placement

The two traversal semantics remain explicit: full-tree collection is used by `query_expr_alias_set`, while expression-reference predicates preserve their historical operand-only behavior. The final physical plan is byte-identical to the base branch.

## Manual A/B measurement

Measured against #819 with the same JIT compiler, production-copy fixture, and 28.8 KB ACL/search query. Each side ran in a freshly restarted process; values are medians of 50 uncached `EXPLAIN COMPILE` samples.

| Metric | #819 base | This PR | Change |
|---|---:|---:|---:|
| untangle | 49.75 ms | 47.36 ms | **-2.39 ms (-4.8%)** |
| planner through plan emission | 176.60 ms | 168.16 ms | **-8.44 ms (-4.8%)** |
| complete compilation | 272.94 ms | 264.56 ms | **-8.38 ms (-3.1%)** |

Both sides produced the same 62,153-byte executable plan with SHA-256 `3f2913bda03c069c9a9e3701e423c37f251b67b61d2350aa36c27ced8b394453`.

An additional anonymized 12-source/24-wide-predicate probe retained byte-identical plans; the earlier narrow version of this change measured 126.53 → 125.54 ms planner time and motivated moving the optimization into the generic predicates rather than leaving it as a physical-lowerer special case.

## Verification

- Scheme startup tests: 1279/1279 under JIT
- `tests/sql/dml/traced-insert-select-pagination.yaml`: 11/11
- `tests/rdf/rdf-spec11-algebra-complete.yaml`: 21/21
- `tests/planner/joins/joins-outer.yaml`: 4/4
- `tests/planner/subqueries/decorrelated-join-reordering.yaml`: 8/8
- Scheme formatter checks, `gofmt`, and `git diff --check`
- normal and JIT builds

The full SQL suite is left to CI as requested.