### PR TITLE
Optimize SQL_CALC_FOUND_ROWS with count plans

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -3305,6 +3305,14 @@ without separately proving two-valued semantics. */
 		(define keys (if (empty_list? (gs_keys stage)) '(1) (gs_keys stage)))
 		(define key_names (group_key_cols keys))
 		(define ags (gs_aggregates stage))
+		(define derived_having (if (nil? (gs_having stage))
+			nil
+			(replace_group_expr
+				(gs_input stage) input_alias alias keys key_names ags (gs_having stage))))
+		(define derived_join (rewrite_derived_ref alias projection (source_join_expr src)))
+		(define source_condition (if (nil? derived_having)
+			derived_join
+			(if (nil? derived_join) derived_having (combine_where derived_having derived_join))))
 		(define logical_extra_sources (if (query_block? (gs_input stage))
 			(map
 				(filter (cdr (qb_sources (gs_input stage))) (lambda (extra)
@@ -3317,7 +3325,7 @@ without separately proving two-valued semantics. */
 			(group_stage_schema stage)
 			(make_stage_output_relation (gs_id stage))
 			(source_outer? src)
-			(rewrite_derived_ref alias projection (source_join_expr src))))
+			source_condition))
 		(list (cons source logical_extra_sources) projection stage))))
 
 (define direct_source_order_item? (lambda (src item)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -8277,12 +8277,26 @@ every title. */
 			(cons (quote !begin) (append definitions row))))))
 
 (define lower_zero_source_query_block (lambda (block)
-	(if (equal? (coalesceNil (qb_where block) true) true)
-		(lower_zero_source_result_expr (qb_fields block))
-		(list (quote if)
-			(lower_scalar_marker_expr (qb_where block))
-			(lower_zero_source_result_expr (qb_fields block))
-			(list (quote list))))))
+	(begin
+		(define where_expr (coalesceNil (qb_where block) true))
+		(define having_expr (coalesceNil (qb_having block) true))
+		(define offset_expr (coalesceNil (qb_offset block) 0))
+		(define limit_expr (coalesceNil (qb_limit block) -1))
+		(define row_expr (lower_zero_source_result_expr (qb_fields block)))
+		(if (and (equal? where_expr true)
+			(and (equal? having_expr true)
+				(and (equal? offset_expr 0) (equal? limit_expr -1))))
+			row_expr
+			(list (quote if)
+				(list (quote and)
+					(lower_scalar_marker_expr where_expr)
+					(list (quote and)
+						(lower_scalar_marker_expr having_expr)
+						(list (quote and)
+							(list (quote equal?) offset_expr 0)
+							(list (quote not) (list (quote equal?) limit_expr 0)))))
+				row_expr
+				(list (quote list)))))))
 
 (define dml_assignment_exprs (lambda (cols)
 	(extract_assoc (coalesceNil cols '()) (lambda (_title expr) expr))))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1082,19 +1082,35 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(qassoc_get facts (quote sql_calc_found_rows) false)
 		_ false
 	)))
+	/* FOUND_ROWS counts the rows in the semantic SELECT result before its
+	ORDER/LIMIT stage. Wrapping that relation keeps DISTINCT, GROUP BY, HAVING,
+	and projection semantics intact while exposing a genuine scalar aggregate to
+	the optimizer instead of counting materialized rows in resultrow. */
+	(define sql_select_found_rows_count_query (lambda (query) (begin
+		(define schema2 (qb_schema query))
+		(if (and (empty_list? (qb_sources query))
+			(and (empty_list? (qb_group query))
+				(and (nil? (qb_having query)) (not (query_block_has_aggregates? query)))))
+			(make_query_block schema2 '()
+				(list "found_rows" (list (quote if) (coalesceNil (qb_where query) true) 1 0))
+				true nil nil nil nil nil '() '() '())
+			(make_query_block schema2
+				(list (list "__found_rows_source" schema2 (sql_select_clear_stage query) false nil))
+				(list "found_rows" (list (quote aggregate) 1 (quote +) 0))
+				true nil nil nil nil nil '() '() '())))))
 	(define sql_build_select_plan (lambda (query) (begin
 		(define expanded_query (sql_expand_views query policy))
 		(define actual_plan (build_queryplan_term expanded_query planning_session tx))
 		(define execution_plan (if (sql_select_calc_found_rows? query)
 			(begin
-				(define count_plan (build_queryplan_term
-					(sql_expand_views (sql_select_clear_stage query) policy) planning_session tx))
+				(define count_plan (build_queryplan_term (sql_select_found_rows_count_query expanded_query) planning_session tx))
 				(list (quote !begin)
-					(list (quote resultrow) nil true)
+					(list (quote session) "found_rows" 0)
 					(list
 						(list (quote lambda) (list (quote resultrow)) count_plan)
 						(list (quote lambda) (list (quote item))
-							(list (quote resultrow) (quote item) true)))
+							(list (quote session) "found_rows"
+								(list (quote get_assoc) (quote item) "found_rows"))))
 					actual_plan))
 			actual_plan))
 		(list (quote !begin)

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -793,20 +793,14 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					(extract_assoc (req "query") (lambda (k v) (session k v)))
 					(set resultrow_called false)
 					(set original_resultrow resultrow)
-					(define resultrow (lambda (row count_only) (if count_only
-						(original_resultrow row true)
-						(begin
-							(set resultrow_called true)
-							(original_resultrow row)))))
+					(define resultrow (lambda (row) (begin
+						(set resultrow_called true)
+						(original_resultrow row))))
 					(set query_result (with_autocommit session session_state query_seq query
 						(lambda (tx) (begin
 							(define formula (cached_parse sql_queryplan_cache (list parse_sql) schema query
 								(list (quote sql-policy-for) (req "username")) (req "username") session true tx))
 							(sql_execute_formula session tx formula resultrow (lambda (_fields) true))))))
-					(define counted_rows (original_resultrow))
-					(if (not (nil? counted_rows))
-						(session "found_rows" counted_rows)
-						nil)
 					/* If no resultrow was called and we got a number, return it as affected_rows */
 					(if (and (not resultrow_called) (number? query_result)) (begin
 						(original_resultrow '("affected_rows" query_result))

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -444,8 +444,6 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 	bufferedRowCount := 0
 	var rowStatus driver.RowStatus
 	var resultlock sync.Mutex
-	var countedRows uint64
-	var countedResult bool
 	emitPreparedRow := func(values []Scmer) {
 		row, err := output.BeginRow()
 		if err != nil {
@@ -510,18 +508,6 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 		callbackFn := NewFunc(func(a ...Scmer) Scmer {
 			resultlock.Lock()
 			defer resultlock.Unlock()
-			if len(a) > 1 && ToBool(a[1]) {
-				// SQL_CALC_FOUND_ROWS sends the unbounded result through the
-				// existing output callback. Counting therefore shares the output
-				// critical section and does not need its own synchronization. A
-				// nil row starts the count so an empty result still publishes zero.
-				countedResult = true
-				if !a[0].IsNil() {
-					countedRows++
-				}
-				return NewBool(true)
-			}
-
 			// function resultrow(item)
 			item := a[0].Slice()
 
@@ -575,11 +561,6 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 	}
 	if rowStatus != driver.RowComplete {
 		m.log.Warning("mysql result rows required recovery flags=%d", rowStatus)
-	}
-	if countedResult {
-		// FOUND_ROWS() belongs to the connection and is read by a later
-		// statement. Publish once after every producer has completed.
-		sessionFunc(NewString("found_rows"), NewInt(int64(countedRows)))
 	}
 	// Retrieve last_insert_id from the session (set by INSERT with AUTO_INCREMENT).
 	// TODO: replace with a dedicated callback parameter to m.querycallback so the

--- a/scm/network.go
+++ b/scm/network.go
@@ -219,8 +219,6 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		}),
 	}
 	var res_lock sync.Mutex
-	var countedRows uint64
-	var countedResult bool
 	res_scm := []Scmer{
 		NewString("res"), NewAny(res),
 		NewString("header"), NewFunc(func(a ...Scmer) Scmer {
@@ -254,26 +252,9 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			return NewString("ok")
 		}),
 		NewString("jsonl"), NewFunc(func(a ...Scmer) Scmer {
+			// print json line (only assoc)
 			res_lock.Lock()
 			defer res_lock.Unlock()
-			if len(a) == 0 {
-				if countedResult {
-					return NewInt(int64(countedRows))
-				}
-				return NewNil()
-			}
-			if len(a) > 1 && ToBool(a[1]) {
-				// Count-only rows use the same serialized response critical section.
-				// The HTTP frontend reads this value once after query completion. A
-				// nil row starts the count so an empty result replaces stale state.
-				countedResult = true
-				if !a[0].IsNil() {
-					countedRows++
-				}
-				return NewBool(true)
-			}
-
-			// print json line (only assoc)
 			io.WriteString(res, "{")
 			dict := mustSliceNet("jsonl", a[0])
 			for i, v := range dict {

--- a/tests/performance/wordpress-postmeta-order-limit.yaml
+++ b/tests/performance/wordpress-postmeta-order-limit.yaml
@@ -53,6 +53,18 @@ test_cases:
     sql: "SELECT ID, post_status, post_type FROM wordpress_perf_posts ORDER BY post_title LIMIT 5"
     expect: {rows: 5}
 
+  - name: "WordPress post pagination with total row count"
+    warmup: 10
+    timing_samples: 50
+    threshold_ms: 5
+    sql: |
+      SELECT SQL_CALC_FOUND_ROWS ID, post_title
+      FROM wordpress_perf_posts
+      WHERE post_type = 'post' AND post_status = 'publish'
+      ORDER BY ID DESC
+      LIMIT 20
+    expect: {rows: 20}
+
   - name: "WordPress filtered postmeta join ordered by newest post"
     warmup: 10
     timing_samples: 30

--- a/tests/sql/compatibility/mysql-application-sql.yaml
+++ b/tests/sql/compatibility/mysql-application-sql.yaml
@@ -104,7 +104,25 @@ test_cases:
             data:
               - total: 3
 
-  - name: "Grouped SQL_CALC_FOUND_ROWS counts a non-null anti join in the output driver"
+  - name: "SQL_CALC_FOUND_ROWS preserves the one-argument resultrow ABI"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define formula
+          (cached_parse cache (list parse_sql) "memcp-tests"
+            "SELECT SQL_CALC_FOUND_ROWS ID FROM wpcompat_posts WHERE post_type = 'post' ORDER BY ID LIMIT 2"
+            nil "root" sess true))
+        (sql_execute_formula sess nil formula (lambda (_row) true) (lambda (_fields) nil))
+        (if (equal? (sess "found_rows") 3)
+          "ok"
+          (error (concat "unexpected found_rows: " (sess "found_rows")))))
+    expect:
+      data: ["ok"]
+
+  - name: "Grouped SQL_CALC_FOUND_ROWS counts non-null anti join rows"
     mysql:
       statements:
         - sql: "SELECT SQL_CALC_FOUND_ROWS p.ID FROM wpcompat_posts p WHERE p.post_type = 'post' AND p.ID NOT IN (SELECT t.term_id FROM wpcompat_terms t WHERE t.term_id = 999) GROUP BY p.ID ORDER BY p.post_date DESC LIMIT 0, 2"
@@ -119,7 +137,65 @@ test_cases:
             data:
               - total: 3
 
-  - name: "Empty SQL_CALC_FOUND_ROWS replaces a previous count with zero"
+  - name: "SQL_CALC_FOUND_ROWS counts distinct result rows"
+    mysql:
+      statements:
+        - sql: "SELECT SQL_CALC_FOUND_ROWS DISTINCT comment_type FROM wpcompat_comments ORDER BY comment_type LIMIT 1"
+          expect:
+            rows: 1
+            data:
+              - comment_type: "comment"
+        - sql: "SELECT FOUND_ROWS() AS total"
+          expect:
+            rows: 1
+            data:
+              - total: 2
+
+  - name: "SQL_CALC_FOUND_ROWS counts grouped result rows"
+    mysql:
+      statements:
+        - sql: "SELECT SQL_CALC_FOUND_ROWS taxonomy, COUNT(*) AS taxonomy_count FROM wpcompat_term_taxonomy GROUP BY taxonomy ORDER BY taxonomy LIMIT 1"
+          expect:
+            rows: 1
+            data:
+              - taxonomy: "category"
+                taxonomy_count: 1
+        - sql: "SELECT FOUND_ROWS() AS total"
+          expect:
+            rows: 1
+            data:
+              - total: 2
+
+  - name: "SQL_CALC_FOUND_ROWS applies HAVING before counting"
+    mysql:
+      statements:
+        - sql: "SELECT SQL_CALC_FOUND_ROWS taxonomy, COUNT(*) AS taxonomy_count FROM wpcompat_term_taxonomy GROUP BY taxonomy HAVING COUNT(*) > 1 LIMIT 1"
+          expect:
+            rows: 1
+            data:
+              - taxonomy: "wp_theme"
+                taxonomy_count: 2
+        - sql: "SELECT FOUND_ROWS() AS total"
+          expect:
+            rows: 1
+            data:
+              - total: 1
+
+  - name: "Derived aggregate preserves its HAVING filter"
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM (
+        SELECT taxonomy, COUNT(*) AS taxonomy_count
+        FROM wpcompat_term_taxonomy
+        GROUP BY taxonomy
+        HAVING COUNT(*) > 1
+      ) AS filtered_taxonomies
+    expect:
+      rows: 1
+      data:
+        - total: 1
+
+  - name: "SQL_CALC_FOUND_ROWS resets an empty result to zero"
     mysql:
       statements:
         - sql: "SELECT SQL_CALC_FOUND_ROWS ID FROM wpcompat_posts WHERE ID < 0 LIMIT 1"
@@ -130,6 +206,18 @@ test_cases:
             rows: 1
             data:
               - total: 0
+
+  - name: "SQL_CALC_FOUND_ROWS counts a no-FROM row hidden by LIMIT zero"
+    mysql:
+      statements:
+        - sql: "SELECT SQL_CALC_FOUND_ROWS 1 AS value LIMIT 0"
+          expect:
+            rows: 0
+        - sql: "SELECT FOUND_ROWS() AS total"
+          expect:
+            rows: 1
+            data:
+              - total: 1
 
   - name: "Non-null NOT IN selects the anti-presence rewrite"
     sql: |

--- a/tests/sql/compatibility/mysql-application-sql.yaml
+++ b/tests/sql/compatibility/mysql-application-sql.yaml
@@ -122,7 +122,7 @@ test_cases:
     expect:
       data: ["ok"]
 
-  - name: "Grouped SQL_CALC_FOUND_ROWS counts non-null anti join rows"
+  - name: "Grouped SQL_CALC_FOUND_ROWS counts a non-null anti join in the output driver"
     mysql:
       statements:
         - sql: "SELECT SQL_CALC_FOUND_ROWS p.ID FROM wpcompat_posts p WHERE p.post_type = 'post' AND p.ID NOT IN (SELECT t.term_id FROM wpcompat_terms t WHERE t.term_id = 999) GROUP BY p.ID ORDER BY p.post_date DESC LIMIT 0, 2"
@@ -195,7 +195,7 @@ test_cases:
       data:
         - total: 1
 
-  - name: "SQL_CALC_FOUND_ROWS resets an empty result to zero"
+  - name: "Empty SQL_CALC_FOUND_ROWS replaces a previous count with zero"
     mysql:
       statements:
         - sql: "SELECT SQL_CALC_FOUND_ROWS ID FROM wpcompat_posts WHERE ID < 0 LIMIT 1"


### PR DESCRIPTION
## Summary

- compile SQL_CALC_FOUND_ROWS as a real scalar COUNT plan over the unlimited semantic result
- store the completed count in the SQL session and restore the one-argument resultrow interface in every frontend
- preserve DISTINCT, GROUP BY, HAVING, empty-result, anti-join, and source-free LIMIT semantics
- keep derived-table HAVING predicates attached when grouped relations become stage outputs

## Correctness

- targeted MySQL compatibility suite: 50/50 passed
- the new cached-plan ABI regression test fails on unmodified master at f28656fa7 with: Apply: function with 1 parameters is supplied with 2 arguments
- added coverage for the one-argument callback ABI, DISTINCT, grouped results, HAVING, empty counts, derived HAVING, and a source-free row hidden by LIMIT 0
- the full suite is intentionally delegated to CI per repository policy

## Manual performance A/B

Fixture: tests/performance/wordpress-postmeta-order-limit.yaml with 8,214 WordPress posts, identical setup and query, 10 warmup executions, 50 timing samples, and a 1.00x host calibration for both reported runs.

Query: filtered published WordPress posts with SQL_CALC_FOUND_ROWS, ORDER BY ID DESC, LIMIT 20.

- master f28656fa7: 4.5 ms
- this branch 2f3f8e2ed: 0.9 ms
- change: 3.6 ms lower latency, 80.0% faster by latency reduction, or 5.0x throughput-equivalent speedup

The count plan lets projection pruning and aggregate lowering avoid materializing every unlimited output row and removes frontend callback counting and locking from the path.