### PR TITLE
Recognize recursive planner predicates in the optimizer

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -897,10 +897,6 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 	(filter (coalesceNil sources '()) (lambda (src)
 		(and (not (source_outer? src)) (source_is_base_table? src))))))
 
-(define expr_referenced_aliases (lambda (default_alias expr)
-	(map (expr_collect_tagged_nth_unique expr (quote get_column) 1)
-		(lambda (tblvar) (resolve_column_alias tblvar default_alias)))))
-
 (define expr_refs_alias? (lambda (default_alias alias expr)
 	(match expr
 		((symbol get_column) tblvar _ _ _) (equal?? (resolve_column_alias tblvar default_alias) alias)

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -922,10 +922,15 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 projection for every source; that turns read-model queries into O(N^2) planner
 work before decorrelation has even started. */
 (define query_expr_alias_set (lambda (default_alias expr aliases)
-	(reduce (tree_collect_tagged_nth_unique expr (quote get_column) 1)
-		(lambda (found tblvar)
-			(set_assoc found (resolve_column_alias tblvar default_alias) true))
-		aliases)))
+	(match expr
+		((symbol get_column) tblvar _ _ _)
+		(set_assoc aliases (resolve_column_alias tblvar default_alias) true)
+		((quote get_column) tblvar _ _ _)
+		(set_assoc aliases (resolve_column_alias tblvar default_alias) true)
+		(cons head tail) (reduce tail (lambda (found item)
+			(query_expr_alias_set default_alias item found))
+			(query_expr_alias_set default_alias head aliases))
+		_ aliases)))
 
 (define query_exprs_alias_set (lambda (default_alias exprs)
 	(reduce (coalesceNil exprs '()) (lambda (aliases expr)

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -902,7 +902,11 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 		(lambda (tblvar) (resolve_column_alias tblvar default_alias)))))
 
 (define expr_refs_alias? (lambda (default_alias alias expr)
-	(expr_tagged_nth_equal? expr (quote get_column) 1 default_alias alias)))
+	(match expr
+		((symbol get_column) tblvar _ _ _) (equal?? (resolve_column_alias tblvar default_alias) alias)
+		((quote get_column) tblvar _ _ _) (equal?? (resolve_column_alias tblvar default_alias) alias)
+		(cons _head tail) (reduce tail (lambda (found item) (or found (expr_refs_alias? default_alias alias item))) false)
+		_ false)))
 
 (define expr_only_refs_alias? (lambda (default_alias alias expr)
 	(match expr
@@ -912,11 +916,8 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 		_ true)))
 
 (define expr_refs_any_alias? (lambda (default_alias aliases expr)
-	/* Testing references must not allocate an intermediate alias list or walk the
-	same expression once per candidate alias. The native predicate short-circuits
-	on the first match and keeps its traversal stack local. */
-	(expr_tagged_nth_matches_any? expr (quote get_column) 1 default_alias
-		(coalesceNil aliases '()))))
+	(reduce (coalesceNil aliases '()) (lambda (found alias)
+		(or found (expr_refs_alias? default_alias alias expr))) false)))
 
 /* Collect bound source aliases once. Join pruning must not rescan a wide
 projection for every source; that turns read-model queries into O(N^2) planner

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2286,27 +2286,6 @@ probe. */
 						(lower_scalar_cardinality_scan_lookup_choice
 							stage lookup_kind lookup_expr scan_expr))))))))
 
-(define collect_join_probe_lookup_columns_acc (lambda (sources default_alias target_alias stage columns_by_alias)
-	(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
-		(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)))
-
-(define collect_join_scalar_aggregate_columns_acc (lambda (sources default_alias target_alias stage columns_by_alias)
-	(reduce (scalar_aggregate_probe_outer_exprs stage) (lambda (acc expr)
-		(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)))
-
-(define collect_join_get_column_acc (lambda (sources default_alias target_alias tblvar tbl_ignorecase col col_ignorecase columns_by_alias)
-	(begin
-		(define src (if (nil? tblvar)
-			(source_for_unqualified_column sources default_alias col col_ignorecase)
-			(source_for_alias sources default_alias tblvar tbl_ignorecase)))
-		(if (or (nil? src) (and (not (nil? target_alias)) (not (equal?? (source_alias src) target_alias))))
-			columns_by_alias
-			(begin
-				(define alias (source_alias src))
-				(define physical_col (resolve_physical_column_name src col col_ignorecase))
-				(qassoc_set columns_by_alias alias
-					(merge_unique (list (qassoc_get columns_by_alias alias '()) (list physical_col)))))))))
-
 (define collect_join_columns_acc (lambda (sources default_alias target_alias expr columns_by_alias)
 	(match expr
 		((symbol driver_membership_probe) _stage probe)
@@ -2322,25 +2301,39 @@ probe. */
 		((quote dml_driver_membership_probe) _fallback_schema _stage probe)
 		(collect_join_columns_acc sources default_alias target_alias probe columns_by_alias)
 		((symbol scalar_first_probe) stage _requested_col)
-		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
+			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
 		((symbol scalar_first_probe) stage _requested_col _stages)
-		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
-		((quote scalar_first_probe) stage _requested_col)
-		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
-		((quote scalar_first_probe) stage _requested_col _stages)
-		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
+			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
+		((quote scalar_first_probe) stage requested_col)
+		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_first_probe) stage requested_col) columns_by_alias)
+		((quote scalar_first_probe) stage requested_col _stages)
+		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_first_probe) stage requested_col) columns_by_alias)
 		((symbol scalar_aggregate_probe) stage _requested_col)
-		(collect_join_scalar_aggregate_columns_acc sources default_alias target_alias stage columns_by_alias)
-		((quote scalar_aggregate_probe) stage _requested_col)
-		(collect_join_scalar_aggregate_columns_acc sources default_alias target_alias stage columns_by_alias)
+		(reduce (scalar_aggregate_probe_outer_exprs stage) (lambda (acc expr)
+			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
+		((quote scalar_aggregate_probe) stage requested_col)
+		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_aggregate_probe) stage requested_col) columns_by_alias)
 		((symbol scalar_cardinality_probe) stage _requested_col)
-		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
-		((quote scalar_cardinality_probe) stage _requested_col)
-		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
-		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase)
-		(collect_join_get_column_acc sources default_alias target_alias tblvar tbl_ignorecase col col_ignorecase columns_by_alias)
+		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
+			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
+		((quote scalar_cardinality_probe) stage requested_col)
+		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_cardinality_probe) stage requested_col) columns_by_alias)
+		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (begin
+			(define src (if (nil? tblvar)
+				(source_for_unqualified_column sources default_alias col col_ignorecase)
+				(source_for_alias sources default_alias tblvar tbl_ignorecase)))
+			(if (or (nil? src) (and (not (nil? target_alias)) (not (equal?? (source_alias src) target_alias))))
+				columns_by_alias
+				(begin
+					(define alias (source_alias src))
+					(define physical_col (resolve_physical_column_name src col col_ignorecase))
+					(qassoc_set columns_by_alias alias
+						(merge_unique (list (qassoc_get columns_by_alias alias '()) (list physical_col)))))))
 		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
-		(collect_join_get_column_acc sources default_alias target_alias tblvar tbl_ignorecase col col_ignorecase columns_by_alias)
+		(collect_join_columns_acc sources default_alias target_alias
+			(list (symbol "get_column") tblvar tbl_ignorecase col col_ignorecase) columns_by_alias)
 		(cons _head tail) (reduce tail (lambda (acc item)
 			(collect_join_columns_acc sources default_alias target_alias item acc)) columns_by_alias)
 		_ columns_by_alias)))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2286,6 +2286,27 @@ probe. */
 						(lower_scalar_cardinality_scan_lookup_choice
 							stage lookup_kind lookup_expr scan_expr))))))))
 
+(define collect_join_probe_lookup_columns_acc (lambda (sources default_alias target_alias stage columns_by_alias)
+	(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
+		(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)))
+
+(define collect_join_scalar_aggregate_columns_acc (lambda (sources default_alias target_alias stage columns_by_alias)
+	(reduce (scalar_aggregate_probe_outer_exprs stage) (lambda (acc expr)
+		(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)))
+
+(define collect_join_get_column_acc (lambda (sources default_alias target_alias tblvar tbl_ignorecase col col_ignorecase columns_by_alias)
+	(begin
+		(define src (if (nil? tblvar)
+			(source_for_unqualified_column sources default_alias col col_ignorecase)
+			(source_for_alias sources default_alias tblvar tbl_ignorecase)))
+		(if (or (nil? src) (and (not (nil? target_alias)) (not (equal?? (source_alias src) target_alias))))
+			columns_by_alias
+			(begin
+				(define alias (source_alias src))
+				(define physical_col (resolve_physical_column_name src col col_ignorecase))
+				(qassoc_set columns_by_alias alias
+					(merge_unique (list (qassoc_get columns_by_alias alias '()) (list physical_col)))))))))
+
 (define collect_join_columns_acc (lambda (sources default_alias target_alias expr columns_by_alias)
 	(match expr
 		((symbol driver_membership_probe) _stage probe)
@@ -2301,39 +2322,25 @@ probe. */
 		((quote dml_driver_membership_probe) _fallback_schema _stage probe)
 		(collect_join_columns_acc sources default_alias target_alias probe columns_by_alias)
 		((symbol scalar_first_probe) stage _requested_col)
-		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
-			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
 		((symbol scalar_first_probe) stage _requested_col _stages)
-		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
-			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
-		((quote scalar_first_probe) stage requested_col)
-		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_first_probe) stage requested_col) columns_by_alias)
-		((quote scalar_first_probe) stage requested_col _stages)
-		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_first_probe) stage requested_col) columns_by_alias)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((quote scalar_first_probe) stage _requested_col)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((quote scalar_first_probe) stage _requested_col _stages)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
 		((symbol scalar_aggregate_probe) stage _requested_col)
-		(reduce (scalar_aggregate_probe_outer_exprs stage) (lambda (acc expr)
-			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
-		((quote scalar_aggregate_probe) stage requested_col)
-		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_aggregate_probe) stage requested_col) columns_by_alias)
+		(collect_join_scalar_aggregate_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((quote scalar_aggregate_probe) stage _requested_col)
+		(collect_join_scalar_aggregate_columns_acc sources default_alias target_alias stage columns_by_alias)
 		((symbol scalar_cardinality_probe) stage _requested_col)
-		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
-			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
-		((quote scalar_cardinality_probe) stage requested_col)
-		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_cardinality_probe) stage requested_col) columns_by_alias)
-		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (begin
-			(define src (if (nil? tblvar)
-				(source_for_unqualified_column sources default_alias col col_ignorecase)
-				(source_for_alias sources default_alias tblvar tbl_ignorecase)))
-			(if (or (nil? src) (and (not (nil? target_alias)) (not (equal?? (source_alias src) target_alias))))
-				columns_by_alias
-				(begin
-					(define alias (source_alias src))
-					(define physical_col (resolve_physical_column_name src col col_ignorecase))
-					(qassoc_set columns_by_alias alias
-						(merge_unique (list (qassoc_get columns_by_alias alias '()) (list physical_col)))))))
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((quote scalar_cardinality_probe) stage _requested_col)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase)
+		(collect_join_get_column_acc sources default_alias target_alias tblvar tbl_ignorecase col col_ignorecase columns_by_alias)
 		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
-		(collect_join_columns_acc sources default_alias target_alias
-			(list (symbol "get_column") tblvar tbl_ignorecase col col_ignorecase) columns_by_alias)
+		(collect_join_get_column_acc sources default_alias target_alias tblvar tbl_ignorecase col col_ignorecase columns_by_alias)
 		(cons _head tail) (reduce tail (lambda (acc item)
 			(collect_join_columns_acc sources default_alias target_alias item acc)) columns_by_alias)
 		_ columns_by_alias)))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4355,26 +4355,15 @@ that touch the current nullable source run in its map callback, after scan has
 either bound a real row or supplied the synthetic NULL row. */
 (define physical_partition_condition_terms (lambda (default_alias current_source future_sources terms scan_ready post_outer pending)
 	(match (coalesceNil terms '())
-		(cons term rest) (if (expr_contains_orc_column? term)
+		(cons term rest) (if (or
+			(expr_contains_orc_column? term)
+			(expr_refs_any_alias? default_alias (source_aliases future_sources) term))
 			(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready post_outer (cons term pending))
-			(begin
-				/* Classify the term from one alias walk. The former nested
-				expr_refs_any_alias? call rescanned it for every future source and
-				expr_refs_alias? scanned it again for nullable current sources. */
-				(define referenced_aliases (map
-					(expr_collect_tagged_nth_unique term (quote get_column) 1)
-					(lambda (tblvar) (resolve_column_alias tblvar default_alias))))
-				(define references_future (reduce future_sources (lambda (found src)
-					(or found (reduce referenced_aliases (lambda (matched referenced_alias)
-						(or matched (equal?? referenced_alias (source_alias src)))) false))) false))
-				(if references_future
-					(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready post_outer (cons term pending))
-					(if (and
-						(source_outer? current_source)
-						(reduce referenced_aliases (lambda (matched referenced_alias)
-							(or matched (equal?? referenced_alias (source_alias current_source)))) false))
-						(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready (cons term post_outer) pending)
-						(physical_partition_condition_terms default_alias current_source future_sources rest (cons term scan_ready) post_outer pending)))))
+			(if (and
+				(source_outer? current_source)
+				(expr_refs_alias? default_alias (source_alias current_source) term))
+				(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready (cons term post_outer) pending)
+				(physical_partition_condition_terms default_alias current_source future_sources rest (cons term scan_ready) post_outer pending)))
 		_ (list
 			(combine_where_terms (reverse scan_ready) true)
 			(combine_where_terms (reverse post_outer) true)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3276,20 +3276,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	/* query_expr_alias_set is the planner JIT coverage target. Native compilation
 	is atomic, so a compiled descriptor means every expression in the function was
-	lowered without a whole-procedure fallback. The callback-free tree collector
-	deduplicates tagged leaves before Scheme builds the alias dictionary. */
+	lowered without a whole-procedure fallback. Its Scheme definition remains a
+	functional tree fold; the optimizer recognizes and lowers the complete shape. */
 	(set resolve_column_alias (jit resolve_column_alias))
 	(set query_expr_alias_set (jit query_expr_alias_set))
 	(assert (jit? resolve_column_alias) (jit-enabled?) "jit coverage: resolve_column_alias is 100% native")
 	(assert (jit? query_expr_alias_set) (jit-enabled?) "jit coverage: query_expr_alias_set is 100% native")
-	(assert (tree_collect_tagged_nth_unique
-		(list 'root
-			(list 'tag 'a)
-			(list 'nested (list 'tag 'b) (list 'tag 'a))
-			(list 'tag 'c (list 'tag 'payload-is-not-a-child)))
-		'tag 1)
-		(list 'a 'b 'c)
-		"tree collector preserves first-seen order, uniqueness, and tagged-leaf boundaries")
 	(assert (expr_collect_tagged_nth_unique
 		(list (list 'lambda (list 'row) (list 'tag 'operator-scope))
 			(list 'tag 'operand-scope))

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3282,26 +3282,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(set query_expr_alias_set (jit query_expr_alias_set))
 	(assert (jit? resolve_column_alias) (jit-enabled?) "jit coverage: resolve_column_alias is 100% native")
 	(assert (jit? query_expr_alias_set) (jit-enabled?) "jit coverage: query_expr_alias_set is 100% native")
-	(assert (expr_collect_tagged_nth_unique
-		(list (list 'lambda (list 'row) (list 'tag 'operator-scope))
-			(list 'tag 'operand-scope))
-		'tag 1)
-		(list 'operand-scope)
-		"expression collector excludes references embedded in operator heads")
-	(assert (expr_tagged_nth_equal?
-		(list '+ (list 'tag nil) (list 'tag 'later)) 'tag 1 'default 'default)
-		true
-		"tagged expression equality applies the default and short-circuits")
-	(assert (expr_tagged_nth_matches_any?
-		(list (list 'lambda '() (list 'tag 'operator-scope))
-			(list 'nested (list 'tag 'operand-scope)))
-		'tag 1 'default (list 'missing 'operand-scope))
-		true
-		"tagged expression membership searches operands without entering the operator")
-	(assert (expr_tagged_nth_matches_any?
-		(list 'root (list 'tag 'present)) 'tag 1 'default (list 'absent))
-		false
-		"tagged expression membership reports a missing value")
 	(assert (query_expr_alias_set 'default (list 'get_column 'a 'x nil nil) '()) (list 'a true)
 		"jit coverage: symbol get_column match")
 	(assert (query_expr_alias_set 'default

--- a/scm/declare.go
+++ b/scm/declare.go
@@ -45,10 +45,14 @@ const (
 
 // Declaration describes a built-in or Scheme-defined function.
 type Declaration struct {
-	Name            string
-	Fn              func(...Scmer) Scmer
-	SpecialForm     SpecialForm
-	IsSpecialForm   bool
+	Name          string
+	Fn            func(...Scmer) Scmer
+	SpecialForm   SpecialForm
+	IsSpecialForm bool
+	// OptimizerOnly marks an implementation primitive that may be emitted by an
+	// optimizer rewrite, but is not part of the Scheme source language. It stays
+	// registered so optimized code can resolve, interpret, and JIT the call.
+	OptimizerOnly   bool
 	Type            *TypeDescriptor
 	RetainsCallArgs bool // native result or state may retain the variadic argument array
 	SyntaxKind      SyntaxKind
@@ -334,7 +338,7 @@ func DeclareTitle(title string) {
 var FreshAlloc = &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}
 
 func (d *Declaration) IsForbidden() bool {
-	return d.Type != nil && d.Type.Forbidden
+	return d.OptimizerOnly || d.Type != nil && d.Type.Forbidden
 }
 
 func (d *Declaration) IsFoldable() bool {
@@ -533,7 +537,7 @@ func WriteDocumentation(folder string) error {
 		}
 		// function name
 		def, ok := declarations[t]
-		if !ok {
+		if !ok || def.IsForbidden() {
 			// unknown entry — ignore gracefully
 			continue
 		}
@@ -758,6 +762,9 @@ func Validate(val Scmer, require string) string {
 		if len(slice) > 0 {
 			def := DeclarationForValue(slice[0])
 			if def != nil {
+				if def.OptimizerOnly {
+					panic(source_info.String() + ": optimizer-only function " + def.Name + " cannot be used in source code")
+				}
 				if len(slice)-1 < def.MinParams() {
 					panic(source_info.String() + ": function " + def.Name + " expects at least " + fmt.Sprintf("%d", def.MinParams()) + " parameters")
 				}
@@ -1062,7 +1069,7 @@ func Help(fn Scmer) string {
 		b.WriteString("\nget further information by typing (help \"functionname\") to get more info\n")
 	} else {
 		def := DeclarationForValue(fn)
-		if def != nil {
+		if def != nil && !def.IsForbidden() {
 			b.WriteString("Help for: " + def.Name + "\n===\n\n")
 			b.WriteString(def.Type.Description + "\n\n")
 			b.WriteString(fmt.Sprintf("Allowed nø of parameters: %d-%d\n\n", def.MinParams(), def.MaxParams()))

--- a/scm/declare_test.go
+++ b/scm/declare_test.go
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package scm
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -226,6 +227,76 @@ func TestDeclarationOwnsOptimizerHook(t *testing.T) {
 	}
 	if !optimized.IsInt() || optimized.Int() != 42 {
 		t.Fatalf("declaration optimizer hook returned %s, want 42", String(optimized))
+	}
+}
+
+func TestOptimizerOnlyDeclarationIsInternalToGeneratedCode(t *testing.T) {
+	oldTitles, oldDeclarations, oldFunctions := declaration_titles, declarations, declarationsByFunction
+	defer func() {
+		declaration_titles, declarations, declarationsByFunction = oldTitles, oldDeclarations, oldFunctions
+	}()
+	declaration_titles = nil
+	declarations = make(map[string]*Declaration)
+	declarationsByFunction = make(map[uintptr]*Declaration)
+
+	env := Env{Vars: make(Vars)}
+	DeclareTitle("Internal")
+	Declare(&env, &Declaration{
+		Name:          "optimizer_only_test",
+		Fn:            func(...Scmer) Scmer { return NewInt(42) },
+		OptimizerOnly: true,
+		Type: &TypeDescriptor{
+			Kind:        "func",
+			Description: "must not be user-visible",
+			Return:      &TypeDescriptor{Kind: "int"},
+		},
+	})
+
+	// Optimized output still resolves and executes the registered primitive.
+	call := NewSlice([]Scmer{NewSymbol("optimizer_only_test")})
+	if got := Eval(call, &env); !got.IsInt() || got.Int() != 42 {
+		t.Fatalf("optimizer-only generated call returned %s, want 42", String(got))
+	}
+
+	assertPanics := func(want string, fn func()) {
+		t.Helper()
+		defer func() {
+			recovered := recover()
+			if recovered == nil || !strings.Contains(fmt.Sprint(recovered), want) {
+				t.Fatalf("panic = %v, want text %q", recovered, want)
+			}
+		}()
+		fn()
+	}
+	assertPanics("optimizer-only function optimizer_only_test", func() {
+		EvalAll(t.Name(), "(optimizer_only_test)", &env)
+	})
+	if help := Help(NewNil()); strings.Contains(help, "optimizer_only_test") {
+		t.Fatalf("optimizer-only declaration appears in help index:\n%s", help)
+	}
+	assertPanics("function not found", func() {
+		Help(NewString("optimizer_only_test"))
+	})
+
+	folder := t.TempDir()
+	if err := WriteDocumentation(folder); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(folder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(folder, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(content), "optimizer_only_test") {
+			t.Fatalf("optimizer-only declaration appears in generated documentation %s", entry.Name())
+		}
 	}
 }
 

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -126,7 +126,8 @@ func groupAssocCapacity(inputLength int) int {
 
 func init_list_assoc_extra() {
 	Declare(&Globalenv, &Declaration{
-		Name: "tree_collect_tagged_nth_unique",
+		Name:          "optimizer_tree_collect_tagged_nth_unique",
+		OptimizerOnly: true,
 		Fn: func(a ...Scmer) Scmer {
 			return treeCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
 		},

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -20,10 +20,6 @@ func treeCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
 	return collectTaggedNthUnique(root, tag, position, true)
 }
 
-func exprCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
-	return collectTaggedNthUnique(root, tag, position, false)
-}
-
 func collectTaggedNthUnique(root, tag Scmer, position int, traverseHeads bool) Scmer {
 	if position < 0 {
 		panic("tagged nth collector expects a non-negative position")
@@ -142,41 +138,10 @@ func init_list_assoc_extra() {
 		},
 	})
 	Declare(&Globalenv, &Declaration{
-		Name: "expr_collect_tagged_nth_unique",
+		Name:          "optimizer_expr_tagged_nth_matches_any",
+		OptimizerOnly: true,
 		Fn: func(a ...Scmer) Scmer {
-			return exprCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
-		},
-		Type: &TypeDescriptor{Kind: "func", Description: "collects unique zero-based nth values of tagged operand expressions without traversing operator heads",
-			Params: []*TypeDescriptor{
-				{Kind: "any", Label: "expression", NoEscape: true},
-				{Kind: "any", Label: "tag", NoEscape: true},
-				{Kind: "number", Label: "position"},
-			},
-			Return: FreshAlloc,
-			Const:  true,
-		},
-	})
-	Declare(&Globalenv, &Declaration{
-		Name: "expr_tagged_nth_equal?",
-		Fn: func(a ...Scmer) Scmer {
-			return NewBool(exprTaggedNthMatchesAny(a[0], a[1], int(ToInt(a[2])), a[3], a[4:5]))
-		},
-		Type: &TypeDescriptor{Kind: "func", Description: "tests whether a tagged operand has the expected nth value, replacing nil with a supplied default",
-			Params: []*TypeDescriptor{
-				{Kind: "any", Label: "expression", NoEscape: true},
-				{Kind: "any", Label: "tag", NoEscape: true},
-				{Kind: "number", Label: "position"},
-				{Kind: "any", Label: "nil replacement", NoEscape: true},
-				{Kind: "any", Label: "expected", NoEscape: true},
-			},
-			Return: &TypeDescriptor{Kind: "bool"},
-			Const:  true,
-		},
-	})
-	Declare(&Globalenv, &Declaration{
-		Name: "expr_tagged_nth_matches_any?",
-		Fn: func(a ...Scmer) Scmer {
-			return NewBool(exprTaggedNthMatchesAny(a[0], a[1], int(ToInt(a[2])), a[3], asSlice(a[4], "expr_tagged_nth_matches_any?")))
+			return NewBool(exprTaggedNthMatchesAny(a[0], a[1], int(ToInt(a[2])), a[3], asSlice(a[4], "optimizer_expr_tagged_nth_matches_any")))
 		},
 		Type: &TypeDescriptor{Kind: "func", Description: "tests whether a tagged operand has any expected nth value, replacing nil with a supplied default",
 			Params: []*TypeDescriptor{

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -2096,6 +2096,170 @@ func optimizeRecursiveTaggedAssocFold(name Symbol, expression Scmer) (Scmer, boo
 	return NewSlice(rewritten), true
 }
 
+// optimizeRecursiveTaggedPredicate recognizes a complete operand-only tree
+// search. It deliberately requires both literal-pattern spellings, the
+// short-circuiting reducer, and the false fallback before replacing the
+// functional recursion with the physical matcher.
+func optimizeRecursiveTaggedPredicate(name Symbol, expression Scmer) (Scmer, bool) {
+	lambda, ok := scmerSlice(expression)
+	if !ok || len(lambda) < 3 || !scmerIsSymbol(lambda[0], "lambda") {
+		return expression, false
+	}
+	params, ok := scmerSlice(lambda[1])
+	body, bodyOK := scmerSlice(lambda[2])
+	if !ok || len(params) != 3 || !bodyOK || len(body) != 10 || !scmerIsSymbol(body[0], "match") ||
+		!astStructuralEqual(body[1], params[2]) || !scmerIsSymbol(body[8], "_") || !scmerIsSymbol(body[9], "false") {
+		return expression, false
+	}
+	firstPattern, firstPatternOK := scmerSlice(body[2])
+	secondPattern, secondPatternOK := scmerSlice(body[4])
+	firstHead, firstHeadOK := func() ([]Scmer, bool) {
+		if !firstPatternOK || len(firstPattern) != 5 {
+			return nil, false
+		}
+		return scmerSlice(firstPattern[0])
+	}()
+	secondHead, secondHeadOK := func() ([]Scmer, bool) {
+		if !secondPatternOK || len(secondPattern) != 5 {
+			return nil, false
+		}
+		return scmerSlice(secondPattern[0])
+	}()
+	if !firstHeadOK || !secondHeadOK || len(firstHead) != 2 || len(secondHead) != 2 ||
+		!scmerIsSymbol(firstHead[0], "symbol") || !scmerIsSymbol(secondHead[0], "quote") ||
+		!astStructuralEqual(firstHead[1], secondHead[1]) || !astStructuralEqual(body[3], body[5]) {
+		return expression, false
+	}
+	leafValue, leafValueOK := scmerSymbol(firstPattern[1])
+	comparison, comparisonOK := scmerSlice(body[3])
+	resolved, resolvedOK := func() ([]Scmer, bool) {
+		if !comparisonOK || len(comparison) != 3 || !scmerIsSymbol(comparison[0], "equal??") || !astStructuralEqual(comparison[2], params[1]) {
+			return nil, false
+		}
+		return scmerSlice(comparison[1])
+	}()
+	if !leafValueOK || !resolvedOK || len(resolved) != 3 ||
+		!scmerIsSymbol(resolved[1], string(leafValue)) || !astStructuralEqual(resolved[2], params[0]) {
+		return expression, false
+	}
+
+	consPattern, consPatternOK := scmerSlice(body[6])
+	reduce, reduceOK := scmerSlice(body[7])
+	if !consPatternOK || !reduceOK || len(consPattern) != 3 || len(reduce) != 4 ||
+		!scmerIsSymbol(consPattern[0], "cons") || !scmerIsSymbol(reduce[0], "reduce") ||
+		!astStructuralEqual(reduce[1], consPattern[2]) || !scmerIsSymbol(reduce[3], "false") {
+		return expression, false
+	}
+	reducer, reducerOK := scmerSlice(reduce[2])
+	if !reducerOK || len(reducer) < 3 || !scmerIsSymbol(reducer[0], "lambda") {
+		return expression, false
+	}
+	reducerParams, reducerParamsOK := scmerSlice(reducer[1])
+	reducerBody, reducerBodyOK := scmerSlice(reducer[2])
+	if !reducerParamsOK || len(reducerParams) != 2 || !reducerBodyOK || len(reducerBody) != 3 ||
+		!scmerIsSymbol(reducerBody[0], "or") || !astStructuralEqual(reducerBody[1], reducerParams[0]) {
+		return expression, false
+	}
+	recursive, recursiveOK := scmerSlice(reducerBody[2])
+	if !recursiveOK || len(recursive) != 4 || !scmerIsSymbol(recursive[0], string(name)) ||
+		!astStructuralEqual(recursive[1], params[0]) || !astStructuralEqual(recursive[2], params[1]) ||
+		!astStructuralEqual(recursive[3], reducerParams[1]) {
+		return expression, false
+	}
+
+	rewritten := append([]Scmer(nil), lambda...)
+	rewritten[2] = NewSlice([]Scmer{
+		NewSymbol("optimizer_expr_tagged_nth_matches_any"),
+		params[2],
+		NewSlice([]Scmer{NewSymbol("quote"), firstHead[1]}),
+		NewInt(1),
+		params[0],
+		NewSlice([]Scmer{NewSymbol("list"), params[1]}),
+	})
+	return NewSlice(rewritten), true
+}
+
+func optimizedTaggedPredicateSpec(value Scmer) (rootSlot, nilSlot, candidateSlot NthLocalVar, tag Scmer, position int, ok bool) {
+	if !value.IsProc() {
+		return 0, 0, 0, NewNil(), 0, false
+	}
+	body, bodyOK := scmerSlice(value.Proc().Body)
+	if !bodyOK || len(body) != 6 || !scmerIsSymbol(body[0], "optimizer_expr_tagged_nth_matches_any") ||
+		!body[1].IsNthLocalVar() || !body[4].IsNthLocalVar() {
+		return 0, 0, 0, NewNil(), 0, false
+	}
+	positionValue := body[3]
+	if stripped, strippedOK := scmerStripSourceInfo(positionValue); strippedOK {
+		positionValue = stripped
+	}
+	candidates, candidatesOK := scmerSlice(body[5])
+	if !positionValue.IsInt() || !candidatesOK {
+		return 0, 0, 0, NewNil(), 0, false
+	}
+	var candidate Scmer
+	switch {
+	case len(candidates) == 2 && scmerIsSymbol(candidates[0], "list"):
+		candidate = candidates[1]
+	case len(candidates) == 4 && scmerIsSymbol(candidates[0], "!list") && candidates[2].IsInt() && candidates[2].Int() == 1:
+		candidate = candidates[3]
+	default:
+		return 0, 0, 0, NewNil(), 0, false
+	}
+	if !candidate.IsNthLocalVar() {
+		return 0, 0, 0, NewNil(), 0, false
+	}
+	return body[1].NthLocalVar(), body[4].NthLocalVar(), candidate.NthLocalVar(), body[2], int(positionValue.Int()), true
+}
+
+// optimizeTaggedPredicateSet recognizes a reduction which ORs calls to an
+// already-recognized tagged predicate. It consolidates N tree walks into one
+// native walk over the candidate set.
+func optimizeTaggedPredicateSet(expression Scmer, env *Env) (Scmer, bool) {
+	lambda, ok := scmerSlice(expression)
+	if !ok || len(lambda) < 3 || !scmerIsSymbol(lambda[0], "lambda") {
+		return expression, false
+	}
+	params, paramsOK := scmerSlice(lambda[1])
+	reduce, reduceOK := scmerSlice(lambda[2])
+	if !paramsOK || len(params) != 3 || !reduceOK || len(reduce) != 4 || !scmerIsSymbol(reduce[0], "reduce") || !scmerIsSymbol(reduce[3], "false") {
+		return expression, false
+	}
+	input, inputOK := scmerSlice(reduce[1])
+	reducer, reducerOK := scmerSlice(reduce[2])
+	if !inputOK || len(input) != 3 || !scmerIsSymbol(input[0], "coalesceNil") || !astStructuralEqual(input[1], params[1]) ||
+		!reducerOK || len(reducer) < 3 || !scmerIsSymbol(reducer[0], "lambda") {
+		return expression, false
+	}
+	reducerParams, reducerParamsOK := scmerSlice(reducer[1])
+	reducerBody, reducerBodyOK := scmerSlice(reducer[2])
+	if !reducerParamsOK || len(reducerParams) != 2 || !reducerBodyOK || len(reducerBody) != 3 ||
+		!scmerIsSymbol(reducerBody[0], "or") || !astStructuralEqual(reducerBody[1], reducerParams[0]) {
+		return expression, false
+	}
+	call, callOK := scmerSlice(reducerBody[2])
+	if !callOK || len(call) != 4 {
+		return expression, false
+	}
+	callee, calleeOK := scmerSymbol(call[0])
+	owner := env.FindRead(callee)
+	if !calleeOK || owner == nil {
+		return expression, false
+	}
+	rootSlot, nilSlot, candidateSlot, tag, position, specOK := optimizedTaggedPredicateSpec(owner.Vars[callee])
+	if !specOK || int(rootSlot) >= len(call)-1 || int(nilSlot) >= len(call)-1 || int(candidateSlot) >= len(call)-1 ||
+		!astStructuralEqual(call[1+int(rootSlot)], params[2]) || !astStructuralEqual(call[1+int(nilSlot)], params[0]) ||
+		!astStructuralEqual(call[1+int(candidateSlot)], reducerParams[1]) {
+		return expression, false
+	}
+
+	rewritten := append([]Scmer(nil), lambda...)
+	rewritten[2] = NewSlice([]Scmer{
+		NewSymbol("optimizer_expr_tagged_nth_matches_any"),
+		params[2], tag, NewInt(int64(position)), params[0], reduce[1],
+	})
+	return NewSlice(rewritten), true
+}
+
 func optimizerProcSequenceForDefinition(name Symbol, expression Scmer) procSequenceKind {
 	if name != Symbol("split_and_terms") {
 		return procSequenceNone
@@ -2706,6 +2870,14 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			v[0] = NewSymbol("setN")
 		}
 		if hasDefinedSym {
+			if rewritten, ok := optimizeRecursiveTaggedPredicate(definedSym, v[2]); ok {
+				v[2] = rewritten
+				ome.rewrite.rewrites++
+			}
+			if rewritten, ok := optimizeTaggedPredicateSet(v[2], env); ok {
+				v[2] = rewritten
+				ome.rewrite.rewrites++
+			}
 			if rewritten, ok := optimizeRecursiveTaggedAssocFold(definedSym, v[2]); ok {
 				v[2] = rewritten
 				ome.rewrite.rewrites++

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -2009,6 +2009,90 @@ func optimizerIsLambda(expr Scmer) bool {
 	return ok && len(items) >= 3 && scmerIsSymbol(items[0], "lambda")
 }
 
+// optimizeRecursiveTaggedAssocFold recognizes the complete functional tree
+// fold used by planner analyses. The source procedure remains an ordinary
+// recursive match/reduce rule; only the optimized body receives the native,
+// callback-friendly traversal. Matching the complete subtree keeps near-miss
+// procedures on their original semantics.
+func optimizeRecursiveTaggedAssocFold(name Symbol, expression Scmer) (Scmer, bool) {
+	lambda, ok := scmerSlice(expression)
+	if !ok || len(lambda) < 3 || !scmerIsSymbol(lambda[0], "lambda") {
+		return expression, false
+	}
+	params, ok := scmerSlice(lambda[1])
+	if !ok || len(params) != 3 {
+		return expression, false
+	}
+	root, rootOK := scmerSymbol(params[1])
+	accumulator, accumulatorOK := scmerSymbol(params[2])
+	body, ok := scmerSlice(lambda[2])
+	if !rootOK || !accumulatorOK || !ok || len(body) != 10 || !scmerIsSymbol(body[0], "match") || !scmerIsSymbol(body[1], string(root)) {
+		return expression, false
+	}
+
+	firstPattern, firstResultOK := scmerSlice(body[2])
+	firstResult := body[3]
+	secondPattern, secondResultOK := scmerSlice(body[4])
+	consPattern, consPatternOK := scmerSlice(body[6])
+	consResult, consResultOK := scmerSlice(body[7])
+	if !firstResultOK || !secondResultOK || !consPatternOK || !consResultOK ||
+		len(firstPattern) != 5 || len(secondPattern) != 5 || len(consPattern) != 3 || len(consResult) != 4 ||
+		!scmerIsSymbol(consPattern[0], "cons") || !scmerIsSymbol(consResult[0], "reduce") ||
+		!scmerIsSymbol(body[8], "_") || !scmerIsSymbol(body[9], string(accumulator)) {
+		return expression, false
+	}
+	firstHead, firstHeadOK := scmerSlice(firstPattern[0])
+	secondHead, secondHeadOK := scmerSlice(secondPattern[0])
+	if !firstHeadOK || !secondHeadOK || len(firstHead) != 2 || len(secondHead) != 2 ||
+		!scmerIsSymbol(firstHead[0], "symbol") || !scmerIsSymbol(secondHead[0], "quote") ||
+		!astStructuralEqual(firstHead[1], secondHead[1]) || !astStructuralEqual(firstResult, body[5]) {
+		return expression, false
+	}
+	leaf, leafOK := scmerSlice(firstResult)
+	leafValue, leafValueOK := scmerSymbol(firstPattern[1])
+	if !leafOK || !leafValueOK || len(leaf) != 4 || !scmerIsSymbol(leaf[0], "set_assoc") ||
+		!scmerIsSymbol(leaf[1], string(accumulator)) || !scmerIsSymbol(leaf[3], "true") {
+		return expression, false
+	}
+
+	head, headOK := scmerSymbol(consPattern[1])
+	tail, tailOK := scmerSymbol(consPattern[2])
+	reducer, reducerOK := scmerSlice(consResult[2])
+	initial, initialOK := scmerSlice(consResult[3])
+	if !headOK || !tailOK || !reducerOK || !initialOK || !scmerIsSymbol(consResult[1], string(tail)) ||
+		len(reducer) < 3 || !scmerIsSymbol(reducer[0], "lambda") {
+		return expression, false
+	}
+	reducerParams, reducerParamsOK := scmerSlice(reducer[1])
+	recursiveTail, recursiveTailOK := scmerSlice(reducer[2])
+	if !reducerParamsOK || len(reducerParams) != 2 || !recursiveTailOK || len(recursiveTail) != 4 || len(initial) != 4 ||
+		!scmerIsSymbol(recursiveTail[0], string(name)) || !scmerIsSymbol(initial[0], string(name)) ||
+		!astStructuralEqual(recursiveTail[1], params[0]) || !astStructuralEqual(initial[1], params[0]) ||
+		!astStructuralEqual(recursiveTail[2], reducerParams[1]) || !astStructuralEqual(recursiveTail[3], reducerParams[0]) ||
+		!scmerIsSymbol(initial[2], string(head)) || !scmerIsSymbol(initial[3], string(accumulator)) {
+		return expression, false
+	}
+
+	callback := NewSlice([]Scmer{
+		NewSymbol("lambda"),
+		NewSlice([]Scmer{NewSymbol(string(accumulator)), NewSymbol(string(leafValue))}),
+		firstResult,
+	})
+	rewritten := append([]Scmer(nil), lambda...)
+	rewritten[2] = NewSlice([]Scmer{
+		NewSymbol("reduce"),
+		NewSlice([]Scmer{
+			NewSymbol("optimizer_tree_collect_tagged_nth_unique"),
+			params[1],
+			NewSlice([]Scmer{NewSymbol("quote"), firstHead[1]}),
+			NewInt(1),
+		}),
+		callback,
+		params[2],
+	})
+	return NewSlice(rewritten), true
+}
+
 func optimizerProcSequenceForDefinition(name Symbol, expression Scmer) procSequenceKind {
 	if name != Symbol("split_and_terms") {
 		return procSequenceNone
@@ -2617,6 +2701,12 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		}
 		if v[1].IsNthLocalVar() {
 			v[0] = NewSymbol("setN")
+		}
+		if hasDefinedSym {
+			if rewritten, ok := optimizeRecursiveTaggedAssocFold(definedSym, v[2]); ok {
+				v[2] = rewritten
+				ome.rewrite.rewrites++
+			}
 		}
 		var returnType TypeInfo
 		v[2], returnType = OptimizeEx(v[2], env, ome, true)

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -360,6 +360,7 @@ type optimizerMetainfo struct {
 	beginDepth                int             // >0 in lexical begin scopes; their definitions do not reach the caller Env
 	inlineDepth               int
 	inlineStack               map[Symbol]bool
+	definitionStack           map[Symbol]bool
 	specializationStack       map[procSpecializationStackKey]bool
 	specializationParamMask   uint64
 	specializationDepth       int
@@ -795,6 +796,7 @@ func (ome *optimizerMetainfo) Copy() (result optimizerMetainfo) {
 	result.beginDepth = ome.beginDepth
 	result.inlineDepth = ome.inlineDepth
 	result.inlineStack = ome.inlineStack
+	result.definitionStack = ome.definitionStack
 	result.specializationStack = ome.specializationStack
 	result.specializationParamMask = ome.specializationParamMask
 	result.specializationDepth = ome.specializationDepth
@@ -829,6 +831,7 @@ func (ome *optimizerMetainfo) CopySharedScope() (result optimizerMetainfo) {
 	result.beginDepth = ome.beginDepth
 	result.inlineDepth = ome.inlineDepth
 	result.inlineStack = ome.inlineStack
+	result.definitionStack = ome.definitionStack
 	result.specializationStack = ome.specializationStack
 	result.specializationParamMask = ome.specializationParamMask
 	result.specializationDepth = ome.specializationDepth
@@ -995,7 +998,7 @@ func tryInlineLeafProc(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bo
 		return NewNil(), tiZero, false
 	}
 	callee, ok := scmerSymbol(v[0])
-	if !ok || (ome.inlineStack != nil && ome.inlineStack[callee]) {
+	if !ok || (ome.inlineStack != nil && ome.inlineStack[callee]) || (ome.definitionStack != nil && ome.definitionStack[callee]) {
 		return NewNil(), tiZero, false
 	}
 	owner := env.FindRead(callee)
@@ -1514,7 +1517,7 @@ func trySpecializeProcCall(v []Scmer, argTypes []TypeInfo, env *Env, ome *optimi
 		return NewNil(), false
 	}
 	callee, ok := scmerSymbol(v[0])
-	if !ok {
+	if !ok || (ome.definitionStack != nil && ome.definitionStack[callee]) {
 		return NewNil(), false
 	}
 	owner := env.FindRead(callee)
@@ -2709,7 +2712,21 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 		}
 		var returnType TypeInfo
-		v[2], returnType = OptimizeEx(v[2], env, ome, true)
+		if hasDefinedSym && optimizerIsLambda(v[2]) {
+			if ome.definitionStack == nil {
+				ome.definitionStack = make(map[Symbol]bool)
+			}
+			wasDefining := ome.definitionStack[definedSym]
+			ome.definitionStack[definedSym] = true
+			v[2], returnType = OptimizeEx(v[2], env, ome, true)
+			if wasDefining {
+				ome.definitionStack[definedSym] = true
+			} else {
+				delete(ome.definitionStack, definedSym)
+			}
+		} else {
+			v[2], returnType = OptimizeEx(v[2], env, ome, true)
+		}
 		transferOwnership = returnType.Transfer()
 		if v[1].IsNthLocalVar() {
 			localType := returnType.ToTypeDescriptor()

--- a/scm/planner_fusion_optimizer_test.go
+++ b/scm/planner_fusion_optimizer_test.go
@@ -195,6 +195,60 @@ func TestOptimizeRejectsPartialTaggedAssocFoldShape(t *testing.T) {
 	}
 }
 
+const plannerTaggedPredicateSource = `(define planner_test_predicate_resolve (lambda (value fallback)
+	(coalesceNil value fallback)))
+(define planner_test_tagged_predicate (lambda (default_alias alias expr)
+	(match expr
+		((symbol get_column) tblvar _ _ _) (equal?? (planner_test_predicate_resolve tblvar default_alias) alias)
+		((quote get_column) tblvar _ _ _) (equal?? (planner_test_predicate_resolve tblvar default_alias) alias)
+		(cons _head tail) (reduce tail (lambda (found item)
+			(or found (planner_test_tagged_predicate default_alias alias item))) false)
+		_ false)))
+(define planner_test_tagged_predicate_set (lambda (default_alias aliases expr)
+	(reduce (coalesceNil aliases '()) (lambda (found alias)
+		(or found (planner_test_tagged_predicate default_alias alias expr))) false)))`
+
+func TestOptimizeRecognizesTaggedPredicateAndCandidateSet(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll(t.Name(), plannerTaggedPredicateSource, env)
+	predicate := env.Vars[Symbol("planner_test_tagged_predicate")]
+	setPredicate := env.Vars[Symbol("planner_test_tagged_predicate_set")]
+	if !predicate.IsProc() || !setPredicate.IsProc() {
+		t.Fatal("tagged predicates were not defined")
+	}
+	for name, proc := range map[string]Scmer{"single": predicate, "set": setPredicate} {
+		serialized := serializedTestExpr(t, env, proc.Proc().Body)
+		if !strings.Contains(serialized, "optimizer_expr_tagged_nth_matches_any") || strings.Contains(serialized, "(reduce ") || strings.Contains(serialized, "(match ") {
+			t.Fatalf("%s tagged predicate was not fused after full-shape recognition: %s", name, serialized)
+		}
+	}
+	tree := NewSlice([]Scmer{
+		NewSlice([]Scmer{
+			NewSlice([]Scmer{NewSymbol("lambda"), NewSlice(nil), NewSlice([]Scmer{NewSymbol("get_column"), NewSymbol("operator"), NewNil(), NewNil(), NewNil()})}),
+		}),
+		NewSlice([]Scmer{NewSymbol("nested"), NewSlice([]Scmer{NewSymbol("get_column"), NewSymbol("operand"), NewNil(), NewNil(), NewNil()})}),
+	})
+	if got := Apply(predicate, NewSymbol("default"), NewSymbol("operator"), tree); !got.IsBool() || got.Bool() {
+		t.Fatalf("tagged predicate entered an operator head: %s", String(got))
+	}
+	if got := Apply(setPredicate, NewSymbol("default"), NewSlice([]Scmer{NewSymbol("missing"), NewSymbol("operand")}), tree); !got.IsBool() || !got.Bool() {
+		t.Fatalf("tagged candidate-set predicate missed an operand: %s", String(got))
+	}
+}
+
+func TestOptimizeRejectsPartialTaggedPredicateShape(t *testing.T) {
+	env := newOptimizerTestEnv()
+	source := strings.Replace(plannerTaggedPredicateSource, "\t\t_ false)))", "\t\t_ true)))", 1)
+	EvalAll(t.Name(), source, env)
+	predicate := env.Vars[Symbol("planner_test_tagged_predicate")]
+	if !predicate.IsProc() {
+		t.Fatal("near-miss tagged predicate was not defined")
+	}
+	if serialized := serializedTestExpr(t, env, predicate.Proc().Body); strings.Contains(serialized, "optimizer_expr_tagged_nth_matches_any") {
+		t.Fatalf("partial tagged predicate shape was fused: %s", serialized)
+	}
+}
+
 func plannerFusionAndTree(depth int, next *int64) Scmer {
 	if depth == 0 {
 		value := NewInt(*next)

--- a/scm/planner_fusion_optimizer_test.go
+++ b/scm/planner_fusion_optimizer_test.go
@@ -137,6 +137,64 @@ func TestOptimizeDoesNotFuseUnrecognizedSplitAndTerms(t *testing.T) {
 	}
 }
 
+const plannerTaggedAssocFoldSource = `(define planner_test_resolve_alias (lambda (value fallback)
+	(coalesceNil value fallback)))
+(define planner_test_tagged_assoc_fold (lambda (default_alias expr aliases)
+	(match expr
+		((symbol get_column) tblvar _ _ _) (set_assoc aliases (planner_test_resolve_alias tblvar default_alias) true)
+		((quote get_column) tblvar _ _ _) (set_assoc aliases (planner_test_resolve_alias tblvar default_alias) true)
+		(cons head tail) (reduce tail (lambda (found item)
+			(planner_test_tagged_assoc_fold default_alias item found))
+			(planner_test_tagged_assoc_fold default_alias head aliases))
+		_ aliases)))`
+
+func TestOptimizeRecognizesRecursiveTaggedAssocFold(t *testing.T) {
+	env := newOptimizerTestEnv()
+	definitionOffset := strings.Index(plannerTaggedAssocFoldSource, "(define planner_test_tagged_assoc_fold")
+	definition, ok := scmerSlice(Read(t.Name(), plannerTaggedAssocFoldSource[definitionOffset:]))
+	if !ok || len(definition) != 3 {
+		t.Fatal("could not parse recursive tagged assoc fold definition")
+	}
+	if _, recognized := optimizeRecursiveTaggedAssocFold(Symbol("planner_test_tagged_assoc_fold"), definition[2]); !recognized {
+		t.Fatalf("raw recursive tagged assoc fold was not recognized: %s", String(definition[2]))
+	}
+	EvalAll(t.Name(), plannerTaggedAssocFoldSource, env)
+	proc := env.Vars[Symbol("planner_test_tagged_assoc_fold")]
+	if !proc.IsProc() {
+		t.Fatal("tagged assoc fold was not defined")
+	}
+	serialized := serializedTestExpr(t, env, proc.Proc().Body)
+	if !strings.Contains(serialized, "optimizer_tree_collect_tagged_nth_unique") || strings.Contains(serialized, "(match ") {
+		t.Fatalf("recursive tagged assoc fold was not lowered after full-shape recognition: %s", serialized)
+	}
+	got := Apply(proc,
+		NewSymbol("default"),
+		NewSlice([]Scmer{
+			NewSymbol("root"),
+			NewSlice([]Scmer{NewSymbol("get_column"), NewSymbol("a"), NewNil(), NewNil(), NewNil()}),
+			NewSlice([]Scmer{NewSymbol("nested"), NewSlice([]Scmer{NewSymbol("get_column"), NewNil(), NewNil(), NewNil(), NewNil()})}),
+		}),
+		NewSlice(nil),
+	)
+	want := NewSlice([]Scmer{NewSymbol("a"), NewBool(true), NewSymbol("default"), NewBool(true)})
+	if !Equal(got, want) {
+		t.Fatalf("lowered tagged assoc fold returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeRejectsPartialTaggedAssocFoldShape(t *testing.T) {
+	env := newOptimizerTestEnv()
+	source := strings.Replace(plannerTaggedAssocFoldSource, "\t\t_ aliases)))", "\t\t_ (list))))", 1)
+	EvalAll(t.Name(), source, env)
+	proc := env.Vars[Symbol("planner_test_tagged_assoc_fold")]
+	if !proc.IsProc() {
+		t.Fatal("near-miss tagged assoc fold was not defined")
+	}
+	if serialized := serializedTestExpr(t, env, proc.Proc().Body); strings.Contains(serialized, "optimizer_tree_collect_tagged_nth_unique") {
+		t.Fatalf("partial tagged assoc fold shape was lowered: %s", serialized)
+	}
+}
+
 func plannerFusionAndTree(depth int, next *int64) Scmer {
 	if depth == 0 {
 		value := NewInt(*next)

--- a/scm/recursive_optimizer_experiment_test.go
+++ b/scm/recursive_optimizer_experiment_test.go
@@ -16,7 +16,10 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const recursiveSpecializationBenchmarkSource = `(define benchmark_recursive_collect (lambda (expr acc)
 	(match expr
@@ -38,6 +41,38 @@ func BenchmarkOptimizeRecursiveOwnershipVariants(b *testing.B) {
 		if !env.Vars[Symbol("benchmark_recursive_collect_entry")].IsProc() {
 			b.Fatal("recursive benchmark Proc was not defined")
 		}
+	}
+}
+
+func TestRecursiveDefinitionDoesNotInlinePreviousBinding(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll(t.Name(), recursiveSpecializationBenchmarkSource, env)
+	// Imported modules can be evaluated again in the same global environment.
+	// The old recursive Proc must not be inlined while its replacement definition
+	// is optimized: doing so grows the body once per recursive ownership shape.
+	EvalAll(t.Name(), recursiveSpecializationBenchmarkSource, env)
+
+	collector := env.Vars[Symbol("benchmark_recursive_collect")]
+	if !collector.IsProc() {
+		t.Fatal("recursive collector was not defined")
+	}
+	serialized := serializedTestExpr(t, env, collector.Proc().Body)
+	if calls := strings.Count(serialized, "benchmark_recursive_collect"); calls > 8 {
+		t.Fatalf("recursive definition expanded its previous binding into %d calls (%d bytes)", calls, len(serialized))
+	}
+	if len(serialized) > 8<<10 {
+		t.Fatalf("recursive definition grew to %d bytes, want at most 8192", len(serialized))
+	}
+
+	entry := env.Vars[Symbol("benchmark_recursive_collect_entry")]
+	got := Apply(entry, NewSlice([]Scmer{
+		NewSymbol("root"),
+		NewSlice([]Scmer{NewSymbol("value"), NewInt(1)}),
+		NewSlice([]Scmer{NewSymbol("value"), NewInt(2)}),
+	}))
+	want := NewSlice([]Scmer{NewInt(1), NewInt(2)})
+	if !Equal(got, want) {
+		t.Fatalf("recursive collector returned %s, want %s", String(got), String(want))
 	}
 }
 


### PR DESCRIPTION
## What

- restore alias-reference checks as ordinary functional Scheme recursion
- recognize the complete recursive `match` / short-circuiting `reduce` shape in `scm/optimizer.go`
- lower an exact match to one internal operand-tree predicate; structurally different functions remain untouched
- recognize the outer candidate reduction and consolidate repeated tree walks into one candidate-set walk
- remove the public planner-specific collector and predicate builtins introduced by the rejected stack
- prevent a recursive redefinition from inlining or specializing the previous same-named procedure
- keep internal physical primitives optimizer-only and unavailable to imported Scheme, help, and generated documentation

This directly addresses the review feedback: Scheme expresses the functional rule, while the optimizer detects and lowers the complete shape. Planner source no longer calls optimizer-only fused functions manually.

## Manual A/B measurement

Compared with stacked prerequisite #819 (`0b4f76726`), normal Go builds, fresh process and data directory per variant, the identical 138-dependent-subquery case from `tests/performance/traced-planner-scaling.yaml`, 5 warmups and 30 cache-busted `EXPLAIN COMPILE` samples:

| Metric (p50) | #819 | #823 | Change |
|---|---:|---:|---:|
| HTTP wall | 567.716 ms | 567.638 ms | -0.078 ms (-0.01%) |
| compile total | 547.134 ms | 547.344 ms | +0.210 ms (+0.04%) |
| planner total | 243.630 ms | 243.968 ms | +0.338 ms (+0.14%) |
| physical prepare | 2.020 ms | 1.999 ms | -0.022 ms (-1.08%) |
| recipe emit | 142.233 ms | 142.172 ms | -0.061 ms (-0.04%) |

The result is neutral within measurement noise. An intermediate implementation that materialized alias lists measured +1.7% HTTP and +3.3% planner; that experiment was removed before this push.

## Verification

- exact-match and near-miss optimizer unit tests
- candidate-set consolidation semantics, including excluding operator heads
- recursive-redefinition growth and result tests
- SPARQL graph algebra: 8/8
- complete SPARQL 1.1 algebra: 21/21, including cold and warm MINUS
- nested ACL callable cache: 7/7
- decorrelated join reordering: 8/8
- planner scaling: 8/8
- Scheme lint, Go formatting, normal build, and `git diff --check`

The full SQL and JIT suites are left to CI as requested.