### PR TITLE
Fuse profitable JIT map-reduce buffer loops

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -717,6 +717,42 @@ type JITStorageGetValueRangeFunc func(uint32, uint32, []Scmer, int)
 // JITStorageGetValueMultiFunc is the native arbitrary-record column-reader ABI.
 type JITStorageGetValueMultiFunc func([]uint32, []Scmer, int)
 
+// JITMapReduceBufferFunc folds rows from a row-major Scmer buffer. The row
+// width and callback are compile-time properties of the function; rows remains
+// explicit so zero-column reducers such as COUNT(*) need no synthetic values.
+type JITMapReduceBufferFunc func(Scmer, []Scmer, int) Scmer
+
+// PrepareJITMapReduceBufferProc returns source suitable for typed buffer-loop
+// inlining. Native declarations with a JIT emitter are wrapped in a procedure
+// so physical operators can specialize the same implementation without
+// teaching the storage package about individual aggregate names.
+func PrepareJITMapReduceBufferProc(source Scmer, arity int) *Proc {
+	if arity < 1 {
+		return nil
+	}
+	if source.GetTag() == tagProc && source.Proc() != nil {
+		return source.Proc()
+	}
+	if source.GetTag() == tagFunc {
+		if proc := JITProcForFunction(source.Func()); proc != nil {
+			return proc
+		}
+	}
+	declaration := DeclarationForValue(source)
+	if declaration == nil || declaration.Type == nil || declaration.Type.JITEmit == nil || len(declaration.Type.Params) != arity {
+		return nil
+	}
+	params := make([]Scmer, arity)
+	body := make([]Scmer, arity+1)
+	body[0] = source
+	for index := range params {
+		parameter := NewSymbol(fmt.Sprintf("\x00buffer-reduce-%d", index))
+		params[index] = parameter
+		body[index+1] = parameter
+	}
+	return &Proc{Params: NewSlice(params), Body: NewSlice(body), En: &Globalenv}
+}
+
 // JITStorageGetValueEmitter emits one scalar storage read. The bound method
 // receiver is the concrete finished storage; index and result use the typed Go ABI.
 type JITStorageGetValueEmitter func(*JITContext, JITValueDesc, JITValueDesc) JITValueDesc

--- a/scm/jit_calibration.go
+++ b/scm/jit_calibration.go
@@ -39,18 +39,21 @@ const (
 // immutable after startup publication; query compilation can therefore read it
 // without locks or hot-path calibration branches.
 type JITCostCalibration struct {
-	Enabled         bool
-	ShapeCount      int
-	SamplesPerShape int
-	CalibrationNS   int64
-	EmitFixedNS     float64
-	EmitUnitNS      float64
-	PublishFixedNS  float64
-	DirectCallNS    float64
-	PredicateUnitNS float64
-	BufferCompileNS float64
-	BufferSavedNS   float64
-	BufferMaxUnits  int
+	Enabled             bool
+	ShapeCount          int
+	SamplesPerShape     int
+	CalibrationNS       int64
+	EmitFixedNS         float64
+	EmitUnitNS          float64
+	PublishFixedNS      float64
+	DirectCallNS        float64
+	PredicateUnitNS     float64
+	BufferCompileNS     float64
+	BufferCompileUnitNS float64
+	BufferCurrentNS     float64
+	BufferFusedNS       float64
+	BufferSavedNS       float64
+	BufferMaxUnits      int
 }
 
 // EstimateCompileNS estimates one query-local emission and publication. The
@@ -90,10 +93,7 @@ func (calibration JITCostCalibration) BreakEvenCandidates(expressionCost, predic
 
 // MapReduceBufferBreakEven returns the number of rows needed to amortize one
 // typed buffer-loop compilation. The startup probe measures the same simple
-// accumulator shape admitted by this criterion. Reducers with more than one
-// physical column or more expensive callbacks keep the already compiled
-// callback loop; measurements show that inlining those shapes does not recover
-// its larger loop overhead.
+// accumulator shape admitted by this fast criterion.
 func (calibration JITCostCalibration) MapReduceBufferBreakEven(expressionCost, columnCount int) int {
 	if !calibration.Enabled || columnCount < 0 || columnCount > 1 || expressionCost > calibration.BufferMaxUnits || calibration.BufferSavedNS <= 0 {
 		return math.MaxInt
@@ -101,6 +101,26 @@ func (calibration JITCostCalibration) MapReduceBufferBreakEven(expressionCost, c
 	// Require twice the measured break-even before switching. This absorbs timer
 	// noise and keeps short scans on the allocation-free existing callback loop.
 	return int(math.Ceil(2 * calibration.BufferCompileNS / calibration.BufferSavedNS))
+}
+
+// MapReduceBufferProbeBreakEven bounds the one-time cost of compiling and
+// comparing an uncalibrated reducer shape to one percent of the whole scan.
+// Unlike MapReduceBufferBreakEven, this admits arbitrary callback arity and
+// expression complexity: the actual reducer decides its own best path on its
+// first representative buffer.
+func (calibration JITCostCalibration) MapReduceBufferProbeBreakEven(expressionCost, columnCount, probeRows int) int {
+	if !calibration.Enabled || expressionCost < 0 || columnCount < 0 || calibration.BufferCurrentNS <= 0 {
+		return math.MaxInt
+	}
+	compileNS := calibration.BufferCompileNS
+	if expressionCost > calibration.BufferMaxUnits {
+		if calibration.BufferCompileUnitNS <= 0 {
+			return math.MaxInt
+		}
+		compileNS += float64(expressionCost-calibration.BufferMaxUnits) * calibration.BufferCompileUnitNS
+	}
+	probeNS := float64(probeRows) * (calibration.BufferCurrentNS + calibration.BufferFusedNS)
+	return int(math.Ceil(100 * (compileNS + probeNS) / calibration.BufferCurrentNS))
 }
 
 type jitCalibrationShape struct {
@@ -135,7 +155,9 @@ func CalibrateJITCosts() JITCostCalibration {
 				return measureJITCalibrationShapes()
 			}()
 			calibration = summarizeJITCalibration(observations)
-			calibration.BufferCompileNS, calibration.BufferSavedNS, calibration.BufferMaxUnits = measureMapReduceBufferCalibration()
+			calibration.BufferCompileNS, calibration.BufferCurrentNS, calibration.BufferFusedNS, calibration.BufferMaxUnits = measureMapReduceBufferCalibration()
+			calibration.BufferCompileUnitNS = measureMapReduceBufferCompileUnit(calibration.BufferCompileNS, calibration.BufferMaxUnits)
+			calibration.BufferSavedNS = math.Max(0, calibration.BufferCurrentNS-calibration.BufferFusedNS)
 		}
 		calibration.CalibrationNS = time.Since(started).Nanoseconds()
 		jitCalibrationData.Store(&calibration)
@@ -143,12 +165,12 @@ func CalibrateJITCosts() JITCostCalibration {
 	return CurrentJITCosts()
 }
 
-func measureMapReduceBufferCalibration() (compileNS, savedNS float64, expressionUnits int) {
+func measureMapReduceBufferCalibration() (compileNS, currentNS, fusedNS float64, expressionUnits int) {
 	template := calibrationProcedure(`(lambda (acc value) (sql_sum_reduce acc value))`)
 	compiled := CompileJIT(NewProcStruct(*cloneCalibrationProcedure(template)), true)
 	proc := compiled.Proc()
 	if proc == nil || proc.Compiled == nil {
-		return 0, 0, 0
+		return 0, 0, 0, 0
 	}
 	expressionUnits = JITExpressionCost(proc.Body)
 	compileSamples := make([]float64, jitCalibrationSamples)
@@ -159,7 +181,7 @@ func measureMapReduceBufferCalibration() (compileNS, savedNS float64, expression
 		compileSamples[sample] = float64(time.Since(started).Nanoseconds())
 	}
 	if fused == nil {
-		return 0, 0, 0
+		return 0, 0, 0, 0
 	}
 	values := make([]Scmer, 16*1024)
 	for index := range values {
@@ -184,10 +206,35 @@ func measureMapReduceBufferCalibration() (compileNS, savedNS float64, expression
 		jitCalibrationSink = acc
 	}
 	compileNS = medianFloat64(compileSamples)
-	savedNS = math.Max(0, medianFloat64(currentSamples)-medianFloat64(fusedSamples))
+	currentNS = medianFloat64(currentSamples)
+	fusedNS = medianFloat64(fusedSamples)
 	runtime.KeepAlive(compiled)
 	runtime.KeepAlive(fused)
-	return compileNS, savedNS, expressionUnits
+	return compileNS, currentNS, fusedNS, expressionUnits
+}
+
+func measureMapReduceBufferCompileUnit(simpleNS float64, simpleUnits int) float64 {
+	template := calibrationProcedure("(lambda (acc a b c) (+ acc (+ a (* b c))))")
+	compiled := CompileJIT(NewProcStruct(*cloneCalibrationProcedure(template)), true)
+	proc := compiled.Proc()
+	if proc == nil || proc.Compiled == nil {
+		return 0
+	}
+	units := JITExpressionCost(proc.Body)
+	if units <= simpleUnits {
+		return 0
+	}
+	samples := make([]float64, jitCalibrationSamples)
+	for sample := range samples {
+		started := time.Now()
+		kernel := CompileJITMapReduceBuffer(proc, []uint8{tagInt, tagInt, tagInt})
+		samples[sample] = float64(time.Since(started).Nanoseconds())
+		if kernel == nil {
+			return 0
+		}
+		runtime.KeepAlive(kernel)
+	}
+	return math.Max(0, (medianFloat64(samples)-simpleNS)/float64(units-simpleUnits))
 }
 
 // CurrentJITCosts returns a value copy so callers cannot mutate the globally

--- a/scm/jit_calibration.go
+++ b/scm/jit_calibration.go
@@ -48,6 +48,9 @@ type JITCostCalibration struct {
 	PublishFixedNS  float64
 	DirectCallNS    float64
 	PredicateUnitNS float64
+	BufferCompileNS float64
+	BufferSavedNS   float64
+	BufferMaxUnits  int
 }
 
 // EstimateCompileNS estimates one query-local emission and publication. The
@@ -85,6 +88,21 @@ func (calibration JITCostCalibration) BreakEvenCandidates(expressionCost, predic
 	return int(math.Ceil(calibration.EstimateCompileNS(expressionCost) / (saved * float64(expectedExecutions))))
 }
 
+// MapReduceBufferBreakEven returns the number of rows needed to amortize one
+// typed buffer-loop compilation. The startup probe measures the same simple
+// accumulator shape admitted by this criterion. Reducers with more than one
+// physical column or more expensive callbacks keep the already compiled
+// callback loop; measurements show that inlining those shapes does not recover
+// its larger loop overhead.
+func (calibration JITCostCalibration) MapReduceBufferBreakEven(expressionCost, columnCount int) int {
+	if !calibration.Enabled || columnCount < 0 || columnCount > 1 || expressionCost > calibration.BufferMaxUnits || calibration.BufferSavedNS <= 0 {
+		return math.MaxInt
+	}
+	// Require twice the measured break-even before switching. This absorbs timer
+	// noise and keeps short scans on the allocation-free existing callback loop.
+	return int(math.Ceil(2 * calibration.BufferCompileNS / calibration.BufferSavedNS))
+}
+
 type jitCalibrationShape struct {
 	source  string
 	argSets [][]Scmer
@@ -117,11 +135,59 @@ func CalibrateJITCosts() JITCostCalibration {
 				return measureJITCalibrationShapes()
 			}()
 			calibration = summarizeJITCalibration(observations)
+			calibration.BufferCompileNS, calibration.BufferSavedNS, calibration.BufferMaxUnits = measureMapReduceBufferCalibration()
 		}
 		calibration.CalibrationNS = time.Since(started).Nanoseconds()
 		jitCalibrationData.Store(&calibration)
 	})
 	return CurrentJITCosts()
+}
+
+func measureMapReduceBufferCalibration() (compileNS, savedNS float64, expressionUnits int) {
+	template := calibrationProcedure(`(lambda (acc value) (sql_sum_reduce acc value))`)
+	compiled := CompileJIT(NewProcStruct(*cloneCalibrationProcedure(template)), true)
+	proc := compiled.Proc()
+	if proc == nil || proc.Compiled == nil {
+		return 0, 0, 0
+	}
+	expressionUnits = JITExpressionCost(proc.Body)
+	compileSamples := make([]float64, jitCalibrationSamples)
+	var fused JITMapReduceBufferFunc
+	for sample := range compileSamples {
+		started := time.Now()
+		fused = CompileJITMapReduceBuffer(proc, []uint8{tagInt})
+		compileSamples[sample] = float64(time.Since(started).Nanoseconds())
+	}
+	if fused == nil {
+		return 0, 0, 0
+	}
+	values := make([]Scmer, 16*1024)
+	for index := range values {
+		values[index] = NewInt(int64(index & 255))
+	}
+	currentSamples := make([]float64, jitCalibrationSamples)
+	fusedSamples := make([]float64, jitCalibrationSamples)
+	args := []Scmer{NewInt(0), NewInt(0)}
+	for sample := range currentSamples {
+		started := time.Now()
+		acc := NewInt(0)
+		for _, value := range values {
+			args[0], args[1] = acc, value
+			acc = proc.Compiled.Native(args...)
+		}
+		currentSamples[sample] = float64(time.Since(started).Nanoseconds()) / float64(len(values))
+		jitCalibrationSink = acc
+
+		started = time.Now()
+		acc = fused(NewInt(0), values, len(values))
+		fusedSamples[sample] = float64(time.Since(started).Nanoseconds()) / float64(len(values))
+		jitCalibrationSink = acc
+	}
+	compileNS = medianFloat64(compileSamples)
+	savedNS = math.Max(0, medianFloat64(currentSamples)-medianFloat64(fusedSamples))
+	runtime.KeepAlive(compiled)
+	runtime.KeepAlive(fused)
+	return compileNS, savedNS, expressionUnits
 }
 
 // CurrentJITCosts returns a value copy so callers cannot mutate the globally

--- a/scm/jit_calibration_test.go
+++ b/scm/jit_calibration_test.go
@@ -49,6 +49,28 @@ func TestJITCalibrationBreakEvenHasNoHiddenSafetyFactor(t *testing.T) {
 	}
 }
 
+func TestJITCalibrationMapReduceBufferBestOf(t *testing.T) {
+	calibration := JITCostCalibration{
+		Enabled:         true,
+		BufferCompileNS: 100,
+		BufferSavedNS:   2,
+		BufferMaxUnits:  40,
+	}
+	if got := calibration.MapReduceBufferBreakEven(40, 1); got != 100 {
+		t.Fatalf("buffer break-even rows = %d, want 100", got)
+	}
+	for _, test := range []struct {
+		units, columns int
+	}{
+		{units: 41, columns: 1},
+		{units: 40, columns: 2},
+	} {
+		if got := calibration.MapReduceBufferBreakEven(test.units, test.columns); got != math.MaxInt {
+			t.Fatalf("ineligible buffer shape (%d units, %d columns) break-even = %d, want MaxInt", test.units, test.columns, got)
+		}
+	}
+}
+
 func TestJITCalibrationAnchorsCallBoundaryToTrivialShapes(t *testing.T) {
 	observations := []jitCalibrationObservation{
 		{workUnits: 0, callNS: 4},
@@ -111,7 +133,7 @@ func TestJITStartupCalibrationPublishesImmutableCostModel(t *testing.T) {
 		t.Fatalf("invalid calibration sampling metadata: %+v", first)
 	}
 	if first.EmitFixedNS < 0 || first.EmitUnitNS < 0 || first.PublishFixedNS < 0 ||
-		first.DirectCallNS < 0 || first.PredicateUnitNS < 0 {
+		first.DirectCallNS < 0 || first.PredicateUnitNS < 0 || first.BufferCompileNS < 0 || first.BufferSavedNS < 0 {
 		t.Fatalf("calibration published a negative cost: %+v", first)
 	}
 	t.Logf("JIT startup calibration: %+v", first)

--- a/scm/jit_calibration_test.go
+++ b/scm/jit_calibration_test.go
@@ -51,10 +51,13 @@ func TestJITCalibrationBreakEvenHasNoHiddenSafetyFactor(t *testing.T) {
 
 func TestJITCalibrationMapReduceBufferBestOf(t *testing.T) {
 	calibration := JITCostCalibration{
-		Enabled:         true,
-		BufferCompileNS: 100,
-		BufferSavedNS:   2,
-		BufferMaxUnits:  40,
+		Enabled:             true,
+		BufferCompileNS:     100,
+		BufferCompileUnitNS: 4,
+		BufferCurrentNS:     10,
+		BufferFusedNS:       5,
+		BufferSavedNS:       2,
+		BufferMaxUnits:      40,
 	}
 	if got := calibration.MapReduceBufferBreakEven(40, 1); got != 100 {
 		t.Fatalf("buffer break-even rows = %d, want 100", got)
@@ -68,6 +71,9 @@ func TestJITCalibrationMapReduceBufferBestOf(t *testing.T) {
 		if got := calibration.MapReduceBufferBreakEven(test.units, test.columns); got != math.MaxInt {
 			t.Fatalf("ineligible buffer shape (%d units, %d columns) break-even = %d, want MaxInt", test.units, test.columns, got)
 		}
+	}
+	if got := calibration.MapReduceBufferProbeBreakEven(80, 3, 1024); got == math.MaxInt {
+		t.Fatal("arbitrary-arity expression was not admitted for an adaptive probe")
 	}
 }
 

--- a/scm/jit_storage_amd64.go
+++ b/scm/jit_storage_amd64.go
@@ -142,7 +142,7 @@ func CompileJITStorageGetValueMulti(emit JITStorageGetValueMultiEmitter) JITStor
 // row-major Scmer buffer. Exact physical column types flow into the inlined
 // callback even though the buffer retains the general Scmer representation.
 func CompileJITMapReduceBuffer(proc *Proc, valueTypes []uint8) JITMapReduceBufferFunc {
-	if proc == nil || len(valueTypes) > 16 {
+	if proc == nil {
 		return nil
 	}
 	types := append([]uint8(nil), valueTypes...)
@@ -158,6 +158,9 @@ func CompileJITMapReduceBuffer(proc *Proc, valueTypes []uint8) JITMapReduceBuffe
 }
 
 func emitJITMapReduceBuffer(ctx *JITContext, proc *Proc, valueTypes []uint8) {
+	// The accumulator is the loop-carried phi. Its canonical home is a rooted
+	// stack pair so calls, type changes and stack growth remain safe. Physical
+	// storage inputs retain their exact types across the same backedge.
 	accumulator := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX}
 	values := jitStorageSliceArg(ctx, RegRCX, RegRDI, RegRSI)
 	rows := jitStorageScalarArg(ctx, RegR8)

--- a/scm/jit_storage_amd64.go
+++ b/scm/jit_storage_amd64.go
@@ -31,6 +31,7 @@ const (
 	jitStorageGetValueABI jitStorageABI = iota
 	jitStorageGetValueRangeABI
 	jitStorageGetValueMultiABI
+	jitMapReduceBufferABI
 )
 
 type jitStorageFuncValue struct {
@@ -135,6 +136,96 @@ func CompileJITStorageGetValueRange(emit JITStorageGetValueRangeEmitter) JITStor
 func CompileJITStorageGetValueMulti(emit JITStorageGetValueMultiEmitter) JITStorageGetValueMultiFunc {
 	_, _, getValueMulti := CompileJITStorageReaders(nil, nil, emit)
 	return getValueMulti
+}
+
+// CompileJITMapReduceBuffer compiles one reducer loop over an already gathered
+// row-major Scmer buffer. Exact physical column types flow into the inlined
+// callback even though the buffer retains the general Scmer representation.
+func CompileJITMapReduceBuffer(proc *Proc, valueTypes []uint8) JITMapReduceBufferFunc {
+	if proc == nil || len(valueTypes) > 16 {
+		return nil
+	}
+	types := append([]uint8(nil), valueTypes...)
+	requests := []jitStorageCompileRequest{{abi: jitMapReduceBufferABI, emit: func(ctx *JITContext) {
+		emitJITMapReduceBuffer(ctx, proc, types)
+	}}}
+	entries, holders := compileJITStorageBatch(requests)
+	if len(entries) != 1 || entries[0] == nil || holders[0] == nil {
+		return nil
+	}
+	valuePointer := unsafe.Pointer(holders[0])
+	return *(*JITMapReduceBufferFunc)(unsafe.Pointer(&valuePointer))
+}
+
+func emitJITMapReduceBuffer(ctx *JITContext, proc *Proc, valueTypes []uint8) {
+	accumulator := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX}
+	values := jitStorageSliceArg(ctx, RegRCX, RegRDI, RegRSI)
+	rows := jitStorageScalarArg(ctx, RegR8)
+	result := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX}
+	ctx.BindReg(RegRAX, &accumulator)
+	ctx.BindReg(RegRBX, &accumulator)
+	ctx.StabilizeDescForControlFlow(&accumulator)
+	ctx.StabilizeDescForControlFlow(&values)
+	ctx.StabilizeDescForControlFlow(&rows)
+
+	rowOff := ctx.AllocStack(8)
+	elementOff := ctx.AllocStack(8)
+	ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, rowOff)
+	ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, elementOff)
+	loop := ctx.ReserveLabel()
+	done := ctx.ReserveLabel()
+	ctx.MarkLabel(loop)
+	rowReg := ctx.AllocReg()
+	rowLimitReg := ctx.AllocRegExcept(rowReg)
+	ctx.EmitLoadFromStack(rowReg, rowOff)
+	ctx.EmitLoadFromStack(rowLimitReg, rows.StackOff)
+	ctx.EmitCmpInt64(rowReg, rowLimitReg)
+	ctx.FreeReg(rowLimitReg)
+	ctx.FreeReg(rowReg)
+	ctx.EmitJcc(CondSignedGreaterOrEqual, done)
+
+	args := make([]JITValueDesc, len(valueTypes)+1)
+	args[0] = accumulator
+	if len(valueTypes) != 0 {
+		elementReg := ctx.AllocReg()
+		ctx.EmitLoadFromStack(elementReg, elementOff)
+		index := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: elementReg, NoHeapPointer: true}
+		ctx.BindReg(elementReg, &index)
+		address := ctx.EmitSliceElementAddress(&values, &index, 16)
+		ctx.FreeDesc(&index)
+		ctx.EnsureDesc(&address)
+		for column, valueType := range valueTypes {
+			value := JITValueDesc{Loc: LocRegPair, Type: valueType, Reg: ctx.AllocRegExcept(address.Reg)}
+			value.Reg2 = ctx.AllocRegExcept(address.Reg, value.Reg)
+			ctx.EmitMovRegMem(value.Reg, address.Reg, int32(column*16))
+			ctx.EmitMovRegMem(value.Reg2, address.Reg, int32(column*16+8))
+			ctx.BindReg(value.Reg, &value)
+			ctx.BindReg(value.Reg2, &value)
+			args[column+1] = value
+		}
+		ctx.FreeDesc(&address)
+	}
+	newAccumulator := JITEmitProcInline(ctx, proc, args, RegR12, JITValueDesc{Loc: LocAny})
+	ctx.EmitStoreScmerToStack(newAccumulator, accumulator.StackOff)
+	ctx.FreeDesc(&newAccumulator)
+
+	rowReg = ctx.AllocReg()
+	ctx.EmitLoadFromStack(rowReg, rowOff)
+	ctx.EmitAddRegImm32(rowReg, 1)
+	ctx.EmitStoreToStack(JITValueDesc{Loc: LocReg, Type: tagInt, Reg: rowReg}, rowOff)
+	if len(valueTypes) != 0 {
+		elementReg := ctx.AllocReg()
+		ctx.EmitLoadFromStack(elementReg, elementOff)
+		ctx.EmitAddRegImm32(elementReg, int32(len(valueTypes)))
+		ctx.EmitStoreToStack(JITValueDesc{Loc: LocReg, Type: tagInt, Reg: elementReg}, elementOff)
+		ctx.FreeReg(elementReg)
+	}
+	ctx.FreeReg(rowReg)
+	ctx.EmitJmp(loop)
+
+	ctx.MarkLabel(done)
+	out := accumulator
+	ctx.EmitMovPairToResult(&out, &result)
 }
 
 func jitStorageScalarArg(ctx *JITContext, reg Reg) JITValueDesc {
@@ -260,6 +351,8 @@ func jitStorageABIName(abi jitStorageABI) string {
 		return "storage.GetValueRange"
 	case jitStorageGetValueMultiABI:
 		return "storage.GetValueMulti"
+	case jitMapReduceBufferABI:
+		return "storage.MapReduceBuffer"
 	default:
 		return "storage.unknown"
 	}
@@ -424,6 +517,8 @@ func jitStorageABIInputRegisters(abi jitStorageABI) uint64 {
 		registers = []Reg{RegRAX, RegRBX, RegRCX, RegRDI, RegRSI, RegR8}
 	case jitStorageGetValueMultiABI:
 		registers = []Reg{RegRAX, RegRBX, RegRCX, RegRDI, RegRSI, RegR8, RegR9}
+	case jitMapReduceBufferABI:
+		registers = []Reg{RegRAX, RegRBX, RegRCX, RegRDI, RegRSI, RegR8}
 	}
 	var mask uint64
 	for _, reg := range registers {
@@ -454,6 +549,14 @@ func jitStorageSpillEntryArgs(ctx *JITContext, abi jitStorageABI) (uintptr, []by
 		ctx.EmitStoreRegMem(RegR8, RegRSP, 48)
 		ctx.EmitStoreRegMem(RegR9, RegRSP, 56)
 		return 8, []byte{0b00010010}
+	case jitMapReduceBufferABI:
+		ctx.EmitStoreRegMem(RegRAX, RegRSP, 8)
+		ctx.EmitStoreRegMem(RegRBX, RegRSP, 16)
+		ctx.EmitStoreRegMem(RegRCX, RegRSP, 24)
+		ctx.EmitStoreRegMem(RegRDI, RegRSP, 32)
+		ctx.EmitStoreRegMem(RegRSI, RegRSP, 40)
+		ctx.EmitStoreRegMem(RegR8, RegRSP, 48)
+		return 7, []byte{0b00001010}
 	default:
 		panic("jit: unknown storage ABI")
 	}
@@ -478,6 +581,13 @@ func jitStorageReloadEntryArgs(ctx *JITContext, abi jitStorageABI) {
 		ctx.EmitMovRegMem(RegRSI, RegRSP, 40)
 		ctx.EmitMovRegMem(RegR8, RegRSP, 48)
 		ctx.EmitMovRegMem(RegR9, RegRSP, 56)
+	case jitMapReduceBufferABI:
+		ctx.EmitMovRegMem(RegRAX, RegRSP, 8)
+		ctx.EmitMovRegMem(RegRBX, RegRSP, 16)
+		ctx.EmitMovRegMem(RegRCX, RegRSP, 24)
+		ctx.EmitMovRegMem(RegRDI, RegRSP, 32)
+		ctx.EmitMovRegMem(RegRSI, RegRSP, 40)
+		ctx.EmitMovRegMem(RegR8, RegRSP, 48)
 	}
 }
 

--- a/scm/jit_storage_fallback.go
+++ b/scm/jit_storage_fallback.go
@@ -38,3 +38,8 @@ func CompileJITStorageGetValueMulti(JITStorageGetValueMultiEmitter) JITStorageGe
 func CompileJITStorageReaders(JITStorageGetValueEmitter, JITStorageGetValueRangeEmitter, JITStorageGetValueMultiEmitter) (JITStorageGetValueFunc, JITStorageGetValueRangeFunc, JITStorageGetValueMultiFunc) {
 	return nil, nil, nil
 }
+
+// CompileJITMapReduceBuffer is unavailable without the patched Go JIT backend.
+func CompileJITMapReduceBuffer(*Proc, []uint8) JITMapReduceBufferFunc {
+	return nil
+}

--- a/storage/mapreduce_fusion_bench_test.go
+++ b/storage/mapreduce_fusion_bench_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+const mapReduceFusionBenchmarkRows = 1_000_000
+
+func TestJITMapReduceBufferBestOf(t *testing.T) {
+	if !scm.JITEnabled() {
+		t.Skip("requires the JIT experiment")
+	}
+	callback := benchmarkMapReduceFusionProc(t, "(lambda (acc amount) (+ acc amount))")
+	minimumRows := scm.CurrentJITCosts().MapReduceBufferBreakEven(scm.JITExpressionCost(callback.Proc().Body), 1)
+	if minimumRows <= 1 || minimumRows > mapReduceFusionBenchmarkRows {
+		t.Fatalf("implausible calibrated buffer break-even: %d", minimumRows)
+	}
+	shard := benchmarkMapReduceFusionShard(minimumRows + 1)
+	mapper := shard.OpenMapReducer([]string{"amount"}, callback, false, 0, nil, nil)
+	defer mapper.Close()
+	if mapper.bufferReduceProc == nil || mapper.bufferMinRows <= 1 {
+		t.Fatalf("simple typed reducer was not admitted: proc=%p min_rows=%d", mapper.bufferReduceProc, mapper.bufferMinRows)
+	}
+	if got := mapper.Stream(scm.NewInt(0), []uint32{0}, nil); !scm.Equal(got, scm.NewInt(1)) {
+		t.Fatalf("point reduction = %s, want 1", scm.String(got))
+	}
+	if mapper.bufferReduceFn != nil {
+		t.Fatal("point reduction paid for a buffer-loop compilation")
+	}
+
+	mapper.bufferMinRows = 8
+	ids := []uint32{1, 2, 3, 4, 5, 6, 7, 8}
+	got := mapper.Stream(scm.NewInt(0), ids, nil)
+	want := int64(0)
+	for _, id := range ids {
+		want += int64(id%251 + 1)
+	}
+	if !scm.Equal(got, scm.NewInt(want)) {
+		t.Fatalf("fused reduction = %s, want %d", scm.String(got), want)
+	}
+	if mapper.bufferReduceFn == nil {
+		t.Fatalf("profitable reducer did not compile after its break-even: seen=%d min=%d columns=%d kind=%d", mapper.bufferSeenRows, mapper.bufferMinRows, mapper.bufferColumnCount, mapper.mapReduceProgram.Kind)
+	}
+	count := benchmarkMapReduceFusionProc(t, "(lambda (acc) (+ acc 1))")
+	countMapper := shard.OpenMapReducer(nil, count, false, 0, nil, nil)
+	defer countMapper.Close()
+	if countMapper.bufferReduceProc == nil {
+		t.Fatal("zero-column accumulator reducer was not admitted")
+	}
+	countMapper.bufferMinRows = len(ids)
+	if got := countMapper.Stream(scm.NewInt(0), ids, nil); !scm.Equal(got, scm.NewInt(int64(len(ids)))) {
+		t.Fatalf("fused count = %s, want %d", scm.String(got), len(ids))
+	}
+
+	floatSum := benchmarkMapReduceFusionProc(t, "(lambda (acc value) (+ acc value))")
+	floatKernel := scm.CompileJITMapReduceBuffer(floatSum.Proc(), []uint8{scm.NewFloat(0).GetTag()})
+	floatValues := []scm.Scmer{scm.NewFloat(1.25), scm.NewFloat(2.5)}
+	if floatKernel == nil || !scm.Equal(floatKernel(scm.NewInt(0), floatValues, len(floatValues)), scm.NewFloat(3.75)) {
+		t.Fatal("buffer reducer did not preserve a dynamic accumulator type transition")
+	}
+
+	sumBinding := scm.Globalenv.FindRead(scm.Symbol("sql_sum_reduce"))
+	if sumBinding == nil {
+		t.Fatal("sql_sum_reduce is not registered")
+	}
+	nativeMapper := shard.OpenMapReducer([]string{"amount"}, sumBinding.Vars[scm.Symbol("sql_sum_reduce")], false, 0, nil, nil)
+	defer nativeMapper.Close()
+	if nativeMapper.bufferReduceProc == nil {
+		wrapped := scm.PrepareJITMapReduceBufferProc(sumBinding.Vars[scm.Symbol("sql_sum_reduce")], 2)
+		wrappedCost := -1
+		if wrapped != nil {
+			wrappedCost = scm.JITExpressionCost(wrapped.Body)
+		}
+		t.Fatalf("native reducer with a JIT emitter was not admitted: kind=%d wrapped=%p cost=%d min=%d main=%d type=%d", nativeMapper.mapReduceProgram.Kind, wrapped, wrappedCost, scm.CurrentJITCosts().MapReduceBufferBreakEven(wrappedCost, 1), nativeMapper.mainCount, nativeMapper.mainCols[0].JITValueType())
+	}
+	nativeMapper.bufferMinRows = len(ids)
+	if got := nativeMapper.Stream(scm.NewNil(), ids, nil); !scm.Equal(got, scm.NewInt(want)) {
+		t.Fatalf("fused native SQL sum = %s, want %d", scm.String(got), want)
+	}
+
+	complex := benchmarkMapReduceFusionProc(t, "(lambda (acc amount) (+ acc (* amount 3)))")
+	complexMapper := shard.OpenMapReducer([]string{"amount"}, complex, false, 0, nil, nil)
+	defer complexMapper.Close()
+	if complexMapper.bufferReduceProc != nil {
+		t.Fatal("complex reducer entered the slower buffer-loop class")
+	}
+
+	wide := benchmarkMapReduceFusionProc(t, "(lambda (acc amount quantity) (+ acc (* amount quantity)))")
+	wideMapper := shard.OpenMapReducer([]string{"amount", "quantity"}, wide, false, 0, nil, nil)
+	defer wideMapper.Close()
+	if wideMapper.bufferReduceProc != nil {
+		t.Fatal("wide reducer entered the slower buffer-loop class")
+	}
+}
+
+func benchmarkMapReduceFusionShard(rows int) *storageShard {
+	amountValues := make([]scm.Scmer, rows)
+	quantityValues := make([]scm.Scmer, rows)
+	for index := range rows {
+		amountValues[index] = scm.NewInt(int64(index%251 + 1))
+		quantityValues[index] = scm.NewInt(int64(index%7 + 1))
+	}
+	amount := buildStorageInt(amountValues)
+	quantity := buildStorageInt(quantityValues)
+	tbl := &table{Columns: []*column{
+		{Name: "amount", Typ: "int"},
+		{Name: "quantity", Typ: "int"},
+	}}
+	shard := &storageShard{
+		t: tbl,
+		columns: map[string]ColumnStorage{
+			"amount":   amount,
+			"quantity": quantity,
+		},
+		deltaColumns: make(map[string]int),
+		main_count:   uint32(rows),
+	}
+	shard.deletions.Reset()
+	return shard
+}
+
+func benchmarkMapReduceFusionProc(tb testing.TB, source string) scm.Scmer {
+	tb.Helper()
+	proc := scm.CompileJIT(optimizedScanProc(tb, source), true)
+	if scm.JITEnabled() && scm.PrepareSerialProc(proc).Kind != scm.SerialProcJIT {
+		tb.Fatalf("benchmark callback did not JIT-compile: %s", source)
+	}
+	return proc
+}
+
+// BenchmarkMapReduceBufferedSpectrum measures the real main-storage consumer:
+// typed bulk readers populate the row-major Scmer buffer before the prepared
+// map-reducer folds it. Batch sizes cover point probes through full analytical
+// scans so a fused-loop threshold can be selected from one stable fixture.
+func BenchmarkMapReduceBufferedSpectrum(b *testing.B) {
+	if !scm.JITEnabled() {
+		b.Skip("requires the JIT experiment")
+	}
+	shard := benchmarkMapReduceFusionShard(mapReduceFusionBenchmarkRows)
+	recids := make([]uint32, mapReduceFusionBenchmarkRows)
+	for index := range recids {
+		recids[index] = uint32(index)
+	}
+
+	shapes := []struct {
+		name    string
+		cols    []string
+		source  string
+		neutral scm.Scmer
+	}{
+		{name: "Count", source: "(lambda (acc) (+ acc 1))", neutral: scm.NewInt(0)},
+		{name: "Sum", cols: []string{"amount"}, source: "(lambda (acc amount) (+ acc amount))", neutral: scm.NewInt(0)},
+		{name: "AffineSum", cols: []string{"amount"}, source: "(lambda (acc amount) (+ acc (* amount 3)))", neutral: scm.NewInt(0)},
+		{name: "TwoColumnSum", cols: []string{"amount", "quantity"}, source: "(lambda (acc amount quantity) (+ acc (* amount quantity)))", neutral: scm.NewInt(0)},
+	}
+	batchSizes := []int{1, 8, 64, 1_024, 60_000, mapReduceFusionBenchmarkRows}
+
+	for _, shape := range shapes {
+		callback := benchmarkMapReduceFusionProc(b, shape.source)
+		mapper := shard.OpenMapReducer(shape.cols, callback, false, 0, nil, nil)
+		defer mapper.Close()
+		valueTypes := make([]uint8, len(mapper.mainCols))
+		for index, column := range mapper.mainCols {
+			valueTypes[index] = column.JITValueType()
+		}
+		proc := callback.Proc()
+		fused := scm.CompileJITMapReduceBuffer(proc, valueTypes)
+		if fused == nil {
+			b.Fatalf("failed to compile fused %s reducer", shape.name)
+		}
+		for _, batchSize := range batchSizes {
+			ids := recids[:batchSize]
+			want := mapper.Stream(shape.neutral, ids, nil)
+			mapper.prefetchMainColumns(ids)
+			if got := fused(shape.neutral, mapper.mainBulkValues, batchSize); !scm.Equal(got, want) {
+				b.Fatalf("fused %s/%d result changed: got %s, want %s", shape.name, batchSize, scm.String(got), scm.String(want))
+			}
+			name := fmt.Sprintf("%s/Rows%d/Current", shape.name, batchSize)
+			b.Run(name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ReportMetric(float64(batchSize), "rows/op")
+				b.ResetTimer()
+				var result scm.Scmer
+				for sample := 0; sample < b.N; sample++ {
+					result = mapper.Stream(shape.neutral, ids, nil)
+				}
+				if !scm.Equal(result, want) {
+					b.Fatalf("result changed: got %s, want %s", scm.String(result), scm.String(want))
+				}
+				runtime.KeepAlive(result)
+			})
+			b.Run(fmt.Sprintf("%s/Rows%d/Fused", shape.name, batchSize), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ReportMetric(float64(batchSize), "rows/op")
+				b.ResetTimer()
+				var result scm.Scmer
+				for sample := 0; sample < b.N; sample++ {
+					mapper.prefetchMainColumns(ids)
+					result = fused(shape.neutral, mapper.mainBulkValues, batchSize)
+				}
+				if !scm.Equal(result, want) {
+					b.Fatalf("result changed: got %s, want %s", scm.String(result), scm.String(want))
+				}
+				runtime.KeepAlive(result)
+			})
+		}
+	}
+}
+
+func BenchmarkMapReduceBufferCompile(b *testing.B) {
+	if !scm.JITEnabled() {
+		b.Skip("requires the JIT experiment")
+	}
+	callback := benchmarkMapReduceFusionProc(b, "(lambda (acc amount) (+ acc amount))")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		compiled := scm.CompileJITMapReduceBuffer(callback.Proc(), []uint8{scm.NewInt(0).GetTag()})
+		if compiled == nil {
+			b.Fatal("failed to compile buffer reducer")
+		}
+		runtime.KeepAlive(compiled)
+	}
+}
+
+// BenchmarkMapReduceBufferedBestOf includes mapper setup, the calibrated lazy
+// compilation decision and the 1024-row scan batches used by production.
+func BenchmarkMapReduceBufferedBestOf(b *testing.B) {
+	if !scm.JITEnabled() {
+		b.Skip("requires the JIT experiment")
+	}
+	shard := benchmarkMapReduceFusionShard(mapReduceFusionBenchmarkRows)
+	recids := make([]uint32, mapReduceFusionBenchmarkRows)
+	for index := range recids {
+		recids[index] = uint32(index)
+	}
+	shapes := []struct {
+		name    string
+		cols    []string
+		source  string
+		neutral scm.Scmer
+	}{
+		{name: "Count", source: "(lambda (acc) (+ acc 1))", neutral: scm.NewInt(0)},
+		{name: "Sum", cols: []string{"amount"}, source: "(lambda (acc amount) (+ acc amount))", neutral: scm.NewInt(0)},
+		{name: "AffineSum", cols: []string{"amount"}, source: "(lambda (acc amount) (+ acc (* amount 3)))", neutral: scm.NewInt(0)},
+		{name: "TwoColumnSum", cols: []string{"amount", "quantity"}, source: "(lambda (acc amount quantity) (+ acc (* amount quantity)))", neutral: scm.NewInt(0)},
+	}
+	for _, shape := range shapes {
+		callback := benchmarkMapReduceFusionProc(b, shape.source)
+		for _, rowCount := range []int{1, 8, 1_024, 60_000, mapReduceFusionBenchmarkRows} {
+			for _, bestOf := range []bool{false, true} {
+				mode := "Baseline"
+				if bestOf {
+					mode = "BestOf"
+				}
+				b.Run(fmt.Sprintf("%s/Rows%d/%s", shape.name, rowCount, mode), func(b *testing.B) {
+					b.ReportAllocs()
+					b.ReportMetric(float64(rowCount), "rows/op")
+					var result scm.Scmer
+					for sample := 0; sample < b.N; sample++ {
+						mapper := shard.OpenMapReducer(shape.cols, callback, false, 0, nil, nil)
+						if !bestOf {
+							mapper.bufferReduceProc = nil
+						}
+						result = shape.neutral
+						for offset := 0; offset < rowCount; offset += defaultScanBufferSize {
+							end := min(offset+defaultScanBufferSize, rowCount)
+							result = mapper.Stream(result, recids[offset:end], nil)
+						}
+						mapper.Close()
+					}
+					runtime.KeepAlive(result)
+				})
+			}
+		}
+	}
+}

--- a/storage/mapreduce_fusion_bench_test.go
+++ b/storage/mapreduce_fusion_bench_test.go
@@ -109,28 +109,60 @@ func TestJITMapReduceBufferBestOf(t *testing.T) {
 	wideMapper := shard.OpenMapReducer([]string{"amount", "quantity"}, wide, false, 0, nil, nil)
 	defer wideMapper.Close()
 	if wideMapper.bufferReduceProc != nil {
-		t.Fatal("wide reducer entered the slower buffer-loop class")
+		t.Fatal("short wide reduction should not pay for adaptive compilation")
+	}
+
+	largeShard := benchmarkMapReduceFusionShard(mapReduceFusionBenchmarkRows)
+	expression := benchmarkMapReduceFusionProc(t, "(lambda (acc amount quantity factor) (+ acc (+ amount (* quantity factor))))")
+	expressionMapper := largeShard.OpenMapReducer([]string{"amount", "quantity", "factor"}, expression, false, 0, nil, nil)
+	defer expressionMapper.Close()
+	wantExpression := expressionMapper.Stream(scm.NewInt(0), ids, nil)
+	expressionMapper.prefetchMainColumns(ids)
+	valueTypes := make([]uint8, len(expressionMapper.mainCols))
+	for index, column := range expressionMapper.mainCols {
+		valueTypes[index] = column.JITValueType()
+	}
+	kernel := scm.CompileJITMapReduceBuffer(expression.Proc(), valueTypes)
+	if kernel == nil {
+		t.Fatal("arbitrary-arity reducer did not compile")
+	}
+	if got := kernel(scm.NewInt(0), expressionMapper.mainBulkValues, len(ids)); !scm.Equal(got, wantExpression) {
+		t.Fatalf("typed expression reducer = %s, want %s", scm.String(got), scm.String(wantExpression))
+	}
+	lifecycleMapper := largeShard.OpenMapReducer([]string{"amount", "quantity", "factor"}, expression, false, 0, nil, nil)
+	lifecycleMapper.prefetchMainColumns(ids)
+	if len(lifecycleMapper.mainBulkValues) == 0 {
+		t.Fatal("lifecycle test did not allocate the query-local value buffer")
+	}
+	lifecycleMapper.Close()
+	if lifecycleMapper.mainBulkValues != nil || lifecycleMapper.bufferReduceProc != nil || lifecycleMapper.bufferValueTypes != nil {
+		t.Fatal("Close retained query-local map-reduce buffer state")
 	}
 }
 
 func benchmarkMapReduceFusionShard(rows int) *storageShard {
 	amountValues := make([]scm.Scmer, rows)
 	quantityValues := make([]scm.Scmer, rows)
+	factorValues := make([]scm.Scmer, rows)
 	for index := range rows {
 		amountValues[index] = scm.NewInt(int64(index%251 + 1))
 		quantityValues[index] = scm.NewInt(int64(index%7 + 1))
+		factorValues[index] = scm.NewInt(int64(index%5 + 1))
 	}
 	amount := buildStorageInt(amountValues)
 	quantity := buildStorageInt(quantityValues)
+	factor := buildStorageInt(factorValues)
 	tbl := &table{Columns: []*column{
 		{Name: "amount", Typ: "int"},
 		{Name: "quantity", Typ: "int"},
+		{Name: "factor", Typ: "int"},
 	}}
 	shard := &storageShard{
 		t: tbl,
 		columns: map[string]ColumnStorage{
 			"amount":   amount,
 			"quantity": quantity,
+			"factor":   factor,
 		},
 		deltaColumns: make(map[string]int),
 		main_count:   uint32(rows),
@@ -172,6 +204,7 @@ func BenchmarkMapReduceBufferedSpectrum(b *testing.B) {
 		{name: "Sum", cols: []string{"amount"}, source: "(lambda (acc amount) (+ acc amount))", neutral: scm.NewInt(0)},
 		{name: "AffineSum", cols: []string{"amount"}, source: "(lambda (acc amount) (+ acc (* amount 3)))", neutral: scm.NewInt(0)},
 		{name: "TwoColumnSum", cols: []string{"amount", "quantity"}, source: "(lambda (acc amount quantity) (+ acc (* amount quantity)))", neutral: scm.NewInt(0)},
+		{name: "ExpressionSum", cols: []string{"amount", "quantity", "factor"}, source: "(lambda (acc amount quantity factor) (+ acc (+ amount (* quantity factor))))", neutral: scm.NewInt(0)},
 	}
 	batchSizes := []int{1, 8, 64, 1_024, 60_000, mapReduceFusionBenchmarkRows}
 
@@ -231,15 +264,30 @@ func BenchmarkMapReduceBufferCompile(b *testing.B) {
 	if !scm.JITEnabled() {
 		b.Skip("requires the JIT experiment")
 	}
-	callback := benchmarkMapReduceFusionProc(b, "(lambda (acc amount) (+ acc amount))")
-	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
-		compiled := scm.CompileJITMapReduceBuffer(callback.Proc(), []uint8{scm.NewInt(0).GetTag()})
-		if compiled == nil {
-			b.Fatal("failed to compile buffer reducer")
+	shapes := []struct {
+		name   string
+		source string
+		cols   int
+	}{
+		{name: "Sum", source: "(lambda (acc amount) (+ acc amount))", cols: 1},
+		{name: "ExpressionSum", source: "(lambda (acc amount quantity factor) (+ acc (+ amount (* quantity factor))))", cols: 3},
+	}
+	for _, shape := range shapes {
+		callback := benchmarkMapReduceFusionProc(b, shape.source)
+		valueTypes := make([]uint8, shape.cols)
+		for index := range valueTypes {
+			valueTypes[index] = scm.NewInt(0).GetTag()
 		}
-		runtime.KeepAlive(compiled)
+		b.Run(shape.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				compiled := scm.CompileJITMapReduceBuffer(callback.Proc(), valueTypes)
+				if compiled == nil {
+					b.Fatal("failed to compile buffer reducer")
+				}
+				runtime.KeepAlive(compiled)
+			}
+		})
 	}
 }
 
@@ -264,6 +312,7 @@ func BenchmarkMapReduceBufferedBestOf(b *testing.B) {
 		{name: "Sum", cols: []string{"amount"}, source: "(lambda (acc amount) (+ acc amount))", neutral: scm.NewInt(0)},
 		{name: "AffineSum", cols: []string{"amount"}, source: "(lambda (acc amount) (+ acc (* amount 3)))", neutral: scm.NewInt(0)},
 		{name: "TwoColumnSum", cols: []string{"amount", "quantity"}, source: "(lambda (acc amount quantity) (+ acc (* amount quantity)))", neutral: scm.NewInt(0)},
+		{name: "ExpressionSum", cols: []string{"amount", "quantity", "factor"}, source: "(lambda (acc amount quantity factor) (+ acc (+ amount (* quantity factor))))", neutral: scm.NewInt(0)},
 	}
 	for _, shape := range shapes {
 		callback := benchmarkMapReduceFusionProc(b, shape.source)

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -17,6 +17,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 package storage
 
 import "fmt"
+import "math"
 import "sync"
 import "sync/atomic"
 import "time"
@@ -1608,23 +1609,28 @@ type ShardMapReducer struct {
 	isBreak            []bool // true for $break column
 	hasBreakCol        bool
 	// tagClosure hoisted fn ptrs — allocated once per mapper, reused per row
-	setClosureFn      []*func(uint32, ...scm.Scmer) scm.Scmer // per $set col
-	incrClosureFn     []*func(uint32, ...scm.Scmer) scm.Scmer // per $increment col
-	invClosureFn      []*func(uint32, ...scm.Scmer) scm.Scmer // per $invalidate col
-	noopClosureFn     *func(uint32, ...scm.Scmer) scm.Scmer   // shared noop
-	breakClosureFn    *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
-	args              []scm.Scmer                             // pre-allocated [accumulator, column...] buffer
-	mapProgram        scm.SerialProc
-	mapReduceProgram  scm.SerialProc
-	mapReduceScmer    scm.Scmer // original Scmer for network serialization
-	bufferReduceProc  *scm.Proc // source retained for a profitable typed main-buffer specialization
-	bufferReduceFn    scm.JITMapReduceBufferFunc
-	bufferValueTypes  [1]uint8
-	bufferColumnCount int
-	bufferMinRows     int
-	bufferSeenRows    int
-	deleteBatch       *triggerBatch // when set, DELETE triggers are batched instead of per-row
-	deletedRows       uint64        // applied DELETEs, published once when the mapper flushes
+	setClosureFn       []*func(uint32, ...scm.Scmer) scm.Scmer // per $set col
+	incrClosureFn      []*func(uint32, ...scm.Scmer) scm.Scmer // per $increment col
+	invClosureFn       []*func(uint32, ...scm.Scmer) scm.Scmer // per $invalidate col
+	noopClosureFn      *func(uint32, ...scm.Scmer) scm.Scmer   // shared noop
+	breakClosureFn     *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
+	args               []scm.Scmer                             // pre-allocated [accumulator, column...] buffer
+	mapProgram         scm.SerialProc
+	mapReduceProgram   scm.SerialProc
+	mapReduceScmer     scm.Scmer // original Scmer for network serialization
+	bufferReduceProc   *scm.Proc // source retained for a profitable typed main-buffer specialization
+	bufferReduceFn     scm.JITMapReduceBufferFunc
+	bufferValueTypes   []uint8
+	bufferColumnCount  int
+	bufferMinRows      int
+	bufferSeenRows     int
+	bufferProbe        bool
+	bufferRejected     bool
+	bufferProbeCount   int
+	bufferProbeFused   int64
+	bufferProbeCurrent int64
+	deleteBatch        *triggerBatch // when set, DELETE triggers are batched instead of per-row
+	deletedRows        uint64        // applied DELETEs, published once when the mapper flushes
 	// Batched side effects: collected during scan, flushed after lock release.
 	// $increment calls are aggregated per (proxy, recid) → one update per unique target.
 	incrementBatch  map[*StorageComputeProxy]map[uint32]scm.Scmer // proxy → recid → accumulated delta
@@ -1708,13 +1714,14 @@ func (t *storageShard) initReadMapReducer(mr *ShardMapReducer, cols []string, ma
 }
 
 func (m *ShardMapReducer) prepareJITBufferReducer() {
-	if (m.mapReduceProgram.Kind != scm.SerialProcJIT && m.mapReduceProgram.Kind != scm.SerialProcNative) || len(m.mainCols) > len(m.bufferValueTypes) {
+	if m.mapReduceProgram.Kind != scm.SerialProcJIT && m.mapReduceProgram.Kind != scm.SerialProcNative {
 		return
 	}
 	proc := scm.PrepareJITMapReduceBufferProc(m.mapReduceScmer, len(m.mainCols)+1)
 	if proc == nil {
 		return
 	}
+	m.bufferValueTypes = make([]uint8, len(m.mainCols))
 	for index, column := range m.mainCols {
 		if column == nil || m.mainBulkReaders[index] == nil {
 			return
@@ -1725,13 +1732,20 @@ func (m *ShardMapReducer) prepareJITBufferReducer() {
 		}
 		m.bufferValueTypes[index] = valueType
 	}
-	minimumRows := scm.CurrentJITCosts().MapReduceBufferBreakEven(scm.JITExpressionCost(proc.Body), len(m.mainCols))
+	costs := scm.CurrentJITCosts()
+	expressionCost := scm.JITExpressionCost(proc.Body)
+	minimumRows := costs.MapReduceBufferBreakEven(expressionCost, len(m.mainCols))
+	probe := minimumRows == math.MaxInt
+	if probe {
+		minimumRows = costs.MapReduceBufferProbeBreakEven(expressionCost, len(m.mainCols), 3*defaultScanBufferSize)
+	}
 	if minimumRows > int(m.mainCount) {
 		return
 	}
 	m.bufferReduceProc = proc
 	m.bufferColumnCount = len(m.mainCols)
 	m.bufferMinRows = minimumRows
+	m.bufferProbe = probe
 }
 
 // MapOne evaluates the mapper for one already-visible record. Ordered scans use
@@ -2132,16 +2146,62 @@ func (m *ShardMapReducer) loadDirectReadArgs(id uint32, rowOffset int, useBulkVa
 	}
 }
 
+func (m *ShardMapReducer) reducePreparedBuffer(acc scm.Scmer, rows int) scm.Scmer {
+	width := m.bufferColumnCount
+	if width == 0 {
+		for range rows {
+			m.args[0] = acc
+			acc = m.mapReduceProgram.Function(m.args...)
+		}
+		return acc
+	}
+	for offset := 0; offset < rows*width; offset += width {
+		m.args[0] = acc
+		copy(m.args[1:], m.mainBulkValues[offset:offset+width])
+		acc = m.mapReduceProgram.Function(m.args...)
+	}
+	runtime.KeepAlive(&m.mapReduceProgram)
+	return acc
+}
+
 func (m *ShardMapReducer) processJITBuffer(acc scm.Scmer, recids []uint32) (scm.Scmer, bool) {
-	if m.bufferReduceProc == nil {
+	if m.bufferReduceProc == nil || m.bufferRejected {
 		return acc, false
 	}
 	m.bufferSeenRows += len(recids)
 	if m.bufferReduceFn == nil && m.bufferSeenRows >= m.bufferMinRows {
-		m.bufferReduceFn = scm.CompileJITMapReduceBuffer(m.bufferReduceProc, m.bufferValueTypes[:m.bufferColumnCount])
+		m.bufferReduceFn = scm.CompileJITMapReduceBuffer(m.bufferReduceProc, m.bufferValueTypes)
 	}
 	if m.bufferReduceFn == nil {
 		return acc, false
+	}
+	if m.bufferProbe {
+		started := time.Now()
+		fused := m.bufferReduceFn(acc, m.mainBulkValues, len(recids))
+		fusedNS := time.Since(started).Nanoseconds()
+		started = time.Now()
+		current := m.reducePreparedBuffer(acc, len(recids))
+		currentNS := time.Since(started).Nanoseconds()
+		m.bufferProbeCount++
+		m.bufferProbeFused += fusedNS
+		m.bufferProbeCurrent += currentNS
+		if !scm.Equal(fused, current) {
+			m.bufferRejected = true
+			m.bufferProbe = false
+			m.bufferReduceFn = nil
+			return current, true
+		}
+		if m.bufferProbeCount < 3 {
+			return current, true
+		}
+		if m.bufferProbeFused*100 >= m.bufferProbeCurrent*98 {
+			m.bufferRejected = true
+			m.bufferProbe = false
+			m.bufferReduceFn = nil
+			return current, true
+		}
+		m.bufferProbe = false
+		return fused, true
 	}
 	acc = m.bufferReduceFn(acc, m.mainBulkValues, len(recids))
 	runtime.KeepAlive(m.bufferReduceProc)
@@ -2478,8 +2538,12 @@ func (m *ShardMapReducer) Close() {
 		width := cap(m.mainBulkBuffer.values) / defaultScanBufferSize
 		mapReducerBulkBufferPools[width-1].Put(m.mainBulkBuffer)
 		m.mainBulkBuffer = nil
-		m.mainBulkValues = nil
 	}
+	clear(m.mainBulkValues)
+	m.mainBulkValues = nil
+	m.bufferReduceFn = nil
+	m.bufferReduceProc = nil
+	m.bufferValueTypes = nil
 }
 
 // FlushSideEffects flushes all batched side effects (triggers, increments,

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1608,17 +1608,23 @@ type ShardMapReducer struct {
 	isBreak            []bool // true for $break column
 	hasBreakCol        bool
 	// tagClosure hoisted fn ptrs — allocated once per mapper, reused per row
-	setClosureFn     []*func(uint32, ...scm.Scmer) scm.Scmer // per $set col
-	incrClosureFn    []*func(uint32, ...scm.Scmer) scm.Scmer // per $increment col
-	invClosureFn     []*func(uint32, ...scm.Scmer) scm.Scmer // per $invalidate col
-	noopClosureFn    *func(uint32, ...scm.Scmer) scm.Scmer   // shared noop
-	breakClosureFn   *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
-	args             []scm.Scmer                             // pre-allocated [accumulator, column...] buffer
-	mapProgram       scm.SerialProc
-	mapReduceProgram scm.SerialProc
-	mapReduceScmer   scm.Scmer     // original Scmer for network serialization
-	deleteBatch      *triggerBatch // when set, DELETE triggers are batched instead of per-row
-	deletedRows      uint64        // applied DELETEs, published once when the mapper flushes
+	setClosureFn      []*func(uint32, ...scm.Scmer) scm.Scmer // per $set col
+	incrClosureFn     []*func(uint32, ...scm.Scmer) scm.Scmer // per $increment col
+	invClosureFn      []*func(uint32, ...scm.Scmer) scm.Scmer // per $invalidate col
+	noopClosureFn     *func(uint32, ...scm.Scmer) scm.Scmer   // shared noop
+	breakClosureFn    *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
+	args              []scm.Scmer                             // pre-allocated [accumulator, column...] buffer
+	mapProgram        scm.SerialProc
+	mapReduceProgram  scm.SerialProc
+	mapReduceScmer    scm.Scmer // original Scmer for network serialization
+	bufferReduceProc  *scm.Proc // source retained for a profitable typed main-buffer specialization
+	bufferReduceFn    scm.JITMapReduceBufferFunc
+	bufferValueTypes  [1]uint8
+	bufferColumnCount int
+	bufferMinRows     int
+	bufferSeenRows    int
+	deleteBatch       *triggerBatch // when set, DELETE triggers are batched instead of per-row
+	deletedRows       uint64        // applied DELETEs, published once when the mapper flushes
 	// Batched side effects: collected during scan, flushed after lock release.
 	// $increment calls are aggregated per (proxy, recid) → one update per unique target.
 	incrementBatch  map[*StorageComputeProxy]map[uint32]scm.Scmer // proxy → recid → accumulated delta
@@ -1698,6 +1704,34 @@ func (t *storageShard) initReadMapReducer(mr *ShardMapReducer, cols []string, ma
 			mr.mainValuesCompiled = false
 		}
 	}
+	mr.prepareJITBufferReducer()
+}
+
+func (m *ShardMapReducer) prepareJITBufferReducer() {
+	if (m.mapReduceProgram.Kind != scm.SerialProcJIT && m.mapReduceProgram.Kind != scm.SerialProcNative) || len(m.mainCols) > len(m.bufferValueTypes) {
+		return
+	}
+	proc := scm.PrepareJITMapReduceBufferProc(m.mapReduceScmer, len(m.mainCols)+1)
+	if proc == nil {
+		return
+	}
+	for index, column := range m.mainCols {
+		if column == nil || m.mainBulkReaders[index] == nil {
+			return
+		}
+		valueType := column.JITValueType()
+		if valueType == scm.JITTypeUnknown {
+			return
+		}
+		m.bufferValueTypes[index] = valueType
+	}
+	minimumRows := scm.CurrentJITCosts().MapReduceBufferBreakEven(scm.JITExpressionCost(proc.Body), len(m.mainCols))
+	if minimumRows > int(m.mainCount) {
+		return
+	}
+	m.bufferReduceProc = proc
+	m.bufferColumnCount = len(m.mainCols)
+	m.bufferMinRows = minimumRows
 }
 
 // MapOne evaluates the mapper for one already-visible record. Ordered scans use
@@ -1992,6 +2026,7 @@ func (t *storageShard) initMapReducer(mr *ShardMapReducer, cols []string, mapRed
 			}
 		}
 	}
+	mr.prepareJITBufferReducer()
 }
 
 // OpenMapReducer creates a retained MapReducer for operators whose mapper
@@ -2097,6 +2132,22 @@ func (m *ShardMapReducer) loadDirectReadArgs(id uint32, rowOffset int, useBulkVa
 	}
 }
 
+func (m *ShardMapReducer) processJITBuffer(acc scm.Scmer, recids []uint32) (scm.Scmer, bool) {
+	if m.bufferReduceProc == nil {
+		return acc, false
+	}
+	m.bufferSeenRows += len(recids)
+	if m.bufferReduceFn == nil && m.bufferSeenRows >= m.bufferMinRows {
+		m.bufferReduceFn = scm.CompileJITMapReduceBuffer(m.bufferReduceProc, m.bufferValueTypes[:m.bufferColumnCount])
+	}
+	if m.bufferReduceFn == nil {
+		return acc, false
+	}
+	acc = m.bufferReduceFn(acc, m.mainBulkValues, len(recids))
+	runtime.KeepAlive(m.bufferReduceProc)
+	return acc, true
+}
+
 func (m *ShardMapReducer) processDirectReadBlock(acc scm.Scmer, recids []uint32) scm.Scmer {
 	if len(recids) == 0 {
 		return acc
@@ -2117,6 +2168,11 @@ func (m *ShardMapReducer) processDirectReadBlock(acc scm.Scmer, recids []uint32)
 	}
 	if recids[0] < m.mainCount {
 		m.prefetchMainColumns(recids)
+	}
+	if recids[0] < m.mainCount {
+		if reduced, ok := m.processJITBuffer(acc, recids); ok {
+			return reduced
+		}
 	}
 	if m.mapReduceProgram.Kind == scm.SerialProcNative {
 		if recids[0] < m.mainCount && len(m.mainBulkReaders) == 1 {
@@ -2218,6 +2274,9 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
 	if !needsPerRowLock && !m.hasUpdateCol && !m.hasIncrementCol && !m.hasSetCol {
 		m.prefetchMainColumns(recids)
+		if reduced, ok := m.processJITBuffer(acc, recids); ok {
+			return reduced
+		}
 	}
 	bulkWidth := len(m.mainBulkReaders)
 	hasBulkValues := bulkWidth > 0 && len(m.mainBulkValues) == len(recids)*bulkWidth
@@ -2272,6 +2331,9 @@ func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, 
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
 	if !needsPerRowLock && !m.hasUpdateCol && !m.hasIncrementCol && !m.hasSetCol {
 		m.prefetchMainColumns(recids)
+		if reduced, ok := m.processJITBuffer(acc, recids); ok {
+			return reduced
+		}
 	}
 	bulkWidth := len(m.mainBulkReaders)
 	hasBulkValues := bulkWidth > 0 && len(m.mainBulkValues) == len(recids)*bulkWidth


### PR DESCRIPTION
## Summary

- fuse the accumulator loop over the existing row-major `mainBulkValues` buffer
- support arbitrary reducer arity and pass every storage column's exact `JITValueType()` into the inlined arithmetic
- keep the accumulator as a loop-carried, GC-safe phi home, preserving dynamic `nil -> int` and `int -> float` transitions
- use the calibrated fast path for simple reducers; other expressions use expression-dependent compile cost plus three real buffer A/B probes
- probe only when compile + probe costs at most 1% of the scan; retain fusion only above 2% measured benefit
- keep delta rows on the existing compiled-lambda path
- clear/pool the value buffer and drop query-local kernel/type references in `ShardMapReducer.Close()`

## Manual A/B measurements

AMD Ryzen 9 7900X3D, linux/amd64, patched Go 1.27 `GOEXPERIMENT=jit`, identical fixtures and 1024-row batches.

| reducer / rows | baseline median | best-of median | change |
|---|---:|---:|---:|
| SUM / 1 | 466.7 ns | 444.1 ns | -4.8% |
| SUM / 8 | 595.9 ns | 551.8 ns | -7.4% |
| SUM / 1,024 | 14.591 us | 14.646 us | +0.4% (no compile) |
| SUM / 60,000 | 819.0 us | 545.8 us | -33.4% |
| SUM / 1,000,000 | 14.593 ms | 7.735 ms | -47.0% |
| COUNT lambda / 60,000 | 720.0 us | 489.6 us | -32.0% |
| COUNT lambda / 1,000,000 | 12.083 ms | 6.871 ms | -43.1% |
| affine SUM / 1,000,000 | 20.545 ms | 20.564 ms | +0.1% (baseline retained) |
| two-column SUM / 1,000,000 | 22.603 ms | 22.565 ms | -0.2% (baseline retained) |

Complex control `(lambda (acc a b c) (+ acc (+ a (* b c))))`, corresponding to integer `SUM(a+b*c)`:

- current loop, 1,000,000 rows: 28.12 ms median
- forced fusion: 30.98 ms median, **+10.2%**, so it must not be selected on this machine
- best-of at 1,000,000 rows: no compilation; identical baseline path and 14 allocations/op
- simple kernel compile: 6.7 us, 7.9 KiB, 58 allocations
- complex kernel compile: 413 us, 1.21 MiB, 497 allocations

The calibration measures both compile anchors. At one million rows the complex query avoids compilation entirely. A sufficiently larger scan may run three probes; because forced fusion is slower here, it is rejected and remaining buffers use the compiled callback.

End-to-end `group-lookup-performance.yaml` cold ungrouped SQL SUM:

- master: 1,000,000 rows in 13.6 ms = 13.6 ns/row
- PR: 3,000,000 rows in 21.0 ms = 7.0 ns/row
- normalized improvement: -48.5%

## Validation

- normal and patched-JIT `go test ./scm ./storage`
- arbitrary three-column expression compilation and correctness
- point through million-row COUNT, SUM, affine, two-column and `a+b*c` spectrum
- dynamic accumulator transitions and deterministic query-local buffer release
- full CI matrix re-running for follow-up commit `2d4b3d84c`
