### PR TITLE
Materialize odd-width JIT lists directly

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -919,7 +919,7 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 projection for every source; that turns read-model queries into O(N^2) planner
 work before decorrelation has even started. */
 (define query_expr_alias_set (lambda (default_alias expr aliases)
-	(reduce (expr_collect_tagged_nth_unique expr (quote get_column) 1)
+	(reduce (tree_collect_tagged_nth_unique expr (quote get_column) 1)
 		(lambda (found tblvar)
 			(set_assoc found (resolve_column_alias tblvar default_alias) true))
 		aliases)))

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -919,7 +919,7 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 projection for every source; that turns read-model queries into O(N^2) planner
 work before decorrelation has even started. */
 (define query_expr_alias_set (lambda (default_alias expr aliases)
-	(reduce (tree_collect_tagged_nth_unique expr (quote get_column) 1)
+	(reduce (expr_collect_tagged_nth_unique expr (quote get_column) 1)
 		(lambda (found tblvar)
 			(set_assoc found (resolve_column_alias tblvar default_alias) true))
 		aliases)))

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -919,15 +919,10 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 projection for every source; that turns read-model queries into O(N^2) planner
 work before decorrelation has even started. */
 (define query_expr_alias_set (lambda (default_alias expr aliases)
-	(match expr
-		((symbol get_column) tblvar _ _ _)
-		(set_assoc aliases (resolve_column_alias tblvar default_alias) true)
-		((quote get_column) tblvar _ _ _)
-		(set_assoc aliases (resolve_column_alias tblvar default_alias) true)
-		(cons head tail) (reduce tail (lambda (found item)
-			(query_expr_alias_set default_alias item found))
-			(query_expr_alias_set default_alias head aliases))
-		_ aliases)))
+	(reduce (tree_collect_tagged_nth_unique expr (quote get_column) 1)
+		(lambda (found tblvar)
+			(set_assoc found (resolve_column_alias tblvar default_alias) true))
+		aliases)))
 
 (define query_exprs_alias_set (lambda (default_alias exprs)
 	(reduce (coalesceNil exprs '()) (lambda (aliases expr)

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -897,12 +897,13 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 	(filter (coalesceNil sources '()) (lambda (src)
 		(and (not (source_outer? src)) (source_is_base_table? src))))))
 
+(define expr_referenced_aliases (lambda (default_alias expr)
+	(map (expr_collect_tagged_nth_unique expr (quote get_column) 1)
+		(lambda (tblvar) (resolve_column_alias tblvar default_alias)))))
+
 (define expr_refs_alias? (lambda (default_alias alias expr)
-	(match expr
-		((symbol get_column) tblvar _ _ _) (equal?? (resolve_column_alias tblvar default_alias) alias)
-		((quote get_column) tblvar _ _ _) (equal?? (resolve_column_alias tblvar default_alias) alias)
-		(cons _head tail) (reduce tail (lambda (found item) (or found (expr_refs_alias? default_alias alias item))) false)
-		_ false)))
+	(reduce (expr_referenced_aliases default_alias expr) (lambda (found referenced_alias)
+		(or found (equal?? referenced_alias alias))) false)))
 
 (define expr_only_refs_alias? (lambda (default_alias alias expr)
 	(match expr
@@ -912,8 +913,14 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 		_ true)))
 
 (define expr_refs_any_alias? (lambda (default_alias aliases expr)
-	(reduce (coalesceNil aliases '()) (lambda (found alias)
-		(or found (expr_refs_alias? default_alias alias expr))) false)))
+	(begin
+		/* Collect once: testing N aliases must not recursively traverse the same
+		expression N times. This predicate is used throughout logical optimization
+		and physical lowering, so keeping that complexity linear is important. */
+		(define referenced_aliases (expr_referenced_aliases default_alias expr))
+		(reduce (coalesceNil aliases '()) (lambda (found alias)
+			(or found (reduce referenced_aliases (lambda (matched referenced_alias)
+				(or matched (equal?? referenced_alias alias))) false))) false))))
 
 /* Collect bound source aliases once. Join pruning must not rescan a wide
 projection for every source; that turns read-model queries into O(N^2) planner

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -902,8 +902,7 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 		(lambda (tblvar) (resolve_column_alias tblvar default_alias)))))
 
 (define expr_refs_alias? (lambda (default_alias alias expr)
-	(reduce (expr_referenced_aliases default_alias expr) (lambda (found referenced_alias)
-		(or found (equal?? referenced_alias alias))) false)))
+	(expr_tagged_nth_equal? expr (quote get_column) 1 default_alias alias)))
 
 (define expr_only_refs_alias? (lambda (default_alias alias expr)
 	(match expr
@@ -913,14 +912,11 @@ the shallow guard instead of walking the wide expression it is about to drop. */
 		_ true)))
 
 (define expr_refs_any_alias? (lambda (default_alias aliases expr)
-	(begin
-		/* Collect once: testing N aliases must not recursively traverse the same
-		expression N times. This predicate is used throughout logical optimization
-		and physical lowering, so keeping that complexity linear is important. */
-		(define referenced_aliases (expr_referenced_aliases default_alias expr))
-		(reduce (coalesceNil aliases '()) (lambda (found alias)
-			(or found (reduce referenced_aliases (lambda (matched referenced_alias)
-				(or matched (equal?? referenced_alias alias))) false))) false))))
+	/* Testing references must not allocate an intermediate alias list or walk the
+	same expression once per candidate alias. The native predicate short-circuits
+	on the first match and keeps its traversal stack local. */
+	(expr_tagged_nth_matches_any? expr (quote get_column) 1 default_alias
+		(coalesceNil aliases '()))))
 
 /* Collect bound source aliases once. Join pruning must not rescan a wide
 projection for every source; that turns read-model queries into O(N^2) planner

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -2315,10 +2315,10 @@ source catalog. join_plan remains the single owner of physical join order. */
 			predicates
 			required_drivers
 			planning_session))
-		(qassoc_set planned (quote tree)
-			(join_order_tree_with_predicates
-				(qassoc_get planned (quote tree) nil)
-				predicates)))))
+		/* join_order_result has already attached every predicate to its unique
+		logical owner. Repeating that recursive reconstruction here used to copy
+		the complete winning tree a second time without changing its value. */
+		planned)))
 
 (define join_optimizer_reorder_result (lambda (tree strategy dp_entries cost cardinality cost_components properties)
 	(list tree strategy dp_entries cost cardinality cost_components properties)))

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -2315,10 +2315,10 @@ source catalog. join_plan remains the single owner of physical join order. */
 			predicates
 			required_drivers
 			planning_session))
-		/* join_order_result has already attached every predicate to its unique
-		logical owner. Repeating that recursive reconstruction here used to copy
-		the complete winning tree a second time without changing its value. */
-		planned)))
+		(qassoc_set planned (quote tree)
+			(join_order_tree_with_predicates
+				(qassoc_get planned (quote tree) nil)
+				predicates)))))
 
 (define join_optimizer_reorder_result (lambda (tree strategy dp_entries cost cardinality cost_components properties)
 	(list tree strategy dp_entries cost cardinality cost_components properties)))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2286,6 +2286,27 @@ probe. */
 						(lower_scalar_cardinality_scan_lookup_choice
 							stage lookup_kind lookup_expr scan_expr))))))))
 
+(define collect_join_probe_lookup_columns_acc (lambda (sources default_alias target_alias stage columns_by_alias)
+	(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
+		(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)))
+
+(define collect_join_scalar_aggregate_columns_acc (lambda (sources default_alias target_alias stage columns_by_alias)
+	(reduce (scalar_aggregate_probe_outer_exprs stage) (lambda (acc expr)
+		(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)))
+
+(define collect_join_get_column_acc (lambda (sources default_alias target_alias tblvar tbl_ignorecase col col_ignorecase columns_by_alias)
+	(begin
+		(define src (if (nil? tblvar)
+			(source_for_unqualified_column sources default_alias col col_ignorecase)
+			(source_for_alias sources default_alias tblvar tbl_ignorecase)))
+		(if (or (nil? src) (and (not (nil? target_alias)) (not (equal?? (source_alias src) target_alias))))
+			columns_by_alias
+			(begin
+				(define alias (source_alias src))
+				(define physical_col (resolve_physical_column_name src col col_ignorecase))
+				(qassoc_set columns_by_alias alias
+					(merge_unique (list (qassoc_get columns_by_alias alias '()) (list physical_col)))))))))
+
 (define collect_join_columns_acc (lambda (sources default_alias target_alias expr columns_by_alias)
 	(match expr
 		((symbol driver_membership_probe) _stage probe)
@@ -2301,39 +2322,25 @@ probe. */
 		((quote dml_driver_membership_probe) _fallback_schema _stage probe)
 		(collect_join_columns_acc sources default_alias target_alias probe columns_by_alias)
 		((symbol scalar_first_probe) stage _requested_col)
-		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
-			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
 		((symbol scalar_first_probe) stage _requested_col _stages)
-		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
-			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
-		((quote scalar_first_probe) stage requested_col)
-		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_first_probe) stage requested_col) columns_by_alias)
-		((quote scalar_first_probe) stage requested_col _stages)
-		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_first_probe) stage requested_col) columns_by_alias)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((quote scalar_first_probe) stage _requested_col)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((quote scalar_first_probe) stage _requested_col _stages)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
 		((symbol scalar_aggregate_probe) stage _requested_col)
-		(reduce (scalar_aggregate_probe_outer_exprs stage) (lambda (acc expr)
-			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
-		((quote scalar_aggregate_probe) stage requested_col)
-		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_aggregate_probe) stage requested_col) columns_by_alias)
+		(collect_join_scalar_aggregate_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((quote scalar_aggregate_probe) stage _requested_col)
+		(collect_join_scalar_aggregate_columns_acc sources default_alias target_alias stage columns_by_alias)
 		((symbol scalar_cardinality_probe) stage _requested_col)
-		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
-			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
-		((quote scalar_cardinality_probe) stage requested_col)
-		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_cardinality_probe) stage requested_col) columns_by_alias)
-		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (begin
-			(define src (if (nil? tblvar)
-				(source_for_unqualified_column sources default_alias col col_ignorecase)
-				(source_for_alias sources default_alias tblvar tbl_ignorecase)))
-			(if (or (nil? src) (and (not (nil? target_alias)) (not (equal?? (source_alias src) target_alias))))
-				columns_by_alias
-				(begin
-					(define alias (source_alias src))
-					(define physical_col (resolve_physical_column_name src col col_ignorecase))
-					(qassoc_set columns_by_alias alias
-						(merge_unique (list (qassoc_get columns_by_alias alias '()) (list physical_col)))))))
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((quote scalar_cardinality_probe) stage _requested_col)
+		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
+		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase)
+		(collect_join_get_column_acc sources default_alias target_alias tblvar tbl_ignorecase col col_ignorecase columns_by_alias)
 		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
-		(collect_join_columns_acc sources default_alias target_alias
-			(list (symbol "get_column") tblvar tbl_ignorecase col col_ignorecase) columns_by_alias)
+		(collect_join_get_column_acc sources default_alias target_alias tblvar tbl_ignorecase col col_ignorecase columns_by_alias)
 		(cons _head tail) (reduce tail (lambda (acc item)
 			(collect_join_columns_acc sources default_alias target_alias item acc)) columns_by_alias)
 		_ columns_by_alias)))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4355,15 +4355,26 @@ that touch the current nullable source run in its map callback, after scan has
 either bound a real row or supplied the synthetic NULL row. */
 (define physical_partition_condition_terms (lambda (default_alias current_source future_sources terms scan_ready post_outer pending)
 	(match (coalesceNil terms '())
-		(cons term rest) (if (or
-			(expr_contains_orc_column? term)
-			(expr_refs_any_alias? default_alias (source_aliases future_sources) term))
+		(cons term rest) (if (expr_contains_orc_column? term)
 			(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready post_outer (cons term pending))
-			(if (and
-				(source_outer? current_source)
-				(expr_refs_alias? default_alias (source_alias current_source) term))
-				(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready (cons term post_outer) pending)
-				(physical_partition_condition_terms default_alias current_source future_sources rest (cons term scan_ready) post_outer pending)))
+			(begin
+				/* Classify the term from one alias walk. The former nested
+				expr_refs_any_alias? call rescanned it for every future source and
+				expr_refs_alias? scanned it again for nullable current sources. */
+				(define referenced_aliases (map
+					(expr_collect_tagged_nth_unique term (quote get_column) 1)
+					(lambda (tblvar) (resolve_column_alias tblvar default_alias))))
+				(define references_future (reduce future_sources (lambda (found src)
+					(or found (reduce referenced_aliases (lambda (matched referenced_alias)
+						(or matched (equal?? referenced_alias (source_alias src)))) false))) false))
+				(if references_future
+					(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready post_outer (cons term pending))
+					(if (and
+						(source_outer? current_source)
+						(reduce referenced_aliases (lambda (matched referenced_alias)
+							(or matched (equal?? referenced_alias (source_alias current_source)))) false))
+						(physical_partition_condition_terms default_alias current_source future_sources rest scan_ready (cons term post_outer) pending)
+						(physical_partition_condition_terms default_alias current_source future_sources rest (cons term scan_ready) post_outer pending)))))
 		_ (list
 			(combine_where_terms (reverse scan_ready) true)
 			(combine_where_terms (reverse post_outer) true)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3290,6 +3290,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		'tag 1)
 		(list 'a 'b 'c)
 		"tree collector preserves first-seen order, uniqueness, and tagged-leaf boundaries")
+	(assert (expr_collect_tagged_nth_unique
+		(list (list 'lambda (list 'row) (list 'tag 'operator-scope))
+			(list 'tag 'operand-scope))
+		'tag 1)
+		(list 'operand-scope)
+		"expression collector excludes references embedded in operator heads")
 	(assert (query_expr_alias_set 'default (list 'get_column 'a 'x nil nil) '()) (list 'a true)
 		"jit coverage: symbol get_column match")
 	(assert (query_expr_alias_set 'default

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3282,7 +3282,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(set query_expr_alias_set (jit query_expr_alias_set))
 	(assert (jit? resolve_column_alias) (jit-enabled?) "jit coverage: resolve_column_alias is 100% native")
 	(assert (jit? query_expr_alias_set) (jit-enabled?) "jit coverage: query_expr_alias_set is 100% native")
-	(assert (tree_collect_tagged_nth_unique
+	(assert (expr_collect_tagged_nth_unique
 		(list 'root
 			(list 'tag 'a)
 			(list 'nested (list 'tag 'b) (list 'tag 'a))
@@ -3290,6 +3290,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		'tag 1)
 		(list 'a 'b 'c)
 		"tree collector preserves first-seen order, uniqueness, and tagged-leaf boundaries")
+	(assert (expr_collect_tagged_nth_unique
+		(list (list 'lambda (list 'row) (list 'tag 'operator-scope))
+			(list 'tag 'operand-scope))
+		'tag 1)
+		(list 'operand-scope)
+		"expression collector does not leak references from a compound operator head")
 	(assert (query_expr_alias_set 'default (list 'get_column 'a 'x nil nil) '()) (list 'a true)
 		"jit coverage: symbol get_column match")
 	(assert (query_expr_alias_set 'default

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3296,6 +3296,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		'tag 1)
 		(list 'operand-scope)
 		"expression collector excludes references embedded in operator heads")
+	(assert (expr_tagged_nth_equal?
+		(list '+ (list 'tag nil) (list 'tag 'later)) 'tag 1 'default 'default)
+		true
+		"tagged expression equality applies the default and short-circuits")
+	(assert (expr_tagged_nth_matches_any?
+		(list (list 'lambda '() (list 'tag 'operator-scope))
+			(list 'nested (list 'tag 'operand-scope)))
+		'tag 1 'default (list 'missing 'operand-scope))
+		true
+		"tagged expression membership searches operands without entering the operator")
+	(assert (expr_tagged_nth_matches_any?
+		(list 'root (list 'tag 'present)) 'tag 1 'default (list 'absent))
+		false
+		"tagged expression membership reports a missing value")
 	(assert (query_expr_alias_set 'default (list 'get_column 'a 'x nil nil) '()) (list 'a true)
 		"jit coverage: symbol get_column match")
 	(assert (query_expr_alias_set 'default

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3276,18 +3276,27 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	/* query_expr_alias_set is the planner JIT coverage target. Native compilation
 	is atomic, so a compiled descriptor means every expression in the function was
-	lowered without a whole-procedure fallback. Exercise representative match paths,
-	the nested reduce lambda, recursion, and both resolve_column_alias branches. */
+	lowered without a whole-procedure fallback. The callback-free tree collector
+	deduplicates tagged leaves before Scheme builds the alias dictionary. */
 	(set resolve_column_alias (jit resolve_column_alias))
 	(set query_expr_alias_set (jit query_expr_alias_set))
 	(assert (jit? resolve_column_alias) (jit-enabled?) "jit coverage: resolve_column_alias is 100% native")
 	(assert (jit? query_expr_alias_set) (jit-enabled?) "jit coverage: query_expr_alias_set is 100% native")
+	(assert (tree_collect_tagged_nth_unique
+		(list 'root
+			(list 'tag 'a)
+			(list 'nested (list 'tag 'b) (list 'tag 'a))
+			(list 'tag 'c (list 'tag 'payload-is-not-a-child)))
+		'tag 1)
+		(list 'a 'b 'c)
+		"tree collector preserves first-seen order, uniqueness, and tagged-leaf boundaries")
 	(assert (query_expr_alias_set 'default (list 'get_column 'a 'x nil nil) '()) (list 'a true)
 		"jit coverage: symbol get_column match")
 	(assert (query_expr_alias_set 'default
-		(list '+ (list 'get_column 'a 'x nil nil) (list 'get_column nil 'y nil nil)) '())
+		(list '+ (list 'get_column 'a 'x nil nil)
+			(list 'nested (list 'get_column nil 'y nil nil) (list 'get_column 'a 'z nil nil))) '())
 		(list 'a true 'default true)
-		"jit coverage: cons recursion and nested reduce lambda")
+		"jit coverage: nested traversal, deduplication, and default alias")
 	(assert (query_expr_alias_set 'default 42 (list 'existing true)) (list 'existing true)
 		"jit coverage: scalar fallback match")
 

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3282,7 +3282,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(set query_expr_alias_set (jit query_expr_alias_set))
 	(assert (jit? resolve_column_alias) (jit-enabled?) "jit coverage: resolve_column_alias is 100% native")
 	(assert (jit? query_expr_alias_set) (jit-enabled?) "jit coverage: query_expr_alias_set is 100% native")
-	(assert (expr_collect_tagged_nth_unique
+	(assert (tree_collect_tagged_nth_unique
 		(list 'root
 			(list 'tag 'a)
 			(list 'nested (list 'tag 'b) (list 'tag 'a))
@@ -3290,12 +3290,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		'tag 1)
 		(list 'a 'b 'c)
 		"tree collector preserves first-seen order, uniqueness, and tagged-leaf boundaries")
-	(assert (expr_collect_tagged_nth_unique
-		(list (list 'lambda (list 'row) (list 'tag 'operator-scope))
-			(list 'tag 'operand-scope))
-		'tag 1)
-		(list 'operand-scope)
-		"expression collector does not leak references from a compound operator head")
 	(assert (query_expr_alias_set 'default (list 'get_column 'a 'x nil nil) '()) (list 'a true)
 		"jit coverage: symbol get_column match")
 	(assert (query_expr_alias_set 'default

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -1834,9 +1834,19 @@ func jitNewSliceResult(values []Scmer, length uint64) Scmer {
 	}
 }
 
+func jitNewSlice1(a Scmer) Scmer {
+	values := []Scmer{a}
+	return jitNewSliceResult(values, 1)
+}
+
 func jitNewSlice2(a, b Scmer) Scmer {
 	values := []Scmer{a, b}
 	return jitNewSliceResult(values, 2)
+}
+
+func jitNewSlice3(a, b, c Scmer) Scmer {
+	values := []Scmer{a, b, c}
+	return jitNewSliceResult(values, 3)
 }
 
 func jitNewSlice4(a, b, c, d Scmer) Scmer {
@@ -1852,6 +1862,16 @@ func jitNewSlice6(a, b, c, d Scmer, tail *[2]Scmer) Scmer {
 	return jitNewSliceResult(values, 6)
 }
 
+func jitNewSlice5(a, b, c, d Scmer, tail *[1]Scmer) Scmer {
+	values := []Scmer{a, b, c, d, tail[0]}
+	return jitNewSliceResult(values, 5)
+}
+
+func jitNewSlice7(a, b, c, d Scmer, tail *[3]Scmer) Scmer {
+	values := []Scmer{a, b, c, d, tail[0], tail[1], tail[2]}
+	return jitNewSliceResult(values, 7)
+}
+
 func jitNewSlice8(a, b, c, d Scmer, tail *[4]Scmer) Scmer {
 	values := []Scmer{a, b, c, d, tail[0], tail[1], tail[2], tail[3]}
 	return jitNewSliceResult(values, 8)
@@ -1859,16 +1879,37 @@ func jitNewSlice8(a, b, c, d Scmer, tail *[4]Scmer) Scmer {
 
 func jitDirectSliceBuilder(length int) uint64 {
 	switch length {
+	case 1:
+		return GoFuncAddr(jitNewSlice1)
 	case 2:
 		return GoFuncAddr(jitNewSlice2)
+	case 3:
+		return GoFuncAddr(jitNewSlice3)
 	case 4:
 		return GoFuncAddr(jitNewSlice4)
+	case 5:
+		return GoFuncAddr(jitNewSlice5)
 	case 6:
 		return GoFuncAddr(jitNewSlice6)
+	case 7:
+		return GoFuncAddr(jitNewSlice7)
 	case 8:
 		return GoFuncAddr(jitNewSlice8)
 	default:
 		return 0
+	}
+}
+
+// jitDirectSliceBuilder historically doubled as an inlining heuristic while
+// only even-width builders existed. Direct materialization is profitable for
+// odd widths too, but that must not silently broaden the set of builtin calls
+// duplicated into callers. Keep policy separate from mechanism.
+func jitDirectSliceBuilderPrefersInlining(length int) bool {
+	switch length {
+	case 2, 4, 6, 8:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -2861,7 +2902,7 @@ func jitGeneratedEmitterInline(ctx *JITContext, declaration *Declaration, args [
 		inline = declaration.Type.JITInlineCallbacks && knownCallback
 	} else if !inline {
 		switch {
-		case declaration.Type.JITVirtualArgs && cost <= jitTrivialVirtualInlineCost && (jitDirectSliceBuilder(len(args)) != 0 || len(args) > 8):
+		case declaration.Type.JITVirtualArgs && cost <= jitTrivialVirtualInlineCost && (jitDirectSliceBuilderPrefersInlining(len(args)) || len(args) > 8):
 			inline = true
 		case declaration.Type.JITVirtualArgs && hasVirtualArgs && cost <= 32:
 			inline = true

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -708,6 +708,38 @@ func TestJITExpressionListResultOwnsBackingStorage(t *testing.T) {
 	}
 }
 
+func TestJITDirectOddSliceBuildersOwnBackingStorage(t *testing.T) {
+	for _, width := range []int{1, 3, 5, 7} {
+		if jitDirectSliceBuilder(width) == 0 {
+			t.Fatalf("missing direct slice builder for width %d", width)
+		}
+		if jitDirectSliceBuilderPrefersInlining(width) {
+			t.Fatalf("materialization support unexpectedly changed inlining policy for width %d", width)
+		}
+		parts := make([]string, width)
+		for index := range parts {
+			parts[index] = "value"
+		}
+		compiled := compileJITExpressionTestProc(t, fmt.Sprintf("(lambda (value) (list %s))", strings.Join(parts, " ")))
+		first := Apply(compiled, NewString("first"))
+		_ = Apply(compiled, NewString("replacement"))
+		items := first.Slice()
+		if len(items) != width {
+			t.Fatalf("width %d builder returned %d items", width, len(items))
+		}
+		for _, item := range items {
+			if !Equal(item, NewString("first")) {
+				t.Fatalf("width %d builder retained transient storage: %s", width, String(first))
+			}
+		}
+	}
+	for _, width := range []int{2, 4, 6, 8} {
+		if !jitDirectSliceBuilderPrefersInlining(width) {
+			t.Fatalf("existing inlining policy changed for width %d", width)
+		}
+	}
+}
+
 func TestJITDynamicListCallOwnsBackingStorage(t *testing.T) {
 	compiled := compileJITExpressionTestProc(t, `(lambda (callback value) (callback value 2 3))`)
 	callableType := &TypeDescriptor{Kind: "func", Return: &TypeDescriptor{Kind: "list"}}

--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -28,7 +28,10 @@ import (
 )
 
 const (
-	jitParserLargeInputBytes           = 64 << 10
+	// Medium generated SQL already creates hundreds of thousands of packrat
+	// entries. Preallocating from 16 KiB avoids repeated slice growth and GC,
+	// while smaller OLTP statements keep the allocation-free lazy path.
+	jitParserLargeInputBytes           = 16 << 10
 	jitParserMemoEntriesPerByteHint    = 20
 	jitParserMemoPreallocateLimit      = 4 << 20
 	jitParserMemoRuleSlotsPerByteHint  = 120

--- a/scm/jit_parser_test.go
+++ b/scm/jit_parser_test.go
@@ -89,6 +89,12 @@ func TestJITParserReleaseDropsOversizedMemoStorage(t *testing.T) {
 }
 
 func TestJITParserMemoCapacityHintIsBounded(t *testing.T) {
+	if got := jitParserMemoEntryCapacity(8 << 10); got != 0 {
+		t.Fatalf("short input capacity hint = %d, want 0", got)
+	}
+	if got := jitParserMemoEntryCapacity(32 << 10); got != (32<<10)*jitParserMemoEntriesPerByteHint {
+		t.Fatalf("complex input capacity hint = %d, want %d", got, (32<<10)*jitParserMemoEntriesPerByteHint)
+	}
 	if got := jitParserMemoEntryCapacity(jitParserLargeInputBytes); got != 0 {
 		t.Fatalf("small input capacity hint = %d, want 0", got)
 	}

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -17,8 +17,16 @@ Copyright (C) 2026  Carl-Philip Hänsch
 package scm
 
 func treeCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
+	return collectTaggedNthUnique(root, tag, position, true)
+}
+
+func exprCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
+	return collectTaggedNthUnique(root, tag, position, false)
+}
+
+func collectTaggedNthUnique(root, tag Scmer, position int, traverseHeads bool) Scmer {
 	if position < 0 {
-		panic("tree_collect_tagged_nth_unique expects a non-negative position")
+		panic("tagged nth collector expects a non-negative position")
 	}
 
 	// Compiler trees are normally shallow and aliases are few. Keep traversal
@@ -56,7 +64,11 @@ func treeCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
 			// data, not another expression to inspect for the same tag.
 			continue
 		}
-		for index := len(items) - 1; index >= 0; index-- {
+		firstChild := 0
+		if !traverseHeads {
+			firstChild = 1
+		}
+		for index := len(items) - 1; index >= firstChild; index-- {
 			pending = append(pending, items[index])
 		}
 	}
@@ -83,6 +95,21 @@ func init_list_assoc_extra() {
 		Type: &TypeDescriptor{Kind: "func", Description: "collects the unique zero-based nth values of tagged nodes in a nested list tree",
 			Params: []*TypeDescriptor{
 				{Kind: "any", Label: "tree", NoEscape: true},
+				{Kind: "any", Label: "tag", NoEscape: true},
+				{Kind: "number", Label: "position"},
+			},
+			Return: FreshAlloc,
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "expr_collect_tagged_nth_unique",
+		Fn: func(a ...Scmer) Scmer {
+			return exprCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "collects unique zero-based nth values of tagged operand expressions without traversing operator heads",
+			Params: []*TypeDescriptor{
+				{Kind: "any", Label: "expression", NoEscape: true},
 				{Kind: "any", Label: "tag", NoEscape: true},
 				{Kind: "number", Label: "position"},
 			},

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -78,6 +78,44 @@ func collectTaggedNthUnique(root, tag Scmer, position int, traverseHeads bool) S
 	return NewSlice(result)
 }
 
+func exprTaggedNthMatchesAny(root, tag Scmer, position int, nilReplacement Scmer, candidates []Scmer) bool {
+	if position < 0 {
+		panic("tagged nth matcher expects a non-negative position")
+	}
+
+	var pendingStorage [64]Scmer
+	pending := pendingStorage[:1]
+	pending[0] = root
+	for len(pending) != 0 {
+		last := len(pending) - 1
+		current := pending[last].WithoutSourceInfo()
+		pending = pending[:last]
+		if !current.IsSlice() {
+			continue
+		}
+		items := current.Slice()
+		if len(items) != 0 && Equal(items[0], tag) {
+			if len(items) > position {
+				candidate := items[position].WithoutSourceInfo()
+				if candidate.IsNil() {
+					candidate = nilReplacement
+				}
+				for _, expected := range candidates {
+					if Equal(candidate, expected) {
+						return true
+					}
+				}
+			}
+			continue
+		}
+		// Expression heads are operators, not operands in the caller's scope.
+		for index := len(items) - 1; index >= 1; index-- {
+			pending = append(pending, items[index])
+		}
+	}
+	return false
+}
+
 func groupAssocCapacity(inputLength int) int {
 	const initialGroups = 32
 	if inputLength < initialGroups {
@@ -114,6 +152,40 @@ func init_list_assoc_extra() {
 				{Kind: "number", Label: "position"},
 			},
 			Return: FreshAlloc,
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "expr_tagged_nth_equal?",
+		Fn: func(a ...Scmer) Scmer {
+			return NewBool(exprTaggedNthMatchesAny(a[0], a[1], int(ToInt(a[2])), a[3], a[4:5]))
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "tests whether a tagged operand has the expected nth value, replacing nil with a supplied default",
+			Params: []*TypeDescriptor{
+				{Kind: "any", Label: "expression", NoEscape: true},
+				{Kind: "any", Label: "tag", NoEscape: true},
+				{Kind: "number", Label: "position"},
+				{Kind: "any", Label: "nil replacement", NoEscape: true},
+				{Kind: "any", Label: "expected", NoEscape: true},
+			},
+			Return: &TypeDescriptor{Kind: "bool"},
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "expr_tagged_nth_matches_any?",
+		Fn: func(a ...Scmer) Scmer {
+			return NewBool(exprTaggedNthMatchesAny(a[0], a[1], int(ToInt(a[2])), a[3], asSlice(a[4], "expr_tagged_nth_matches_any?")))
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "tests whether a tagged operand has any expected nth value, replacing nil with a supplied default",
+			Params: []*TypeDescriptor{
+				{Kind: "any", Label: "expression", NoEscape: true},
+				{Kind: "any", Label: "tag", NoEscape: true},
+				{Kind: "number", Label: "position"},
+				{Kind: "any", Label: "nil replacement", NoEscape: true},
+				{Kind: "list", Label: "expected values", NoEscape: true},
+			},
+			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
 		},
 	})

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -16,9 +16,9 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
-func treeCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
+func exprCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
 	if position < 0 {
-		panic("tree_collect_tagged_nth_unique expects a non-negative position")
+		panic("expr_collect_tagged_nth_unique expects a non-negative position")
 	}
 
 	// Compiler trees are normally shallow and aliases are few. Keep traversal
@@ -56,7 +56,10 @@ func treeCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
 			// data, not another expression to inspect for the same tag.
 			continue
 		}
-		for index := len(items) - 1; index >= 0; index-- {
+		// Expression heads are operators. They may themselves be compound values
+		// (for example an embedded lambda), but are not operands of this expression
+		// and must not contribute references to its caller's scope.
+		for index := len(items) - 1; index >= 1; index-- {
 			pending = append(pending, items[index])
 		}
 	}
@@ -76,11 +79,11 @@ func groupAssocCapacity(inputLength int) int {
 
 func init_list_assoc_extra() {
 	Declare(&Globalenv, &Declaration{
-		Name: "tree_collect_tagged_nth_unique",
+		Name: "expr_collect_tagged_nth_unique",
 		Fn: func(a ...Scmer) Scmer {
-			return treeCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
+			return exprCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
 		},
-		Type: &TypeDescriptor{Kind: "func", Description: "collects the unique zero-based nth values of tagged nodes in a nested list tree",
+		Type: &TypeDescriptor{Kind: "func", Description: "collects unique zero-based nth values of tagged operand expressions without traversing operator heads",
 			Params: []*TypeDescriptor{
 				{Kind: "any", Label: "tree", NoEscape: true},
 				{Kind: "any", Label: "tag", NoEscape: true},

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -16,9 +16,9 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
-func exprCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
+func treeCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
 	if position < 0 {
-		panic("expr_collect_tagged_nth_unique expects a non-negative position")
+		panic("tree_collect_tagged_nth_unique expects a non-negative position")
 	}
 
 	// Compiler trees are normally shallow and aliases are few. Keep traversal
@@ -56,10 +56,7 @@ func exprCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
 			// data, not another expression to inspect for the same tag.
 			continue
 		}
-		// Expression heads are operators. They may themselves be compound values
-		// (for example an embedded lambda), but are not operands of this expression
-		// and must not contribute references to its caller's scope.
-		for index := len(items) - 1; index >= 1; index-- {
+		for index := len(items) - 1; index >= 0; index-- {
 			pending = append(pending, items[index])
 		}
 	}
@@ -79,11 +76,11 @@ func groupAssocCapacity(inputLength int) int {
 
 func init_list_assoc_extra() {
 	Declare(&Globalenv, &Declaration{
-		Name: "expr_collect_tagged_nth_unique",
+		Name: "tree_collect_tagged_nth_unique",
 		Fn: func(a ...Scmer) Scmer {
-			return exprCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
+			return treeCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
 		},
-		Type: &TypeDescriptor{Kind: "func", Description: "collects unique zero-based nth values of tagged operand expressions without traversing operator heads",
+		Type: &TypeDescriptor{Kind: "func", Description: "collects the unique zero-based nth values of tagged nodes in a nested list tree",
 			Params: []*TypeDescriptor{
 				{Kind: "any", Label: "tree", NoEscape: true},
 				{Kind: "any", Label: "tag", NoEscape: true},

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -16,6 +16,56 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
+func treeCollectTaggedNthUnique(root, tag Scmer, position int) Scmer {
+	if position < 0 {
+		panic("tree_collect_tagged_nth_unique expects a non-negative position")
+	}
+
+	// Compiler trees are normally shallow and aliases are few. Keep traversal
+	// state on the stack for those common cases; append retains correct behavior
+	// for unusually deep trees without imposing a fixed planner limit.
+	var pendingStorage [64]Scmer
+	pending := pendingStorage[:1]
+	pending[0] = root
+	var uniqueStorage [8]Scmer
+	unique := uniqueStorage[:0]
+
+	for len(pending) != 0 {
+		last := len(pending) - 1
+		current := pending[last].WithoutSourceInfo()
+		pending = pending[:last]
+		if !current.IsSlice() {
+			continue
+		}
+		items := current.Slice()
+		if len(items) != 0 && Equal(items[0], tag) {
+			if len(items) > position {
+				candidate := items[position].WithoutSourceInfo()
+				seen := false
+				for _, existing := range unique {
+					if Equal(existing, candidate) {
+						seen = true
+						break
+					}
+				}
+				if !seen {
+					unique = append(unique, candidate)
+				}
+			}
+			// A tagged node is one logical leaf for this operation. Its payload is
+			// data, not another expression to inspect for the same tag.
+			continue
+		}
+		for index := len(items) - 1; index >= 0; index-- {
+			pending = append(pending, items[index])
+		}
+	}
+
+	result := make([]Scmer, len(unique))
+	copy(result, unique)
+	return NewSlice(result)
+}
+
 func groupAssocCapacity(inputLength int) int {
 	const initialGroups = 32
 	if inputLength < initialGroups {
@@ -25,6 +75,21 @@ func groupAssocCapacity(inputLength int) int {
 }
 
 func init_list_assoc_extra() {
+	Declare(&Globalenv, &Declaration{
+		Name: "tree_collect_tagged_nth_unique",
+		Fn: func(a ...Scmer) Scmer {
+			return treeCollectTaggedNthUnique(a[0], a[1], int(ToInt(a[2])))
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "collects the unique zero-based nth values of tagged nodes in a nested list tree",
+			Params: []*TypeDescriptor{
+				{Kind: "any", Label: "tree", NoEscape: true},
+				{Kind: "any", Label: "tag", NoEscape: true},
+				{Kind: "number", Label: "position"},
+			},
+			Return: FreshAlloc,
+			Const:  true,
+		},
+	})
 	Declare(&Globalenv, &Declaration{
 		Name: "group_assoc",
 		Fn: func(a ...Scmer) Scmer {


### PR DESCRIPTION
## Summary

- add direct JIT result builders for one-, three-, five-, and seven-element Scheme lists
- avoid building those common AST/result shapes in an invocation-frame array and copying them through `JITNewSliceCopy`
- separate direct-materialization capability from the existing builtin-inlining heuristic, so supporting new widths cannot silently broaden inlining policy
- verify that every new builder returns independently owned backing storage across subsequent calls

This branch is intentionally implemented on top of #823, but the PR targets `master` as the requested follow-up. Once #823 lands, GitHub will reduce this PR to the final commit automatically.

## Manual A/B measurements

Same production-copy 28.6 KiB ACL/search query, JIT build, `EXPLAIN COMPILE`, 15 warmups, 300 cache-busted samples:

| Metric (p50) | #823 baseline | This PR | Change |
|---|---:|---:|---:|
| parser | 65.409 ms | 63.359 ms | -3.13% |
| compile total | 153.100 ms | 152.262 ms | -0.55% |
| HTTP wall | 155.199 ms | 154.358 ms | -0.54% |
| physical plan | 52,933 bytes / 2,600 nodes | 52,933 bytes / 2,600 nodes | unchanged |

Small-query guard (`SELECT 1`, 50 warmups, 1,000 cache-busted samples):

| Metric (p50) | #823 baseline | This PR | Change |
|---|---:|---:|---:|
| compile total | 165.697 us | 162.871 us | -1.71% |
| HTTP wall | 454.668 us | 450.619 us | -0.89% |

Temporary focused JIT microbenchmark, identical source and 500 ms x 3 samples per width (median):

| Result width | Baseline | This PR | Change |
|---:|---:|---:|---:|
| 1 | 19.97 ns | 12.28 ns | -38.5% |
| 3 | 26.57 ns | 17.09 ns | -35.7% |
| 5 | 38.29 ns | 26.36 ns | -31.2% |
| 7 | 78.62 ns | 67.83 ns | -13.7% |

Allocation count and bytes remain at the semantic minimum: one independently owned result allocation of 16 bytes per element.

## Validation

- normal `go test ./scm`
- JIT `go test ./scm`
- startup Scheme suite: 1281/1281
- `traced-insert-select-pagination.yaml`: 11/11
- `decorrelated-join-reordering.yaml`: 8/8
- `acl-boolean-membership-scaling.yaml`: 35/35
- `rdf-spec-graph-algebra.yaml`: 8/8

The full SQL and performance A/B suites are left to CI as required.
