### PR TITLE
Fuse calibrated typed filter buffers within shard scans

### DIFF
--- a/.github/workflows/jit-test.yml
+++ b/.github/workflows/jit-test.yml
@@ -90,7 +90,7 @@ jobs:
           sudo apt-get install -y mariadb-client
 
       - name: Run tests with JIT enabled
-        run: bash git-pre-commit
+        run: bash git-pre-commit --fail-fast
 
       - name: Verify dump and restore compatibility with JIT enabled
         env:

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -722,11 +722,16 @@ type JITStorageGetValueMultiFunc func([]uint32, []Scmer, int)
 // explicit so zero-column reducers such as COUNT(*) need no synthetic values.
 type JITMapReduceBufferFunc func(Scmer, []Scmer, int) Scmer
 
-// PrepareJITMapReduceBufferProc returns source suitable for typed buffer-loop
-// inlining. Native declarations with a JIT emitter are wrapped in a procedure
-// so physical operators can specialize the same implementation without
-// teaching the storage package about individual aggregate names.
-func PrepareJITMapReduceBufferProc(source Scmer, arity int) *Proc {
+// JITFilterBufferFunc evaluates a typed row-major Scmer buffer and compacts
+// the corresponding record identifiers in place. The row width and predicate
+// are compile-time properties of the function.
+type JITFilterBufferFunc func([]uint32, []Scmer) int
+
+// PrepareJITBufferProc returns source suitable for typed buffer-loop inlining.
+// Native declarations with a JIT emitter are wrapped in a procedure so physical
+// operators can specialize the same implementation without teaching the
+// storage package about individual scalar or aggregate names.
+func PrepareJITBufferProc(source Scmer, arity int) *Proc {
 	if arity < 1 {
 		return nil
 	}
@@ -746,7 +751,7 @@ func PrepareJITMapReduceBufferProc(source Scmer, arity int) *Proc {
 	body := make([]Scmer, arity+1)
 	body[0] = source
 	for index := range params {
-		parameter := NewSymbol(fmt.Sprintf("\x00buffer-reduce-%d", index))
+		parameter := NewSymbol(fmt.Sprintf("\x00buffer-arg-%d", index))
 		params[index] = parameter
 		body[index+1] = parameter
 	}

--- a/scm/jit_calibration.go
+++ b/scm/jit_calibration.go
@@ -39,21 +39,28 @@ const (
 // immutable after startup publication; query compilation can therefore read it
 // without locks or hot-path calibration branches.
 type JITCostCalibration struct {
-	Enabled             bool
-	ShapeCount          int
-	SamplesPerShape     int
-	CalibrationNS       int64
-	EmitFixedNS         float64
-	EmitUnitNS          float64
-	PublishFixedNS      float64
-	DirectCallNS        float64
-	PredicateUnitNS     float64
-	BufferCompileNS     float64
-	BufferCompileUnitNS float64
-	BufferCurrentNS     float64
-	BufferFusedNS       float64
-	BufferSavedNS       float64
-	BufferMaxUnits      int
+	Enabled                   bool
+	ShapeCount                int
+	SamplesPerShape           int
+	CalibrationNS             int64
+	EmitFixedNS               float64
+	EmitUnitNS                float64
+	PublishFixedNS            float64
+	DirectCallNS              float64
+	PredicateUnitNS           float64
+	BufferCompileNS           float64
+	BufferCompileUnitNS       float64
+	BufferCurrentNS           float64
+	BufferFusedNS             float64
+	BufferSavedNS             float64
+	BufferMaxUnits            int
+	FilterBufferCompileNS     float64
+	FilterBufferCompileUnitNS float64
+	FilterBufferCurrentNS     float64
+	FilterBufferFusedNS       float64
+	FilterBufferSavedNS       float64
+	FilterBufferMaxUnits      int
+	FilterBufferMinimumRows   int
 }
 
 // EstimateCompileNS estimates one query-local emission and publication. The
@@ -123,6 +130,25 @@ func (calibration JITCostCalibration) MapReduceBufferProbeBreakEven(expressionCo
 	return int(math.Ceil(100 * (compileNS + probeNS) / calibration.BufferCurrentNS))
 }
 
+// FilterBufferBreakEven returns the number of rows needed to amortize a typed
+// predicate loop. Startup calibration compares the same row-major buffer and
+// compaction work with and without the fused loop; bulk column decoding is an
+// additional storage-side benefit and is deliberately not needed to justify it.
+func (calibration JITCostCalibration) FilterBufferBreakEven(expressionCost, columnCount int) int {
+	if !calibration.Enabled || expressionCost < 0 || columnCount < 1 || calibration.FilterBufferSavedNS <= 0 {
+		return math.MaxInt
+	}
+	compileNS := calibration.FilterBufferCompileNS
+	if expressionCost > calibration.FilterBufferMaxUnits {
+		if calibration.FilterBufferCompileUnitNS <= 0 {
+			return math.MaxInt
+		}
+		compileNS += float64(expressionCost-calibration.FilterBufferMaxUnits) * calibration.FilterBufferCompileUnitNS
+	}
+	// Keep timer noise and unmeasured gather costs away from point queries.
+	return int(math.Ceil(2 * compileNS / calibration.FilterBufferSavedNS))
+}
+
 type jitCalibrationShape struct {
 	source  string
 	argSets [][]Scmer
@@ -158,11 +184,96 @@ func CalibrateJITCosts() JITCostCalibration {
 			calibration.BufferCompileNS, calibration.BufferCurrentNS, calibration.BufferFusedNS, calibration.BufferMaxUnits = measureMapReduceBufferCalibration()
 			calibration.BufferCompileUnitNS = measureMapReduceBufferCompileUnit(calibration.BufferCompileNS, calibration.BufferMaxUnits)
 			calibration.BufferSavedNS = math.Max(0, calibration.BufferCurrentNS-calibration.BufferFusedNS)
+			calibration.FilterBufferCompileNS, calibration.FilterBufferCurrentNS, calibration.FilterBufferFusedNS, calibration.FilterBufferMaxUnits = measureFilterBufferCalibration()
+			calibration.FilterBufferCompileUnitNS = measureFilterBufferCompileUnit(calibration.FilterBufferCompileNS, calibration.FilterBufferMaxUnits)
+			calibration.FilterBufferSavedNS = math.Max(0, calibration.FilterBufferCurrentNS-calibration.FilterBufferFusedNS)
+			calibration.FilterBufferMinimumRows = calibration.FilterBufferBreakEven(0, 1)
 		}
 		calibration.CalibrationNS = time.Since(started).Nanoseconds()
 		jitCalibrationData.Store(&calibration)
 	})
 	return CurrentJITCosts()
+}
+
+func measureFilterBufferCalibration() (compileNS, currentNS, fusedNS float64, expressionUnits int) {
+	template := calibrationProcedure(`(lambda (value) (> value 127))`)
+	compiled := CompileJIT(NewProcStruct(*cloneCalibrationProcedure(template)), true)
+	proc := compiled.Proc()
+	if proc == nil || proc.Compiled == nil {
+		return 0, 0, 0, 0
+	}
+	expressionUnits = JITExpressionCost(proc.Body)
+	compileSamples := make([]float64, jitCalibrationSamples)
+	var fused JITFilterBufferFunc
+	for sample := range compileSamples {
+		started := time.Now()
+		fused = CompileJITFilterBuffer(proc, []uint8{tagInt})
+		compileSamples[sample] = float64(time.Since(started).Nanoseconds())
+	}
+	if fused == nil {
+		return 0, 0, 0, 0
+	}
+	const rows = 16 * 1024
+	values := make([]Scmer, rows)
+	ids := make([]uint32, rows)
+	for index := range values {
+		values[index] = NewInt(int64(index & 255))
+		ids[index] = uint32(index)
+	}
+	currentSamples := make([]float64, jitCalibrationSamples)
+	fusedSamples := make([]float64, jitCalibrationSamples)
+	args := []Scmer{NewInt(0)}
+	for sample := range currentSamples {
+		started := time.Now()
+		out := 0
+		for index, value := range values {
+			args[0] = value
+			if ToBool(proc.Compiled.Native(args...)) {
+				ids[out] = uint32(index)
+				out++
+			}
+		}
+		currentSamples[sample] = float64(time.Since(started).Nanoseconds()) / rows
+		jitCalibrationSink = NewInt(int64(out))
+
+		for index := range ids {
+			ids[index] = uint32(index)
+		}
+		started = time.Now()
+		out = fused(ids, values)
+		fusedSamples[sample] = float64(time.Since(started).Nanoseconds()) / rows
+		jitCalibrationSink = NewInt(int64(out))
+	}
+	compileNS = medianFloat64(compileSamples)
+	currentNS = medianFloat64(currentSamples)
+	fusedNS = medianFloat64(fusedSamples)
+	runtime.KeepAlive(compiled)
+	runtime.KeepAlive(fused)
+	return compileNS, currentNS, fusedNS, expressionUnits
+}
+
+func measureFilterBufferCompileUnit(simpleNS float64, simpleUnits int) float64 {
+	template := calibrationProcedure("(lambda (a b c) (and (> (+ a (* b c)) 127) (< (- c a) 511)))")
+	compiled := CompileJIT(NewProcStruct(*cloneCalibrationProcedure(template)), true)
+	proc := compiled.Proc()
+	if proc == nil || proc.Compiled == nil {
+		return 0
+	}
+	units := JITExpressionCost(proc.Body)
+	if units <= simpleUnits {
+		return 0
+	}
+	samples := make([]float64, jitCalibrationSamples)
+	for sample := range samples {
+		started := time.Now()
+		kernel := CompileJITFilterBuffer(proc, []uint8{tagInt, tagInt, tagInt})
+		samples[sample] = float64(time.Since(started).Nanoseconds())
+		if kernel == nil {
+			return 0
+		}
+		runtime.KeepAlive(kernel)
+	}
+	return math.Max(0, (medianFloat64(samples)-simpleNS)/float64(units-simpleUnits))
 }
 
 func measureMapReduceBufferCalibration() (compileNS, currentNS, fusedNS float64, expressionUnits int) {

--- a/scm/jit_calibration_test.go
+++ b/scm/jit_calibration_test.go
@@ -77,6 +77,25 @@ func TestJITCalibrationMapReduceBufferBestOf(t *testing.T) {
 	}
 }
 
+func TestJITCalibrationFilterBufferBestOf(t *testing.T) {
+	calibration := JITCostCalibration{
+		Enabled:                   true,
+		FilterBufferCompileNS:     100,
+		FilterBufferCompileUnitNS: 4,
+		FilterBufferSavedNS:       5,
+		FilterBufferMaxUnits:      20,
+	}
+	if got := calibration.FilterBufferBreakEven(20, 3); got != 40 {
+		t.Fatalf("filter buffer break-even rows = %d, want 40", got)
+	}
+	if got := calibration.FilterBufferBreakEven(30, 3); got != 56 {
+		t.Fatalf("complex filter buffer break-even rows = %d, want 56", got)
+	}
+	if got := calibration.FilterBufferBreakEven(20, 0); got != math.MaxInt {
+		t.Fatalf("zero-column filter break-even = %d, want MaxInt", got)
+	}
+}
+
 func TestJITCalibrationAnchorsCallBoundaryToTrivialShapes(t *testing.T) {
 	observations := []jitCalibrationObservation{
 		{workUnits: 0, callNS: 4},

--- a/scm/jit_storage_amd64.go
+++ b/scm/jit_storage_amd64.go
@@ -32,6 +32,7 @@ const (
 	jitStorageGetValueRangeABI
 	jitStorageGetValueMultiABI
 	jitMapReduceBufferABI
+	jitFilterBufferABI
 )
 
 type jitStorageFuncValue struct {
@@ -155,6 +156,163 @@ func CompileJITMapReduceBuffer(proc *Proc, valueTypes []uint8) JITMapReduceBuffe
 	}
 	valuePointer := unsafe.Pointer(holders[0])
 	return *(*JITMapReduceBufferFunc)(unsafe.Pointer(&valuePointer))
+}
+
+// CompileJITFilterBuffer emits one predicate body around the complete batch
+// loop. Exact physical tags let arithmetic and comparisons skip runtime type
+// dispatch even though values retain their general Scmer representation.
+func CompileJITFilterBuffer(proc *Proc, valueTypes []uint8) JITFilterBufferFunc {
+	if proc == nil {
+		return nil
+	}
+	types := append([]uint8(nil), valueTypes...)
+	requests := []jitStorageCompileRequest{{abi: jitFilterBufferABI, emit: func(ctx *JITContext) {
+		emitJITFilterBuffer(ctx, proc, types, nil)
+	}}}
+	entries, holders := compileJITStorageBatch(requests)
+	if len(entries) != 1 || entries[0] == nil || holders[0] == nil {
+		return nil
+	}
+	valuePointer := unsafe.Pointer(holders[0])
+	return *(*JITFilterBufferFunc)(unsafe.Pointer(&valuePointer))
+}
+
+// CompileJITFilterStorage compiles main-storage reads directly into a filter
+// loop. The returned function uses the record-ID slice; its value slice is unused.
+func CompileJITFilterStorage(proc *Proc, valueTypes []uint8, readers []JITStorageGetValueEmitter) JITFilterBufferFunc {
+	if proc == nil || len(valueTypes) != len(readers) {
+		return nil
+	}
+	entries, holders := compileJITStorageBatch([]jitStorageCompileRequest{{abi: jitFilterBufferABI, emit: func(ctx *JITContext) {
+		emitJITFilterBuffer(ctx, proc, valueTypes, readers)
+	}}})
+	if len(entries) != 1 || entries[0] == nil || holders[0] == nil {
+		return nil
+	}
+	valuePointer := unsafe.Pointer(holders[0])
+	return *(*JITFilterBufferFunc)(unsafe.Pointer(&valuePointer))
+}
+
+func emitJITFilterBuffer(ctx *JITContext, proc *Proc, valueTypes []uint8, readers []JITStorageGetValueEmitter) {
+	recids := jitStorageSliceArg(ctx, RegRAX, RegRBX, RegRCX)
+	values := jitStorageSliceArg(ctx, RegRDI, RegRSI, RegR8)
+	ctx.StabilizeDescForControlFlow(&recids)
+	ctx.StabilizeDescForControlFlow(&values)
+	rowOff := ctx.AllocStack(8)
+	outOff := ctx.AllocStack(8)
+	ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, rowOff)
+	ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, outOff)
+
+	loop := ctx.ReserveLabel()
+	accepted := ctx.ReserveLabel()
+	next := ctx.ReserveLabel()
+	done := ctx.ReserveLabel()
+	ctx.MarkLabel(loop)
+	rowReg := ctx.AllocReg()
+	limitReg := ctx.AllocRegExcept(rowReg)
+	ctx.EmitLoadFromStack(rowReg, rowOff)
+	ctx.EmitLoadFromStack(limitReg, recids.StackOff+8)
+	ctx.EmitCmpInt64(rowReg, limitReg)
+	ctx.FreeReg(limitReg)
+	ctx.FreeReg(rowReg)
+	ctx.EmitJcc(CondSignedGreaterOrEqual, done)
+
+	args := make([]JITValueDesc, len(valueTypes))
+	if readers != nil {
+		for column, reader := range readers {
+			reg := ctx.AllocReg()
+			ctx.EmitLoadFromStack(reg, rowOff)
+			index := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: reg, NoHeapPointer: true}
+			ctx.BindReg(reg, &index)
+			address := ctx.EmitSliceElementAddress(&recids, &index, 4)
+			ctx.FreeDesc(&index)
+			idReg := ctx.AllocRegExcept(address.Reg)
+			ctx.EmitMovRegMemL(idReg, address.Reg, 0)
+			ctx.FreeDesc(&address)
+			id := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: idReg, NoHeapPointer: true}
+			ctx.BindReg(idReg, &id)
+			args[column] = reader(ctx, id, JITValueDesc{Loc: LocAny})
+			args[column].Type = valueTypes[column]
+			ctx.StabilizeDescForControlFlow(&args[column])
+		}
+	} else if len(valueTypes) != 0 {
+		elementReg := ctx.AllocReg()
+		ctx.EmitLoadFromStack(elementReg, rowOff)
+		if len(valueTypes) != 1 {
+			ctx.EmitImulRegImm32(elementReg, int32(len(valueTypes)))
+		}
+		index := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: elementReg, NoHeapPointer: true}
+		ctx.BindReg(elementReg, &index)
+		address := ctx.EmitSliceElementAddress(&values, &index, 16)
+		ctx.FreeDesc(&index)
+		ctx.EnsureDesc(&address)
+		for column, valueType := range valueTypes {
+			ctx.EnsureDesc(&address)
+			value := JITValueDesc{Loc: LocRegPair, Type: valueType, Reg: ctx.AllocRegExcept(address.Reg)}
+			value.Reg2 = ctx.AllocRegExcept(address.Reg, value.Reg)
+			ctx.EmitMovRegMem(value.Reg, address.Reg, int32(column*16))
+			ctx.EmitMovRegMem(value.Reg2, address.Reg, int32(column*16+8))
+			args[column] = value
+			ctx.BindReg(value.Reg, &args[column])
+			ctx.BindReg(value.Reg2, &args[column])
+			ctx.StabilizeDescForControlFlow(&args[column])
+		}
+		ctx.FreeDesc(&address)
+	}
+	predicate := JITEmitProcInline(ctx, proc, args, RegR12, JITValueDesc{Loc: LocAny})
+	boolean := ctx.EmitBoolDesc(&predicate, JITValueDesc{Loc: LocAny})
+	ctx.FreeDesc(&predicate)
+	if boolean.Loc == LocImm {
+		if boolean.Imm.Bool() {
+			ctx.EmitJmp(accepted)
+		} else {
+			ctx.EmitJmp(next)
+		}
+	} else {
+		ctx.EmitCmpRegImm32(boolean.Reg, 0)
+		ctx.FreeDesc(&boolean)
+		ctx.EmitJcc(CondNotEqual, accepted)
+		ctx.EmitJmp(next)
+	}
+
+	ctx.MarkLabel(accepted)
+	rowReg = ctx.AllocReg()
+	ctx.EmitLoadFromStack(rowReg, rowOff)
+	row := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: rowReg, NoHeapPointer: true}
+	ctx.BindReg(rowReg, &row)
+	readAddress := ctx.EmitSliceElementAddress(&recids, &row, 4)
+	ctx.FreeDesc(&row)
+	recidReg := ctx.AllocRegExcept(readAddress.Reg)
+	ctx.EmitMovRegMemL(recidReg, readAddress.Reg, 0)
+	ctx.FreeDesc(&readAddress)
+	recid := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: recidReg, NoHeapPointer: true}
+	ctx.BindReg(recidReg, &recid)
+	ctx.ProtectReg(recidReg)
+	outReg := ctx.AllocRegExcept(recidReg)
+	ctx.EmitLoadFromStack(outReg, outOff)
+	outIndex := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: outReg, NoHeapPointer: true}
+	ctx.BindReg(outReg, &outIndex)
+	writeAddress := ctx.EmitSliceElementAddress(&recids, &outIndex, 4)
+	ctx.FreeDesc(&outIndex)
+	ctx.EmitStoreRegMemL(recidReg, writeAddress.Reg, 0)
+	ctx.UnprotectReg(recidReg)
+	ctx.FreeDesc(&recid)
+	ctx.FreeDesc(&writeAddress)
+	outReg = ctx.AllocReg()
+	ctx.EmitLoadFromStack(outReg, outOff)
+	ctx.EmitAddRegImm32(outReg, 1)
+	ctx.EmitStoreToStack(JITValueDesc{Loc: LocReg, Type: tagInt, Reg: outReg}, outOff)
+	ctx.FreeReg(outReg)
+
+	ctx.MarkLabel(next)
+	rowReg = ctx.AllocReg()
+	ctx.EmitLoadFromStack(rowReg, rowOff)
+	ctx.EmitAddRegImm32(rowReg, 1)
+	ctx.EmitStoreToStack(JITValueDesc{Loc: LocReg, Type: tagInt, Reg: rowReg}, rowOff)
+	ctx.FreeReg(rowReg)
+	ctx.EmitJmp(loop)
+	ctx.MarkLabel(done)
+	ctx.EmitLoadFromStack(RegRAX, outOff)
 }
 
 func emitJITMapReduceBuffer(ctx *JITContext, proc *Proc, valueTypes []uint8) {
@@ -356,6 +514,8 @@ func jitStorageABIName(abi jitStorageABI) string {
 		return "storage.GetValueMulti"
 	case jitMapReduceBufferABI:
 		return "storage.MapReduceBuffer"
+	case jitFilterBufferABI:
+		return "storage.FilterBuffer"
 	default:
 		return "storage.unknown"
 	}
@@ -522,6 +682,8 @@ func jitStorageABIInputRegisters(abi jitStorageABI) uint64 {
 		registers = []Reg{RegRAX, RegRBX, RegRCX, RegRDI, RegRSI, RegR8, RegR9}
 	case jitMapReduceBufferABI:
 		registers = []Reg{RegRAX, RegRBX, RegRCX, RegRDI, RegRSI, RegR8}
+	case jitFilterBufferABI:
+		registers = []Reg{RegRAX, RegRBX, RegRCX, RegRDI, RegRSI, RegR8}
 	}
 	var mask uint64
 	for _, reg := range registers {
@@ -560,6 +722,14 @@ func jitStorageSpillEntryArgs(ctx *JITContext, abi jitStorageABI) (uintptr, []by
 		ctx.EmitStoreRegMem(RegRSI, RegRSP, 40)
 		ctx.EmitStoreRegMem(RegR8, RegRSP, 48)
 		return 7, []byte{0b00001010}
+	case jitFilterBufferABI:
+		ctx.EmitStoreRegMem(RegRAX, RegRSP, 8)
+		ctx.EmitStoreRegMem(RegRBX, RegRSP, 16)
+		ctx.EmitStoreRegMem(RegRCX, RegRSP, 24)
+		ctx.EmitStoreRegMem(RegRDI, RegRSP, 32)
+		ctx.EmitStoreRegMem(RegRSI, RegRSP, 40)
+		ctx.EmitStoreRegMem(RegR8, RegRSP, 48)
+		return 7, []byte{0b00010010}
 	default:
 		panic("jit: unknown storage ABI")
 	}
@@ -585,6 +755,13 @@ func jitStorageReloadEntryArgs(ctx *JITContext, abi jitStorageABI) {
 		ctx.EmitMovRegMem(RegR8, RegRSP, 48)
 		ctx.EmitMovRegMem(RegR9, RegRSP, 56)
 	case jitMapReduceBufferABI:
+		ctx.EmitMovRegMem(RegRAX, RegRSP, 8)
+		ctx.EmitMovRegMem(RegRBX, RegRSP, 16)
+		ctx.EmitMovRegMem(RegRCX, RegRSP, 24)
+		ctx.EmitMovRegMem(RegRDI, RegRSP, 32)
+		ctx.EmitMovRegMem(RegRSI, RegRSP, 40)
+		ctx.EmitMovRegMem(RegR8, RegRSP, 48)
+	case jitFilterBufferABI:
 		ctx.EmitMovRegMem(RegRAX, RegRSP, 8)
 		ctx.EmitMovRegMem(RegRBX, RegRSP, 16)
 		ctx.EmitMovRegMem(RegRCX, RegRSP, 24)

--- a/scm/jit_storage_fallback.go
+++ b/scm/jit_storage_fallback.go
@@ -43,3 +43,12 @@ func CompileJITStorageReaders(JITStorageGetValueEmitter, JITStorageGetValueRange
 func CompileJITMapReduceBuffer(*Proc, []uint8) JITMapReduceBufferFunc {
 	return nil
 }
+
+// CompileJITFilterBuffer is unavailable without the patched Go JIT backend.
+func CompileJITFilterBuffer(*Proc, []uint8) JITFilterBufferFunc {
+	return nil
+}
+
+func CompileJITFilterStorage(*Proc, []uint8, []JITStorageGetValueEmitter) JITFilterBufferFunc {
+	return nil
+}

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -162,6 +162,19 @@ func OrderRelationLess(fn func(...Scmer) Scmer) func(Scmer, Scmer) bool {
 	return func(a, b Scmer) bool { return ToBool(fn(a, b)) }
 }
 
+// binaryCollationLess keeps boolean/text keys in the same textual order in
+// both directions. Less is the coercing expression comparator: its bool-left
+// arm converts to integers, while its string-left arm renders a bool as text.
+// That asymmetry must not enter an index (true < "3" and "3" < true).
+// Keep expression comparison itself unchanged, including numeric coercions.
+func binaryCollationLess(a, b Scmer) bool {
+	if (a.IsBool() && (b.IsString() || b.IsSymbol())) ||
+		(b.IsBool() && (a.IsString() || a.IsSymbol())) {
+		return String(a) < String(b)
+	}
+	return Less(a, b)
+}
+
 /* SQL LIKE operator implementation on strings */
 func StrLike(str, pattern string) bool {
 	if !strings.ContainsAny(pattern, "%_\\") {
@@ -11778,16 +11791,16 @@ func init_strings() {
 				return cached.(Scmer)
 			}
 			// Binary and bare-charset relations are the dominant index case. Keep
-			// their canonical callback to one function dispatch: Less already owns
+			// their canonical callback to one function dispatch: binaryCollationLess owns
 			// the required ASC NULL-first semantics, and swapping its operands owns
 			// DESC NULL-last semantics. A closure per metadata key keeps callback
 			// identity distinct even when two names have identical byte ordering.
 			if collationName == "bin" || collationName == "binary" || collationName == "utf8" || collationName == "utf8mb4" {
 				less := func(left, right Scmer) bool {
 					if reverse {
-						return Less(right, left)
+						return binaryCollationLess(right, left)
 					}
-					return Less(left, right)
+					return binaryCollationLess(left, right)
 				}
 				fn := func(args ...Scmer) Scmer {
 					return NewBool(less(args[0], args[1]))
@@ -11819,14 +11832,14 @@ func init_strings() {
 					if m[2] == "bin" { // binary
 						// Return closures that compare raw UTF-8 byte order; register for serialization
 						if len(a) > 1 && ToBool(a[1]) {
-							f := func(a ...Scmer) Scmer { return GreaterScm(a...) }
+							f := func(a ...Scmer) Scmer { return NewBool(binaryCollationLess(a[1], a[0])) }
 							collateRegistry.Store(FunctionIdentity(f), struct {
 								Collation string
 								Reverse   bool
 							}{Collation: String(a[0]), Reverse: true})
 							return NewFunc(f)
 						}
-						f := func(a ...Scmer) Scmer { return LessScm(a...) }
+						f := func(a ...Scmer) Scmer { return NewBool(binaryCollationLess(a[0], a[1])) }
 						collateRegistry.Store(FunctionIdentity(f), struct {
 							Collation string
 							Reverse   bool

--- a/scm/strings_test.go
+++ b/scm/strings_test.go
@@ -18,6 +18,55 @@ package scm
 
 import "testing"
 
+func TestBinaryCollationBooleanTextOrder(t *testing.T) {
+	values := []Scmer{NewNil(), NewBool(false), NewBool(true),
+		NewString(""), NewString("0"), NewString("1"), NewString("3"),
+		NewString("false"), NewString("true"), NewString("view"), NewString("yes"),
+		NewSymbol("true"), NewString("ä")}
+	for _, name := range []string{"bin", "binary", "utf8", "utf8mb4", "utf8mb4_bin"} {
+		for _, reverse := range []bool{false, true} {
+			factory := Apply(Globalenv.Vars[Symbol("collate")], NewString(name), NewBool(reverse))
+			less := OrderRelationLess(factory.Func())
+			for i, a := range values {
+				if less(a, a) {
+					t.Fatalf("%s reverse=%v: irreflexivity at %d", name, reverse, i)
+				}
+				for j, b := range values {
+					ab, ba := less(a, b), less(b, a)
+					if ab && ba {
+						t.Fatalf("%s reverse=%v: asymmetric order at %d,%d", name, reverse, i, j)
+					}
+					for k, c := range values {
+						if ab && less(b, c) && !less(a, c) {
+							t.Fatalf("%s reverse=%v: non-transitive order at %d,%d,%d", name, reverse, i, j, k)
+						}
+						if !ab && !ba && !less(b, c) && !less(c, b) && (less(a, c) || less(c, a)) {
+							t.Fatalf("%s reverse=%v: non-transitive equivalence at %d,%d,%d", name, reverse, i, j, k)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestBinaryCollationPreservesNumericAndExpressionComparisons(t *testing.T) {
+	// The index fix must not redefine coercing expression comparisons or
+	// change the existing numeric/string search-key conversions.
+	if !Less(NewBool(true), NewString("3")) {
+		t.Fatal("coercing expression comparison changed")
+	}
+	values := []Scmer{NewNil(), NewInt(-1), NewInt(2), NewInt(10), NewFloat(2.5),
+		NewString("2"), NewString("10"), NewDate(42)}
+	for _, a := range values {
+		for _, b := range values {
+			if binaryCollationLess(a, b) != Less(a, b) {
+				t.Fatalf("numeric/text compatibility changed for %v and %v", a, b)
+			}
+		}
+	}
+}
+
 func TestLikePatternNeedsCaseFold(t *testing.T) {
 	tests := []struct {
 		pattern string

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -25,6 +25,24 @@ import (
 
 var benchmarkBoundaries analyzedBoundaries
 
+func TestInterpolationUsesIndexOrder(t *testing.T) {
+	order := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString("bin"), scm.NewBool(false))
+	less := scm.OrderRelationLess(order.Func())
+	values := []scm.Scmer{scm.NewNil(), scm.NewString("3"), scm.NewBool(false), scm.NewString("false"), scm.NewBool(true), scm.NewString("true"), scm.NewString("view")}
+	for _, key := range values {
+		want := 0
+		for want < len(values) && less(values[want], key) {
+			want++
+		}
+		for _, min := range []scm.Scmer{scm.NewNil(), values[1]} {
+			got := interpolationSearch(0, len(values), key, min, values[len(values)-1], func(i int) scm.Scmer { return values[i] }, less)
+			if got != want {
+				t.Fatalf("key %v: got %d, want %d", key, got, want)
+			}
+		}
+	}
+}
+
 func testEqualScanAccess(column string, value scm.Scmer) (scm.Scmer, []scm.Scmer) {
 	return scm.NewSlice([]scm.Scmer{
 		newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),

--- a/storage/index.go
+++ b/storage/index.go
@@ -1814,6 +1814,10 @@ start_scan:
 	mainIdx := 0
 	if firstSorted >= 0 && !indexBounds.lower(bounds, firstSorted).IsNil() {
 		if s.usesNaturalAscendingOrder(firstSorted) {
+			less := scm.Less
+			if firstSorted < len(s.ColOrder) && s.ColOrder[firstSorted] != nil {
+				less = s.ColOrder[firstSorted]
+			}
 			var interpMin, interpMax scm.Scmer
 			if len(state.minVals) > firstSorted {
 				interpMin = state.minVals[firstSorted]
@@ -1822,7 +1826,7 @@ start_scan:
 			mainIdx = interpolationSearch(searchLo, searchN, indexBounds.lower(bounds, firstSorted), interpMin, interpMax,
 				func(idx int) scm.Scmer {
 					return cols[firstSorted].get(getRecid(idx))
-				})
+				}, less)
 		} else {
 			mainIdx = searchLo + sort.Search(searchN, func(idx int) bool {
 				value := cols[firstSorted].get(getRecid(searchLo + idx))

--- a/storage/interpolation.go
+++ b/storage/interpolation.go
@@ -30,7 +30,9 @@ import (
 //
 // getVal reads the value at a given position in the sorted index.
 // minVal/maxVal are the first/last values in the sorted range.
-func interpolationSearch(lo, n int, key scm.Scmer, minVal, maxVal scm.Scmer, getVal func(int) scm.Scmer) int {
+// less must be the index's ordering, including its equivalence classes;
+// coercing expression equality cannot safely decide a search direction.
+func interpolationSearch(lo, n int, key scm.Scmer, minVal, maxVal scm.Scmer, getVal func(int) scm.Scmer, less func(scm.Scmer, scm.Scmer) bool) int {
 	if n <= 0 {
 		return lo
 	}
@@ -48,14 +50,14 @@ func interpolationSearch(lo, n int, key scm.Scmer, minVal, maxVal scm.Scmer, get
 			}
 			// Probe the guess position
 			gv := getVal(guess)
-			if scm.Less(key, gv) || scm.Equal(key, gv) {
+			if !less(gv, key) {
 				// key <= guess: search in [lo, guess+1)
 				upperN := guess - lo + 1
 				if upperN > n {
 					upperN = n
 				}
 				return lo + sort.Search(upperN, func(i int) bool {
-					return !scm.Less(getVal(lo+i), key) // getVal(pos) >= key
+					return !less(getVal(lo+i), key) // getVal(pos) >= key
 				})
 			}
 			// key > guess: search in [guess+1, lo+n)
@@ -65,13 +67,13 @@ func interpolationSearch(lo, n int, key scm.Scmer, minVal, maxVal scm.Scmer, get
 				return lo + n
 			}
 			return newLo + sort.Search(newN, func(i int) bool {
-				return !scm.Less(getVal(newLo+i), key)
+				return !less(getVal(newLo+i), key)
 			})
 		}
 	}
 	// Fallback: plain binary search
 	return lo + sort.Search(n, func(i int) bool {
-		return !scm.Less(getVal(lo+i), key)
+		return !less(getVal(lo+i), key)
 	})
 }
 

--- a/storage/mapreduce_fusion_bench_test.go
+++ b/storage/mapreduce_fusion_bench_test.go
@@ -86,7 +86,7 @@ func TestJITMapReduceBufferBestOf(t *testing.T) {
 	nativeMapper := shard.OpenMapReducer([]string{"amount"}, sumBinding.Vars[scm.Symbol("sql_sum_reduce")], false, 0, nil, nil)
 	defer nativeMapper.Close()
 	if nativeMapper.bufferReduceProc == nil {
-		wrapped := scm.PrepareJITMapReduceBufferProc(sumBinding.Vars[scm.Symbol("sql_sum_reduce")], 2)
+		wrapped := scm.PrepareJITBufferProc(sumBinding.Vars[scm.Symbol("sql_sum_reduce")], 2)
 		wrappedCost := -1
 		if wrapped != nil {
 			wrappedCost = scm.JITExpressionCost(wrapped.Body)

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -1818,6 +1818,120 @@ func (t *storageShard) filterNativeArgConstantScanBatch(batch []uint32, conditio
 	return outN
 }
 
+type typedScanFilter struct {
+	shard      *storageShard
+	mainCount  uint32
+	width      int
+	multiFuncs []scm.JITStorageGetValueMultiFunc
+	kernel     scm.JITFilterBufferFunc
+	values     []scm.Scmer
+	pooled     *mapReducerBulkBuffer
+}
+
+func (t *storageShard) prepareTypedScanFilter(condition scm.Scmer, ccols []ColumnStorage, cReaders []ColumnReader, estimatedRows int) *typedScanFilter {
+	if len(ccols) == 0 || estimatedRows <= 0 {
+		return nil
+	}
+	proc := scm.PrepareJITBufferProc(condition, len(ccols))
+	if proc == nil {
+		return nil
+	}
+	minimumRows := scm.CurrentJITCosts().FilterBufferBreakEven(scm.JITExpressionCost(proc.Body), len(ccols))
+	if minimumRows > estimatedRows {
+		return nil
+	}
+	valueTypes := make([]uint8, len(ccols))
+	multiFuncs := make([]scm.JITStorageGetValueMultiFunc, len(ccols))
+	for index, column := range ccols {
+		if column == nil || cReaders[index] == nil {
+			return nil
+		}
+		valueType := column.JITValueType()
+		if valueType == scm.JITTypeUnknown {
+			return nil
+		}
+		valueTypes[index] = valueType
+		multiFuncs[index] = compiledColumnGetValueMulti(cReaders[index])
+	}
+	kernel := scm.CompileJITFilterBuffer(proc, valueTypes)
+	if kernel == nil {
+		return nil
+	}
+	return &typedScanFilter{
+		shard: t, mainCount: t.main_count, width: len(ccols),
+		multiFuncs: multiFuncs, kernel: kernel,
+	}
+}
+
+func (filter *typedScanFilter) close() {
+	if filter == nil {
+		return
+	}
+	clear(filter.values)
+	filter.values = nil
+	if filter.pooled != nil {
+		clear(filter.pooled.values)
+		mapReducerBulkBufferPools[filter.width-1].Put(filter.pooled)
+		filter.pooled = nil
+	}
+	filter.kernel = nil
+}
+
+func (filter *typedScanFilter) filterMain(batch []uint32, readers []ColumnReader) int {
+	needed := len(batch) * filter.width
+	if cap(filter.values) < needed {
+		if filter.pooled == nil && filter.width <= inlineMapReducerColumns && needed <= defaultScanBufferSize*filter.width {
+			pool := &mapReducerBulkBufferPools[filter.width-1]
+			if pooled := pool.Get(); pooled != nil {
+				filter.pooled = pooled.(*mapReducerBulkBuffer)
+			} else {
+				filter.pooled = &mapReducerBulkBuffer{values: make([]scm.Scmer, defaultScanBufferSize*filter.width)}
+			}
+			filter.values = filter.pooled.values[:needed]
+		} else {
+			filter.values = make([]scm.Scmer, needed)
+		}
+	} else {
+		filter.values = filter.values[:needed]
+	}
+	for index, reader := range readers {
+		if getValueMulti := filter.multiFuncs[index]; getValueMulti != nil {
+			getValueMulti(batch, filter.values[index:], filter.width)
+		} else {
+			reader.GetValueMulti(batch, filter.values[index:], filter.width)
+		}
+	}
+	return filter.kernel(batch, filter.values)
+}
+
+func (filter *typedScanFilter) filterBatch(batch []uint32, conditionCols []string, ccols []ColumnStorage, cReaders []ColumnReader, conditionGetters []mapArgGetter, cdataset []scm.Scmer, condition *scm.SerialProc) int {
+	out := 0
+	for start := 0; start < len(batch); {
+		main := batch[start] < filter.mainCount
+		end := start + 1
+		for end < len(batch) && (batch[end] < filter.mainCount) == main {
+			end++
+		}
+		selected := 0
+		if main {
+			selected = filter.filterMain(batch[start:end], cReaders)
+		} else {
+			selected = filter.shard.filterScanBatchDynamic(batch[start:end], conditionCols, ccols, cReaders, conditionGetters, cdataset, condition)
+		}
+		copy(batch[out:], batch[start:start+selected])
+		out += selected
+		start = end
+	}
+	return out
+}
+
+func (t *storageShard) filterScanBatchDynamic(batch []uint32, conditionCols []string, ccols []ColumnStorage, cReaders []ColumnReader, conditionGetters []mapArgGetter, cdataset []scm.Scmer, condition *scm.SerialProc) int {
+	if condition.Kind == scm.SerialProcNativeArgConstant {
+		return t.filterNativeArgConstantScanBatch(batch, conditionCols, ccols, cReaders, conditionGetters, condition)
+	}
+	return t.filterConditionScanBatch(batch, conditionCols, ccols, cReaders, conditionGetters, cdataset, condition)
+}
+
 func (t *storageShard) filterVisibleBatchedScanBatch(batch []uint32, batchIDs []uint32, batchID uint32, visibleUpper uint32, hasMutationCallback bool, currentTx *TxContext, mutationSeen map[uint64]struct{}) int {
 	outN := 0
 	for _, idx := range batch {
@@ -1896,7 +2010,6 @@ func (t *storageShard) scanFirstRecord(access scanAccess, conditionCols []string
 		}
 		cdataset = make([]scm.Scmer, len(conditionCols))
 	}
-
 	locked := false
 	if !skipShardReadLock {
 		t.mu.RLock()
@@ -2157,6 +2270,17 @@ func (t *storageShard) scan(access scanAccess, conditionCols []string, condition
 		}
 		cdataset = make([]scm.Scmer, len(conditionCols))
 	}
+	estimatedFilterRows := int(t.main_count)
+	var typedFilter *typedScanFilter
+	// Shard population is not an estimate of an index range's candidates.
+	// Only full scans can use it to amortize a scan-local compilation.
+	if !conditionAlwaysTrue && access.len() == 0 && estimatedFilterRows > defaultScanBufferSize {
+		minimumFilterRows := scm.CurrentJITCosts().FilterBufferMinimumRows
+		if minimumFilterRows > 0 && estimatedFilterRows >= minimumFilterRows {
+			typedFilter = t.prepareTypedScanFilter(condition, ccols, cReaders, estimatedFilterRows)
+		}
+	}
+	defer typedFilter.close()
 
 	// MapReducer for the fused callback phase (builds column readers internally)
 	var mapperStorage ShardMapReducer
@@ -2219,10 +2343,10 @@ func (t *storageShard) scan(access scanAccess, conditionCols []string, condition
 		candidateCount += int64(len(batch))
 		outN := t.filterVisibleScanBatch(batch, visibleUpper, hasMutationCallback, currentTx, mutationSeen)
 		if !conditionAlwaysTrue && outN > 0 {
-			if conditionProgram.Kind == scm.SerialProcNativeArgConstant {
-				outN = t.filterNativeArgConstantScanBatch(batch[:outN], conditionCols, ccols, cReaders, conditionGetters, &conditionProgram)
+			if typedFilter != nil {
+				outN = typedFilter.filterBatch(batch[:outN], conditionCols, ccols, cReaders, conditionGetters, cdataset, &conditionProgram)
 			} else {
-				outN = t.filterConditionScanBatch(batch[:outN], conditionCols, ccols, cReaders, conditionGetters, cdataset, &conditionProgram)
+				outN = t.filterScanBatchDynamic(batch[:outN], conditionCols, ccols, cReaders, conditionGetters, cdataset, &conditionProgram)
 			}
 		}
 		if outN > 0 {

--- a/storage/scan_column_cost_bench_test.go
+++ b/storage/scan_column_cost_bench_test.go
@@ -18,13 +18,15 @@ package storage
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/launix-de/memcp/scm"
 )
 
-const scanColumnCostRows = 65536
+const scanColumnCostRows = 60000
 
 func scanColumnCostTable(b testing.TB, name string, rows int) (*table, []string) {
 	b.Helper()
@@ -395,5 +397,315 @@ func BenchmarkScanFilterExpressionCost(b *testing.B) {
 				}
 			})
 		}
+	}
+}
+
+func BenchmarkScanFilterSpectrum(b *testing.B) {
+	for _, rows := range []int{1, 8, 64, 1024, 8192, 60000} {
+		tbl, cols := scanColumnCostTable(b, fmt.Sprintf("filter_spectrum_%d", rows), rows)
+		for _, shape := range []struct {
+			name      string
+			source    string
+			columnCnt int
+		}{
+			{name: "simple", source: "(lambda (a) (> a -1))", columnCnt: 1},
+			{name: "arithmetic", source: "(lambda (a b c) (> (+ a (* b c)) -1))", columnCnt: 3},
+		} {
+			condition := scm.Eval(scm.Optimize(scm.Read("scan filter spectrum", shape.source), &scm.Globalenv, nil), &scm.Globalenv)
+			callback := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] })
+			b.Run(fmt.Sprintf("rows=%05d/shape=%s", rows, shape.name), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					tbl.scan(nil, newScanAccessSchema(scanAccessConsumerScan, nil, -1), nil,
+						cols[:shape.columnCnt], condition, nil, callback, scm.NewNil(), scm.NewNil(), false)
+				}
+			})
+		}
+	}
+}
+
+func TestJITTypedFilterBufferCompactsRecordIDs(t *testing.T) {
+	if !scm.JITEnabled() {
+		t.Skip("requires the JIT experiment")
+	}
+	costs := scm.CurrentJITCosts()
+	t.Logf("filter calibration: compile %.0f ns, scalar %.2f ns/row, fused %.2f ns/row, minimum %d rows",
+		costs.FilterBufferCompileNS, costs.FilterBufferCurrentNS, costs.FilterBufferFusedNS, costs.FilterBufferMinimumRows)
+	predicate := optimizedScanProc(t, "(lambda (a b) (and (> a 1) (< b 8)))")
+	proc := predicate.Proc()
+	if proc == nil {
+		t.Fatal("optimized predicate has no JIT procedure")
+	}
+	kernel := scm.CompileJITFilterBuffer(proc, []uint8{scm.TagInt, scm.TagInt})
+	if kernel == nil {
+		t.Fatal("typed filter buffer did not compile")
+	}
+	if count := kernel(nil, nil); count != 0 {
+		t.Fatalf("empty filter returned %d records", count)
+	}
+	ids := []uint32{10, 11, 12, 13}
+	values := []scm.Scmer{
+		scm.NewInt(1), scm.NewInt(7),
+		scm.NewInt(2), scm.NewInt(8),
+		scm.NewInt(3), scm.NewInt(6),
+		scm.NewInt(4), scm.NewInt(5),
+	}
+	if count := kernel(ids, values); count != 2 || ids[0] != 12 || ids[1] != 13 {
+		t.Fatalf("filtered ids = %v count=%d, want [12 13] count=2", ids, count)
+	}
+}
+
+func BenchmarkFilterBufferLocalCompile(b *testing.B) {
+	if !scm.JITEnabled() {
+		b.Skip("requires JIT")
+	}
+	for _, shape := range []struct {
+		name, source string
+		width        int
+	}{
+		{"simple", "(lambda (a) (> a 127))", 1},
+		{"arithmetic", "(lambda (a b c) (> (+ a (* b c)) 127))", 3},
+	} {
+		proc := benchmarkMapReduceFusionProc(b, shape.source).Proc()
+		for _, typed := range []bool{false, true} {
+			tags := make([]uint8, shape.width)
+			for i := range tags {
+				tags[i] = scm.JITTypeUnknown
+				if typed {
+					tags[i] = scm.TagInt
+				}
+			}
+			b.Run(fmt.Sprintf("%s/typed=%v", shape.name, typed), func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					kernel := scm.CompileJITFilterBuffer(proc, tags)
+					if kernel == nil {
+						b.Fatal("compile failed")
+					}
+					runtime.KeepAlive(kernel)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkFilterBufferLocalScan(b *testing.B) {
+	if !scm.JITEnabled() {
+		b.Skip("requires JIT")
+	}
+	shard := benchmarkMapReduceFusionShard(60000)
+	cols := []string{"amount", "quantity", "factor"}
+	readers := make([]ColumnReader, len(cols))
+	emitters := make([]scm.JITStorageGetValueEmitter, len(cols))
+	for i, col := range cols {
+		storage := shard.getColumnStorageOrPanic(col, false, nil)
+		readers[i] = newCachedColumnReaderTx(storage, nil)
+		emitters[i] = storage.JITEmit
+	}
+	for _, shape := range []struct {
+		name, source string
+		width        int
+	}{
+		{"simple", "(lambda (a) (> a 127))", 1},
+		{"arithmetic", "(lambda (a b c) (> (+ a (* b c)) 127))", 3},
+	} {
+		proc := benchmarkMapReduceFusionProc(b, shape.source)
+		for _, rows := range []int{0, 1, 64, 1024, 8192, 60000} {
+			for _, mode := range []string{"lambda", "buffer-dynamic", "buffer-typed", "direct-typed"} {
+				b.Run(fmt.Sprintf("%s/rows=%d/%s", shape.name, rows, mode), func(b *testing.B) {
+					ids := make([]uint32, defaultScanBufferSize)
+					args := make([]scm.Scmer, shape.width)
+					want := 0
+					for row := 0; row < rows; row++ {
+						for col := range args {
+							args[col] = readers[col].GetValue(uint32(row))
+						}
+						if scm.ToBool(scm.Apply(proc, args...)) {
+							want++
+						}
+					}
+					tags := make([]uint8, shape.width)
+					for i := range tags {
+						tags[i] = scm.JITTypeUnknown
+						if mode == "buffer-typed" || mode == "direct-typed" {
+							tags[i] = scm.TagInt
+						}
+					}
+					b.ReportAllocs()
+					b.ResetTimer()
+					for range b.N {
+						filter := typedScanFilter{width: shape.width}
+						if mode != "lambda" {
+							if mode == "direct-typed" {
+								filter.kernel = scm.CompileJITFilterStorage(proc.Proc(), tags, emitters[:shape.width])
+							} else {
+								filter.kernel = scm.CompileJITFilterBuffer(proc.Proc(), tags)
+							}
+							if filter.kernel == nil {
+								b.Fatal("compile failed")
+							}
+							filter.multiFuncs = make([]scm.JITStorageGetValueMultiFunc, shape.width)
+							for i := range filter.multiFuncs {
+								filter.multiFuncs[i] = compiledColumnGetValueMulti(readers[i])
+							}
+						}
+						count := 0
+						for offset := 0; offset < rows; offset += len(ids) {
+							batch := ids[:min(len(ids), rows-offset)]
+							for i := range batch {
+								batch[i] = uint32(offset + i)
+							}
+							if filter.kernel != nil {
+								if mode == "direct-typed" {
+									count += filter.kernel(batch, nil)
+									continue
+								}
+								count += filter.filterMain(batch, readers[:shape.width])
+								continue
+							}
+							for _, id := range batch {
+								for i := range args {
+									args[i] = readers[i].GetValue(id)
+								}
+								if scm.ToBool(scm.Apply(proc, args...)) {
+									count++
+								}
+							}
+						}
+						filter.close()
+						if count != want {
+							b.Fatalf("got %d matches, want %d", count, want)
+						}
+						runtime.KeepAlive(count)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestFilterBufferWideArithmetic(t *testing.T) {
+	if !scm.JITEnabled() {
+		t.Skip("requires JIT")
+	}
+	for _, width := range []int{1, 3, 8, 16} {
+		params := make([]string, width)
+		tags := make([]uint8, width)
+		for i := range params {
+			params[i] = fmt.Sprintf("c%d", i)
+			tags[i] = scm.TagInt
+		}
+		proc := benchmarkMapReduceFusionProc(t, fmt.Sprintf("(lambda (%s) (> (+ %s) 100))", strings.Join(params, " "), strings.Join(params, " ")))
+		kernel := scm.CompileJITFilterBuffer(proc.Proc(), tags)
+		if kernel == nil {
+			t.Fatalf("width %d failed compilation", width)
+		}
+		ids := make([]uint32, 128)
+		values := make([]scm.Scmer, len(ids)*width)
+		var want []uint32
+		for row := range ids {
+			ids[row] = uint32(row + 200)
+			for col := 0; col < width; col++ {
+				values[row*width+col] = scm.NewInt(int64(row + col))
+			}
+			if scm.ToBool(scm.Apply(proc, values[row*width:(row+1)*width]...)) {
+				want = append(want, ids[row])
+			}
+		}
+		count := kernel(ids, values)
+		if count != len(want) {
+			t.Fatalf("width %d count %d want %d", width, count, len(want))
+		}
+		for i := range want {
+			if ids[i] != want[i] {
+				t.Fatalf("width %d row %d got %d want %d", width, i, ids[i], want[i])
+			}
+		}
+	}
+}
+
+func TestTypedFilterMixedMainDelta(t *testing.T) {
+	if !scm.JITEnabled() {
+		t.Skip("requires JIT")
+	}
+	shard := benchmarkMapReduceFusionShard(4)
+	shard.mu.Lock()
+	shard.deltaColumns["amount"] = 0
+	shard.inserts = [][]scm.Scmer{{scm.NewFloat(3.5)}, {scm.NewNil()}}
+	shard.mu.Unlock()
+	column := shard.getColumnStorageOrPanic("amount", false, nil)
+	readers := []ColumnReader{newCachedColumnReaderTx(column, nil)}
+	predicate := benchmarkMapReduceFusionProc(t, "(lambda (a) (> a 2))")
+	kernel := scm.CompileJITFilterBuffer(predicate.Proc(), []uint8{column.JITValueType()})
+	if kernel == nil {
+		t.Fatal("filter did not compile")
+	}
+	filter := typedScanFilter{shard: shard, mainCount: 4, width: 1, kernel: kernel,
+		multiFuncs: []scm.JITStorageGetValueMultiFunc{compiledColumnGetValueMulti(readers[0])}}
+	defer filter.close()
+	condition := scm.PrepareSerialProc(predicate)
+	ids := []uint32{0, 4, 3, 5, 1, 2}
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+	count := filter.filterBatch(ids, []string{"amount"}, []ColumnStorage{column}, readers,
+		make([]mapArgGetter, 1), make([]scm.Scmer, 1), &condition)
+	want := []uint32{4, 3, 2}
+	if count != len(want) {
+		t.Fatalf("got %d matches, want %d", count, len(want))
+	}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("got %v, want %v", ids[:count], want)
+		}
+	}
+}
+
+// Exercise concurrent ownership transfers through the actual shared pool.
+// Both scan consumers must finish every read/write before returning a buffer.
+func TestScanBulkBufferConcurrentRelease(t *testing.T) {
+	for _, reducer := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reducer=%v", reducer), func(t *testing.T) {
+			var workers sync.WaitGroup
+			for worker := 0; worker < 8; worker++ {
+				workers.Add(1)
+				go func(worker int) {
+					defer workers.Done()
+					for iteration := 0; iteration < 2000; iteration++ {
+						pooled, _ := mapReducerBulkBufferPools[0].Get().(*mapReducerBulkBuffer)
+						if pooled == nil {
+							pooled = &mapReducerBulkBuffer{values: make([]scm.Scmer, defaultScanBufferSize)}
+						}
+						want := scm.NewInt(int64(worker*2000 + iteration + 1))
+						for index := range pooled.values {
+							pooled.values[index] = want
+						}
+						runtime.Gosched()
+						for _, value := range pooled.values {
+							if !scm.Equal(value, want) {
+								t.Errorf("buffer changed while owned by worker %d", worker)
+								return
+							}
+						}
+						if reducer {
+							mapper := ShardMapReducer{mainBulkBuffer: pooled, mainBulkValues: pooled.values}
+							mapper.Close()
+							if mapper.mainBulkBuffer != nil || mapper.mainBulkValues != nil {
+								t.Error("reducer retained released buffer")
+								return
+							}
+						} else {
+							filter := typedScanFilter{width: 1, pooled: pooled, values: pooled.values}
+							filter.close()
+							if filter.pooled != nil || filter.values != nil {
+								t.Error("filter retained released buffer")
+								return
+							}
+						}
+					}
+				}(worker)
+			}
+			workers.Wait()
+		})
 	}
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1717,7 +1717,7 @@ func (m *ShardMapReducer) prepareJITBufferReducer() {
 	if m.mapReduceProgram.Kind != scm.SerialProcJIT && m.mapReduceProgram.Kind != scm.SerialProcNative {
 		return
 	}
-	proc := scm.PrepareJITMapReduceBufferProc(m.mapReduceScmer, len(m.mainCols)+1)
+	proc := scm.PrepareJITBufferProc(m.mapReduceScmer, len(m.mainCols)+1)
 	if proc == nil {
 		return
 	}
@@ -2533,14 +2533,14 @@ func (m *ShardMapReducer) Close() {
 	if m.hasUpdateCol && m.currentTx != nil && m.currentTx.getShardTx(m.shard) != nil {
 		m.currentTx.RegisterTouchedShard(m.shard)
 	}
+	clear(m.mainBulkValues)
+	m.mainBulkValues = nil
 	if m.mainBulkBuffer != nil {
 		clear(m.mainBulkBuffer.values)
 		width := cap(m.mainBulkBuffer.values) / defaultScanBufferSize
 		mapReducerBulkBufferPools[width-1].Put(m.mainBulkBuffer)
 		m.mainBulkBuffer = nil
 	}
-	clear(m.mainBulkValues)
-	m.mainBulkValues = nil
 	m.bufferReduceFn = nil
 	m.bufferReduceProc = nil
 	m.bufferValueTypes = nil

--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -122,8 +122,7 @@ func (s *StorageEnum) symbolLo(idx int) uint64 {
 
 func (s *StorageEnum) findValue(val scm.Scmer) int {
 	for i := uint8(0); i < s.k; i++ {
-		// strict: NULL only matches NULL
-		if val.IsNil() == s.values[i].IsNil() && (val.IsNil() || scm.Equal(s.values[i], val)) {
+		if storageValueEqual(s.values[i], val) {
 			return int(i)
 		}
 	}
@@ -181,9 +180,9 @@ func (s *StorageEnum) prepare() {
 
 func (s *StorageEnum) scan(i uint32, value scm.Scmer) {
 	s.scanTotal++
-	// find existing symbol (strict: NULL only matches NULL)
+	// Dictionary identity must not coerce distinct stored values.
 	for j := uint8(0); j < s.k; j++ {
-		if value.IsNil() == s.values[j].IsNil() && (value.IsNil() || scm.Equal(s.values[j], value)) {
+		if storageValueEqual(s.values[j], value) {
 			s.scanFreqs[j]++
 			return
 		}

--- a/storage/storage-scmer.go
+++ b/storage/storage-scmer.go
@@ -234,15 +234,29 @@ func (s *StorageSCMER) SetValue(i uint32, v scm.Scmer) {
 	s.values[i] = v
 }
 
+// storageValueEqual identifies interchangeable dictionary/constant values,
+// not values that happen to compare equal after expression coercions. Scalar
+// representation equality also preserves large integers, signed zero, NaN
+// payloads and date zones. Text may have distinct backing allocations.
+func storageValueEqual(a, b scm.Scmer) bool {
+	if a == b {
+		return true
+	}
+	if a.IsString() && b.IsString() {
+		return a.String() == b.String()
+	}
+	if a.IsSymbol() && b.IsSymbol() {
+		return a.String() == b.String()
+	}
+	return false
+}
+
 func (s *StorageSCMER) scan(i uint32, value scm.Scmer) {
 	// enum detection: track up to enumMaxSymbols distinct values with frequencies
 	if s.enumK != 0xFF {
 		found := false
 		for j := uint8(0); j < s.enumK; j++ {
-			// Use strict comparison: NULL is only equal to NULL
-			// (scm.Equal treats NULL == 0 == false per Scheme semantics,
-			// but storage needs them distinguished)
-			if value.IsNil() == s.enumVals[j].IsNil() && (value.IsNil() || scm.Equal(s.enumVals[j], value)) {
+			if storageValueEqual(s.enumVals[j], value) {
 				s.enumFreqs[j]++
 				found = true
 				break

--- a/storage/storage_compress_test.go
+++ b/storage/storage_compress_test.go
@@ -97,6 +97,46 @@ func verifyStorage(t *testing.T, col ColumnStorage, n int, gen func(int) scm.Scm
 
 // --- StorageInt tests ---
 
+func TestCompressionDoesNotCollapseBooleanText(t *testing.T) {
+	values := []scm.Scmer{scm.NewBool(true), scm.NewString("yes"), scm.NewString("3"), scm.NewString("view")}
+	col := buildViaCompression(len(values), func(i int) scm.Scmer { return values[i] })
+	for i, want := range values {
+		got := col.GetValue(uint32(i))
+		if scm.String(got) != scm.String(want) {
+			t.Fatalf("row %d: got %v, want %v (%T)", i, got, want, col)
+		}
+	}
+}
+
+func TestStorageValueIdentity(t *testing.T) {
+	pairs := [][2]scm.Scmer{
+		{scm.NewInt(1 << 53), scm.NewInt((1 << 53) + 1)},
+		{scm.NewFloat(0), scm.NewFloat(math.Copysign(0, -1))},
+		{scm.NewFloat(math.Float64frombits(0x7ff8000000000001)), scm.NewFloat(math.Float64frombits(0x7ff8000000000002))},
+		{scm.NewInt(1), scm.NewFloat(1)},
+		{scm.NewBool(true), scm.NewString("true")},
+		{scm.NewString("symbol"), scm.NewSymbol("symbol")},
+	}
+	for _, pair := range pairs {
+		if !storageValueEqual(pair[0], pair[0]) || storageValueEqual(pair[0], pair[1]) || storageValueEqual(pair[1], pair[0]) {
+			t.Fatalf("storage identity merged distinct scalar representations: %v / %v", pair[0], pair[1])
+		}
+	}
+}
+
+func TestEnumPreservesDistinctScalarValues(t *testing.T) {
+	values := []scm.Scmer{scm.NewBool(true), scm.NewString("view"), scm.NewInt(1), scm.NewString("1"), scm.NewBool(false), scm.NewInt(0), scm.NewNil(), scm.NewString("")}
+	col := buildEnum(256, func(i int) scm.Scmer { return values[i%len(values)] })
+	for _, stored := range []ColumnStorage{col, serializeDeserialize(col)} {
+		for i := 0; i < 256; i++ {
+			got, want := stored.GetValue(uint32(i)), values[i%len(values)]
+			if got.GetTag() != want.GetTag() || scm.String(got) != scm.String(want) {
+				t.Fatalf("row %d: got %v (tag %d), want %v (tag %d)", i, got, got.GetTag(), want, want.GetTag())
+			}
+		}
+	}
+}
+
 func TestStorageIntPipeline(t *testing.T) {
 	// Build StorageInt directly (bypass proposeCompression heuristics)
 	n := 200

--- a/tests/performance/typed-filter-buffer.yaml
+++ b/tests/performance/typed-filter-buffer.yaml
@@ -1,0 +1,51 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed without any warranty; see
+# <https://www.gnu.org/licenses/> for the GNU General Public License.
+
+metadata:
+  version: "1.0"
+  description: "Typed main-storage filtering and multi-column arithmetic aggregates"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS typed_filter_buffer"
+  - sql: "CREATE TABLE typed_filter_buffer (a INT, b INT, c INT) ENGINE=memory"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "typed_filter_buffer")
+          '("a" "b" "c")
+          (map (produceN 60000) (lambda (i) (list i 2 3))))
+        (rebuild))
+
+test_cases:
+  - name: "Full main shard arithmetic aggregate"
+    sql: "SELECT SUM(a+b*c) AS total FROM typed_filter_buffer"
+    timing_samples: 5
+    expect:
+      data: [{total: 1800330000}]
+  - name: "Residual filter before arithmetic aggregate"
+    sql: "SELECT COUNT(*) AS n, SUM(a+b*c) AS total FROM typed_filter_buffer WHERE a+0 >= 30000"
+    timing_samples: 5
+    expect:
+      data: [{n: 30000, total: 1350165000}]
+  - name: "Empty filtered aggregate"
+    sql: "SELECT COUNT(*) AS n FROM typed_filter_buffer WHERE a+0 < 0"
+    expect:
+      data: [{n: 0}]
+  - name: "Add delta row"
+    sql: "INSERT INTO typed_filter_buffer (a,b,c) VALUES (60000,2,3)"
+  - name: "Main and delta use the same predicate semantics"
+    sql: "SELECT COUNT(*) AS n, SUM(a+b*c) AS total FROM typed_filter_buffer WHERE a+0 >= 30000"
+    expect:
+      data: [{n: 30001, total: 1350225006}]
+  - name: "Invalid filter binding fails"
+    sql: "SELECT COUNT(*) FROM typed_filter_buffer WHERE missing_column > 0"
+    expect: {error: true}
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS typed_filter_buffer"

--- a/tests/storage/indexes/index-delta-merge.yaml
+++ b/tests/storage/indexes/index-delta-merge.yaml
@@ -55,6 +55,33 @@ test_cases:
     sql: "SELECT missing FROM idx_merge_bool_text WHERE o = true"
     expect: {error: true}
 
+  - name: "Rebuild preserves distinct boolean and text values"
+    setup:
+      - scm: '(rebuild (table "memcp-tests" "idx_merge_bool_text") true true)'
+    sql: "SELECT s, CONCAT(o, '') AS value FROM idx_merge_bool_text WHERE s IN ('http://spec11-minus.example/b', 'http://test26.org/item', 'http://test25.org/c', 'http://robust01.org/comp') ORDER BY s"
+    expect:
+      rows: 4
+      data:
+        - {s: "http://robust01.org/comp", value: "view"}
+        - {s: "http://spec11-minus.example/b", value: "true"}
+        - {s: "http://test25.org/c", value: "3"}
+        - {s: "http://test26.org/item", value: "yes"}
+
+  - name: "Boolean delta lookup agrees with rebuilt text storage"
+    setup:
+      - scm: |
+          (insert (table "memcp-tests" "idx_merge_bool_text") '("s" "p" "o")
+            (list (list "second" "http://spec11-minus.example/deleted" true)
+              (list "null" "http://spec11-minus.example/deleted" nil)))
+    sql: "SELECT s FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true ORDER BY s"
+    expect: {rows: 2, data: [{s: "http://spec11-minus.example/b"}, {s: "second"}]}
+
+  - name: "Boolean/text lookup survives another rebuild"
+    setup:
+      - scm: '(rebuild (table "memcp-tests" "idx_merge_bool_text") true true)'
+    sql: "SELECT s FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true ORDER BY s"
+    expect: {rows: 2, data: [{s: "http://spec11-minus.example/b"}, {s: "second"}]}
+
   # ==============================================================
   # Phase 1: Setup — populate main, build non-unique index
   # ==============================================================

--- a/tests/storage/indexes/index-delta-merge.yaml
+++ b/tests/storage/indexes/index-delta-merge.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
 # Tests for non-unique index delta+main streaming merge
 # Exercises StorageIndex.iterate() where main items (StorageInt) and
 # delta items (deltaBtree) are interleaved in sorted order.
@@ -8,7 +11,50 @@ metadata:
   version: "1.0"
   description: "Non-unique index: delta+main streaming merge, matrix multiply"
 
+# A degree-8 delta B-tree splits with this 17-row reduction of the MINUS
+# regression. The mixed boolean/text comparator must remain symmetric across
+# cold and warm lookup.
+setup:
+  - sql: "DROP TABLE IF EXISTS idx_merge_bool_text"
+  - sql: "CREATE TABLE idx_merge_bool_text (s TEXT, p TEXT, o TEXT) ENGINE=MEMORY"
+  - scm: |
+      (insert (table "memcp-tests" "idx_merge_bool_text") '("s" "p" "o")
+        (list (list "http://spec11-minus.example/b" "http://spec11-minus.example/deleted" true)
+          (list "http://test26.org/item" "http://test26.org/val" "yes")
+          (list "http://test25.org/c" "http://test25.org/p" "3")
+          (list "http://test25.org/b" "http://test25.org/p" "2")
+          (list "http://test25.org/a" "http://test25.org/p" "1")
+          (list "http://test23.org/item" "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" "http://test23.org/Thing")
+          (list "http://test07.org/x3" "http://test07.org/y" "three")
+          (list "http://test07.org/x2" "http://test07.org/y" "two")
+          (list "http://test07.org/x1" "http://test07.org/y" "one")
+          (list "http://test06.org/second" "http://test06.org/n" "2")
+          (list "http://test03.org/bob" "http://test03.org/name" "Bob")
+          (list "http://test02.org/alice" "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" "http://test02.org/Person")
+          (list "t01_main" "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" "t01_Page")
+          (list "http://robust07.org/item" "http://robust07.org/path" "C:\\Users\\\test\\file.txt")
+          (list "http://robust06.org/item" "http://robust06.org/html" "<h1>Hello</h1><p>World</p>")
+          (list "http://robust05.org/item" "http://robust05.org/val" "it's a test")
+          (list "http://robust01.org/comp" "http://robust01.org/componentName" "view")))
+
 test_cases:
+  - name: "RHS row exists without object access boundary"
+    sql: "SELECT COUNT(*) AS n FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted'"
+    expect: {rows: 1, data: [{n: 1}]}
+  - name: "Indexed boolean RHS lookup must retain the same row"
+    sql: "SELECT COUNT(*) AS n FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true"
+    expect: {rows: 1, data: [{n: 1}]}
+  - name: "Warm indexed boolean RHS lookup must retain the same row"
+    sql: "SELECT COUNT(*) AS n FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true"
+    expect: {rows: 1, data: [{n: 1}]}
+  - name: "Ordered indexed boolean lookup retains the RHS row"
+    sql: "SELECT s FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true ORDER BY s"
+    expect: {rows: 1, data: [{s: "http://spec11-minus.example/b"}]}
+
+  - name: "Boolean/text lookup rejects unknown columns"
+    sql: "SELECT missing FROM idx_merge_bool_text WHERE o = true"
+    expect: {error: true}
+
   # ==============================================================
   # Phase 1: Setup — populate main, build non-unique index
   # ==============================================================
@@ -315,6 +361,7 @@ test_cases:
           total: 342
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS idx_merge_bool_text"
   - sql: "DROP TABLE IF EXISTS idx_merge"
   - sql: "DROP TABLE IF EXISTS idx_dim"
   - sql: "DROP TABLE IF EXISTS idx93_mat_a"


### PR DESCRIPTION
Full scans currently call the predicate once per row without propagating the finished storage's exact Scmer tags into that loop. This adds a scan-local typed buffer filter: bulk column readers fill a bounded row-major Scmer buffer, and a JIT loop evaluates the predicate and compacts record IDs in place.

Startup calibration now measures filter-loop compilation and scalar/fused predicate costs, estimates additional expression emission, and requires twice the measured break-even. Small scans, indexed candidate sets without a reliable population estimate, unknown physical tags and delta rows keep their existing path. No kernel cache or specialization mutex is added: the function is retained only by the shard scan; its existing JIT code lease becomes reclaimable after the scan drops it.

The shared pool lifecycle is also corrected in both filter cleanup and MapReducer.Close: all buffer accesses finish before Put. A concurrent ownership-transfer test covers both consumers under the race detector.

### Manual A/B

Baseline: master `ede42c89c`. Candidate: this branch. Same fixture and benchmark sources in both worktrees, patched Go with `GOEXPERIMENT=jit`, AMD Ryzen 9 7900X3D, CPU affinity 10, `GOMAXPROCS=1`, five samples with `-benchtime=150ms`; medians below. Fixtures are built/rebuilt outside the timed region. Go benchmark warmup and calibration are identical; each timed scan includes scan-local compilation where selected. Expression fixture is exactly 60,000 rows. No SQL plan or compiled filter kernel is cached by this change.

```
GOMAXPROCS=1 GOEXPERIMENT=jit taskset -c 10 "$GOROOT/bin/go" test ./storage \
  -run '^$' -bench '^(BenchmarkScanFilterSpectrum|BenchmarkScanFilterExpressionCost)$' \
  -benchmem -benchtime=150ms -count=5
```

| Case | master µs | PR µs | latency change |
|---|---:|---:|---:|
| 60k shape=same_column; terms=01 | 1286.606 | 1164.101 | -9.5% |
| 60k shape=same_column; terms=02 | 2781.283 | 1625.047 | -41.6% |
| 60k shape=same_column; terms=04 | 4354.494 | 2087.015 | -52.1% |
| 60k shape=same_column; terms=08 | 8716.644 | 8655.550 | -0.7% |
| 60k shape=same_column; terms=16 | 16486.779 | 15033.708 | -8.8% |
| 60k shape=distinct_columns; terms=01 | 1305.403 | 1263.655 | -3.2% |
| 60k shape=distinct_columns; terms=02 | 3505.697 | 2074.355 | -40.8% |
| 60k shape=distinct_columns; terms=04 | 6211.385 | 3425.220 | -44.9% |
| 60k shape=distinct_columns; terms=08 | 12029.300 | 12378.465 | 2.9% |
| 60k shape=distinct_columns; terms=16 | 27923.334 | 31854.206 | 14.1% |
| rows=00001; shape=simple | 0.863 | 0.858 | -0.6% |
| rows=00001; shape=arithmetic | 1.766 | 1.821 | 3.1% |
| rows=00008; shape=simple | 1.013 | 1.041 | 2.8% |
| rows=00008; shape=arithmetic | 2.663 | 2.724 | 2.3% |
| rows=00064; shape=simple | 2.304 | 2.355 | 2.2% |
| rows=00064; shape=arithmetic | 8.028 | 8.084 | 0.7% |
| rows=01024; shape=simple | 23.299 | 23.424 | 0.5% |
| rows=01024; shape=arithmetic | 84.997 | 86.050 | 1.2% |
| rows=08192; shape=simple | 180.089 | 183.462 | 1.9% |
| rows=08192; shape=arithmetic | 628.912 | 635.553 | 1.1% |
| rows=60000; shape=simple | 1289.336 | 1172.729 | -9.0% |
| rows=60000; shape=arithmetic | 4499.501 | 4628.866 | 2.9% |

These measurements are not a universal speed guarantee. The 16-distinct-column case measured +14.1%; it retains the scalar path. Small cases also show low-single-digit overhead/variation. The substantial gains are the admitted 2–4-term filters.

### Fusion experiment (including local compilation)

`BenchmarkFilterBufferLocalScan` compares scalar reads + predicate calls, a dynamic buffer kernel, a typed buffer kernel, and directly inlined storage GetValue + typed predicate. Same integer fixture, 1024-row batches, three samples at 100ms, correct result counts checked against the scalar implementation. These exploratory samples were unpinned, separately from the pinned master/PR comparison above. All kernels are compiled once per measured scan and then released.

| Expression / rows | lambda µs | buffer dynamic µs | buffer typed µs | direct typed µs |
|---|---:|---:|---:|---:|
| a > 127 / 0 | 0.004 | 16.463 | 75.300 | 76.416 |
| a > 127 / 1 | 0.023 | 16.704 | 91.962 | 93.102 |
| a > 127 / 64 | 1.260 | 20.677 | 84.577 | 92.783 |
| a > 127 / 1024 | 19.750 | 30.148 | 94.013 | 106.839 |
| a > 127 / 8192 | 157.915 | 117.687 | 131.460 | 138.367 |
| a > 127 / 60000 | 1167.011 | 768.819 | 647.121 | 688.254 |
| a+b*c > 127 / 0 | 0.004 | 35.200 | 402.488 | 372.079 |
| a+b*c > 127 / 1 | 0.041 | 35.662 | 435.623 | 493.138 |
| a+b*c > 127 / 64 | 2.435 | 37.127 | 346.663 | 373.669 |
| a+b*c > 127 / 1024 | 39.086 | 66.494 | 480.445 | 478.477 |
| a+b*c > 127 / 8192 | 303.479 | 253.974 | 687.311 | 721.739 |
| a+b*c > 127 / 60000 | 2302.252 | 1641.384 | 2475.457 | 2646.404 |

The typed intermediate buffer wins the simple large case over fully inlined GetValue. Arithmetic shows why unconditional type specialization is not appropriate yet: its typed emitter costs hundreds of microseconds and more allocation than dynamic emission. Direct-storage fusion is retained as a reproducible experimental compiler entry/benchmark, but is not selected by production scans. The dynamic-buffer alternative also wins some medium/complex cases; this PR conservatively enables only calibrated typed fusion and does not claim those remaining cases are optimized.

### Validation

- Patched-Go `go test ./scm ./storage`.
- Stock-Go `go test ./scm ./storage`.
- `go test -race ./storage -run '^TestScanBulkBufferConcurrentRelease$'`.
- Empty input, record-ID compaction, 1/3/8/16 bound columns, arithmetic, mixed main/delta with float/NULL delta values.
- SQL `tests/performance/typed-filter-buffer.yaml`: 6/6 cases, including `SUM(a+b*c)`, residual filtering, empty result, main/delta and an invalid binding.
- Full SQL and performance gates are left to PR CI per repository workflow.

## Comparator correction (e60f5fc5f)

The MINUS failure reproduces on stock master 91f16c249 and JIT. A 17-row reduction triggers a B-tree split; the supplied comparator previously accepted both true < "3" and "3" < true. Binary collations now compare boolean/text pairs textually in both directions. Expression Less and numeric coercions remain unchanged. Interpolation search now uses the index comparator, including its equivalence classes.

Validation: stock and patched JIT go test ./scm ./storage pass; index-delta-merge and rdf-spec11-algebra-complete YAML suites pass with both binaries. Tests cover cold/warm/ordered delta lookup, ordering laws for Bool/Text/NULL in five collations ASC/DESC, numeric compatibility and interpolation search. Full CI pending; no new performance claim from these correctness tests.

Limitations: arbitrary mixed numeric/text ordering remains outside this narrow correction. The separate mixed Bool/Text rebuild issue discovered here is fixed by b171525f3; see the correction below.

## Stock CI correction: compression identity (b171525f3)

The stock failure is reproducible with native-index.yaml and index-delta-merge.yaml running together. The stock runner executes these suites concurrently; the former calls a global rebuild while the latter contains mixed boolean/text values. The JIT fail-fast runner executes suites serially, explaining why that job passed. No test isolation workaround was added.

StorageSCMER constant/enum detection and StorageEnum symbol lookup were using coercing expression equality. With true as the first symbol, distinct nonempty text values were treated as one constant; the final build value ("view") replaced every row. New isolated Go tests reproduced both the constant collapse and enum symbol collapse before the fix. Storage dictionary/constant identity now uses exact scalar representation or matching text content, never numeric/truthiness coercions. This also distinguishes large integers, signed zero, NaN payloads and numeric/text/bool tags. Existing disk formats and expression comparisons are unchanged.

Validation:
- Stock and patched JIT: go test ./scm ./storage pass.
- Final branch including current master 7db1a4dd3: 89/89 targeted cases pass with each binary (native-index, index-delta-merge, rdf-spec11-algebra-complete, jit-match-list-normalization).
- Formerly failing native-index + index-delta-merge parallel combination passed five consecutive fresh-server stock runs.
- Restored forced-rebuild, distinct-value and mixed main/delta regression coverage; added enum serialization round-trip checks.
- Pushed head aadfccd73; fresh CI results are pending. This correctness follow-up makes no new performance claim.
