### PR TITLE
test: preserve numeric grammar semantics across parser specialization

### DIFF
--- a/tests/sql/expressions/numeric-parser-specialization.yaml
+++ b/tests/sql/expressions/numeric-parser-specialization.yaml
@@ -1,0 +1,58 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "Numeric parser specialization preserves grammar bounds"
+setup: []
+test_cases:
+  # Explicit optional digits are equivalent to {1,9}, but also give the FIRST
+  # analysis a precise digit set. Repetition plus two precedence levels makes
+  # this exercise the speculative numeric leaf, not only the generic parser.
+  - name: "Nine-digit numeric grammar accepts its upper boundary"
+    scm: |
+      (begin
+        (define parse_number (jit (lambda (input) (begin
+          (define number (parser (define x (regex "-?(?:[0-9][0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?(?:\\.[0-9]*)?|\\.[0-9]+)(?:e-?[0-9]+)?" true)) (simplify x)))
+          (define primary (parser (or number "a" "b" "c" "d" "f" "g" "h" "i")))
+          (define level1 (parser (or "x" primary)))
+          (define level2 (parser (or "y" level1)))
+          ((parser '((define values (+ level2 ",")) ";" $) values) input)))))
+        (if (equal? (parse_number "123456789;") (list 123456789))
+          true (error "numeric parser changed the parsed value")))
+  - name: "Numeric fast path must not accept a tenth digit"
+    scm: |
+      (begin
+        (define parse_number (jit (lambda (input) (begin
+          (define number (parser (define x (regex "-?(?:[0-9][0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?(?:\\.[0-9]*)?|\\.[0-9]+)(?:e-?[0-9]+)?" true)) (simplify x)))
+          (define primary (parser (or number "a" "b" "c" "d" "f" "g" "h" "i")))
+          (define level1 (parser (or "x" primary)))
+          (define level2 (parser (or "y" level1)))
+          ((parser '((define values (+ level2 ",")) ";" $) values) input)))))
+        (parse_number "1234567890;"))
+    expect:
+      error: true
+  - name: "Canonical numeric grammar preserves decimal and exponent values"
+    scm: |
+      (begin
+        (define parse_number (jit (lambda (input) (begin
+          (define number (parser (define x (regex "-?(?:[0-9]+\\.?[0-9]*|\\.[0-9]+)(?:e-?[0-9]+)?" true)) (simplify x)))
+          (define primary (parser (or number "a" "b" "c" "d" "f" "g" "h" "i")))
+          (define level1 (parser (or "x" primary)))
+          (define level2 (parser (or "y" level1)))
+          ((parser '((define values (+ level2 ",")) ";" $) values) input)))))
+        (if (equal? (parse_number "1234567890, 12.5, 1E3, -.5, 7.;")
+                    (list 1234567890 12.5 1000 -0.5 7))
+          true (error "canonical numeric parser changed values")))
+  - name: "Case-sensitive exponent grammar must not accept uppercase E"
+    scm: |
+      (begin
+        (define parse_number (jit (lambda (input) (begin
+          (define number (parser (define x (regex "-?(?:[0-9]+\\.?[0-9]*|\\.[0-9]+)(?:e-?[0-9]+)?" false)) (simplify x)))
+          (define primary (parser (or number "a" "b" "c" "d" "f" "g" "h" "i")))
+          (define level1 (parser (or "x" primary)))
+          (define level2 (parser (or "y" level1)))
+          ((parser '((define values (+ level2 ",")) ";" $) values) input)))))
+        (parse_number "1E3;"))
+    expect:
+      error: true
+cleanup: []


### PR DESCRIPTION
## Summary

Add four YAML tests preserving numeric parser semantics across JIT specialization: a nine-digit bound, its rejected tenth digit, valid decimal/exponent values, and a case-sensitive exponent grammar rejecting uppercase `E`.

## Scope

The reported P1 was in an **uncommitted numeric-lexer experiment**, not in current master. This PR deliberately adds regression coverage only; it does not introduce that lexer or claim to fix an existing master regression. The experimental correction uses structural regex equality, including flags, rather than finite sample agreement. Shipping that optimization requires separate review and performance evidence.

The test grammar uses two precedence levels inside a repeated value list. The nine-digit bound is expressed as one required digit and eight optional digits: unlike a counted repeat, this exposes a precise digit FIRST set to the existing analysis and reaches the speculative literal path.

## Verification

- Experimental mutation check: removing the structural authorization gate makes two tests fail by incorrectly accepting `1234567890;` and `1E3;`; both positive controls still pass (2/4).
- Corrected experiment: 4/4 pass with a JIT-enabled binary.
- Current-master branch (`ede42c89c`): targeted JIT-enabled YAML run **4/4 passed**, 85 ms total; startup Scheme tests **1276/1276 passed**.
- Full SQL and JIT suites are left to CI. No production instance changes.

No performance behavior is changed by this test-only PR; there is no speedup claim or performance A/B measurement to attribute to it.
