### PR TITLE
perf: eliminate redundant list copies in JIT match normalization

### DIFF
--- a/scm/jit_match.go
+++ b/scm/jit_match.go
@@ -19,25 +19,26 @@ package scm
 import (
 	"fmt"
 	"regexp"
-	"unsafe"
 )
 
 // Match lowering is architecture-independent. It describes values, branches,
 // loads, and calls through the common JIT emitter API; only that API's machine
 // instruction implementation belongs in an architecture-specific file.
-var jitMatchEmptyListStorage [1]Scmer
-
-func jitMatchAsGoSlice(value Scmer) []Scmer {
+// Matching inspects an existing Scheme list; it is not a new list producer.
+// Preserve its backing storage just as the statically known tagSlice path does.
+// Do not use the general escaping Go-slice materializer here: that API must
+// copy potentially frame-backed producer buffers, whereas doing so for every
+// match arm duplicates immutable input trees even in read-only accessors.
+func jitMatchListValueNative(value Scmer) Scmer {
+	if value.GetTag() == tagSlice {
+		return value
+	}
 	list, ok := scmerAsSlice(value)
 	if !ok {
-		return nil
+		return NewNil()
 	}
-	// A non-nil pointer distinguishes a successfully normalized empty list from
-	// a non-list without adding a fourth ABI result word to the emitted call.
-	if len(list) == 0 && unsafe.SliceData(list) == nil {
-		return jitMatchEmptyListStorage[:0]
-	}
-	return list
+	// Keep the existing snapshot behavior for dictionaries and wrapped values.
+	return NewSlice(append([]Scmer(nil), list...))
 }
 
 func jitMatchSymbolLiteralWords(valuePtr *byte, valueAux uint64, expectedPtr *byte, expectedAux uint64) bool {
@@ -259,13 +260,13 @@ func jitMatchListValue(ctx *JITContext, value JITValueDesc, failLabel JITLabel) 
 	normalized := value
 	typeKnown := value.Type == tagSlice
 	if !typeKnown {
-		header := ctx.EmitGoCallScalar(GoFuncAddr(jitMatchAsGoSlice), []JITValueDesc{value}, 3)
-		ctx.BindReg(header.Reg, &header)
-		ctx.BindReg(header.Reg2, &header)
-		ctx.BindReg(header.Reg3, &header)
-		ctx.EmitCmpRegImm32(header.Reg, 0)
-		ctx.EmitJump(CondEqual, failLabel)
-		normalized = ctx.EmitNewSliceFromGoSlice(&header)
+		normalized = ctx.EmitGoCallScalar(GoFuncAddr(jitMatchListValueNative), []JITValueDesc{value}, 2)
+		ctx.EmitMovRegReg(ctx.ScratchReg, normalized.Reg2)
+		ctx.EmitAndRegImm32(ctx.ScratchReg, 0xff)
+		ctx.EmitCmpRegImm32(ctx.ScratchReg, int32(tagSlice))
+		ctx.EmitJump(CondNotEqual, failLabel)
+		normalized.Type = tagSlice
+		normalized.Rooted = true
 	}
 	normalized.KnownSliceLen = value.KnownSliceLen
 	normalized.KnownSliceCap = value.KnownSliceCap
@@ -731,7 +732,3 @@ func jitCompileMatch(ctx *JITContext, list []Scmer, sliceBase Reg, result JITVal
 	}
 	return target
 }
-
-// EmitNewSliceFromGoSlice retags a Go []Scmer header as a Scheme list without
-// allocating or copying its backing storage. Ownership of the data pointer is
-// transferred from slice to the returned descriptor.

--- a/tests/sql/expressions/jit-match-list-normalization.yaml
+++ b/tests/sql/expressions/jit-match-list-normalization.yaml
@@ -1,0 +1,50 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "JIT match normalization preserves dynamic list values and escaping tails"
+setup: []
+test_cases:
+  - name: "Dynamic record matching preserves values and rejects non-lists"
+    scm: |
+      (begin
+        (define project (jit (lambda (value)
+          (match value '(a b c d e) c _ false))))
+        (if (equal? (map (list (list 1 2 3 4 5) (list 6 7 8 9 10)
+                             (list) nil "not a list" (list 1 2)) project)
+                    (list 3 8 false false false false))
+          true (error "dynamic match changed record or failure semantics")))
+  - name: "Escaping matched tails remain valid across subsequent calls"
+    scm: |
+      (begin
+        (define tail (jit (lambda (value)
+          (match value (cons head rest) rest _ (list)))))
+        (define rows (map (produceN 1000) (lambda (i)
+          (tail (list i (+ i 1) (+ i 2))))))
+        (if (equal? rows (map (produceN 1000) (lambda (i) (list (+ i 1) (+ i 2)))))
+          true (error "matched tails retained transient storage")))
+  - name: "Empty list match differs from non-list fallback"
+    scm: |
+      (begin
+        (define classify (jit (lambda (value)
+          (match value '() "empty" (cons head tail) "nonempty" _ "other"))))
+        (if (equal? (map (list (list) (list nil) nil false 0 "") classify)
+                    (list "empty" "nonempty" "other" "other" "other" "other"))
+          true (error "empty-list normalization changed match semantics")))
+  - name: "Wrapped lists retain matching semantics"
+    scm: |
+      (begin
+        (define project (jit (lambda (value)
+          (match value '(a b c d e) c _ false))))
+        (if (equal? (project (source "match-test" 1 1 (list 1 2 3 4 5))) 3)
+          true (error "source-wrapped list failed to normalize")))
+  - name: "Dictionary matching retains flat-list normalization"
+    scm: |
+      (begin
+        (define data (reduce (produceN 20) (lambda (acc i)
+          (set_assoc acc (concat "k" i) i)) (list)))
+        (define size (jit (lambda (value)
+          (match value (list? items) (count items) _ -1))))
+        (if (equal? (size data) 40)
+          true (error "dictionary match changed its flattened length")))
+cleanup: []


### PR DESCRIPTION
## Summary

Avoid copying an existing Scheme list merely to match it when its type was not statically known. This is a general JIT match-normalization change, not a query-shape rule, grammar specialization, or cost-model adjustment.

The old path converted a value to a Go slice and then called the general escaping slice materializer. That materializer correctly copies potentially frame-backed producers, but it is the wrong operation for inspecting an already existing Scheme list. Even a five-field accessor copied its whole input record. Recursive compiler visitors repeated those copies for their match alternatives.

The new helper returns an existing `tagSlice` value unchanged, matching the established statically known-list path. Non-list normalization (dictionaries and SourceInfo-wrapped values) retains its previous snapshot behavior. The emitted code checks the returned tag so an empty list remains distinct from a failed conversion. The general producer materialization API and its ownership safeguards are unchanged.

## Evidence and prioritization

Started from current master `91f16c249`, not from the unpublished numeric-lexer experiment. Three read-only EXPLAIN COMPILE checks on the application instance put physical emission around 76 ms, parsing around 72 ms, and decorrelation around 49 ms. Reordering was only 2.6 ms there; a much slower reorder in the offline clone was not treated as the application's primary bottleneck.

Linux perf on repeated full compilations identified roughly 26% of user CPU cycles in background GC. Differential allocation profiles identified `JITNewSliceCopy` as the largest allocator: approximately 50–52 MiB and almost one million allocations per compilation. Symbolizing its callers identified recursive stage-expression rewriting and even read-only source accessors. Serialized optimized Scheme functions and actual JIT machine-code dumps confirmed the accessor's extra normalization/materialization call sequence.

No specialized numeric lexer or SIMD regex path is introduced.

## Manual A/B measurements

Both binaries were built with the same JIT-enabled Go toolchain. A and B used identical offline data clones, the same SQL, authentication, settings and default session bindings. Requests alternated A/B then B/A to reduce drift from other workloads on the host. Each query had three warmup rounds and **20 measured compilations per variant**, with a unique comment per round. Measurement uses `tools/benchmark_compile.py`'s EXPLAIN COMPILE request and percentile calculation.

These are complete uncached **compilation** timings, not SQL execution or browser request timings.

| Query / phase | Master p50 | PR p50 | Change | Master p95 | PR p95 |
|---|---:|---:|---:|---:|---:|
| Wide ACL + search list, LIMIT 72: full compile | 257.47 ms | 194.27 ms | -63.20 ms / -24.5% | 277.11 ms | 223.65 ms |
| Same list: decorrelation | 43.63 ms | 29.24 ms | -33.0% | 51.52 ms | 35.76 ms |
| Same list: physical emission | 65.10 ms | 47.75 ms | -26.6% | 71.67 ms | 56.84 ms |
| Associated search COUNT: full compile | 132.43 ms | 119.67 ms | -12.76 ms / -9.6% | 170.44 ms | 139.07 ms |
| Same COUNT: decorrelation | 11.60 ms | 8.54 ms | -26.3% | 12.53 ms | 9.74 ms |
| Same COUNT: physical emission | 10.91 ms | 8.55 ms | -21.6% | 13.90 ms | 10.48 ms |

Differential allocation sampling over separate repeated-compilation runs showed approximately **151 -> 107 MiB allocated per list compilation**, with `JITNewSliceCopy` dropping from approximately **52 -> 4 MiB**. These are sampled allocation volumes, not retained database RAM.

All measured A/B samples had identical AST/IR node counts, physical plan node/byte counts, stage counts and scan counts. An additional plain EXPLAIN comparison for the list was byte-identical (84,107-byte response). This changes the work needed to compile the plan, not its operators.

Limitations: initial sequential measurements were inconsistent under changing external CPU load and were not used as speedup evidence. Offline selectivity lookups also have different cache conditions from the running application, so the full-compile improvement should not be extrapolated directly to browser latency. Go's CPU profiler crashed the diagnostic JIT process; Linux perf and separate allocation snapshots were used instead. The application process was neither restarted nor patched.

## Validation

- New YAML suite: **5/5 pass on both master and the change**, covering dynamically typed records, non-list fallback, empty lists, escaping tails across subsequent calls, SourceInfo wrappers, and dictionary normalization.
- Existing `tests/performance/traced-planner-scaling.yaml`: **8/8 pass**.
- Existing `tests/sql/expressions/numeric-parser-specialization.yaml`: **4/4 pass**.
- Startup Scheme tests: **1276/1276 pass** in the JIT-enabled test process.
- JIT-enabled build and `git diff --check` pass.
- Full suites and performance A/B are left to CI; no existing tests or limits were weakened.

Temporary profiling endpoints, dumps, application SQL, and data clones are not included in this PR.
