### PR TITLE
Cost EXISTS carriers at their consumers and remove identity grouping

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -5939,9 +5939,46 @@ names in projections, predicates, and correlated subqueries. */
 			(union_offset block)
 			(union_facts block)))))
 
+/* A projection grouped by its sole base source's complete primary key has
+exactly one row per group. With no aggregates or HAVING, grouping is an
+identity, not a competing physical operator. Remove it before decorrelation
+so a surrounding COUNT (including FOUND_ROWS) sees the same row relation and
+membership remains available to the ordinary costed scan alternatives.
+Do not generalize this proof to joins, nullable UNIQUE keys or partial PKs. */
+(define remove_identity_primary_key_group (lambda (block)
+	(if (and (query_block? block)
+		(and (single_source? (qb_sources block))
+			(and (not (empty_list? (qb_group block)))
+				(and (nil? (qb_having block))
+					(and (empty_list? (qb_stages block))
+						(not (or (expr_has_local_aggregates? (qb_fields block))
+							(or (reduce (qb_order block) (lambda (found item)
+								(or found (expr_has_local_aggregates? (car item)))) false)
+								(expr_has_local_aggregates? (qb_hidden block))))))))))
+		(begin
+			(define src (car (qb_sources block)))
+			(define pk (source_primary_key_columns src))
+			(define cols (map (qb_group block) (lambda (expr)
+				(match expr
+					'(op alias alias_ic col col_ic)
+					(if (and (or (equal? op (symbol "get_column")) (equal? op (quote get_column)))
+						(equal? (source_for_alias (list src) (source_alias src) alias alias_ic) src))
+						(source_column_name src col col_ic) nil)
+					_ nil))))
+			(if (and (not (empty_list? pk))
+				(and (not (contains? cols nil))
+					(reduce pk (lambda (complete col)
+						(and complete (and (contains? cols col)
+							(source_column_guaranteed_nonnull? src col)))) true)))
+				(make_query_block (qb_schema block) (qb_sources block) (qb_fields block)
+					(qb_where block) '() nil (qb_order block) (qb_limit block) (qb_offset block)
+					(qb_hidden block) (qb_stages block) (qb_facts block))
+				block))
+		block)))
+
 (define untangle_query (lambda (query ctx)
 	(begin
-		(define normalized (normalize_query_ast query))
+		(define normalized (remove_identity_primary_key_group (normalize_query_ast query)))
 		(match (logical_op normalized)
 			(symbol query-block) (untangle_query_block normalized ctx)
 			(symbol union-block) (untangle_union_block normalized ctx)

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -3323,15 +3323,17 @@ planning preserves the proven bound without consulting index availability. */
 					(or found (membership_expr_has_driver_alternative? item))) false)))
 		_ false)))
 
-(define membership_driver_local_filter (lambda (driver sources block)
+(define membership_driver_local_filter (lambda (driver block)
 	(begin
 		(define default_alias (qassoc_get (qb_facts block) (quote default_alias)
 			(source_alias driver)))
-		(define other_aliases (map (filter (coalesceNil sources '()) (lambda (src)
-			(not (equal? (source_alias src) (source_alias driver))))) source_alias))
+		/* A promoted presence stage may already be absent from sources while
+		its output is still referenced by this predicate. Prove locality positively:
+		a negative check against the remaining aliases would sample that unbound
+		stage output as nil and incorrectly estimate zero driver rows. */
 		(combine_where_terms
 			(filter (split_and_terms (membership_driver_filter (qb_where block))) (lambda (term)
-				(not (expr_refs_any_alias? default_alias other_aliases term))))
+				(expr_only_refs_alias? default_alias (source_alias driver) term)))
 			true))))
 
 (define membership_aggregate_pushdown_driver_rows (lambda (block)
@@ -3502,6 +3504,9 @@ either physical alternative or sampling the table again. */
 			other supported candidate carrier reads a prepared group-stage cache. */
 			(list (quote membership_candidate_cache_backed)
 				(not (union_block? (gs_input stage))))
+			(list (quote membership_driver_cache_backed)
+				(and (not (union_block? (gs_input stage)))
+					(nil? (recset_domain_source (gs_input stage)))))
 			(list (quote membership_candidate_scan_invocations) (qassoc_get work (quote scan_invocations) 1))
 			(list (quote membership_candidate_filter_columns) (qassoc_get work (quote filter_columns) 0))
 			(list (quote membership_candidate_map_columns) (qassoc_get work (quote map_columns) (count (gs_keys stage))))
@@ -3517,7 +3522,7 @@ either physical alternative or sampling the table again. */
 	(if (nil? driver)
 		'()
 		(begin
-			(define condition (membership_driver_local_filter driver sources block))
+			(define condition (membership_driver_local_filter driver block))
 			(define profile (membership_source_work_profile driver condition
 				(list (qb_fields block) (qb_group block) (qb_having block)
 					(qb_order block) (qb_hidden block)) planning_session))
@@ -3576,7 +3581,7 @@ carrier crossover. */
 		(define driver_estimate (if (nil? driver)
 			nil
 			(planner_source_filter_estimate driver
-				(membership_driver_local_filter driver sources block) 512 tx planning_session)))
+				(membership_driver_local_filter driver block) 512 tx planning_session)))
 		(define driver_rows (membership_estimated_work_rows driver_estimate driver_input_rows))
 		(define candidate_rows (planner_stage_input_rows (gs_input stage)))
 		(define candidate_probe_branches (if (union_block? (gs_input stage))
@@ -4103,14 +4108,31 @@ calibrated components used by the other membership carriers. */
 					(membership_work_value work (quote membership_downstream_probe_branches) 0)))
 			driver_rows 0.65))))
 
-(define membership_driver_probe_cost (lambda (driver_rows probe_branches downstream_probe_branches)
+(define membership_driver_probe_cost (lambda (driver_rows probe_branches downstream_probe_branches work)
 	(begin
 		(define probes (* driver_rows probe_branches))
+		/* Compare complete executable alternatives. Projection already charges
+		its driver scan; charging only point probes on this side incorrectly makes
+		that scan free. A complex domain also prepares its canonical cache before
+		probing it, exactly as the projected-cache alternative does. */
+		(define driver_scan (planner_cost
+			(+ (* (membership_work_value work (quote membership_driver_scan_invocations) 1)
+				planner_membership_scan_invocation_ns)
+				(if (membership_work_value work (quote membership_driver_cache_backed) false)
+					planner_membership_group_cache_startup_ns 0))
+			(* driver_rows (+ planner_membership_scan_row_ns
+				(* (membership_work_value work (quote membership_driver_filter_columns) 0)
+					planner_membership_filter_column_row_ns)
+				(* (membership_work_value work (quote membership_driver_map_columns) 0)
+					planner_membership_map_column_row_ns)
+				(* (membership_work_value work (quote membership_driver_expression_operations) 0)
+					planner_membership_expression_operation_row_ns)))
+			0 0 0 0 0 0 driver_rows 0.75))
 		/* A driver membership check lowers each candidate branch to an indexed
 		point-presence probe. Keep that storage subscan distinct from the ordered
 		candidate-key index calibrated below. */
 		(planner_cost_add
-			(planner_membership_direct_probe_cost probes)
+			(planner_cost_add driver_scan (planner_membership_direct_probe_cost probes) driver_rows 0.75)
 			(planner_membership_downstream_probe_cost
 				(* driver_rows downstream_probe_branches))
 			driver_rows 0.75))))
@@ -4164,7 +4186,7 @@ calibrated components used by the other membership carriers. */
 				(if (equal? driver_strategy (quote driver_order_membership_probe))
 					(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows work)
 					(membership_driver_probe_cost driver_rows probe_branches
-						(membership_work_value work (quote membership_downstream_probe_branches) 0))))))))
+						(membership_work_value work (quote membership_downstream_probe_branches) 0) work)))))))
 
 (define membership_cost_options_for_telemetry (lambda (telemetry planning_session)
 	(begin
@@ -5538,10 +5560,10 @@ deliberately retained: dropping one would change COUNT and other aggregates. */
 						(equal? (qassoc_get (gs_facts stage) (quote null_semantics) nil) (quote scalar))
 						(equal? (qassoc_get (gs_facts stage) (quote null_semantics) nil) (quote exists)))
 						(and (not (stage_has_residual_outer_refs? stage))
-						(and (equal? (count (gs_keys stage))
-							(count (qassoc_get (gs_facts stage) (quote lookup-keys) '())))
-							(and (equal? (stage_result_max_rows_per_partition stage) 1)
-								(not (has_assoc? referenced_aliases (source_alias src)))))))))))))
+							(and (equal? (count (gs_keys stage))
+								(count (qassoc_get (gs_facts stage) (quote lookup-keys) '())))
+								(and (equal? (stage_result_max_rows_per_partition stage) 1)
+									(not (has_assoc? referenced_aliases (source_alias src)))))))))))))
 
 (define prune_unused_stage_outputs_reversed (lambda (reversed_sources default_alias stage_index referenced_aliases)
 	(match (coalesceNil reversed_sources '())
@@ -6575,6 +6597,18 @@ remain ordinary residual predicates. */
 			ir
 			(make_ir (ir_kind ir) outer_block all_stages (ir_context_of ir) (ir_return ir))))))
 
+/* Partitioning on a complete non-null unique key cannot reduce the number of
+stage probes: each surviving row still owns one group. The partition alternative
+adds strictly positive startup/build cost to the same probes, independently of
+selectivity. Prove that dominance before sampling, and do not install a runtime
+sampling guard for a choice that no cardinality change can reverse. */
+(define aggregate_pushdown_identity_partition? (lambda (driver columns)
+	(reduce (source_unique_key_sets driver) (lambda (found key)
+		(or found (and (not (empty_list? key))
+			(reduce key (lambda (complete col)
+				(and complete (and (contains? columns col)
+					(source_column_guaranteed_nonnull? driver col)))) true)))) false)))
+
 (define aggregate_pushdown_logical (lambda (ir planning_session tx)
 	(begin
 		(define block (ir_root ir))
@@ -6595,8 +6629,12 @@ remain ordinary residual predicates. */
 					(aggregate_pushdown_probe_bindings driver bound_terms))
 				(define columns
 					(aggregate_pushdown_key_columns block driver movable_terms))
-				(if (or (empty_list? movable_terms) (empty_list? columns))
-					ir
+				(if (or (or (empty_list? movable_terms) (empty_list? columns))
+					(aggregate_pushdown_identity_partition? driver columns))
+					(begin
+						/* Schema changes invalidate the uniqueness proof as well as the plan. */
+						(planner_record_table_statistics_guards (list driver) planning_session)
+						ir)
 					(begin
 						(define residual (combine_where_terms residual_terms true))
 						(define stage_count (max 1 (count

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -98,20 +98,31 @@ partner. */
 			col
 			(coalesceNil (source_column_name src col true) col)))))
 
+/* A membership marker carries one distinguished probe, but its decorrelated
+domain can contain additional lookup keys. Both direct and joined scan filters
+must bind the whole domain before lowering; otherwise a non-leading key becomes
+an unbound symbol in the callback when costing selects the probe alternative. */
+(define membership_probe_outer_exprs (lambda (stage probe)
+	(cons probe (qassoc_get (gs_facts stage) (quote lookup-keys) '()))))
+
+(define extract_membership_columns_for_alias (lambda (src stage probe)
+	(merge_unique (map (membership_probe_outer_exprs stage probe) (lambda (expr)
+		(extract_columns_for_alias src expr))))))
+
 (define extract_columns_for_alias (lambda (src expr)
 	(match expr
-		((symbol driver_membership_probe) _stage probe)
-		(extract_columns_for_alias src probe)
-		((quote driver_membership_probe) _stage probe)
-		(extract_columns_for_alias src probe)
-		((symbol driver_membership_subscan_probe) _stage probe)
-		(extract_columns_for_alias src probe)
-		((quote driver_membership_subscan_probe) _stage probe)
-		(extract_columns_for_alias src probe)
-		((symbol dml_driver_membership_probe) _fallback_schema _stage probe)
-		(extract_columns_for_alias src probe)
-		((quote dml_driver_membership_probe) _fallback_schema _stage probe)
-		(extract_columns_for_alias src probe)
+		((symbol driver_membership_probe) stage probe)
+		(extract_membership_columns_for_alias src stage probe)
+		((quote driver_membership_probe) stage probe)
+		(extract_membership_columns_for_alias src stage probe)
+		((symbol driver_membership_subscan_probe) stage probe)
+		(extract_membership_columns_for_alias src stage probe)
+		((quote driver_membership_subscan_probe) stage probe)
+		(extract_membership_columns_for_alias src stage probe)
+		((symbol dml_driver_membership_probe) _fallback_schema stage probe)
+		(extract_membership_columns_for_alias src stage probe)
+		((quote dml_driver_membership_probe) _fallback_schema stage probe)
+		(extract_membership_columns_for_alias src stage probe)
 		((symbol scalar_first_probe) stage _requested_col)
 		(merge_unique (map (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (key)
 			(extract_columns_for_alias src key))))
@@ -2309,18 +2320,24 @@ probe. */
 
 (define collect_join_columns_acc (lambda (sources default_alias target_alias expr columns_by_alias)
 	(match expr
-		((symbol driver_membership_probe) _stage probe)
-		(collect_join_columns_acc sources default_alias target_alias probe columns_by_alias)
-		((quote driver_membership_probe) _stage probe)
-		(collect_join_columns_acc sources default_alias target_alias probe columns_by_alias)
-		((symbol driver_membership_subscan_probe) _stage probe)
-		(collect_join_columns_acc sources default_alias target_alias probe columns_by_alias)
-		((quote driver_membership_subscan_probe) _stage probe)
-		(collect_join_columns_acc sources default_alias target_alias probe columns_by_alias)
-		((symbol dml_driver_membership_probe) _fallback_schema _stage probe)
-		(collect_join_columns_acc sources default_alias target_alias probe columns_by_alias)
-		((quote dml_driver_membership_probe) _fallback_schema _stage probe)
-		(collect_join_columns_acc sources default_alias target_alias probe columns_by_alias)
+		((symbol driver_membership_probe) stage probe)
+		(reduce (membership_probe_outer_exprs stage probe) (lambda (acc expr)
+			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
+		((quote driver_membership_probe) stage probe)
+		(reduce (membership_probe_outer_exprs stage probe) (lambda (acc expr)
+			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
+		((symbol driver_membership_subscan_probe) stage probe)
+		(reduce (membership_probe_outer_exprs stage probe) (lambda (acc expr)
+			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
+		((quote driver_membership_subscan_probe) stage probe)
+		(reduce (membership_probe_outer_exprs stage probe) (lambda (acc expr)
+			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
+		((symbol dml_driver_membership_probe) _fallback_schema stage probe)
+		(reduce (membership_probe_outer_exprs stage probe) (lambda (acc expr)
+			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
+		((quote dml_driver_membership_probe) _fallback_schema stage probe)
+		(reduce (membership_probe_outer_exprs stage probe) (lambda (acc expr)
+			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
 		((symbol scalar_first_probe) stage _requested_col)
 		(collect_join_probe_lookup_columns_acc sources default_alias target_alias stage columns_by_alias)
 		((symbol scalar_first_probe) stage _requested_col _stages)
@@ -3503,9 +3520,9 @@ the auto-index chooses the concrete access path on both tables. */
 				(quoted_runtime_list (list target_col)))))))
 
 /* An equality-only presence domain needs no aggregate cache: duplicate RHS
-keys do not change existence. Prove that the complete domain is this one
-column and the residual reads only the RHS before projecting its row set.
-Multi-key, computed-key and dependent stages retain their cache carrier. */
+keys do not change existence. Partition the complete domain into target-column
+joins and query-invariant lookup filters (including explicit session keys).
+Never drop a domain component or reconstruct a dependent/computed-key stage. */
 (define direct_presence_projection_parts (lambda (src membership)
 	(begin
 		(define stage (car membership))
@@ -3514,16 +3531,26 @@ Multi-key, computed-key and dependent stages retain their cache carrier. */
 		(define lookup (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
 		(if (and (presence_probe_stage? stage)
 			(and (source_is_base_table? input)
-				(and (equal? (count keys) 1) (equal? (count lookup) 1))))
+				(and (not (empty_list? keys)) (equal? (count keys) (count lookup)))))
 			(begin
-				(define rhs_col (direct_column_name_for_alias input (car keys)))
-				(define lhs_col (direct_column_name_for_alias src (car lookup)))
+				(define parts (map (produceN (count keys)) (lambda (idx)
+					(begin
+						(define rhs (direct_column_name_for_alias input (nth keys idx)))
+						(define lhs (direct_column_name_for_alias src (nth lookup idx)))
+						(if (or (nil? rhs)
+							(and (nil? lhs) (not (empty_list? (query_expr_alias_set nil (nth lookup idx) '())))))
+							nil
+							(list rhs lhs (if (nil? lhs)
+								(list (quote equal??) (nth keys idx) (nth lookup idx)) true)))))))
 				(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-				(if (and (not (nil? rhs_col))
-					(and (equal? lhs_col (nth membership 2))
-						(empty_list? (external_column_refs_for_alias (source_alias input) condition))))
-					(list input rhs_col lhs_col condition)
-					nil))
+				(if (or (contains? parts nil)
+					(not (empty_list? (external_column_refs_for_alias (source_alias input) condition))))
+					nil
+					(begin
+						(define joins (filter parts (lambda (part) (not (nil? (cadr part))))))
+						(if (not (contains? (map joins cadr) (nth membership 2))) nil
+							(list input (map joins car) (map joins cadr)
+								(combine_where_terms (cons condition (map parts (lambda (part) (nth part 2)))) true))))))
 			nil))))
 
 (define recset_project_join_expr_for_membership_raw (lambda (src membership)
@@ -3537,25 +3564,25 @@ Multi-key, computed-key and dependent stages retain their cache carrier. */
 				(physical_query_tx_symbol)
 				(candidate_recset_filter_source (nth direct 0)
 					(source_table_expr (nth direct 0)) (nth direct 3))
-				(quoted_runtime_list (list (nth direct 1)))
+				(quoted_runtime_list (nth direct 1))
 				(source_table_expr src)
-				(quoted_runtime_list (list (nth direct 2))))
-		(if (union_block? input)
-			(begin
-				(define projected (map (union_branches input) (lambda (branch)
-					(recset_project_join_branch_expr src branch target_col))))
-				(if (reduce projected (lambda (unsupported item) (or unsupported (nil? item))) false)
-					nil
-					(if (single_source? projected)
-						(car projected)
-						(list (quote recset_union)
-							(physical_query_tx_symbol)
-							(cons (quote list) projected)))))
-			(if (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote in_membership))
-				(membership_cache_recset_project_join_expr src stage target_col)
-				(if (recset_probe_stage_shape? stage)
-					(exists_recset_project_join_expr src stage)
-					nil)))))))
+				(quoted_runtime_list (nth direct 2)))
+			(if (union_block? input)
+				(begin
+					(define projected (map (union_branches input) (lambda (branch)
+						(recset_project_join_branch_expr src branch target_col))))
+					(if (reduce projected (lambda (unsupported item) (or unsupported (nil? item))) false)
+						nil
+						(if (single_source? projected)
+							(car projected)
+							(list (quote recset_union)
+								(physical_query_tx_symbol)
+								(cons (quote list) projected)))))
+				(if (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote in_membership))
+					(membership_cache_recset_project_join_expr src stage target_col)
+					(if (recset_probe_stage_shape? stage)
+						(exists_recset_project_join_expr src stage)
+						nil)))))))
 
 /* A source-local estimate cannot describe cardinality after an FK projection:
 matching most keys may still reach only a handful of driver rows. Translate an
@@ -3633,7 +3660,7 @@ plan, while an autoindex or data growth which changes the winner recompiles it. 
 					candidate_input_rows candidate_rows driver_rows facts)
 				(membership_driver_probe_cost driver_rows
 					(qassoc_get facts (quote membership_candidate_probe_branches) 1)
-					(qassoc_get facts (quote membership_downstream_probe_branches) 0)))
+					(qassoc_get facts (quote membership_downstream_probe_branches) 0) facts))
 			nil))
 		(define batch_facts (merge (list
 			(list
@@ -3940,7 +3967,7 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 							candidate_input_rows candidate_rows driver_rows cost_facts)
 						(membership_driver_probe_cost driver_rows
 							(qassoc_get facts (quote membership_candidate_probe_branches) 1)
-							(qassoc_get cost_facts (quote membership_downstream_probe_branches) 0)))
+							(qassoc_get cost_facts (quote membership_downstream_probe_branches) 0) cost_facts))
 					nil))
 				(define batch_cost_facts (if allow_ordered_batch
 					(merge (list
@@ -5898,7 +5925,12 @@ state through an assoc and one-element payload lists adds no semantics. */
 		(define table_expr (if (nil? formula)
 			(if (nil? membership)
 				nil
-				(recset_project_join_expr_for_membership src membership))
+				(begin
+					(define plan (recset_project_join_plan_for_membership_using
+						src membership (quote aggregate) (planner_source_row_count src) false nil 0 true nil
+						(quote group_fill) (planner_context_session facts) (planner_context_tx facts)))
+					(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
+						(cadr plan) nil)))
 			(nth formula 1)))
 		(list table_expr
 			(if (nil? formula)

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -3502,11 +3502,44 @@ the auto-index chooses the concrete access path on both tables. */
 				(source_table_expr target_src)
 				(quoted_runtime_list (list target_col)))))))
 
+/* An equality-only presence domain needs no aggregate cache: duplicate RHS
+keys do not change existence. Prove that the complete domain is this one
+column and the residual reads only the RHS before projecting its row set.
+Multi-key, computed-key and dependent stages retain their cache carrier. */
+(define direct_presence_projection_parts (lambda (src membership)
+	(begin
+		(define stage (car membership))
+		(define input (gs_input stage))
+		(define keys (gs_keys stage))
+		(define lookup (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+		(if (and (presence_probe_stage? stage)
+			(and (source_is_base_table? input)
+				(and (equal? (count keys) 1) (equal? (count lookup) 1))))
+			(begin
+				(define rhs_col (direct_column_name_for_alias input (car keys)))
+				(define lhs_col (direct_column_name_for_alias src (car lookup)))
+				(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+				(if (and (not (nil? rhs_col))
+					(and (equal? lhs_col (nth membership 2))
+						(empty_list? (external_column_refs_for_alias (source_alias input) condition))))
+					(list input rhs_col lhs_col condition)
+					nil))
+			nil))))
+
 (define recset_project_join_expr_for_membership_raw (lambda (src membership)
 	(begin
 		(define stage (nth membership 0))
 		(define target_col (nth membership 2))
 		(define input (gs_input stage))
+		(define direct (direct_presence_projection_parts src membership))
+		(if (not (nil? direct))
+			(list (quote recset_project_join)
+				(physical_query_tx_symbol)
+				(candidate_recset_filter_source (nth direct 0)
+					(source_table_expr (nth direct 0)) (nth direct 3))
+				(quoted_runtime_list (list (nth direct 1)))
+				(source_table_expr src)
+				(quoted_runtime_list (list (nth direct 2))))
 		(if (union_block? input)
 			(begin
 				(define projected (map (union_branches input) (lambda (branch)
@@ -3522,7 +3555,7 @@ the auto-index chooses the concrete access path on both tables. */
 				(membership_cache_recset_project_join_expr src stage target_col)
 				(if (recset_probe_stage_shape? stage)
 					(exists_recset_project_join_expr src stage)
-					nil))))))
+					nil)))))))
 
 /* A source-local estimate cannot describe cardinality after an FK projection:
 matching most keys may still reach only a handful of driver rows. Translate an
@@ -3769,12 +3802,18 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 		/* merge is right-biased. Reorder telemetry owns statistics-sensitive
 		physical work, so place it after the late-consumer fallback; otherwise the
 		fallback replaces index-reduced row and byte counts. */
-		(define facts (merge (list
+		(define estimated_facts (merge (list
 			(membership_candidate_work_facts stage planning_session)
 			(gs_facts stage))))
+		/* Carrier-specific work belongs here, after the logical estimates. A
+		direct RHS projection neither prepares nor reads an aggregate cache. */
+		(define facts (if (nil? (direct_presence_projection_parts src membership))
+			estimated_facts
+			(qassoc_set estimated_facts (quote membership_candidate_cache_backed) false)))
 		(define consumer_facts (qassoc_set
 			(if (equal? consumer (quote aggregate))
-				(qassoc_set facts (quote membership_consumer) (quote aggregate))
+				(qassoc_set (qassoc_set facts (quote membership_consumer) (quote aggregate))
+					(quote membership_order_limit_driver) false)
 				facts)
 			(quote membership_downstream_probe_branches)
 			/* ORDER/LIMIT carriers change how many rows reach downstream work even
@@ -3794,7 +3833,8 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 		(if (or (nil? raw_expr)
 			(not (or
 				(equal? (qassoc_get facts (quote purpose) nil) (quote in_membership))
-				(equal? (qassoc_get facts (quote purpose) nil) (quote in_candidate)))))
+				(or (equal? (qassoc_get facts (quote purpose) nil) (quote in_candidate))
+					(presence_probe_stage? stage)))))
 			(if (nil? raw_expr) nil (list "candidate_keyset" raw_expr))
 			(begin
 				/* Membership reorder already records this estimate in stage facts. Only
@@ -4985,7 +5025,9 @@ self-joins of the same base table still describe two distinct row roles. */
 			(list
 				(list (quote condition) (coalesceNil (qb_where block) true))
 				(list (quote domain) session_keys)
-				(list (quote lookup-keys) session_keys))))))
+				(list (quote lookup-keys) session_keys)
+				(list (quote physical_planning_session) (planner_context_session (qb_facts block)))
+				(list (quote physical_planning_tx) (planner_context_tx (qb_facts block))))))))
 
 (define make_group_stage_for_query_block (lambda (block)
 	(begin
@@ -5523,7 +5565,7 @@ every group row and its canonical identity stays independent of bound values. */
 		(cons agg_expr (cons agg_reduce (cons agg_neutral _rest))) (begin
 			(define src (list alias schema tbl false nil))
 			(define agg_col (aggregate_col_name_using src ag))
-			(define membership_parts (base_group_membership_parts src condition))
+			(define membership_parts (base_group_membership_parts src condition (gs_facts stage)))
 			(define membership_expr (car membership_parts))
 			(define effective_condition (cadr membership_parts))
 			(if (expr_contains_driver_membership? condition)
@@ -5687,7 +5729,7 @@ otherwise unnecessary one-entry associative group. */
 			true)
 		(define ag (cadr scalar_parts))
 		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-		(define membership_parts (base_group_membership_parts src condition))
+		(define membership_parts (base_group_membership_parts src condition (gs_facts stage)))
 		(define membership_expr (car membership_parts))
 		(define effective_condition (cadr membership_parts))
 		(define membership_var (symbol "__group_membership_recset"))
@@ -5829,18 +5871,43 @@ state through an assoc and one-element payload lists adds no semantics. */
 					true))
 			state_plan))))
 
-(define base_group_membership_parts (lambda (src condition)
+(define base_group_membership_parts (lambda (src condition facts)
 	(begin
+		/* Group fills consume the complete input, not the outer ORDER/LIMIT
+		window. Keep anti-membership visible to the same costed carrier builder
+		as positive membership; only two-valued presence stages may participate
+		in the exact complement/difference formula. Nullable IN remains a
+		residual unless its separate truth contract has been discharged. */
+		(define formula_terms (driver_membership_formula_terms_for_source src condition))
+		(define formula_bindings (if (reduce formula_terms (lambda (found term)
+			(or found (nth term 4))) false)
+			(filter (map formula_terms (lambda (term)
+				(begin
+					(define plan (recset_project_join_plan_for_membership_using
+						/* This marker runs in the group fill's input filter, before
+						the residual predicates. The output LIMIT does not bound its
+						probes: every input row can reach this call. */
+						src term (quote aggregate) (planner_source_row_count src) false nil 0 true nil
+						(quote group_fill) (planner_context_session facts) (planner_context_tx facts)))
+					(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
+						(list term (membership_recset_var src term) (cadr plan)) nil))))
+				(lambda (binding) (not (nil? binding))))
+			'()))
+		(define formula (driver_membership_recset_formula src condition formula_bindings))
 		(define membership (driver_membership_for_source src condition))
-		(define table_expr (if (nil? membership)
-			nil
-			(recset_project_join_expr_for_membership src membership)))
+		(define table_expr (if (nil? formula)
+			(if (nil? membership)
+				nil
+				(recset_project_join_expr_for_membership src membership))
+			(nth formula 1)))
 		(list table_expr
-			(strip_driver_membership_for_source src condition (if (nil? table_expr) nil membership))))))
+			(if (nil? formula)
+				(strip_driver_membership_for_source src condition (if (nil? table_expr) nil membership))
+				(strip_driver_membership_formula_terms condition (car formula)))))))
 
-(define build_base_group_into_plan (lambda (schema tbl alias src grouptbl keys key_names condition ags)
+(define build_base_group_into_plan (lambda (schema tbl alias src grouptbl keys key_names condition ags facts)
 	(begin
-		(define membership_parts (base_group_membership_parts src condition))
+		(define membership_parts (base_group_membership_parts src condition facts))
 		(define membership_expr (car membership_parts))
 		(define effective_condition (cadr membership_parts))
 		(define membership_var (symbol "__group_membership_recset"))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4002,6 +4002,74 @@ RecSet; membership edges retain their own physical operators. */
 				(quote membership_consumer) nil)
 				(quote order_limit))))))
 
+/* Both trees implement exactly residual AND NOT EXISTS. Eager difference
+filters the entire driver before ordering; a complement boundary leaves the
+same residual inside scan_order so LIMIT can brake. Do not push the residual
+eagerly merely because it is present: cost the work at its actual consumer.
+Only scalar estimates and Costgen coefficients are used here, never alternative
+plan construction or timing during compilation. */
+(define anti_membership_prefilter_preferred? (lambda (src residual formula block)
+	(if (not (and (query_limit_active? (qb_offset block) (qb_limit block))
+		(order_items_belong_to_source? src (qb_order block))))
+		true
+		(begin
+			(define planning_session (planner_context_session (qb_facts block)))
+			(define tx (planner_context_tx (qb_facts block)))
+			(define rows (planner_source_row_count src))
+			(define target (probe_limit_work_rows (qb_limit block) planning_session))
+			(define offset (planner_literal_value (coalesceNil (qb_offset block) 0) planning_session))
+			(define estimate (planner_source_filter_estimate src residual 512 tx planning_session))
+			(define matches (planner_estimated_matching_rows estimate rows rows))
+			/* The excluded set's density must be complemented. Treating a zero-row
+			EXISTS domain as zero surviving NOT EXISTS rows destroys the LIMIT estimate.
+			Unknown domains conservatively deny an early-stop benefit. */
+			(define retained_fraction (reduce (car formula) (lambda (fraction term)
+				(begin
+					(define stage (car term))
+					(define input (gs_input stage))
+					(define input_rows (if (source_is_base_table? input) (planner_source_row_count input) nil))
+					(define candidate_estimate (if (source_is_base_table? input)
+						(planner_source_filter_estimate input
+							(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
+							512 tx planning_session) nil))
+					(define candidate_rows (planner_estimated_matching_rows candidate_estimate input_rows input_rows))
+					(planner_record_table_statistics_guards (list input) planning_session)
+					(if (and (number? input_rows) (number? candidate_rows))
+						(* fraction (if (> input_rows 0) (- 1 (min 1 (/ candidate_rows input_rows))) 1))
+						0))) 1))
+			(if (not (and (number? rows) (and (number? matches) (and (number? target) (number? offset)))))
+				true
+				(begin
+					(define accepted (* matches retained_fraction))
+					(define visited (if (> accepted 0) (min rows (/ (* (+ target offset) rows) accepted)) rows))
+					(define work (membership_source_work_profile src residual '() planning_session))
+					(define row_ns (+ planner_membership_scan_row_ns
+						(* (qassoc_get work (quote filter_columns) 0) planner_membership_filter_column_row_ns)
+						(* (qassoc_get work (quote expression_operations) 0) planner_membership_expression_operation_row_ns)))
+					(define eager_ns (+ planner_membership_scan_invocation_ns (* rows row_ns)
+						(* matches planner_membership_recset_build_row_ns)
+						(* (membership_ordered_recset_sort_work accepted) planner_membership_ordered_recset_sort_unit_ns)))
+					(define lazy_ns (+ (* visited row_ns)
+						(* rows planner_membership_recset_build_row_ns)
+						(* visited planner_membership_ordered_driver_input_row_ns)))
+					(define decision_id (concat "anti_membership_filter:" (source_alias src) ":"
+						(stable_structural_hash residual true)))
+					(define normal (if (< lazy_ns eager_ns) "ordered_complement_filter" "prefiltered_difference"))
+					(define chosen (planner_physical_choice decision_id normal
+						(list "ordered_complement_filter" "prefiltered_difference") planning_session))
+					(planner_record_table_statistics_guards (list src) planning_session)
+					(planner_record_session_value_guards (list residual (qb_limit block) (qb_offset block)) planning_session)
+					(planner_record_physical_decision (list
+						(list "decision_id" decision_id) (list "decision" "anti_membership_filter")
+						(list "chosen" chosen) (list "reason" "lowest_total_ns")
+						(list "inputs" (list (list "input_rows" rows) (list "residual_rows" matches)
+							(list "retained_fraction" retained_fraction) (list "visited_rows" visited)
+							(list "limit" target) (list "offset" offset)))
+						(list "alternatives" (list
+							(list (list "plan" "ordered_complement_filter") (list "total_ns" lazy_ns))
+							(list (list "plan" "prefiltered_difference") (list "total_ns" eager_ns))))) planning_session)
+					(equal? chosen "prefiltered_difference")))))))
+
 (define lower_single_source_query_block (lambda (block)
 	(begin
 		(define src (car (qb_sources block)))
@@ -4155,7 +4223,8 @@ RecSet; membership edges retain their own physical operators. */
 				whole visible table. This is both exact and the useful Difference case. */
 				(define membership_formula_difference_driver (and membership_formula_driver
 					(and (empty_list? (nth membership_formula 3))
-						(not (equal? membership_formula_residual true)))))
+						(and (not (equal? membership_formula_residual true))
+							(anti_membership_prefilter_preferred? src membership_formula_residual membership_formula block)))))
 				(define membership_formula_expr (if membership_formula_difference_driver
 					(begin
 						(define base_cols (extract_columns_for_alias src membership_formula_residual))
@@ -8232,12 +8301,12 @@ physical decision and preserve its runtime recompile gate. */
 								(qb_schema block) scan_sources scan_plan first_alias needed_exprs
 								final_condition fields order_items (qb_offset block) (qb_limit block)
 								stage_catalog (qb_facts block))
-						(if (physical_prejoin_supported? block)
-							(lower_query_block_through_prejoin block)
-							(lower_materialized_join_order
-								(qb_schema block) scan_sources scan_plan first_alias needed_exprs
-								final_condition fields order_items (qb_offset block) (qb_limit block)
-								stage_catalog (qb_facts block)))))
+							(if (physical_prejoin_supported? block)
+								(lower_query_block_through_prejoin block)
+								(lower_materialized_join_order
+									(qb_schema block) scan_sources scan_plan first_alias needed_exprs
+									final_condition fields order_items (qb_offset block) (qb_limit block)
+									stage_catalog (qb_facts block)))))
 ))))))
 
 (define zero_source_field_expr_key (lambda (expr)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -1489,7 +1489,7 @@ outer joins. */
 				leave aggregate values to the filtered lazy computed columns. */
 				(if (empty_list? aggregate_probe_bindings)
 					(non_scalar_order_aggregates ags)
-					'()))))
+					'()) (gs_facts stage))))
 		(define cleanup_plan (if (query_block? src)
 			nil
 			(build_group_keytable_cleanup schema tbl alias grouptbl keys key_names)))

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -162,6 +162,19 @@ func OrderRelationLess(fn func(...Scmer) Scmer) func(Scmer, Scmer) bool {
 	return func(a, b Scmer) bool { return ToBool(fn(a, b)) }
 }
 
+// binaryCollationLess keeps boolean/text keys in the same textual order in
+// both directions. Less is the coercing expression comparator: its bool-left
+// arm converts to integers, while its string-left arm renders a bool as text.
+// That asymmetry must not enter an index (true < "3" and "3" < true).
+// Keep expression comparison itself unchanged, including numeric coercions.
+func binaryCollationLess(a, b Scmer) bool {
+	if (a.IsBool() && (b.IsString() || b.IsSymbol())) ||
+		(b.IsBool() && (a.IsString() || a.IsSymbol())) {
+		return String(a) < String(b)
+	}
+	return Less(a, b)
+}
+
 /* SQL LIKE operator implementation on strings */
 func StrLike(str, pattern string) bool {
 	if !strings.ContainsAny(pattern, "%_\\") {
@@ -11778,16 +11791,16 @@ func init_strings() {
 				return cached.(Scmer)
 			}
 			// Binary and bare-charset relations are the dominant index case. Keep
-			// their canonical callback to one function dispatch: Less already owns
+			// their canonical callback to one function dispatch: binaryCollationLess owns
 			// the required ASC NULL-first semantics, and swapping its operands owns
 			// DESC NULL-last semantics. A closure per metadata key keeps callback
 			// identity distinct even when two names have identical byte ordering.
 			if collationName == "bin" || collationName == "binary" || collationName == "utf8" || collationName == "utf8mb4" {
 				less := func(left, right Scmer) bool {
 					if reverse {
-						return Less(right, left)
+						return binaryCollationLess(right, left)
 					}
-					return Less(left, right)
+					return binaryCollationLess(left, right)
 				}
 				fn := func(args ...Scmer) Scmer {
 					return NewBool(less(args[0], args[1]))
@@ -11819,14 +11832,14 @@ func init_strings() {
 					if m[2] == "bin" { // binary
 						// Return closures that compare raw UTF-8 byte order; register for serialization
 						if len(a) > 1 && ToBool(a[1]) {
-							f := func(a ...Scmer) Scmer { return GreaterScm(a...) }
+							f := func(a ...Scmer) Scmer { return NewBool(binaryCollationLess(a[1], a[0])) }
 							collateRegistry.Store(FunctionIdentity(f), struct {
 								Collation string
 								Reverse   bool
 							}{Collation: String(a[0]), Reverse: true})
 							return NewFunc(f)
 						}
-						f := func(a ...Scmer) Scmer { return LessScm(a...) }
+						f := func(a ...Scmer) Scmer { return NewBool(binaryCollationLess(a[0], a[1])) }
 						collateRegistry.Store(FunctionIdentity(f), struct {
 							Collation string
 							Reverse   bool

--- a/scm/strings_test.go
+++ b/scm/strings_test.go
@@ -18,6 +18,55 @@ package scm
 
 import "testing"
 
+func TestBinaryCollationBooleanTextOrder(t *testing.T) {
+	values := []Scmer{NewNil(), NewBool(false), NewBool(true),
+		NewString(""), NewString("0"), NewString("1"), NewString("3"),
+		NewString("false"), NewString("true"), NewString("view"), NewString("yes"),
+		NewSymbol("true"), NewString("ä")}
+	for _, name := range []string{"bin", "binary", "utf8", "utf8mb4", "utf8mb4_bin"} {
+		for _, reverse := range []bool{false, true} {
+			factory := Apply(Globalenv.Vars[Symbol("collate")], NewString(name), NewBool(reverse))
+			less := OrderRelationLess(factory.Func())
+			for i, a := range values {
+				if less(a, a) {
+					t.Fatalf("%s reverse=%v: irreflexivity at %d", name, reverse, i)
+				}
+				for j, b := range values {
+					ab, ba := less(a, b), less(b, a)
+					if ab && ba {
+						t.Fatalf("%s reverse=%v: asymmetric order at %d,%d", name, reverse, i, j)
+					}
+					for k, c := range values {
+						if ab && less(b, c) && !less(a, c) {
+							t.Fatalf("%s reverse=%v: non-transitive order at %d,%d,%d", name, reverse, i, j, k)
+						}
+						if !ab && !ba && !less(b, c) && !less(c, b) && (less(a, c) || less(c, a)) {
+							t.Fatalf("%s reverse=%v: non-transitive equivalence at %d,%d,%d", name, reverse, i, j, k)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestBinaryCollationPreservesNumericAndExpressionComparisons(t *testing.T) {
+	// The index fix must not redefine coercing expression comparisons or
+	// change the existing numeric/string search-key conversions.
+	if !Less(NewBool(true), NewString("3")) {
+		t.Fatal("coercing expression comparison changed")
+	}
+	values := []Scmer{NewNil(), NewInt(-1), NewInt(2), NewInt(10), NewFloat(2.5),
+		NewString("2"), NewString("10"), NewDate(42)}
+	for _, a := range values {
+		for _, b := range values {
+			if binaryCollationLess(a, b) != Less(a, b) {
+				t.Fatalf("numeric/text compatibility changed for %v and %v", a, b)
+			}
+		}
+	}
+}
+
 func TestLikePatternNeedsCaseFold(t *testing.T) {
 	tests := []struct {
 		pattern string

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -25,6 +25,24 @@ import (
 
 var benchmarkBoundaries analyzedBoundaries
 
+func TestInterpolationUsesIndexOrder(t *testing.T) {
+	order := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString("bin"), scm.NewBool(false))
+	less := scm.OrderRelationLess(order.Func())
+	values := []scm.Scmer{scm.NewNil(), scm.NewString("3"), scm.NewBool(false), scm.NewString("false"), scm.NewBool(true), scm.NewString("true"), scm.NewString("view")}
+	for _, key := range values {
+		want := 0
+		for want < len(values) && less(values[want], key) {
+			want++
+		}
+		for _, min := range []scm.Scmer{scm.NewNil(), values[1]} {
+			got := interpolationSearch(0, len(values), key, min, values[len(values)-1], func(i int) scm.Scmer { return values[i] }, less)
+			if got != want {
+				t.Fatalf("key %v: got %d, want %d", key, got, want)
+			}
+		}
+	}
+}
+
 func testEqualScanAccess(column string, value scm.Scmer) (scm.Scmer, []scm.Scmer) {
 	return scm.NewSlice([]scm.Scmer{
 		newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),

--- a/storage/index.go
+++ b/storage/index.go
@@ -1767,14 +1767,16 @@ start_scan:
 	if selected != nil {
 		selected(s, true)
 	}
-	// A fully index-covered filter cannot reject an otherwise visible row. When
-	// this active index also supplies ORDER BY, emit only the requested prefix
-	// per callback so LIMIT can brake inside the index walk. The caller-owned
-	// pooled buffer remains allocated at its normal size; only its visible slice
-	// is shortened, so the hot path adds no allocation.
+	// Start an ordered LIMIT with only its requested window. A residual predicate
+	// may reject it, but that is a reason to refill, not to fetch a full batch of
+	// expensive text columns before the consumer gets its first chance to brake.
+	// If the window is insufficient, geometrically grow to the ordinary batch
+	// size. The backing buffer is unchanged: no allocation or row materialization
+	// is added, and sparse/no-hit predicates regain bulk throughput quickly.
 	cmpCols := s.queryIndexPrefixLen(bounds, indexBounds)
 	firstSorted, lastSorted, sortedMask, unboundedMask := s.boundKernel(bounds, cmpCols)
-	if options != nil && options.boundaryCoveredLimit && options.orderedLimit > 0 &&
+	maxBatchSize := len(buf)
+	if options != nil && options.orderedLimit > 0 &&
 		options.orderedLimit < len(buf) && indexCoversBoundaryOrder(s, true, bounds, cmpCols) {
 		buf = buf[:options.orderedLimit]
 	}
@@ -1957,6 +1959,10 @@ start_scan:
 		if bufN == len(buf) {
 			if !emitRowMatchers(matchers, buf[:bufN], callback) {
 				stopped = true
+			} else if len(buf) < maxBatchSize && !options.boundaryCoveredLimit {
+				// Only a continuing consumer asks for more. Do not equate a short
+				// physical batch with SQL LIMIT satisfaction or discard rejected rows.
+				buf = buf[:min(maxBatchSize, len(buf)*2)]
 			}
 			bufN = 0
 		}

--- a/storage/index.go
+++ b/storage/index.go
@@ -1816,6 +1816,10 @@ start_scan:
 	mainIdx := 0
 	if firstSorted >= 0 && !indexBounds.lower(bounds, firstSorted).IsNil() {
 		if s.usesNaturalAscendingOrder(firstSorted) {
+			less := scm.Less
+			if firstSorted < len(s.ColOrder) && s.ColOrder[firstSorted] != nil {
+				less = s.ColOrder[firstSorted]
+			}
 			var interpMin, interpMax scm.Scmer
 			if len(state.minVals) > firstSorted {
 				interpMin = state.minVals[firstSorted]
@@ -1824,7 +1828,7 @@ start_scan:
 			mainIdx = interpolationSearch(searchLo, searchN, indexBounds.lower(bounds, firstSorted), interpMin, interpMax,
 				func(idx int) scm.Scmer {
 					return cols[firstSorted].get(getRecid(idx))
-				})
+				}, less)
 		} else {
 			mainIdx = searchLo + sort.Search(searchN, func(idx int) bool {
 				value := cols[firstSorted].get(getRecid(searchLo + idx))

--- a/storage/interpolation.go
+++ b/storage/interpolation.go
@@ -30,7 +30,9 @@ import (
 //
 // getVal reads the value at a given position in the sorted index.
 // minVal/maxVal are the first/last values in the sorted range.
-func interpolationSearch(lo, n int, key scm.Scmer, minVal, maxVal scm.Scmer, getVal func(int) scm.Scmer) int {
+// less must be the index's ordering, including its equivalence classes;
+// coercing expression equality cannot safely decide a search direction.
+func interpolationSearch(lo, n int, key scm.Scmer, minVal, maxVal scm.Scmer, getVal func(int) scm.Scmer, less func(scm.Scmer, scm.Scmer) bool) int {
 	if n <= 0 {
 		return lo
 	}
@@ -48,14 +50,14 @@ func interpolationSearch(lo, n int, key scm.Scmer, minVal, maxVal scm.Scmer, get
 			}
 			// Probe the guess position
 			gv := getVal(guess)
-			if scm.Less(key, gv) || scm.Equal(key, gv) {
+			if !less(gv, key) {
 				// key <= guess: search in [lo, guess+1)
 				upperN := guess - lo + 1
 				if upperN > n {
 					upperN = n
 				}
 				return lo + sort.Search(upperN, func(i int) bool {
-					return !scm.Less(getVal(lo+i), key) // getVal(pos) >= key
+					return !less(getVal(lo+i), key) // getVal(pos) >= key
 				})
 			}
 			// key > guess: search in [guess+1, lo+n)
@@ -65,13 +67,13 @@ func interpolationSearch(lo, n int, key scm.Scmer, minVal, maxVal scm.Scmer, get
 				return lo + n
 			}
 			return newLo + sort.Search(newN, func(i int) bool {
-				return !scm.Less(getVal(newLo+i), key)
+				return !less(getVal(newLo+i), key)
 			})
 		}
 	}
 	// Fallback: plain binary search
 	return lo + sort.Search(n, func(i int) bool {
-		return !scm.Less(getVal(lo+i), key)
+		return !less(getVal(lo+i), key)
 	})
 }
 

--- a/storage/scan_order_coverage_test.go
+++ b/storage/scan_order_coverage_test.go
@@ -333,8 +333,8 @@ func TestCoveredOrderedLimitBrakesInsideIndexBatch(t *testing.T) {
 			queue.candidateCount, limit)
 	}
 
-	// An additional acceptance predicate can still reject index matches, so it
-	// must retain the ordinary scan batch instead of claiming full coverage.
+	// A residual predicate does not prove coverage. It can still start with a
+	// small batch, provided continuation refills/grows rather than truncating.
 	acceptAll := buildProc([]string{"bucket"}, scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("equal?"),
 		scm.NewSymbol("bucket"),
@@ -342,9 +342,27 @@ func TestCoveredOrderedLimitBrakesInsideIndexBatch(t *testing.T) {
 	}))
 	acceptAll.Proc().En.Vars[equalSymbol] = equalFn
 	queue = run([]string{"bucket"}, acceptAll)
-	if queue.candidateCount <= limit {
-		t.Fatalf("acceptance predicate incorrectly used covered LIMIT batch: %d candidates",
+	if queue.candidateCount != limit {
+		t.Fatalf("all-accepting residual loaded an oversized first batch: %d candidates",
 			queue.candidateCount)
+	}
+	for _, threshold := range []int64{5, 3000, rows} {
+		accept := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+			return scm.NewBool(values[0].Int() >= threshold)
+		})
+		queue = run([]string{"rank"}, accept)
+		want := min(limit, rows-int(threshold))
+		if len(queue.items) != want {
+			t.Fatalf("residual threshold %d returned %d rows, want %d", threshold, len(queue.items), want)
+		}
+		for i, id := range queue.items {
+			if int64(id) != threshold+int64(i) {
+				t.Fatalf("residual threshold %d item %d = %d", threshold, i, id)
+			}
+		}
+		if queue.candidateCount < threshold+int64(want) {
+			t.Fatalf("residual threshold %d failed to refill: %d candidates", threshold, queue.candidateCount)
+		}
 	}
 
 	// Visibility is checked after index iteration. A short covered batch may be

--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -122,8 +122,7 @@ func (s *StorageEnum) symbolLo(idx int) uint64 {
 
 func (s *StorageEnum) findValue(val scm.Scmer) int {
 	for i := uint8(0); i < s.k; i++ {
-		// strict: NULL only matches NULL
-		if val.IsNil() == s.values[i].IsNil() && (val.IsNil() || scm.Equal(s.values[i], val)) {
+		if storageValueEqual(s.values[i], val) {
 			return int(i)
 		}
 	}
@@ -181,9 +180,9 @@ func (s *StorageEnum) prepare() {
 
 func (s *StorageEnum) scan(i uint32, value scm.Scmer) {
 	s.scanTotal++
-	// find existing symbol (strict: NULL only matches NULL)
+	// Dictionary identity must not coerce distinct stored values.
 	for j := uint8(0); j < s.k; j++ {
-		if value.IsNil() == s.values[j].IsNil() && (value.IsNil() || scm.Equal(s.values[j], value)) {
+		if storageValueEqual(s.values[j], value) {
 			s.scanFreqs[j]++
 			return
 		}

--- a/storage/storage-scmer.go
+++ b/storage/storage-scmer.go
@@ -234,15 +234,29 @@ func (s *StorageSCMER) SetValue(i uint32, v scm.Scmer) {
 	s.values[i] = v
 }
 
+// storageValueEqual identifies interchangeable dictionary/constant values,
+// not values that happen to compare equal after expression coercions. Scalar
+// representation equality also preserves large integers, signed zero, NaN
+// payloads and date zones. Text may have distinct backing allocations.
+func storageValueEqual(a, b scm.Scmer) bool {
+	if a == b {
+		return true
+	}
+	if a.IsString() && b.IsString() {
+		return a.String() == b.String()
+	}
+	if a.IsSymbol() && b.IsSymbol() {
+		return a.String() == b.String()
+	}
+	return false
+}
+
 func (s *StorageSCMER) scan(i uint32, value scm.Scmer) {
 	// enum detection: track up to enumMaxSymbols distinct values with frequencies
 	if s.enumK != 0xFF {
 		found := false
 		for j := uint8(0); j < s.enumK; j++ {
-			// Use strict comparison: NULL is only equal to NULL
-			// (scm.Equal treats NULL == 0 == false per Scheme semantics,
-			// but storage needs them distinguished)
-			if value.IsNil() == s.enumVals[j].IsNil() && (value.IsNil() || scm.Equal(s.enumVals[j], value)) {
+			if storageValueEqual(s.enumVals[j], value) {
 				s.enumFreqs[j]++
 				found = true
 				break

--- a/storage/storage_compress_test.go
+++ b/storage/storage_compress_test.go
@@ -97,6 +97,46 @@ func verifyStorage(t *testing.T, col ColumnStorage, n int, gen func(int) scm.Scm
 
 // --- StorageInt tests ---
 
+func TestCompressionDoesNotCollapseBooleanText(t *testing.T) {
+	values := []scm.Scmer{scm.NewBool(true), scm.NewString("yes"), scm.NewString("3"), scm.NewString("view")}
+	col := buildViaCompression(len(values), func(i int) scm.Scmer { return values[i] })
+	for i, want := range values {
+		got := col.GetValue(uint32(i))
+		if scm.String(got) != scm.String(want) {
+			t.Fatalf("row %d: got %v, want %v (%T)", i, got, want, col)
+		}
+	}
+}
+
+func TestStorageValueIdentity(t *testing.T) {
+	pairs := [][2]scm.Scmer{
+		{scm.NewInt(1 << 53), scm.NewInt((1 << 53) + 1)},
+		{scm.NewFloat(0), scm.NewFloat(math.Copysign(0, -1))},
+		{scm.NewFloat(math.Float64frombits(0x7ff8000000000001)), scm.NewFloat(math.Float64frombits(0x7ff8000000000002))},
+		{scm.NewInt(1), scm.NewFloat(1)},
+		{scm.NewBool(true), scm.NewString("true")},
+		{scm.NewString("symbol"), scm.NewSymbol("symbol")},
+	}
+	for _, pair := range pairs {
+		if !storageValueEqual(pair[0], pair[0]) || storageValueEqual(pair[0], pair[1]) || storageValueEqual(pair[1], pair[0]) {
+			t.Fatalf("storage identity merged distinct scalar representations: %v / %v", pair[0], pair[1])
+		}
+	}
+}
+
+func TestEnumPreservesDistinctScalarValues(t *testing.T) {
+	values := []scm.Scmer{scm.NewBool(true), scm.NewString("view"), scm.NewInt(1), scm.NewString("1"), scm.NewBool(false), scm.NewInt(0), scm.NewNil(), scm.NewString("")}
+	col := buildEnum(256, func(i int) scm.Scmer { return values[i%len(values)] })
+	for _, stored := range []ColumnStorage{col, serializeDeserialize(col)} {
+		for i := 0; i < 256; i++ {
+			got, want := stored.GetValue(uint32(i)), values[i%len(values)]
+			if got.GetTag() != want.GetTag() || scm.String(got) != scm.String(want) {
+				t.Fatalf("row %d: got %v (tag %d), want %v (tag %d)", i, got, got.GetTag(), want, want.GetTag())
+			}
+		}
+	}
+}
+
 func TestStorageIntPipeline(t *testing.T) {
 	// Build StorageInt directly (bypass proposeCompression heuristics)
 	n := 200

--- a/tests/planner/subqueries/indexed-membership-costing.yaml
+++ b/tests/planner/subqueries/indexed-membership-costing.yaml
@@ -55,6 +55,67 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS imc_file"
 
 test_cases:
+  - name: "Unique partition dominance needs no per-request selectivity scan"
+    scm: |
+      (begin
+        (define planning (sql_queryplan_compile_session (newsession) nil))
+        (with_session planning (lambda ()
+          (parse_sql "memcp-tests"
+            "SELECT SQL_CALC_FOUND_ROWS d.id FROM imc_domain d WHERE d.direct_flag = 0 AND NOT EXISTS (SELECT 1 FROM imc_assignment a WHERE a.actor_id = 99 AND a.domain_id = d.id) ORDER BY d.id DESC LIMIT 10"
+            (lambda args true) planning nil)))
+        (not (strlike (serialize (sql_queryplan_guard_from_session planning))
+          "%scan_selectivity_estimate%")))
+    expect:
+      data: [true]
+
+  - name: "Partition dominance requires every non-null unique key component"
+    scm: |
+      (begin
+        (define src '("d" "memcp-tests" "imc_domain" false nil))
+        (and (aggregate_pushdown_identity_partition? src '("id" "direct_flag"))
+          (not (aggregate_pushdown_identity_partition? src '("direct_flag")))))
+    expect:
+      data: [true]
+
+  - name: "Ordered anti-membership keeps a broad residual inside the limited scan"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT d.id FROM imc_domain d
+      WHERE d.direct_flag = 0 AND NOT EXISTS (
+        SELECT 1 FROM imc_assignment a WHERE a.actor_id = 99 AND a.domain_id = d.id
+      ) ORDER BY d.id DESC LIMIT 10
+    expect:
+      result_contains: ["anti_membership_filter", "chosen ordered_complement_filter", "recset_not"]
+      result_not_contains: ["recset_difference"]
+
+  - name: "Ordered anti-membership returns the complete page and found-row count"
+    session_id: "imc_ordered_anti"
+    warmup: 5
+    timing_samples: 20
+    sql: |
+      SELECT SQL_CALC_FOUND_ROWS d.id FROM imc_domain d
+      WHERE d.direct_flag = 0 AND NOT EXISTS (
+        SELECT 1 FROM imc_assignment a WHERE a.actor_id = 99 AND a.domain_id = d.id
+      ) ORDER BY d.id DESC LIMIT 10
+    expect:
+      data: [{id: 639}, {id: 637}, {id: 636}, {id: 635}, {id: 634},
+             {id: 633}, {id: 632}, {id: 631}, {id: 630}, {id: 629}]
+
+  - name: "Ordered anti-membership counts all matches before LIMIT"
+    session_id: "imc_ordered_anti"
+    sql: "SELECT FOUND_ROWS() AS n"
+    expect:
+      data: [{n: 581}]
+
+  - name: "Ordered anti-membership retains OFFSET and nonempty exclusions"
+    sql: |
+      SELECT d.id FROM imc_domain d
+      WHERE d.direct_flag = 0 AND NOT EXISTS (
+        SELECT 1 FROM imc_assignment a WHERE a.actor_id = 7 AND a.domain_id = d.id
+      ) ORDER BY d.id DESC LIMIT 2 OFFSET 2
+    expect:
+      data: [{id: 635}, {id: 633}]
+
   - name: "Grouped anti-membership enumerates physical carriers"
     sql: |
       EXPLAIN PHYSICAL

--- a/tests/planner/subqueries/indexed-membership-costing.yaml
+++ b/tests/planner/subqueries/indexed-membership-costing.yaml
@@ -17,8 +17,8 @@ setup:
   - sql: "CREATE TABLE imc_file (id INT PRIMARY KEY, filename VARCHAR(64), search VARCHAR(4096))"
   - sql: "CREATE TABLE imc_document (id INT PRIMARY KEY, file_id INT, sort_key INT)"
   - sql: "CREATE TABLE imc_acl (document_id INT PRIMARY KEY, allowed INT)"
-  - sql: "CREATE TABLE imc_domain (id INT PRIMARY KEY, direct_flag INT)"
-  - sql: "CREATE TABLE imc_assignment (domain_id INT, actor_id INT, allowed INT)"
+  - sql: "CREATE TABLE imc_domain (id INT NOT NULL PRIMARY KEY, direct_flag INT)"
+  - sql: "CREATE TABLE imc_assignment (domain_id INT NOT NULL, actor_id INT, allowed INT)"
   - sql: "CREATE TABLE imc_override (domain_id INT, actor_id INT, allowed INT)"
   - scm: |
       (begin
@@ -55,6 +55,83 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS imc_file"
 
 test_cases:
+  - name: "Grouped anti-membership enumerates physical carriers"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT d.id, COUNT(*) AS n FROM imc_domain d
+      WHERE d.id NOT IN (
+        SELECT a.domain_id FROM imc_assignment a WHERE a.actor_id = 7
+      ) GROUP BY d.id ORDER BY d.id DESC LIMIT 10
+    expect:
+      result_contains:
+        - "candidate_keyset"
+        - "driver_filter_join_probe"
+        - "driver_rows 640"
+      result_not_contains:
+        - ".grp:imc_assignment:"
+
+  - name: "Grouped anti-membership returns the ordered page"
+    warmup: 5
+    timing_samples: 20
+    sql: |
+      SELECT SQL_CALC_FOUND_ROWS d.id FROM imc_domain d
+      WHERE d.id NOT IN (
+        SELECT a.domain_id FROM imc_assignment a WHERE a.actor_id = 7
+      ) GROUP BY d.id ORDER BY d.id DESC LIMIT 10
+    expect:
+      data: [{id: 639}, {id: 637}, {id: 635}, {id: 633}, {id: 631},
+             {id: 629}, {id: 627}, {id: 625}, {id: 623}, {id: 621}]
+
+  - name: "Grouped anti-membership alternatives preserve the complete result"
+    sql: |
+      EXPLAIN PHYSICAL CALIBRATE
+      SELECT d.id, COUNT(*) AS n FROM imc_domain d
+      WHERE d.id NOT IN (
+        SELECT a.domain_id FROM imc_assignment a WHERE a.actor_id = 7
+      ) GROUP BY d.id ORDER BY d.id DESC LIMIT 10
+    expect:
+      result_contains: ["candidate_keyset", "driver_filter_join_probe", "result_equal"]
+      result_not_contains: ['"result_equal": false']
+
+  - name: "Primary-key projection grouping does not create a group cache"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT d.id FROM imc_domain d
+      WHERE d.id NOT IN (SELECT a.domain_id FROM imc_assignment a WHERE a.actor_id = 7)
+      GROUP BY d.id ORDER BY d.id DESC LIMIT 10
+    expect:
+      result_contains: ["scan_order", "membership_carrier"]
+      result_not_contains: [".grp:imc_domain:"]
+
+  - name: "Non-unique grouping still removes duplicates"
+    sql: "SELECT direct_flag FROM imc_domain GROUP BY direct_flag ORDER BY direct_flag"
+    expect:
+      data: [{direct_flag: 0}, {direct_flag: 1}]
+
+  - name: "Primary-key grouping retains HAVING"
+    sql: "SELECT id FROM imc_domain GROUP BY id HAVING COUNT(*) > 1"
+    expect: {rows: 0}
+
+  - name: "Grouped anti-membership preserves unmatched rows"
+    sql: |
+      SELECT COUNT(*) AS n FROM imc_domain d
+      WHERE NOT EXISTS (
+        SELECT 1 FROM imc_assignment a WHERE a.domain_id = d.id AND a.actor_id = 7
+      )
+    expect:
+      data: [{n: 320}]
+
+  - name: "Grouped positive and negative membership preserve intersection"
+    sql: |
+      SELECT COUNT(*) AS n FROM imc_domain d
+      WHERE EXISTS (
+        SELECT 1 FROM imc_assignment a WHERE a.domain_id = d.id AND a.actor_id = 7
+      ) AND NOT EXISTS (
+        SELECT 1 FROM imc_override o WHERE o.domain_id = d.id AND o.actor_id = 7
+      )
+    expect:
+      data: [{n: 213}]
+
   - name: "UNION estimate algebra preserves hook upper bounds"
     scm: |
       (begin

--- a/tests/storage/indexes/index-delta-merge.yaml
+++ b/tests/storage/indexes/index-delta-merge.yaml
@@ -55,6 +55,33 @@ test_cases:
     sql: "SELECT missing FROM idx_merge_bool_text WHERE o = true"
     expect: {error: true}
 
+  - name: "Rebuild preserves distinct boolean and text values"
+    setup:
+      - scm: '(rebuild (table "memcp-tests" "idx_merge_bool_text") true true)'
+    sql: "SELECT s, CONCAT(o, '') AS value FROM idx_merge_bool_text WHERE s IN ('http://spec11-minus.example/b', 'http://test26.org/item', 'http://test25.org/c', 'http://robust01.org/comp') ORDER BY s"
+    expect:
+      rows: 4
+      data:
+        - {s: "http://robust01.org/comp", value: "view"}
+        - {s: "http://spec11-minus.example/b", value: "true"}
+        - {s: "http://test25.org/c", value: "3"}
+        - {s: "http://test26.org/item", value: "yes"}
+
+  - name: "Boolean delta lookup agrees with rebuilt text storage"
+    setup:
+      - scm: |
+          (insert (table "memcp-tests" "idx_merge_bool_text") '("s" "p" "o")
+            (list (list "second" "http://spec11-minus.example/deleted" true)
+              (list "null" "http://spec11-minus.example/deleted" nil)))
+    sql: "SELECT s FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true ORDER BY s"
+    expect: {rows: 2, data: [{s: "http://spec11-minus.example/b"}, {s: "second"}]}
+
+  - name: "Boolean/text lookup survives another rebuild"
+    setup:
+      - scm: '(rebuild (table "memcp-tests" "idx_merge_bool_text") true true)'
+    sql: "SELECT s FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true ORDER BY s"
+    expect: {rows: 2, data: [{s: "http://spec11-minus.example/b"}, {s: "second"}]}
+
   # ==============================================================
   # Phase 1: Setup — populate main, build non-unique index
   # ==============================================================

--- a/tests/storage/indexes/index-delta-merge.yaml
+++ b/tests/storage/indexes/index-delta-merge.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
 # Tests for non-unique index delta+main streaming merge
 # Exercises StorageIndex.iterate() where main items (StorageInt) and
 # delta items (deltaBtree) are interleaved in sorted order.
@@ -8,7 +11,50 @@ metadata:
   version: "1.0"
   description: "Non-unique index: delta+main streaming merge, matrix multiply"
 
+# A degree-8 delta B-tree splits with this 17-row reduction of the MINUS
+# regression. The mixed boolean/text comparator must remain symmetric across
+# cold and warm lookup.
+setup:
+  - sql: "DROP TABLE IF EXISTS idx_merge_bool_text"
+  - sql: "CREATE TABLE idx_merge_bool_text (s TEXT, p TEXT, o TEXT) ENGINE=MEMORY"
+  - scm: |
+      (insert (table "memcp-tests" "idx_merge_bool_text") '("s" "p" "o")
+        (list (list "http://spec11-minus.example/b" "http://spec11-minus.example/deleted" true)
+          (list "http://test26.org/item" "http://test26.org/val" "yes")
+          (list "http://test25.org/c" "http://test25.org/p" "3")
+          (list "http://test25.org/b" "http://test25.org/p" "2")
+          (list "http://test25.org/a" "http://test25.org/p" "1")
+          (list "http://test23.org/item" "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" "http://test23.org/Thing")
+          (list "http://test07.org/x3" "http://test07.org/y" "three")
+          (list "http://test07.org/x2" "http://test07.org/y" "two")
+          (list "http://test07.org/x1" "http://test07.org/y" "one")
+          (list "http://test06.org/second" "http://test06.org/n" "2")
+          (list "http://test03.org/bob" "http://test03.org/name" "Bob")
+          (list "http://test02.org/alice" "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" "http://test02.org/Person")
+          (list "t01_main" "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" "t01_Page")
+          (list "http://robust07.org/item" "http://robust07.org/path" "C:\\Users\\\test\\file.txt")
+          (list "http://robust06.org/item" "http://robust06.org/html" "<h1>Hello</h1><p>World</p>")
+          (list "http://robust05.org/item" "http://robust05.org/val" "it's a test")
+          (list "http://robust01.org/comp" "http://robust01.org/componentName" "view")))
+
 test_cases:
+  - name: "RHS row exists without object access boundary"
+    sql: "SELECT COUNT(*) AS n FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted'"
+    expect: {rows: 1, data: [{n: 1}]}
+  - name: "Indexed boolean RHS lookup must retain the same row"
+    sql: "SELECT COUNT(*) AS n FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true"
+    expect: {rows: 1, data: [{n: 1}]}
+  - name: "Warm indexed boolean RHS lookup must retain the same row"
+    sql: "SELECT COUNT(*) AS n FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true"
+    expect: {rows: 1, data: [{n: 1}]}
+  - name: "Ordered indexed boolean lookup retains the RHS row"
+    sql: "SELECT s FROM idx_merge_bool_text WHERE p = 'http://spec11-minus.example/deleted' AND o = true ORDER BY s"
+    expect: {rows: 1, data: [{s: "http://spec11-minus.example/b"}]}
+
+  - name: "Boolean/text lookup rejects unknown columns"
+    sql: "SELECT missing FROM idx_merge_bool_text WHERE o = true"
+    expect: {error: true}
+
   # ==============================================================
   # Phase 1: Setup — populate main, build non-unique index
   # ==============================================================
@@ -315,6 +361,7 @@ test_cases:
           total: 342
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS idx_merge_bool_text"
   - sql: "DROP TABLE IF EXISTS idx_merge"
   - sql: "DROP TABLE IF EXISTS idx_dim"
   - sql: "DROP TABLE IF EXISTS idx93_mat_a"


### PR DESCRIPTION
## Goal and result

### Integrated RDF MINUS correctness fixes

Current head `4aa807c91` includes the requested cherry-picks (with source attribution):

- `e60f5fc5f` -> `c7d657e9b`: consistent binary bool/text index ordering; interpolation search uses the index comparator.
- `b171525f3` -> `4aa807c91`: constant/enum compression preserves distinct scalar representations instead of applying coercing expression equality.

Integration validation: **43/43** index/delta/rebuild SQL cases and **21/21** SPARQL algebra cases (including MINUS), with the newly built JIT binary. Comparator, interpolation, compression and ordered-LIMIT Go regression tests pass with both vanilla and patched-Go JIT. These changes do not alter serialization formats or introduce cleanup/deletion paths.

Repeated the complete fixture-verified Q2 + FOUND_ROWS benchmark on this head with the same protocol/warmup/sample settings below: **3.674 ms MemCP+JIT vs 4.736 ms MariaDB**, **22.4% lower latency**. Results and count remain identical. New CI is running; full CI success is not assumed.

Make the **original WordPress search query (Q2), including SQL_CALC_FOUND_ROWS and the subsequent SELECT FOUND_ROWS(), faster than MariaDB through normal SQL planning and the query-plan cache**. Final measurements use no forced or handwritten plan.

Warm end-to-end: **3.627 ms MemCP+JIT vs 4.559 ms MariaDB** (20.4% lower latency). Master MemCP+JIT measured **12.804 ms** with the same fixture/client configuration: a 3.53x baseline-to-candidate speedup. A separate alternating run measured MariaDB 5.750 / candidate 4.188 ms (27.2% lower latency).

Q1/comment count and Q3/Yoast are outside this PR.

## Problem -> solution

1. **Lost physical alternatives.** Presence/EXISTS stages bypassed the carrier cost comparison; group fills recognized positive membership only. Admit proven presence stages to existing costed carriers and connect group fills to the exact complement/difference algebra. Logical IR still contains no scans, RecSets or physical cache tables.
2. **Wrong consumer workload.** A group fill consumes the full input, not its enclosing LIMIT 10. Pass its planning context and full workload explicitly; charge outer scan work on both alternatives. Estimate genuinely source-local residuals only: a removed stage alias must not be sampled as an unbound symbol.
3. **Incomplete domain bindings.** A presence marker's distinguished probe is not its whole decorrelated domain. Collect all lookup-key dependencies, including non-leading keys. Direct RHS projection now supports complete composite column domains plus query-invariant/session lookup filters. Computed/dependent domains retain existing carriers.
4. **Unnecessary grouping and cache-guard sampling.** Remove projection-only grouping on the sole source's complete non-null primary key. Separately, prove that partitioning on a complete non-null unique key cannot reduce aggregate stage probes: it adds startup/build work to the same probes. Discard this dominated alternative before sampling instead of installing a per-request guard for an impossible crossover. Keep schema/statistics guards. A CPU profile attributed **53.8% cumulative CPU to EstimateFilteredRows.func3**; the emitted guard explicitly sampled the posts predicate on every warm request.
5. **Hidden LIMIT braking.** Compare eager filtered-RecSet difference with a complement source whose residual stays inside scan_order. Cost estimated residual/domain selectivity and OFFSET+LIMIT using existing Costgen coefficients. Expose both alternatives in EXPLAIN PHYSICAL/calibration. Q2 selects the latter instead of scanning the complete residual before ordering.
6. **Oversized first batch.** Diagnostics confirmed an active order-covering index, but its first batch contained 1,024 candidates and accumulated 94–138 matches for LIMIT 10. Start at the requested window even with a residual; when the consumer continues, grow geometrically up to the ordinary batch size. Reuse the same pooled buffer. This does not claim filter coverage, stop after rejected rows, materialize SQL rows, or change visibility/order. Temporary diagnostics were removed.

No query-name special cases, new storage operator, query-specific cost constants, or changes to SQL NULL semantics.

## Manual A/B and MariaDB measurements

Baseline: master `ede42c89c428254c02967925715c9a0d5ea032fb`. Candidate: `01e5b9b3b`. The branch bases on `91f16c249`; the intervening master commit adds parser tests only. Both MemCP variants use patched Go with GOEXPERIMENT=jit; the candidate binary includes the batching fix.

Query: `../wordpress-db-lab/profiles/queries/wordpress_search.sql`, unmodified, followed by `SELECT FOUND_ROWS()` on the same persistent connection.

Fixture: **22,063 posts and 7,701 term relationships**, in one reused private data directory. MariaDB had one additional Auto Draft row versus our original normalized dump; it was copied into the private MemCP fixture before final measurements. All Q2 input columns were compared row-for-row (normalizing only client datetime representations). Both databases return the same ten ordered IDs and **FOUND_ROWS() = 2050**. MariaDB data was not modified.

Method: persistent PyMySQL/TCP, autocommit; 20 warmup pairs, 11 batches of 20 pairs, median milliseconds per pair. MariaDB/MemCP batches alternate, reversing order each batch. Normal CPU scheduling on a shared development machine; tracing/debugging disabled. Baseline/candidate servers use the identical data directory sequentially. These are **warm** measurements with the normal cache enabled, not a controlled cold comparison.

| Run | MariaDB | MemCP+JIT | Comparison |
|---|---:|---:|---|
| Master baseline | 4.457 ms | 12.804 ms | 2.87x slower than MariaDB |
| Candidate, first run | 5.750 ms | 4.188 ms | 27.2% lower latency than MariaDB |
| Candidate, repeated after baseline | 4.559 ms | 3.627 ms | 20.4% lower latency than MariaDB |

Candidate vs master: **12.804 -> 3.627 ms**, -9.177 ms / **71.7% lower latency**. Host variability is visible in MariaDB's run medians, so both candidate runs are reported. Earlier CLI and component-only measurements are superseded by these complete, fixture-verified SQL measurements.

Local reproduction artifacts: `/tmp/wordpress-query-analysis/q2_probe.py --compare --label LABEL`, `q2-probes.jsonl`, profiles and test logs in the same reused directory. Start the appropriate revision with `--no-repl`, ports 4339/3319 and the same private fixture. The script verifies every result/count pair.

## Validation and CI

- Current JIT binary: **187/187** targeted SQL cases across indexed membership, prejoin/scalar subselect, session group cache, UNION probes, RecSets, SPARQL algebra and prepared statements.
- Aggregate-pushdown performance: **2/2**, retaining low-cardinality FK partitioning (10,000 rows; cold 77 ms, warm 1.7 ms). Identity dominance does not disable useful partitioning.
- Ordered-scan/RecSet Go needle tests pass with **vanilla and patched-Go JIT**. Coverage includes accepting residuals, rejected prefixes, sparse/no matches, deleted-row refills and incomplete order coverage. The old assertion requiring over-fetch for every residual was replaced by exact-result/refill checks and an explicit first-batch bound.
- New SQL regressions cover ordered anti-membership, complete page/FOUND_ROWS, OFFSET, nonempty exclusions, unique-key dominance and absence of the unnecessary sampling guard.
- Existing CI-failing prejoin, UNION carrier, ordered RecSet and session-group cases pass locally without weakening their assertions.
- Scheme formatter/check and git diff --check run. Existing parenthesis-warning counts remain optimize 10, physical-expr 4, physical-plan 7; no new warning.

The previous pushed head's CI was red. This update fixes its reproduced failures; full correctness/performance are delegated to the new CI run, **not claimed green in advance**. Please review before merging.
