### PR TITLE
perf: choose exact semijoin carriers for counts and grouped output

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -5075,7 +5075,7 @@ the logical lookup still carries an alias which no longer exists. */
 
 (define join_reorder_node_using (lambda (stage_catalog node planning_session tx)
 	(if (query_block? node)
-		(reorder_query_block_with_candidate_strategy_using stage_catalog node planning_session tx)
+		(reorder_query_block_with_candidate_strategy_using stage_catalog (join_null_rejection_facts node) planning_session tx)
 		(if (union_block? node)
 			(make_union_block
 				(union_mode node)
@@ -6691,3 +6691,28 @@ sampling guard for a choice that no cardinality change can reverse. */
 			(ir_return ir)))))
 
 /* ------------------------------------------------------------------------- */
+
+/* A nullable-side WHERE predicate rejects the synthetic row only when it is
+provably UNKNOWN there. Keep this proof in logical optimization; physical
+semijoin carriers consume the fact without moving predicates across a barrier.
+The whitelist is deliberately conservative (COALESCE/IS NULL are not strict). */
+(define join_null_propagating? (lambda (src expr)
+	(match expr
+		((symbol get_column) alias _ci col _cci)
+		(source_alias_matches? src (source_alias src) alias false)
+		(cons head tail)
+		(if (equal? (string head) "sql_in")
+			(join_null_propagating? src (cadr tail))
+			(and (contains? '("equal??" "sql_not") (string head))
+				(reduce tail (lambda (found item)
+					(or found (join_null_propagating? src item))) false)))
+		_ false)))
+
+(define join_null_rejection_facts (lambda (block)
+	(begin
+		(define rejected (map (filter (qb_sources block) (lambda (src)
+			(and (source_outer? src)
+				(reduce (split_and_terms (coalesceNil (qb_where block) true))
+					(lambda (found term) (or found (join_null_propagating? src term))) false)))) source_alias))
+		(if (empty_list? rejected) block
+			(query_block_with_reorder_facts block (list (list (quote null_rejected_aliases) rejected)))))))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -10387,15 +10387,17 @@ existing scan and expression primitives. No predicate is discarded. */
 		(define terms (split_and_terms condition))
 		(define indexed (filter terms (lambda (term) (semijoin_index_term? src term))))
 		(define residual (filter terms (lambda (term) (not (contains? indexed term)))))
-		(if (or (empty_list? indexed) (empty_list? residual))
-			(semijoin_residual_recset src input condition)
-			(list (quote if)
-				(list (quote semijoin_split_filter_wins?) (quoted_runtime_list src)
-					(quoted_runtime_list indexed) (count residual))
-				(semijoin_residual_recset src
-					(candidate_recset_filter_source src input (combine_where_terms indexed true))
-					(combine_where_terms residual true))
-				(semijoin_residual_recset src input condition))))))
+		(if (empty_list? residual)
+			(candidate_recset_filter_source src input condition)
+			(if (empty_list? indexed)
+				(semijoin_residual_recset src input condition)
+				(list (quote if)
+					(list (quote semijoin_split_filter_wins?) (quoted_runtime_list src)
+						(quoted_runtime_list indexed) (count residual))
+					(semijoin_residual_recset src
+						(candidate_recset_filter_source src input (combine_where_terms indexed true))
+						(combine_where_terms residual true))
+					(semijoin_residual_recset src input condition)))))))
 
 (define semijoin_direct_recset (lambda (spec)
 	(begin

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -6677,15 +6677,15 @@ the costgen threshold. */
 				(list "column" "accumulated_ns" "int" (list) (list)))
 			(list "engine" "sloppy") true)
 		(define claim (newsession))
-		(claim "build" (>= elapsed_ns threshold_ns))
+		(claim "build" (and (number? threshold_ns) (>= elapsed_ns threshold_ns)))
 		(insert (table "system_statistic" "group_cache_candidates")
 			'("canonical_name" "accumulated_ns")
-			(list (list canonical_name (if (>= elapsed_ns threshold_ns) 0 elapsed_ns)))
+			(list (list canonical_name (if (and (number? threshold_ns) (>= elapsed_ns threshold_ns)) 0 elapsed_ns)))
 			'("accumulated_ns" "NEW.accumulated_ns" "$update")
 			(lambda (old_accumulated_ns new_elapsed_ns $update)
 				(begin
 					(define next_accumulated_ns (+ old_accumulated_ns new_elapsed_ns))
-					(define build (>= next_accumulated_ns threshold_ns))
+					(define build (and (number? threshold_ns) (>= next_accumulated_ns threshold_ns)))
 					(claim "build" build)
 					($update (list "accumulated_ns"
 						(if build 0 next_accumulated_ns)))
@@ -9523,26 +9523,42 @@ row callback. */
 
 (define emit_physical_queryplan (lambda (ir)
 	(begin
-		(define plan (match (ir_return ir)
-			(symbol rows) (match (logical_op (ir_root ir))
-				(symbol query-block) (lower_query_block_with_cataloged_stages (ir_root ir))
-				(symbol union-block) (lower_union_block (ir_root ir))
-				_ (neumann_fail "build_queryplan" "unknown logical root"))
-			((symbol dml) target_schema target_tbl) (match (logical_op (ir_root ir))
-				(symbol query-block) (lower_dml_query_block_with_stages (ir_root ir) target_schema target_tbl)
-				(symbol union-block) (lower_dml_union_block_with_stages (ir_root ir) target_schema target_tbl)
-				_ (neumann_fail "build_queryplan" "DML lowering expects a query-block root"))
-			((symbol dml-many) target_specs) (match (logical_op (ir_root ir))
-				(symbol query-block) (lower_multi_target_delete_with_stages (ir_root ir) target_specs)
-				_ (neumann_fail "build_queryplan" "multi-target DELETE lowering expects a query-block root"))
-			_ (neumann_fail "build_queryplan" "DML lowering is intentionally not scaffolded yet")))
+		(define candidate (if (equal? (ir_return ir) (quote rows)) (semijoin_carrier_spec (ir_root ir)) nil))
+		(define carrier (if (nil? candidate) nil
+			(begin
+				(define cache_name (if (and (nth candidate 5)
+					(not (equal? (prejoin_source_table_key (car candidate)) (prejoin_source_table_key (cadr candidate)))))
+					(car (semijoin_cached_predicate candidate)) nil))
+				(define selected (semijoin_root_preferred? candidate cache_name))
+				(planner_record_guard_condition
+					(list (quote equal?) (list (quote semijoin_root_preferred?) (quoted_runtime_list candidate) cache_name) selected)
+					(planner_context_session (qb_facts (ir_root ir))))
+				(if selected candidate nil))))
+		(define plan (if (not (nil? carrier))
+			(lower_semijoin_carrier (ir_root ir) carrier)
+			(match (ir_return ir)
+				(symbol rows) (match (logical_op (ir_root ir))
+					(symbol query-block) (lower_query_block_with_cataloged_stages (ir_root ir))
+					(symbol union-block) (lower_union_block (ir_root ir))
+					_ (neumann_fail "build_queryplan" "unknown logical root"))
+				((symbol dml) target_schema target_tbl) (match (logical_op (ir_root ir))
+					(symbol query-block) (lower_dml_query_block_with_stages (ir_root ir) target_schema target_tbl)
+					(symbol union-block) (lower_dml_union_block_with_stages (ir_root ir) target_schema target_tbl)
+					_ (neumann_fail "build_queryplan" "DML lowering expects a query-block root"))
+				((symbol dml-many) target_specs) (match (logical_op (ir_root ir))
+					(symbol query-block) (lower_multi_target_delete_with_stages (ir_root ir) target_specs)
+					_ (neumann_fail "build_queryplan" "multi-target DELETE lowering expects a query-block root"))
+				_ (neumann_fail "build_queryplan" "DML lowering is intentionally not scaffolded yet"))))
 		(define consolidated_plan (consolidate_closed_group_prepares ir plan))
 		(define complete_plan (complete_emitted_prepare_bindings ir consolidated_plan))
 		(define deduplicated_plan (deduplicate_lazy_prepare_recipes complete_plan))
 		(define memoized_plan (if (empty_list? (ir_stages ir))
 			deduplicated_plan
 			(consolidate_query_invariant_presence_memos deduplicated_plan)))
-		(require_physical_scan_relations memoized_plan))))
+		(define checked (require_physical_scan_relations memoized_plan))
+		(if (and (not (nil? carrier)) (and (not (nth carrier 5))
+			(qassoc_get (qb_facts (ir_root ir)) (quote sql_calc_found_rows) false)))
+			(list (quote found_rows_result) checked) checked))))
 
 (define build_queryplan (lambda (ir)
 	(emit_physical_queryplan (prepare_physical_queryplan ir nil nil))))
@@ -9806,41 +9822,45 @@ RecSet node is written into logical IR. */
 (define physical_operator_family_for_decision (lambda (plan decision)
 	(begin
 		(define kind (qassoc_get decision "decision" nil))
-		(if (equal? kind "membership_carrier")
-			(begin
-				(define chosen (qassoc_get decision "chosen" nil))
-				/* A compound query may contain key indexes and projected RecSets for
-				unrelated ACL stages. Validate the primitive required by this decision's
-				chosen alternative instead of assigning the whole plan to the first
-				operator family found globally. Falling back to the global classifier
-				still makes a genuinely unreachable forced alternative fail calibration. */
-				(if (or
-					(and (equal? chosen "ordered_batch_accept")
-						(physical_expr_has_head? plan (quote scan_order_batch_accept)))
-					(and (equal? chosen "prefiltered_candidate_keyset")
-						(physical_prefiltered_membership_expr? plan))
-					(and (equal? chosen "candidate_keyset")
-						(physical_expr_has_head? plan (quote recset_project_join)))
-					(and (equal? chosen "driver_order_membership_probe")
-						(physical_expr_has_head? plan (quote recset_key_index)))
-					(and (equal? chosen "driver_filter_join_probe")
-						(not (physical_expr_has_head? plan (quote scan_order_batch_accept)))))
-					chosen
-					(physical_membership_operator_family plan)))
-			(if (equal? kind "scan_join_order")
-				(if (physical_expr_has_head? plan (quote scan_join_order))
-					(if (equal? (qassoc_get decision "chosen" nil)
-						"scan_join_order_batched_probe")
-						"scan_join_order_batched_probe" "scan_join_order")
-					"legacy_join_tree")
-				(if (equal? kind "direct_group_join")
-					(if (physical_expr_has_group_relation? plan)
-						"group_carrier" "direct_group_join")
-					(if (equal? kind "scan_lookup")
-						(if (physical_expr_has_head? plan (quote scan_lookup))
-							"scan_lookup"
-							(if (physical_expr_has_head? plan (quote scan_order)) "scan_order" "unknown"))
-						"unknown")))))))
+		(if (equal? kind "semijoin_carrier")
+			(if (semijoin_plan_has_operator? plan "recset_project_join")
+				(if (semijoin_plan_has_operator? plan "initialize_cache_table") "prejoin_recset" "projected_recset")
+				(if (semijoin_plan_has_operator? plan "createcolumn") "predicate_cache" "unknown"))
+			(if (equal? kind "membership_carrier")
+				(begin
+					(define chosen (qassoc_get decision "chosen" nil))
+					/* A compound query may contain key indexes and projected RecSets for
+					unrelated ACL stages. Validate the primitive required by this decision's
+					chosen alternative instead of assigning the whole plan to the first
+					operator family found globally. Falling back to the global classifier
+					still makes a genuinely unreachable forced alternative fail calibration. */
+					(if (or
+						(and (equal? chosen "ordered_batch_accept")
+							(physical_expr_has_head? plan (quote scan_order_batch_accept)))
+						(and (equal? chosen "prefiltered_candidate_keyset")
+							(physical_prefiltered_membership_expr? plan))
+						(and (equal? chosen "candidate_keyset")
+							(physical_expr_has_head? plan (quote recset_project_join)))
+						(and (equal? chosen "driver_order_membership_probe")
+							(physical_expr_has_head? plan (quote recset_key_index)))
+						(and (equal? chosen "driver_filter_join_probe")
+							(not (physical_expr_has_head? plan (quote scan_order_batch_accept)))))
+						chosen
+						(physical_membership_operator_family plan)))
+				(if (equal? kind "scan_join_order")
+					(if (physical_expr_has_head? plan (quote scan_join_order))
+						(if (equal? (qassoc_get decision "chosen" nil)
+							"scan_join_order_batched_probe")
+							"scan_join_order_batched_probe" "scan_join_order")
+						"legacy_join_tree")
+					(if (equal? kind "direct_group_join")
+						(if (physical_expr_has_group_relation? plan)
+							"group_carrier" "direct_group_join")
+						(if (equal? kind "scan_lookup")
+							(if (physical_expr_has_head? plan (quote scan_lookup))
+								"scan_lookup"
+								(if (physical_expr_has_head? plan (quote scan_order)) "scan_order" "unknown"))
+							"unknown"))))))))
 
 (define physical_expr_has_group_relation? (lambda (expr)
 	(match expr
@@ -9916,7 +9936,7 @@ protocol callback receives only the calibration row. */
 	(begin
 		(define decision_id (qassoc_get decision "decision_id" "unknown"))
 		(define decision_kind (qassoc_get decision "decision" nil))
-		(define expected_family (if (or (equal? decision_kind "membership_carrier")
+		(define expected_family (if (or (equal? decision_kind "semijoin_carrier") (equal? decision_kind "membership_carrier")
 			(or (equal? decision_kind "scan_join_order")
 				(equal? decision_kind "direct_group_join")))
 			variant operator_family))
@@ -10274,3 +10294,378 @@ protocol callback receives only the calibration row. */
 				"group_caches" raw_group_caches
 				/* Backward-compatible telemetry alias; use group_caches in new integrations. */
 				"group_carriers" raw_group_caches)))))
+
+/* Exact base-record carriers for two-leaf joins. The logical tree remains
+intact. A unique lookup preserves COUNT multiplicity; grouping by the carrier
+PK permits projecting a many-side RecSet without multiplying output rows. */
+(define semijoin_count_field? (lambda (expr)
+	(match expr
+		((symbol aggregate) 1 (symbol +) 0) true
+		_ false)))
+
+(define semijoin_stable_expr? (lambda (expr)
+	(match expr
+		((symbol quote) value) true
+		((symbol get_column) alias ci col cci) true
+		(cons head tail)
+		(and (contains? '("list" "and" "or" "equal??" "sql_not" "sql_in" "<" ">" "<=" ">=" "simplify") (string head))
+			(reduce tail (lambda (ok item) (and ok (semijoin_stable_expr? item))) true))
+		_ (or (nil? expr) (or (number? expr) (or (string? expr) (or (equal? expr true) (equal? expr false))))))))
+
+(define semijoin_carrier_spec (lambda (block)
+	(if (or (not (query_block? block))
+		(or (not (equal? (count (qb_sources block)) 2))
+			(or (not (empty_list? (qb_stages block)))
+				(or (not (nil? (qb_having block))) (not (empty_list? (qb_hidden block)))))))
+		nil
+		(begin
+			(define sources (qb_sources block))
+			(define tree (query_block_join_plan block sources))
+			(define aliases (join_optimizer_tree_aliases tree))
+			(define grouped_sources (filter sources (lambda (src) (source_primary_key_grouped? block src))))
+			(define driver (if (single_source? grouped_sources) (car grouped_sources)
+				(join_optimizer_source_by_alias sources (car aliases))))
+			(define lookup (car (filter sources (lambda (src) (not (equal? (source_alias src) (source_alias driver)))))))
+			(define default_alias (qassoc_get (qb_facts block) (quote default_alias) (source_alias (car sources))))
+			(define terms (merge_unique (list
+				(map (join_optimizer_tree_predicates tree) join_order_pred_expr)
+				(split_and_terms (coalesceNil (qb_where block) true))
+				(merge (map sources (lambda (src) (split_and_terms (coalesceNil (source_join_expr src) true))))))))
+			(define edges (filter terms (lambda (term)
+				(not (nil? (union_semijoin_equal_parts driver lookup term))))))
+			(define local (filter terms (lambda (term) (not (contains? edges term)))))
+			(define driver_terms (filter local (lambda (term)
+				(not (expr_refs_sources? default_alias (list lookup) term)))))
+			(define lookup_terms (filter local (lambda (term) (not (contains? driver_terms term)))))
+			(define fields (expand_query_block_fields sources (qb_fields block)))
+			(define count_mode (and (equal? (count fields) 2)
+				(and (semijoin_count_field? (cadr fields))
+					(and (empty_list? (qb_group block)) (empty_list? (qb_order block))))))
+			(define grouped_mode (and (not (query_block_has_aggregates? block))
+				(and (source_primary_key_grouped? block driver)
+					(not (reduce (merge (list (qb_group block) (order_exprs (qb_order block))
+						(extract_assoc fields (lambda (_name expr) expr))))
+						(lambda (used expr) (or used (expr_refs_sources? default_alias (list lookup) expr))) false)))))
+			(define keys (map edges (lambda (term) (union_semijoin_equal_parts driver lookup term))))
+			(define lookup_unique (and (not (empty_list? (source_primary_key_columns lookup)))
+				(reduce (source_primary_key_columns lookup) (lambda (ok col)
+					(and ok (contains? (map keys car) col))) true)))
+			(if (and (source_is_base_table? driver) (source_is_base_table? lookup)
+				(not (source_outer? driver))
+				(or (not (source_outer? lookup))
+					(contains? (qassoc_get (qb_facts block) (quote null_rejected_aliases) '()) (source_alias lookup)))
+				(not (empty_list? edges))
+				(reduce lookup_terms (lambda (ok term)
+					(and ok (not (expr_refs_sources? default_alias (list driver) term)))) true)
+				(reduce terms (lambda (ok term) (and ok (semijoin_stable_expr? term))) true)
+				(or (and count_mode lookup_unique)
+					(and grouped_mode
+						(reduce (qb_group block) (lambda (ok expr) (and ok (semijoin_stable_expr? expr))) true)
+						(reduce (order_exprs (qb_order block)) (lambda (ok expr)
+							(and ok (not (nil? (direct_column_name_for_alias driver expr))))) true)
+						(reduce (extract_assoc fields (lambda (_title expr) expr)) (lambda (ok expr)
+							(and ok (semijoin_stable_expr? expr))) true))))
+				(list driver lookup keys (combine_where_terms driver_terms true)
+					(combine_where_terms lookup_terms true) count_mode fields)
+				nil)))))
+
+/* Indexable local comparisons precede computed residuals when their estimated
+saved expression work pays for another scan. All coefficients are costgen's
+existing scan and expression primitives. No predicate is discarded. */
+(define semijoin_index_term? (lambda (src term)
+	(match term
+		'(op left right)
+		(and (contains? '("equal??" "<" ">" "<=" ">=") (string op))
+			(or (and (not (nil? (direct_column_name_for_alias src left)))
+				(or (number? right) (string? right)))
+				(and (not (nil? (direct_column_name_for_alias src right)))
+					(or (number? left) (string? left)))))
+		_ false)))
+
+(define semijoin_filter_recset (lambda (src input condition)
+	(begin
+		(define terms (split_and_terms condition))
+		(define indexed (filter terms (lambda (term) (semijoin_index_term? src term))))
+		(define residual (filter terms (lambda (term) (not (contains? indexed term)))))
+		(if (or (empty_list? indexed) (empty_list? residual))
+			(semijoin_residual_recset src input condition)
+			(list (quote if)
+				(list (quote semijoin_split_filter_wins?) (quoted_runtime_list src)
+					(quoted_runtime_list indexed) (count residual))
+				(semijoin_residual_recset src
+					(candidate_recset_filter_source src input (combine_where_terms indexed true))
+					(combine_where_terms residual true))
+				(semijoin_residual_recset src input condition))))))
+
+(define semijoin_direct_recset (lambda (spec)
+	(begin
+		(define driver (nth spec 0))
+		(define lookup (nth spec 1))
+		(define keys (nth spec 2))
+		(define projected (list (quote recset_project_join) (physical_query_tx_symbol)
+			(semijoin_filter_recset lookup (source_table_expr lookup) (nth spec 4))
+			(quoted_runtime_list (map keys car)) (source_table_expr driver)
+			(quoted_runtime_list (map keys cadr))))
+		(if (nth spec 5)
+			(begin
+				(define cols (extract_columns_for_alias driver (nth spec 3)))
+				(compile_scan_plan (quote scan) (physical_query_tx_symbol) projected
+					(quoted_runtime_list cols)
+					(list (quote lambda) (map cols (lambda (col) (scan_callback_symbol_for_alias (source_alias driver) col)))
+						(lower_column_expr_for_alias driver (nth spec 3)))
+					(quoted_runtime_list '()) (quote scan_count) 0 (quote +) false))
+			(candidate_recset_filter_source driver projected (nth spec 3))))))
+
+(define semijoin_output_plan (lambda (block spec accepted)
+	(begin
+		(define driver (car spec))
+		(define fields (nth spec 6))
+		(if (nth spec 5)
+			(semijoin_count_output block fields (list (quote recset_count) accepted))
+			(begin
+				(define order (coalesceNil (qb_order block) '()))
+
+				(define mapcols (merge_unique (map (extract_assoc fields (lambda (_title expr) expr))
+					(lambda (expr) (extract_columns_for_alias driver expr)))))
+				(list (quote !begin)
+					(if (qassoc_get (qb_facts block) (quote sql_calc_found_rows) false)
+						(list (quote session) "found_rows" (list (quote recset_count) accepted)) nil)
+					(compile_scan_plan (quote scan_order) (physical_query_tx_symbol) accepted
+						(quoted_runtime_list '()) (list (quote lambda) '() true)
+						(quoted_runtime_list (map order (lambda (item) (direct_column_name_for_alias driver (car item)))))
+						(cons (quote list) (map order (lambda (item)
+							(canonical_order_relation (cadr item) (source_column_order_collation driver (direct_column_name_for_alias driver (car item))))))) 0
+						(coalesceNil (qb_offset block) 0) (coalesceNil (qb_limit block) -1)
+						(quoted_runtime_list mapcols)
+						(list (quote lambda) (cons (quote _acc) (map mapcols (lambda (col) (scan_callback_symbol_for_alias (source_alias driver) col))))
+							(list (quote !begin)
+								(list (quote resultrow) (cons (quote list) (map_assoc fields
+									(lambda (_title expr) (lower_column_expr_for_alias driver expr))))) (quote _acc)))
+						nil false)))))))
+
+(define semijoin_cached_predicate (lambda (spec)
+	(begin
+		(define driver (car spec))
+		(define lookup (cadr spec))
+		(define keys (nth spec 2))
+		(define local (nth spec 3))
+		(define remote (nth spec 4))
+		(define columns (merge_unique (list (extract_columns_for_alias driver local) (map keys cadr))))
+		(define lookup_columns (merge_unique (list (extract_columns_for_alias lookup remote) (map keys car))))
+		(define test (combine_where_terms (cons (lower_column_expr_for_alias lookup remote)
+			(map keys (lambda (pair)
+				(list (quote equal??) (scan_callback_symbol_for_alias (source_alias lookup) (car pair))
+					(list (quote outer) 1 (scan_callback_symbol_for_alias (source_alias driver) (cadr pair))))))) true))
+		(define qualified_body (list (quote and) (lower_column_expr_for_alias driver local)
+			(list (quote >) (compile_scan_plan (quote scan) nil (source_table_expr lookup)
+				(quoted_runtime_list lookup_columns)
+				(list (quote lambda) (map lookup_columns (lambda (col) (scan_callback_symbol_for_alias (source_alias lookup) col))) test)
+				(quoted_runtime_list '()) (quote scan_count) 0 (quote +) false) 0)))
+		(define names (merge (list
+			(map columns (lambda (col) (list (scan_callback_symbol_for_alias (source_alias driver) col) (symbol col))))
+			(map lookup_columns (lambda (col) (list (scan_callback_symbol_for_alias (source_alias lookup) col) (symbol col)))))))
+		(define unqualify (lambda (expr) (match expr
+			(cons head tail) (cons (unqualify head) (map tail unqualify))
+			_ (qassoc_get names expr expr))))
+		(define body (unqualify qualified_body))
+		(define name (concat ".predicate:" (stable_structural_hash (list (source_schema driver) (source_relation driver) (source_schema lookup) (source_relation lookup) columns body) true)))
+		(list name
+			(list (quote createcolumn) (source_table_expr driver) name "any" (quoted_runtime_list '()) (quoted_runtime_list '("temp" true))
+				(quoted_runtime_list columns)
+				(list (quote lambda) (map columns symbol) body))
+			(compile_scan_plan (quote scan) (physical_query_tx_symbol) (source_table_expr driver)
+				(quoted_runtime_list (list name)) (list (quote lambda) (list (quote accepted)) (list (quote equal?) (quote accepted) true))
+				(quoted_runtime_list '()) (quote scan_count) 0 (quote +) false)))))
+
+/* Marker is an identity at execution time; only the root physical emitter may
+wrap a plan with it. The SQL frontend then omits its independent count plan. */
+(define found_rows_result (lambda (value) value))
+
+(define semijoin_complete_block (lambda (block)
+	(make_query_block (qb_schema block) (qb_sources block) (qb_fields block)
+		(combine_where_terms (merge_unique (list
+			(split_and_terms (coalesceNil (qb_where block) true))
+			(map (join_optimizer_tree_predicates (query_block_join_plan block (qb_sources block))) join_order_pred_expr))) true)
+		(qb_group block) (qb_having block) (qb_order block) (qb_limit block) (qb_offset block)
+		(qb_hidden block) (qb_stages block) (qb_facts block))))
+
+(define semijoin_prejoin_plan (lambda (block spec)
+	(begin
+		(define complete (semijoin_complete_block block))
+		(if (not (physical_prejoin_supported? complete)) nil
+			(begin
+				(define sources (qb_sources block))
+				(define driver (car spec))
+				(define lookup (cadr spec))
+				(define default_alias (qassoc_get (qb_facts block) (quote default_alias) (source_alias (car sources))))
+				(define name (prejoin_table_name complete default_alias))
+				(define src (list name (qb_schema block) name false nil))
+				(define columns (map (extract_columns_for_alias lookup (nth spec 4))
+					(lambda (col) (prejoin_column_name sources (source_alias lookup) col))))
+				(define prepare (car (physical_prejoin_plan complete)))
+				(define narrow (lambda (expr)
+					(match expr
+						(cons (symbol createcolumn) args)
+						(if (contains? columns (cadr args)) expr nil)
+						(cons (symbol !begin) rest)
+						(cons (quote !begin) (map rest narrow))
+						_ expr)))
+				(define matches (semijoin_filter_recset src (source_table_expr src)
+					(prejoin_rewrite_expr sources default_alias name (nth spec 4))))
+				(define keys (source_primary_key_columns driver))
+				(list name (narrow prepare)
+					(candidate_recset_filter_source driver
+						(list (quote recset_project_join) (physical_query_tx_symbol) matches
+							(quoted_runtime_list (map keys (lambda (col) (prejoin_column_name sources (source_alias driver) col))))
+							(source_table_expr driver) (quoted_runtime_list keys)) (nth spec 3))))))))
+
+/* Runtime selection reads only immutable catalog metadata. Keeping the whole
+inequality here also handles DML growth, repartitioning and cache eviction
+without freezing a statistics-dependent decision in the SQL plan cache. */
+(define semijoin_scan_work_ns (lambda (input columns)
+	(+ (* (table_shard_count input) planner_membership_scan_invocation_ns)
+		(* (scan_estimate input) (+ planner_membership_scan_row_ns
+			(* columns planner_membership_filter_column_row_ns))))))
+
+(define semijoin_cache_wins? (lambda (driver lookup cache count_mode)
+	(if (nil? cache) false
+		(< (if count_mode
+			(semijoin_scan_work_ns driver 1)
+			(semijoin_scan_work_ns cache 1))
+			(+ (semijoin_scan_work_ns lookup 1)
+				(* (scan_estimate driver) planner_membership_recset_build_row_ns))))))
+
+(define lower_semijoin_carrier (lambda (block spec)
+	(begin
+		(define driver (car spec))
+		(define lookup (cadr spec))
+		(define count_mode (nth spec 5))
+		(define cached (if count_mode
+			(if (equal? (prejoin_source_table_key driver) (prejoin_source_table_key lookup)) nil (semijoin_cached_predicate spec))
+			(semijoin_prejoin_plan block spec)))
+		(define direct (semijoin_direct_recset spec))
+		(define accepted (quote __semijoin_accepted))
+		(define output (if count_mode (semijoin_count_output block (nth spec 6) accepted)
+			(semijoin_output_plan block spec accepted)))
+		(define direct_plan (list (quote !begin) (list (quote define) accepted direct) output))
+		(if (nil? cached) direct_plan
+			(begin
+				(define name (car cached))
+				(define ready (if count_mode
+					(list (quote resolve_column_name) (source_schema driver) (source_relation driver) name false)
+					(list (quote table) (qb_schema block) name)))
+				(define warm_plan (list (quote !begin) (nth cached 1)
+					(list (quote define) accepted (nth cached 2))
+					(if count_mode (semijoin_count_output block (nth spec 6) accepted) output)))
+				(define planning_session (planner_context_session (qb_facts block)))
+				(define decision_id (concat "semijoin_carrier:" (stable_structural_hash
+					(list (source_schema driver) (source_relation driver) (source_schema lookup) (source_relation lookup)
+						(nth spec 2) (nth spec 3) (nth spec 4) count_mode) true)))
+				(define driver_table (table (source_schema driver) (source_relation driver)))
+				(define lookup_table (table (source_schema lookup) (source_relation lookup)))
+				(define cache_table (if count_mode driver_table (table (qb_schema block) name)))
+				(define is_ready (if count_mode
+					(not (nil? (resolve_column_name (source_schema driver) (source_relation driver) name false)))
+					(cache_table_ready? cache_table)))
+				(define cache_variant (if count_mode "predicate_cache" "prejoin_recset"))
+				(define projected_ns (+ (semijoin_scan_work_ns lookup_table 1)
+					(* (scan_estimate driver_table) planner_membership_recset_build_row_ns)))
+				(define cached_ns (+
+					(if (nil? cache_table) planner_membership_scan_invocation_ns (semijoin_scan_work_ns cache_table 1))
+					(if is_ready 0 (if count_mode (* (scan_estimate driver_table) planner_membership_direct_probe_row_ns)
+						(+ projected_ns (* (scan_estimate lookup_table) planner_group_relation_build_row_ns))))))
+				(define normal_choice (if (and is_ready (< cached_ns projected_ns)) cache_variant "projected_recset"))
+				(define chosen (planner_physical_choice decision_id normal_choice (list "projected_recset" cache_variant) planning_session))
+				(define forced (planner_physical_override decision_id planning_session))
+				(planner_record_physical_decision (list
+					(list "decision_id" decision_id) (list "decision" "semijoin_carrier")
+					(list "chosen" chosen) (list "selection" (if (nil? forced) "runtime_cost" "forced"))
+					(list "reason" "exact_base_records; live_partition_and_cache_costs")
+					(list "inputs" (list (list "input_rows" (scan_estimate lookup_table))
+						(list "driver_input_rows" (scan_estimate driver_table))
+						(list "cache_ready" is_ready)))
+					(list "alternatives" (map (list (list "projected_recset" projected_ns) (list cache_variant cached_ns))
+						(lambda (entry) (list (list "plan" (car entry)) (list "cost"
+							(planner_cost_explain (planner_cost (cadr entry) 0 0 0 0 0 0 0 0 0.5)))))))) planning_session)
+				(define budget (list (quote *) (list (quote scan_estimate) (source_table_expr driver)) planner_membership_direct_probe_row_ns))
+				(define cold_plan (if count_mode
+					(list (quote if)
+						(list (quote semijoin_cache_work_paid?) (physical_query_tx_symbol) name budget)
+						warm_plan
+						(list (quote !begin)
+							(list (quote define) (quote __semijoin_started) (list (quote nanotime)))
+							direct_plan
+							/* Credit observed work after returning the relational result.
+							A later invocation, which demonstrates reuse, may pay for
+							the cache. The first call never builds a speculative cache. */
+							(list (quote group_cache_candidate_accumulate) name
+								(list (quote -) (list (quote nanotime)) (quote __semijoin_started)) nil)
+							nil))
+					direct_plan))
+				(if (not (nil? forced)) (if (equal? chosen "projected_recset") direct_plan warm_plan)
+					(list (quote if) (list (quote tx_requires_query_local_cache) (physical_query_tx_symbol)) direct_plan
+						(list (quote if)
+							(list (quote and) (if count_mode (list (quote not) (list (quote nil?) ready))
+								(list (quote cache_table_ready?) ready))
+								(list (quote semijoin_cache_wins?) (source_table_expr driver) (source_table_expr lookup)
+									(if count_mode (source_table_expr driver) ready) count_mode))
+							warm_plan cold_plan))))))))
+
+(define semijoin_count_output (lambda (block fields value)
+	(list (quote if)
+		(list (quote and) (list (quote <=) (coalesceNil (qb_offset block) 0) 0)
+			(list (quote not) (list (quote equal?) (coalesceNil (qb_limit block) -1) 0)))
+		(list (quote resultrow) (list (quote list) (car fields) value)) nil)))
+
+(define semijoin_split_filter_wins? (lambda (src indexed residual_width)
+	(begin
+		(define input_rows (scan_estimate (table (source_schema src) (source_relation src))))
+		(define selectivity (reduce indexed (lambda (value term)
+			(* value (join_optimizer_expr_selectivity (list src) (source_alias src) term))) 1))
+		(define matching_rows (* input_rows selectivity))
+		(< (+ planner_membership_scan_invocation_ns (* matching_rows planner_membership_recset_build_row_ns))
+			(* (- input_rows matching_rows) residual_width planner_membership_expression_operation_row_ns)))))
+
+/* A small unique indexed join can beat constructing a complete projected
+carrier. Guard this crossover as well as the runtime cache/direct decision. */
+(define semijoin_root_preferred? (lambda (spec cache_name)
+	(if (not (nth spec 5)) true
+		(begin
+			(define driver (table (source_schema (car spec)) (source_relation (car spec))))
+			(define lookup (table (source_schema (cadr spec)) (source_relation (cadr spec))))
+			(if (or (nil? driver) (nil? lookup)) false
+				(or (and (not (nil? cache_name))
+					(not (nil? (resolve_column_name (source_schema (car spec)) (source_relation (car spec)) cache_name false)))
+					(semijoin_cache_wins? driver lookup driver true))
+					(< (+ (semijoin_scan_work_ns lookup 1)
+						(* (scan_estimate driver) planner_membership_recset_build_row_ns))
+						(* (scan_estimate driver) planner_membership_direct_probe_row_ns))))))))
+
+/* An index definition over the base table is not proof that a computed range
+has been applied to a RecSet boundary. Keep the residual callback explicit;
+this also avoids preparing a whole computed column for a small subset. */
+(define semijoin_residual_recset (lambda (src input condition)
+	(begin
+		(define cols (extract_columns_for_alias src condition))
+		(list (quote scan_recset) (physical_query_tx_symbol) input
+			(quoted_runtime_list '()) (quoted_runtime_list '())
+			(quoted_runtime_list cols)
+			(list (quote lambda) (map cols (lambda (col) (scan_callback_symbol_for_alias (source_alias src) col)))
+				(lower_column_expr_for_alias src condition))))))
+
+(define semijoin_plan_has_operator? (lambda (expr name)
+	(match expr
+		((symbol quote) _value) false
+		(cons head tail) (or (equal? (serialize head) name)
+			(or (semijoin_plan_has_operator? head name)
+				(reduce tail (lambda (found item) (or found (semijoin_plan_has_operator? item name))) false)))
+		_ false)))
+
+(define semijoin_cache_work_paid? (lambda (tx name threshold_ns)
+	(begin
+		(define candidates (table "system_statistic" "group_cache_candidates"))
+		(if (nil? candidates) false
+			(scan tx candidates
+				(list 369436175368192 (scan_boundary "equal" "canonical_name" 0 0 true true "" false)) (list name)
+				'() (lambda () true) '("accumulated_ns")
+				(lambda (_acc elapsed) (>= elapsed threshold_ns)) false (lambda (a b) (or a b)) false)))))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -10590,7 +10590,10 @@ without freezing a statistics-dependent decision in the SQL plan cache. */
 				(define budget (list (quote *) (list (quote scan_estimate) (source_table_expr driver)) planner_membership_direct_probe_row_ns))
 				(define cold_plan (if count_mode
 					(list (quote if)
-						(list (quote semijoin_cache_work_paid?) (physical_query_tx_symbol) name budget)
+						(list (quote and)
+							(list (quote semijoin_cache_wins?) (source_table_expr driver) (source_table_expr lookup)
+								(source_table_expr driver) true)
+							(list (quote semijoin_cache_work_paid?) (physical_query_tx_symbol) name budget))
 						warm_plan
 						(list (quote !begin)
 							(list (quote define) (quote __semijoin_started) (list (quote nanotime)))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1101,7 +1101,8 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	(define sql_build_select_plan (lambda (query) (begin
 		(define expanded_query (sql_expand_views query policy))
 		(define actual_plan (build_queryplan_term expanded_query planning_session tx))
-		(define execution_plan (if (sql_select_calc_found_rows? query)
+		(define execution_plan (if (and (sql_select_calc_found_rows? query)
+			(not (equal? (car actual_plan) (quote found_rows_result))))
 			(begin
 				(define count_plan (build_queryplan_term (sql_select_found_rows_count_query expanded_query) planning_session tx))
 				(list (quote !begin)

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -428,6 +428,66 @@ func TestJITPersistentRegisterBankExcludesGoScratchR15(t *testing.T) {
 	}
 }
 
+//go:noinline
+//go:nosplit
+func jitTestZeroBuffer(dst *[32]byte) {
+	*dst = [32]byte{}
+}
+
+func TestJITFloatRegisterPressurePreservesGoZeroRegister(t *testing.T) {
+	const name = "jit_test_fp_zero_register"
+	for _, nativeCall := range []bool{false, true} {
+		label := "return"
+		if nativeCall {
+			label = "native call"
+		}
+		t.Run(label, func(t *testing.T) {
+			buffer := new([32]byte)
+			declaration := &Declaration{
+				Name: name,
+				Fn:   func(...Scmer) Scmer { return NewInt(0) },
+				Type: &TypeDescriptor{Kind: "func", Return: &TypeDescriptor{Kind: "int"},
+					JITEmit: func(ctx *JITContext, _ []Scmer, _ []JITValueDesc, result JITValueDesc) JITValueDesc {
+						// Exhaust the production FP bank, as scalar overflow and
+						// generated builtin temporaries do under register pressure.
+						ctx.EmitMovRegImm64(ctx.ScratchReg, 1)
+						for ctx.FreeFPRegs != 0 {
+							ctx.EmitMovGPRToFP(ctx.AllocFPReg(), ctx.ScratchReg)
+						}
+						if nativeCall {
+							ctx.TrackPointer(unsafe.Pointer(buffer))
+							ctx.EmitGoCallVoid(GoFuncAddr(jitTestZeroBuffer), []JITValueDesc{
+								{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(unsafe.Pointer(buffer)))), NoHeapPointer: true},
+							})
+						}
+						target := jitEnsureResultPair(ctx, result)
+						ctx.EmitMakeInt(target, JITValueDesc{Loc: LocFPReg, Type: tagInt, Reg: RegX15})
+						// Restore the ABI even on the broken implementation so the
+						// test reports failure without corrupting the test runner.
+						ctx.EmitMovRegImm64(ctx.ScratchReg, 0)
+						ctx.EmitMovGPRToFP(RegX15, ctx.ScratchReg)
+						return target
+					},
+				},
+			}
+			Declare(&Globalenv, declaration)
+			defer func() {
+				delete(Globalenv.Vars, Symbol(name))
+				delete(declarations, name)
+				delete(declarationsByFunction, FunctionIdentity(declaration.Fn))
+			}()
+			compiled := compileJITExpressionTestProc(t, `(lambda () (jit_test_fp_zero_register))`)
+			got := compiled.Proc().jitFunction()()
+			if got.Int() != 0 {
+				t.Errorf("Go ABI zero register contains %d after FP register pressure", got.Int())
+			}
+			if *buffer != [32]byte{} {
+				t.Errorf("native Go zero initialization wrote %x", *buffer)
+			}
+		})
+	}
+}
+
 func TestJITRegisterHomesTradeOuterForMoreValuableInnerPlan(t *testing.T) {
 	code := make([]byte, 256)
 	start := unsafe.Pointer(&code[0])

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -54,12 +54,15 @@ var jitX86RegisterBank = JITRegisterBank{
 	TemporaryReserve: 7,
 }
 
+// Go ABIInternal requires X15 to contain zero at calls and returns. Keep it
+// out of both persistent FP homes and temporary/overflow allocation: native
+// Go code uses it to initialize stack frames and zero heap objects.
 var jitX86FPRegisterBank = JITRegisterBank{
 	Registers: [16]Reg{
 		RegX2, RegX3, RegX4, RegX5, RegX6, RegX7, RegX8,
-		RegX9, RegX10, RegX11, RegX12, RegX13, RegX14, RegX15,
+		RegX9, RegX10, RegX11, RegX12, RegX13, RegX14,
 	},
-	Count:            14,
+	Count:            13,
 	TemporaryReserve: 2,
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -945,6 +945,26 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "table_shard_count",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			if a[0].IsNil() {
+				return scm.NewInt(0)
+			}
+			t := TableFromScmer(a[0])
+			if t == nil {
+				return scm.NewInt(0)
+			}
+			// The topology is an immutable atomic snapshot. No shard internals
+			// are read, and repartitioning cannot invalidate this slice.
+			return scm.NewInt(int64(len(t.ActiveShards())))
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "return the O(1) active partition count for physical scan costing",
+			Params: []*scm.TypeDescriptor{{Kind: "table", Label: "table"}},
+			Return: &scm.TypeDescriptor{Kind: "int"},
+		},
+	})
+
+	scm.Declare(&en, &scm.Declaration{
 		Name: "table_planner_statistics",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
@@ -3324,6 +3344,26 @@ func Init(en scm.Env) {
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
+	scm.Declare(&en, &scm.Declaration{
+		Name: "cache_table_ready?",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			if a[0].IsNil() {
+				return scm.NewBool(false)
+			}
+			t := TableFromScmer(a[0])
+			if t == nil {
+				return scm.NewBool(false)
+			}
+			t.cacheInitMu.Lock()
+			defer t.cacheInitMu.Unlock()
+			return scm.NewBool(t.cacheInitialized)
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "inspect canonical cache initialization without building or waiting for it",
+			Params: []*scm.TypeDescriptor{{Kind: "table", Label: "table"}},
+			Return: &scm.TypeDescriptor{Kind: "bool"},
+		},
+	})
+
 	scm.Declare(&en, &scm.Declaration{
 		Name: "initialize_cache_table",
 

--- a/tests/performance/wordpress-join-plans.yaml
+++ b/tests/performance/wordpress-join-plans.yaml
@@ -1,0 +1,65 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+metadata:
+  description: WordPress comment exclusion and grouped numeric metadata joins
+  isolated: true
+  physical_calibration: true
+  cache_state: warm_operator_state
+  compile_state: cached_plan_execution_only
+setup:
+- sql: DROP TABLE IF EXISTS wpbench_comments
+- sql: DROP TABLE IF EXISTS wpbench_postmeta
+- sql: DROP TABLE IF EXISTS wpbench_posts
+- sql: CREATE TABLE wpbench_posts (ID BIGINT PRIMARY KEY, post_type TEXT, post_status TEXT, post_date BIGINT) ENGINE=sloppy
+- sql: CREATE TABLE wpbench_comments (comment_ID BIGINT PRIMARY KEY, comment_post_ID BIGINT, comment_approved TEXT,
+    comment_type TEXT) ENGINE=sloppy
+- sql: CREATE TABLE wpbench_postmeta (meta_id BIGINT PRIMARY KEY, post_id BIGINT, meta_key TEXT, meta_value TEXT)
+    ENGINE=sloppy
+- scm: |
+    (insert (table "memcp-tests" "wpbench_posts") '("ID" "post_type" "post_status" "post_date")
+      (map (produceN 22062) (lambda (i) (list (+ i 1) (if (< i 200) "product" "post") "publish" i))))
+- scm: |
+    (insert (table "memcp-tests" "wpbench_comments") '("comment_ID" "comment_post_ID" "comment_approved" "comment_type")
+      (map (produceN 6001) (lambda (i) (list (+ i 1) (+ i 1) "1" "comment"))))
+- scm: |
+    (insert (table "memcp-tests" "wpbench_postmeta") '("meta_id" "post_id" "meta_key" "meta_value")
+      (map (produceN 60000) (lambda (i) (list (+ i 1) (+ 1 (mod i 22062))
+        (if (< (mod i 10) 2) "_yoast_wpseo_linkdex" "other") "99"))))
+- scm: (rebuild)
+test_cases:
+- name: Count comments after nullable-side exclusion
+  warmup: 20
+  timing_samples: 11
+  sql: |
+    SELECT COUNT(*) AS n FROM wpbench_comments c
+    LEFT JOIN wpbench_posts p ON c.comment_post_ID = p.ID
+    WHERE c.comment_approved = '1' AND c.comment_type NOT IN ('note')
+      AND c.comment_type != 'order_note' AND c.comment_type != 'webhook_delivery'
+      AND c.comment_type != 'action_log' AND p.post_type NOT IN ('product')
+  expect:
+    rows: 1
+    data:
+    - n: 5801
+  physical_calibration: true
+  calibration_decision: semijoin_carrier
+  threshold_ms: 1000
+- name: Grouped metadata cast with found rows and empty matching range
+  warmup: 20
+  timing_samples: 11
+  sql: |
+    SELECT SQL_CALC_FOUND_ROWS p.ID FROM wpbench_posts p
+    INNER JOIN wpbench_postmeta m ON p.ID = m.post_id
+    WHERE m.meta_key = '_yoast_wpseo_linkdex'
+      AND CAST(m.meta_value AS SIGNED) BETWEEN '1' AND '40'
+      AND p.post_type = 'post' AND p.post_status = 'publish'
+    GROUP BY p.ID ORDER BY p.post_date DESC LIMIT 0, 10
+  expect:
+    rows: 0
+  physical_calibration: true
+  calibration_decision: semijoin_carrier
+  threshold_ms: 1000
+cleanup:
+- sql: DROP TABLE IF EXISTS wpbench_comments
+- sql: DROP TABLE IF EXISTS wpbench_postmeta
+- sql: DROP TABLE IF EXISTS wpbench_posts

--- a/tests/performance/wordpress-postmeta-order-limit.yaml
+++ b/tests/performance/wordpress-postmeta-order-limit.yaml
@@ -160,7 +160,8 @@ test_cases:
       rows: 1
       result_contains:
         - '.prejoin:'
-        - '.grp:'
+        - 'semijoin_carrier'
+        - 'recset_project_join'
         - 'scan_order'
 
   - name: "WordPress handwritten equivalent-driver batched scan_join_order"

--- a/tests/planner/joins/semijoin-carriers.yaml
+++ b/tests/planner/joins/semijoin-carriers.yaml
@@ -1,0 +1,587 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+metadata:
+  description: Exact semijoin carriers, nullable joins, cache invalidation and FOUND_ROWS
+  isolated: true
+  requires_mysql: true
+setup:
+- sql: DROP TABLE IF EXISTS sj_guard_children
+- sql: DROP TABLE IF EXISTS sj_guard_parents
+- sql: CREATE TABLE sj_guard_parents (id INT PRIMARY KEY, flag TEXT)
+- sql: CREATE TABLE sj_guard_children (id INT PRIMARY KEY, pid INT)
+- sql: INSERT INTO sj_guard_parents VALUES (1,NULL),(2,'ok')
+- scm: (insert (table "memcp-tests" "sj_guard_parents") '("id" "flag") (map (produceN 40) (lambda (i) (list (+ i
+    3) "bad"))))
+- sql: INSERT INTO sj_guard_children VALUES (1,1),(2,2),(3,999),(4,NULL),(5,2)
+test_cases:
+- name: DROP TABLE IF EXISTS wp_comments
+  sql: DROP TABLE IF EXISTS wp_comments
+  expect: {}
+- name: DROP TABLE IF EXISTS wp_postmeta
+  sql: DROP TABLE IF EXISTS wp_postmeta
+  expect: {}
+- name: DROP TABLE IF EXISTS wp_posts
+  sql: DROP TABLE IF EXISTS wp_posts
+  expect: {}
+- name: CREATE TABLE wp_posts (ID BIGINT PRIMARY KEY, post_type TEXT, post_status TEXT, post_date BIGIN
+  sql: CREATE TABLE wp_posts (ID BIGINT PRIMARY KEY, post_type TEXT, post_status TEXT, post_date BIGINT)
+  expect: {}
+- name: CREATE TABLE wp_comments (comment_ID BIGINT PRIMARY KEY, comment_post_ID BIGINT, comment_approv
+  sql: CREATE TABLE wp_comments (comment_ID BIGINT PRIMARY KEY, comment_post_ID BIGINT, comment_approved TEXT, comment_type
+    TEXT)
+  expect: {}
+- name: CREATE TABLE wp_postmeta (meta_id BIGINT PRIMARY KEY, post_id BIGINT, meta_key TEXT, meta_value
+  sql: CREATE TABLE wp_postmeta (meta_id BIGINT PRIMARY KEY, post_id BIGINT, meta_key TEXT, meta_value TEXT)
+  expect: {}
+- name: INSERT INTO wp_posts VALUES (1,'post','publish',10),(2,'product','publish',20),(3,NULL,'publish
+  sql: INSERT INTO wp_posts VALUES (1,'post','publish',10),(2,'product','publish',20),(3,NULL,'publish',30),(4,'page','publish',40)
+  expect: {}
+- name: INSERT INTO wp_comments VALUES (1,1,'1','comment'),(2,1,'1','comment'),(3,2,'1','comment'),(4,3
+  sql: INSERT INTO wp_comments VALUES (1,1,'1','comment'),(2,1,'1','comment'),(3,2,'1','comment'),(4,3,'1','comment'),(5,999,'1','comment'),(6,NULL,'1','comment'),(7,4,'1','note'),(8,4,'1','order_note'),(9,4,'1',NULL),(10,4,'0','comment'),(11,4,'1','comment'),(12,1,NULL,'comment')
+  expect: {}
+- name: Q1 NULLs, misses and repeated comment-to-post keys
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 3
+  warmup: 20
+  timing_samples: 3
+- name: Q1 NULLs, misses and repeated comment-to-post keys with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: UPDATE wp_posts SET post_type='product' WHERE ID=1
+  sql: UPDATE wp_posts SET post_type='product' WHERE ID=1
+  expect: {}
+- name: Q1 post filter invalidation
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 1
+  warmup: 20
+  timing_samples: 3
+- name: Q1 post filter invalidation with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: UPDATE wp_posts SET post_type='post' WHERE ID=2
+  sql: UPDATE wp_posts SET post_type='post' WHERE ID=2
+  expect: {}
+- name: Q1 post becomes eligible
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 2
+  warmup: 20
+  timing_samples: 3
+- name: Q1 post becomes eligible with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: UPDATE wp_posts SET post_type='post' WHERE ID=3
+  sql: UPDATE wp_posts SET post_type='post' WHERE ID=3
+  expect: {}
+- name: Q1 NULL becomes eligible
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 3
+  warmup: 20
+  timing_samples: 3
+- name: Q1 NULL becomes eligible with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: INSERT INTO wp_posts VALUES (999,'post','publish',99)
+  sql: INSERT INTO wp_posts VALUES (999,'post','publish',99)
+  expect: {}
+- name: Q1 previously missing post inserted
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 4
+  warmup: 20
+  timing_samples: 3
+- name: Q1 previously missing post inserted with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: DELETE FROM wp_posts WHERE ID=4
+  sql: DELETE FROM wp_posts WHERE ID=4
+  expect: {}
+- name: Q1 post deleted
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 3
+  warmup: 20
+  timing_samples: 3
+- name: Q1 post deleted with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: UPDATE wp_comments SET comment_post_ID=3 WHERE comment_ID=1
+  sql: UPDATE wp_comments SET comment_post_ID=3 WHERE comment_ID=1
+  expect: {}
+- name: Q1 comment join key changes
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 4
+  warmup: 20
+  timing_samples: 3
+- name: Q1 comment join key changes with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: UPDATE wp_posts SET ID=30 WHERE ID=3
+  sql: UPDATE wp_posts SET ID=30 WHERE ID=3
+  expect: {}
+- name: Q1 post primary key changes
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 2
+  warmup: 20
+  timing_samples: 3
+- name: Q1 post primary key changes with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: INSERT INTO wp_comments VALUES (13,2,'1','comment')
+  sql: INSERT INTO wp_comments VALUES (13,2,'1','comment')
+  expect: {}
+- name: Q1 comment inserted
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 3
+  warmup: 20
+  timing_samples: 3
+- name: Q1 comment inserted with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: UPDATE wp_comments SET comment_approved='0' WHERE comment_ID=13
+  sql: UPDATE wp_comments SET comment_approved='0' WHERE comment_ID=13
+  expect: {}
+- name: Q1 comment approval changes
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 2
+  warmup: 20
+  timing_samples: 3
+- name: Q1 comment approval changes with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: DELETE FROM wp_comments WHERE comment_ID=3
+  sql: DELETE FROM wp_comments WHERE comment_ID=3
+  expect: {}
+- name: Q1 comment deleted
+  sql: |
+    SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 1
+    data:
+    - COUNT(*): 1
+  warmup: 20
+  timing_samples: 3
+- name: Q1 comment deleted with forced carriers
+  sql: |
+    EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) FROM wp_comments LEFT JOIN wp_posts AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID WHERE ( comment_approved = '1' ) AND comment_type NOT IN ('note') AND comment_type != 'order_note' AND comment_type != 'webhook_delivery' AND comment_type != 'action_log' AND wp_posts_to_exclude_reviews.post_type NOT IN ('product');
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: INSERT INTO wp_posts VALUES (1,'post','publish',10)
+  sql: INSERT INTO wp_posts VALUES (1,'post','publish',10)
+  expect:
+    error: true
+- name: DELETE FROM wp_comments
+  sql: DELETE FROM wp_comments
+  expect: {}
+- name: DELETE FROM wp_posts
+  sql: DELETE FROM wp_posts
+  expect: {}
+- name: INSERT INTO wp_posts VALUES (1,'post','publish',101),(2,'post','publish',102),(3,'post','publis
+  sql: INSERT INTO wp_posts VALUES (1,'post','publish',101),(2,'post','publish',102),(3,'post','publish',103),(4,'post','publish',104),(5,'post','publish',105),(6,'post','publish',106),(7,'post','publish',107),(8,'post','publish',108),(9,'post','publish',109),(10,'post','publish',110),(11,'post','publish',111),(12,'post','publish',112),(13,'post','publish',113),(14,'post','publish',114),(15,'post','publish',115),(16,'product','publish',116),(17,'post','draft',117),(18,'post','publish',118),(19,'post','publish',119),(20,'post','publish',120),(21,'post','publish',121)
+  expect: {}
+- name: INSERT INTO wp_postmeta VALUES (1,1,'_yoast_wpseo_linkdex','20'),(2,2,'_yoast_wpseo_linkdex','2
+  sql: INSERT INTO wp_postmeta VALUES (1,1,'_yoast_wpseo_linkdex','20'),(2,2,'_yoast_wpseo_linkdex','20'),(3,3,'_yoast_wpseo_linkdex','20'),(4,4,'_yoast_wpseo_linkdex','20'),(5,5,'_yoast_wpseo_linkdex','20'),(6,6,'_yoast_wpseo_linkdex','20'),(7,7,'_yoast_wpseo_linkdex','20'),(8,8,'_yoast_wpseo_linkdex','20'),(9,9,'_yoast_wpseo_linkdex','20'),(10,10,'_yoast_wpseo_linkdex','20'),(11,11,'_yoast_wpseo_linkdex','20'),(12,12,'_yoast_wpseo_linkdex','20'),(13,13,'_yoast_wpseo_linkdex','20'),(14,14,'_yoast_wpseo_linkdex','1'),(15,15,'_yoast_wpseo_linkdex','40'),(16,16,'_yoast_wpseo_linkdex','20'),(17,17,'_yoast_wpseo_linkdex','20'),(18,1,'_yoast_wpseo_linkdex','1'),(19,1,'_yoast_wpseo_linkdex','40'),(20,1,'_yoast_wpseo_linkdex','0'),(21,1,'_yoast_wpseo_linkdex','41'),(22,1,'_yoast_wpseo_linkdex',NULL),(23,1,NULL,'20'),(24,999,'_yoast_wpseo_linkdex','20'),(25,NULL,'_yoast_wpseo_linkdex','20'),(27,18,'_yoast_wpseo_linkdex','0'),(28,19,'_yoast_wpseo_linkdex','41'),(29,20,'_yoast_wpseo_linkdex',NULL),(30,21,'unrelated','20')
+  expect: {}
+- name: Prepare and compare both nonempty grouped semijoin alternatives
+  sql: EXPLAIN PHYSICAL CALIBRATE SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON
+    ( wp_posts.ID = wp_postmeta.post_id ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value
+    AS SIGNED) BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish'))
+    GROUP BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 10
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: Q3 duplicates, NULLs, sort and LIMIT
+  mysql:
+    statements:
+    - sql: SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id
+        ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value AS SIGNED)
+        BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish')) GROUP
+        BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 10
+      expect:
+        rows: 10
+        data:
+        - ID: 15
+        - ID: 14
+        - ID: 13
+        - ID: 12
+        - ID: 11
+        - ID: 10
+        - ID: 9
+        - ID: 8
+        - ID: 7
+        - ID: 6
+    - sql: SELECT FOUND_ROWS() AS n
+      expect:
+        rows: 1
+        data:
+        - n: 15
+- name: UPDATE wp_postmeta SET meta_value='41' WHERE post_id=15
+  sql: UPDATE wp_postmeta SET meta_value='41' WHERE post_id=15
+  expect: {}
+- name: Q3 cast leaves range
+  mysql:
+    statements:
+    - sql: SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id
+        ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value AS SIGNED)
+        BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish')) GROUP
+        BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 10
+      expect:
+        rows: 10
+        data:
+        - ID: 14
+        - ID: 13
+        - ID: 12
+        - ID: 11
+        - ID: 10
+        - ID: 9
+        - ID: 8
+        - ID: 7
+        - ID: 6
+        - ID: 5
+    - sql: SELECT FOUND_ROWS() AS n
+      expect:
+        rows: 1
+        data:
+        - n: 14
+- name: UPDATE wp_posts SET post_status='publish' WHERE ID=17
+  sql: UPDATE wp_posts SET post_status='publish' WHERE ID=17
+  expect: {}
+- name: Q3 post status enters result
+  mysql:
+    statements:
+    - sql: SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id
+        ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value AS SIGNED)
+        BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish')) GROUP
+        BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 10
+      expect:
+        rows: 10
+        data:
+        - ID: 17
+        - ID: 14
+        - ID: 13
+        - ID: 12
+        - ID: 11
+        - ID: 10
+        - ID: 9
+        - ID: 8
+        - ID: 7
+        - ID: 6
+    - sql: SELECT FOUND_ROWS() AS n
+      expect:
+        rows: 1
+        data:
+        - n: 15
+- name: DELETE FROM wp_postmeta WHERE post_id=14
+  sql: DELETE FROM wp_postmeta WHERE post_id=14
+  expect: {}
+- name: Q3 last metadata row removed
+  mysql:
+    statements:
+    - sql: SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id
+        ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value AS SIGNED)
+        BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish')) GROUP
+        BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 10
+      expect:
+        rows: 10
+        data:
+        - ID: 17
+        - ID: 13
+        - ID: 12
+        - ID: 11
+        - ID: 10
+        - ID: 9
+        - ID: 8
+        - ID: 7
+        - ID: 6
+        - ID: 5
+    - sql: SELECT FOUND_ROWS() AS n
+      expect:
+        rows: 1
+        data:
+        - n: 14
+- name: INSERT INTO wp_postmeta VALUES (26,15,'_yoast_wpseo_linkdex','40')
+  sql: INSERT INTO wp_postmeta VALUES (26,15,'_yoast_wpseo_linkdex','40')
+  expect: {}
+- name: Q3 new matching metadata inserted
+  mysql:
+    statements:
+    - sql: SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id
+        ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value AS SIGNED)
+        BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish')) GROUP
+        BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 10
+      expect:
+        rows: 10
+        data:
+        - ID: 17
+        - ID: 15
+        - ID: 13
+        - ID: 12
+        - ID: 11
+        - ID: 10
+        - ID: 9
+        - ID: 8
+        - ID: 7
+        - ID: 6
+    - sql: SELECT FOUND_ROWS() AS n
+      expect:
+        rows: 1
+        data:
+        - n: 15
+- name: UPDATE wp_posts SET post_date=999 WHERE ID=1
+  sql: UPDATE wp_posts SET post_date=999 WHERE ID=1
+  expect: {}
+- name: Q3 ordering column invalidated
+  mysql:
+    statements:
+    - sql: SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id
+        ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value AS SIGNED)
+        BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish')) GROUP
+        BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 10
+      expect:
+        rows: 10
+        data:
+        - ID: 1
+        - ID: 17
+        - ID: 15
+        - ID: 13
+        - ID: 12
+        - ID: 11
+        - ID: 10
+        - ID: 9
+        - ID: 8
+        - ID: 7
+    - sql: SELECT FOUND_ROWS() AS n
+      expect:
+        rows: 1
+        data:
+        - n: 15
+- name: Q3 OFFSET counts distinct groups
+  mysql:
+    statements:
+    - sql: SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id
+        ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value AS SIGNED)
+        BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish')) GROUP
+        BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 2, 3
+      expect:
+        rows: 3
+        data:
+        - ID: 15
+        - ID: 13
+        - ID: 12
+    - sql: SELECT FOUND_ROWS() AS n
+      expect:
+        rows: 1
+        data:
+        - n: 15
+- name: Q3 LIMIT zero still counts all groups
+  mysql:
+    statements:
+    - sql: SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id
+        ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value AS SIGNED)
+        BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish')) GROUP
+        BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 0
+      expect:
+        rows: 0
+        data: []
+    - sql: SELECT FOUND_ROWS() AS n
+      expect:
+        rows: 1
+        data:
+        - n: 15
+- name: UPDATE wp_postmeta SET meta_value='0'
+  sql: UPDATE wp_postmeta SET meta_value='0'
+  expect: {}
+- name: Q3 empty result replaces previous FOUND_ROWS
+  mysql:
+    statements:
+    - sql: SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id
+        ) WHERE 1=1 AND ( ( wp_postmeta.meta_key = '_yoast_wpseo_linkdex' AND CAST(wp_postmeta.meta_value AS SIGNED)
+        BETWEEN '1' AND '40' ) ) AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish')) GROUP
+        BY wp_posts.ID ORDER BY wp_posts.post_date DESC LIMIT 0, 0
+      expect:
+        rows: 0
+        data: []
+    - sql: SELECT FOUND_ROWS() AS n
+      expect:
+        rows: 1
+        data:
+        - n: 0
+- name: DROP TABLE wp_comments
+  sql: DROP TABLE wp_comments
+  expect: {}
+- name: DROP TABLE wp_postmeta
+  sql: DROP TABLE wp_postmeta
+  expect: {}
+- name: DROP TABLE wp_posts
+  sql: DROP TABLE wp_posts
+  expect: {}
+- name: Null rejecting lookup preserves repeated foreign keys
+  sql: SELECT COUNT(*) AS n FROM sj_guard_children c LEFT JOIN sj_guard_parents p ON p.id=c.pid WHERE p.flag NOT
+    IN ('bad')
+  expect:
+    rows: 1
+    data:
+    - n: 2
+- name: Nullable WHERE disjunction keeps missing partners
+  sql: SELECT COUNT(*) AS n FROM sj_guard_children c LEFT JOIN sj_guard_parents p ON p.id=c.pid WHERE p.flag NOT
+    IN ('bad') OR p.id IS NULL
+  expect:
+    rows: 1
+    data:
+    - n: 4
+- name: COALESCE keeps null extended partners
+  sql: SELECT COUNT(*) AS n FROM sj_guard_children c LEFT JOIN sj_guard_parents p ON p.id=c.pid WHERE COALESCE(p.flag,'ok')='ok'
+  expect:
+    rows: 1
+    data:
+    - n: 5
+- name: IS NULL is not a rejecting predicate
+  sql: SELECT COUNT(*) AS n FROM sj_guard_children c LEFT JOIN sj_guard_parents p ON p.id=c.pid WHERE p.flag IS
+    NULL
+  expect:
+    rows: 1
+    data:
+    - n: 3
+- name: Negated nullable equality preserves unknown
+  sql: SELECT COUNT(*) AS n FROM sj_guard_children c LEFT JOIN sj_guard_parents p ON p.id=c.pid WHERE NOT (p.flag='bad')
+  expect:
+    rows: 1
+    data:
+    - n: 2
+- name: Prepare guarded count cache before transaction tests
+  sql: EXPLAIN PHYSICAL CALIBRATE SELECT COUNT(*) AS n FROM sj_guard_children c LEFT JOIN sj_guard_parents p ON
+    p.id=c.pid WHERE p.flag NOT IN ('bad')
+  expect:
+    rows: 2
+    data:
+    - result_equal: true
+    - result_equal: true
+- name: Shared semijoin caches are bypassed for explicit transactions
+  mysql:
+    statements:
+    - sql: SELECT COUNT(*) AS n FROM sj_guard_children c LEFT JOIN sj_guard_parents p ON p.id=c.pid WHERE p.flag
+        NOT IN ('bad')
+      expect:
+        rows: 1
+        data:
+        - n: 2
+    - sql: BEGIN
+    - sql: UPDATE sj_guard_parents SET flag='bad' WHERE id=2
+    - sql: SELECT COUNT(*) AS n FROM sj_guard_children c LEFT JOIN sj_guard_parents p ON p.id=c.pid WHERE p.flag
+        NOT IN ('bad')
+      expect:
+        rows: 1
+        data:
+        - n: 0
+    - sql: ROLLBACK
+    - sql: SELECT COUNT(*) AS n FROM sj_guard_children c LEFT JOIN sj_guard_parents p ON p.id=c.pid WHERE p.flag
+        NOT IN ('bad')
+      expect:
+        rows: 1
+        data:
+        - n: 2
+- name: Nonunique lookup keeps join multiplicity
+  sql: SELECT COUNT(*) n FROM sj_guard_parents p JOIN sj_guard_children c ON p.id=c.pid
+  expect:
+    rows: 1
+    data:
+    - n: 3
+cleanup:
+- sql: DROP TABLE IF EXISTS sj_guard_children
+- sql: DROP TABLE IF EXISTS sj_guard_parents
+- sql: DROP TABLE IF EXISTS wp_comments
+- sql: DROP TABLE IF EXISTS wp_postmeta
+- sql: DROP TABLE IF EXISTS wp_posts

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -243,7 +243,12 @@ type constants struct {
 func main() {
 	patch := flag.Bool("patch", false, "rewrite lib/queryplan-physical-expr.scm")
 	jsonl := flag.String("jsonl", "", "write raw measurements as JSONL")
+	suiteFilter := flag.String("suite", "", "restrict workload paths to this substring")
+	validateOnly := flag.Bool("validate-only", false, "execute and validate forced alternatives without refitting coefficients")
 	flag.Parse()
+	if *suiteFilter != "" && !*validateOnly {
+		fatal(errors.New("--suite requires --validate-only; coefficient fitting needs the complete workload set"))
+	}
 
 	root, err := repoRoot()
 	if err != nil {
@@ -252,6 +257,15 @@ func main() {
 	suites, err := discoverSuites(root)
 	if err != nil {
 		fatal(err)
+	}
+	if *suiteFilter != "" {
+		selected := suites[:0]
+		for _, current := range suites {
+			if strings.Contains(current.Path, *suiteFilter) {
+				selected = append(selected, current)
+			}
+		}
+		suites = selected
 	}
 	if len(suites) == 0 {
 		fatal(errors.New("no tests/**/*.yaml suite has metadata.physical_calibration: true"))
@@ -294,6 +308,10 @@ func main() {
 		if err := writeJSONL(*jsonl, raw); err != nil {
 			fatal(err)
 		}
+	}
+	if *validateOnly {
+		fmt.Printf("Validated %d forced-plan observations across %d suites; coefficients unchanged.\n", len(observations), len(suites))
+		return
 	}
 	// Coefficient fitting remains scoped to the membership-carrier family. Other
 	// calibrated decision families are executed and result-checked above, but
@@ -1097,6 +1115,10 @@ func validateRaceWinner(row calibrationRow, decisionID, plan string) error {
 			row.RowsPerProbe == nil || row.AggregateWidth == nil {
 			return fmt.Errorf("direct grouped join variant has incomplete measurements: %+v", row)
 		}
+	} else if row.Decision == "semijoin_carrier" {
+		if row.InputRows == nil || row.DriverInputRows == nil {
+			return fmt.Errorf("semijoin variant has incomplete measurements: %+v", row)
+		}
 	} else if isScanLookupDecision(row.Decision) {
 		if row.ProbeInvocations == nil {
 			return fmt.Errorf("%s variant has incomplete measurements: %+v", row.Decision, row)
@@ -1261,6 +1283,11 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 }
 
 func rowFeatures(row calibrationRow) ([]float64, error) {
+	// Semijoin formulas reuse existing primitive coefficients. These rows
+	// validate complete alternatives and must not become membership-fit inputs.
+	if row.Decision == "semijoin_carrier" {
+		return make([]float64, 25), nil
+	}
 	if isScanLookupDecision(row.Decision) {
 		if row.ProbeInvocations == nil {
 			return nil, fmt.Errorf("%s work profile contains nil probe count: %+v", row.Decision, row)

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -697,3 +697,15 @@ func TestRaceCalibrationVariantsCancelsSlowerPlan(t *testing.T) {
 		t.Fatalf("timeout lower bound %f must exceed winner time %f", rows[1].LowerBoundNS, rows[0].WholeQueryExecutionNS)
 	}
 }
+
+func TestSemijoinCalibrationDoesNotRequireMembershipFeatures(t *testing.T) {
+	features, err := rowFeatures(calibrationRow{Decision: "semijoin_carrier", Plan: "projected_recset"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, feature := range features {
+		if feature != 0 {
+			t.Fatal("semijoin observation leaked into membership coefficient fitting")
+		}
+	}
+}


### PR DESCRIPTION
Q1's null-rejecting LEFT JOIN count and Q3's primary-key GROUP BY can execute through exact base-record sets instead of repeated joins and aggregation. This adds generic, costed physical alternatives and shares Q3's result carrier with FOUND_ROWS. Q2 (`wordpress_search`) is outside this change.

- Logical optimization records conservative null-rejection facts. Physical lowering requires complete join predicates and either a unique lookup for COUNT or a grouped carrier primary key with carrier-only output/order expressions.
- COUNT chooses projected records or an invalidated computed predicate index. Observed execution work amortizes cache construction; explicit transactions use query-local records.
- Grouped output projects qualifying lookup records onto the carrier. An initialized canonical prejoin is a cheaper alternative when live statistics support it; ordinary execution does not build a missing prejoin speculatively.
- Selection uses catalog row/partition counts and existing costgen primitive weights. Forced variants are validated through `tools/costgen --validate-only`; no query-name rules, arbitrary cutoffs, relational Scheme lists or session-held relational results.
- Fully indexable semijoin filters retain the existing indexed scan lowerer. Computed predicates retain explicit residual evaluation.

The branch is rebased on master `50fc99d40`, including the Bool/Text index-order and compression fixes. Commit `446a18562` also fixes the JIT crash exposed by Q3 and the grouped-cache CI suite: XMM15 was available for FP temporaries/overflow although Go ABIInternal requires it to contain zero at calls and returns. A live value of 1 poisoned native heap/stack zero initialization. XMM15 is now excluded from allocation. The new execution-level ABI test fails before the fix (including native zero initialization writing ones) and passes afterwards; it restores XMM15 before returning so a regression does not corrupt the test runner.

Manual SQL end-to-end control after the rebase and JIT fix (milliseconds):

| Query | master 50fc99d40 first call | PR 446a18562 first call | master warm median | PR warm median | Warm reduction |
|---|---:|---:|---:|---:|---:|
| Q1 | 456.943 | 179.203 | 105.858277 | 0.136349 | 105.721928 ms / 99.871% |
| Q3 | 263023.977 | 1963.692 | 2555.852948 | 13.204751 | 2542.648197 ms / 99.483% |

Both binaries use patched Go `84fe25ee45468f5e3920c11c24e2bbb926fc3a72`, `GOEXPERIMENT=jit`, the same `profile-data-20260906` fixture and database `wordpress_compare_memcp`, and one persistent local MySQL connection in autocommit. Five warmups, five measured batches; Q1 ten executions/batch, Q3 one. First call is reported separately after process startup. Lazy cache/index preparation during warmup is outside the warm median; first-call latency does not mean all caches are ready. OS page cache was not cleared. Processes opened the fixture sequentially. The owned Q1 predicate column and scalar promotion record were removed after measurement. The existing shutdown/rebuild hang required diagnostic termination of the benchmark process after the completed queries; no process retains the fixture.

Q1 returns 5801 in both versions. This fixture has no matching Q3 meta key: both return an empty result and FOUND_ROWS=0, checked on the same connection outside the timed query. Synthetic tests separately validate nonempty Q3, duplicate metadata, NULLs, ordered pagination, LIMIT zero, FOUND_ROWS and subsequent writes. Fixture cardinalities are 6001 comments / 22062 posts / 14013 postmeta rows, with 2 / 1326 / 201640 active partitions. Historical MariaDB medians (3.204 / 0.142 ms) and the original MemCP JIT medians (196.36 / 12.52 ms) were not rerun and are not the A/B baseline in this table.

Earlier full development A/B on master `91f16c249`, with 20 warmups and 11 batches (Q1 twenty executions/batch, Q3 one), measured Q1 125.680 → 0.165 ms and Q3 2772.088 → 12.766 ms. First calls: Q1 740.053 → 490.062 ms, Q3 248126.776 → 1443.096 ms. A separately initialized canonical prejoin let ordinary Q3 SQL select `prejoin_recset` at 0.124438 ms warm; its separate initialization request took 189049.813 ms. That prepared-cache result is historical and is not the natural-warmup result above. Initial preparation also caused second-request transients (Q1 17955.253 ms, Q3 2990.286 ms), excluded from warm medians.

Current local validation:

- JIT ABI regression demonstrated red before / green after; targeted register, stack, overflow and Go-call tests pass.
- 246 targeted SQL cases pass with JIT: semijoin carriers 72, grouped-cache invalidation 143, RDF algebra/MINUS 21, reversed comparisons 10.
- All eleven local WordPress/Elementor checks pass with unchanged limits.
- Existing development validation covers outer joins, join deduplication, incremental prejoin changes, MySQL compatibility, rollback, costgen forced alternatives and statistics/cache APIs.
- All CI checks pass on `446a18562`: ordinary SQL, full JIT-SQL, Go tests with and without JIT, performance A/B, packaging, alternative storage and policy checks.

The green performance job is not proof that every synthetic shape became faster: its small Q3 fixture measures 1.564 → 4.798 ms (+206.7%), accepted by the runner's general jitter allowance. This is an existing planner tradeoff, also present before the XMM15 fix (earlier CI: 1.529 → 4.844 ms). It is distinct from the large-fixture SQL end-to-end improvement above and remains a limitation of the current grouped-carrier choice.

Raw evidence remains in `/tmp/wordpress-query-analysis/`: `final-samples.jsonl`, `rebase50-master-measure.log`, `xmm15-pr-control-measure.log`, `xmm15-control-metadata.json` (binary hashes and configuration), `xmm15-*.{explain,ir,physical,reorder}.json`, `xmm15-{before,after,sql-needle,perf-needle}.log` and GDB logs. Large completed server logs are losslessly compressed as `.log.gz`.
