### PR TITLE
JIT: preserve numeric type information through Float lowering

### DIFF
--- a/scm/alu.go
+++ b/scm/alu.go
@@ -4032,23 +4032,7 @@ func init_alu() {
 					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.StabilizeDescForControlFlow(&d139)
-					var d314 JITValueDesc
-					if d139.Loc == LocImm {
-						d314 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d139.Imm.Float())}
-					} else if d139.Type == tagFloat && d139.Loc == LocReg {
-						d314 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d139.Reg}
-						ctx.BindReg(d139.Reg, &d314)
-						ctx.BindReg(d139.Reg, &d314)
-					} else if d139.Type == tagFloat && d139.Loc == LocRegPair {
-						ctx.FreeReg(d139.Reg)
-						d314 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d139.Reg2}
-						ctx.BindReg(d139.Reg2, &d314)
-						ctx.BindReg(d139.Reg2, &d314)
-					} else {
-						d314 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d139}, 1)
-						d314.Type = tagFloat
-						ctx.BindReg(d314.Reg, &d314)
-					}
+					d314 = ctx.EmitFloatDesc(d139)
 					ctx.EnsureDesc(&d4)
 					ctx.EnsureDesc(&d314)
 					ctx.EnsureDescsTogether(&d4, &d314)
@@ -5233,43 +5217,11 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d93 = args[0]
 					d93.ID = 0
-					var d94 JITValueDesc
-					if d93.Loc == LocImm {
-						d94 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d93.Imm.Float())}
-					} else if d93.Type == tagFloat && d93.Loc == LocReg {
-						d94 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d93.Reg}
-						ctx.BindReg(d93.Reg, &d94)
-						ctx.BindReg(d93.Reg, &d94)
-					} else if d93.Type == tagFloat && d93.Loc == LocRegPair {
-						ctx.FreeReg(d93.Reg)
-						d94 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d93.Reg2}
-						ctx.BindReg(d93.Reg2, &d94)
-						ctx.BindReg(d93.Reg2, &d94)
-					} else {
-						d94 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d93}, 1)
-						d94.Type = tagFloat
-						ctx.BindReg(d94.Reg, &d94)
-					}
+					d94 = ctx.EmitFloatDesc(d93)
 					ctx.FreeDesc(&d93)
 					d95 = args[1]
 					d95.ID = 0
-					var d96 JITValueDesc
-					if d95.Loc == LocImm {
-						d96 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d95.Imm.Float())}
-					} else if d95.Type == tagFloat && d95.Loc == LocReg {
-						d96 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d95.Reg}
-						ctx.BindReg(d95.Reg, &d96)
-						ctx.BindReg(d95.Reg, &d96)
-					} else if d95.Type == tagFloat && d95.Loc == LocRegPair {
-						ctx.FreeReg(d95.Reg)
-						d96 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d95.Reg2}
-						ctx.BindReg(d95.Reg2, &d96)
-						ctx.BindReg(d95.Reg2, &d96)
-					} else {
-						d96 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d95}, 1)
-						d96.Type = tagFloat
-						ctx.BindReg(d96.Reg, &d96)
-					}
+					d96 = ctx.EmitFloatDesc(d95)
 					ctx.FreeDesc(&d95)
 					ctx.EnsureDesc(&d94)
 					resultTarget97 := false
@@ -7679,23 +7631,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d176 = args[0]
 					d176.ID = 0
-					var d177 JITValueDesc
-					if d176.Loc == LocImm {
-						d177 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d176.Imm.Float())}
-					} else if d176.Type == tagFloat && d176.Loc == LocReg {
-						d177 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d176.Reg}
-						ctx.BindReg(d176.Reg, &d177)
-						ctx.BindReg(d176.Reg, &d177)
-					} else if d176.Type == tagFloat && d176.Loc == LocRegPair {
-						ctx.FreeReg(d176.Reg)
-						d177 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d176.Reg2}
-						ctx.BindReg(d176.Reg2, &d177)
-						ctx.BindReg(d176.Reg2, &d177)
-					} else {
-						d177 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d176}, 1)
-						d177.Type = tagFloat
-						ctx.BindReg(d177.Reg, &d177)
-					}
+					d177 = ctx.EmitFloatDesc(d176)
 					ctx.StabilizeDescForControlFlow(&d177)
 					ctx.FreeDesc(&d176)
 					if ps.General {
@@ -10955,23 +10891,7 @@ func init_alu() {
 						ctx.UnprotectReg(d4.Reg)
 						d528 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(dynamicArgOff529), Rooted: true}
 					}
-					var d530 JITValueDesc
-					if d528.Loc == LocImm {
-						d530 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d528.Imm.Float())}
-					} else if d528.Type == tagFloat && d528.Loc == LocReg {
-						d530 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d528.Reg}
-						ctx.BindReg(d528.Reg, &d530)
-						ctx.BindReg(d528.Reg, &d530)
-					} else if d528.Type == tagFloat && d528.Loc == LocRegPair {
-						ctx.FreeReg(d528.Reg)
-						d530 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d528.Reg2}
-						ctx.BindReg(d528.Reg2, &d530)
-						ctx.BindReg(d528.Reg2, &d530)
-					} else {
-						d530 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d528}, 1)
-						d530.Type = tagFloat
-						ctx.BindReg(d530.Reg, &d530)
-					}
+					d530 = ctx.EmitFloatDesc(d528)
 					ctx.EnsureDesc(&d5)
 					ctx.EnsureDesc(&d530)
 					ctx.EnsureDescsTogether(&d5, &d530)
@@ -13705,23 +13625,7 @@ func init_alu() {
 						ctx.UnprotectReg(d7.Reg)
 						d867 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(dynamicArgOff868), Rooted: true}
 					}
-					var d869 JITValueDesc
-					if d867.Loc == LocImm {
-						d869 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d867.Imm.Float())}
-					} else if d867.Type == tagFloat && d867.Loc == LocReg {
-						d869 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d867.Reg}
-						ctx.BindReg(d867.Reg, &d869)
-						ctx.BindReg(d867.Reg, &d869)
-					} else if d867.Type == tagFloat && d867.Loc == LocRegPair {
-						ctx.FreeReg(d867.Reg)
-						d869 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d867.Reg2}
-						ctx.BindReg(d867.Reg2, &d869)
-						ctx.BindReg(d867.Reg2, &d869)
-					} else {
-						d869 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d867}, 1)
-						d869.Type = tagFloat
-						ctx.BindReg(d869.Reg, &d869)
-					}
+					d869 = ctx.EmitFloatDesc(d867)
 					ctx.EnsureDesc(&d6)
 					ctx.EnsureDesc(&d869)
 					ctx.EnsureDescsTogether(&d6, &d869)
@@ -18388,23 +18292,7 @@ func init_alu() {
 					}
 					ctx.ReclaimUntrackedRegs()
 					ctx.StabilizeDescForControlFlow(&d106)
-					var d445 JITValueDesc
-					if d106.Loc == LocImm {
-						d445 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d106.Imm.Float())}
-					} else if d106.Type == tagFloat && d106.Loc == LocReg {
-						d445 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d106.Reg}
-						ctx.BindReg(d106.Reg, &d445)
-						ctx.BindReg(d106.Reg, &d445)
-					} else if d106.Type == tagFloat && d106.Loc == LocRegPair {
-						ctx.FreeReg(d106.Reg)
-						d445 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d106.Reg2}
-						ctx.BindReg(d106.Reg2, &d445)
-						ctx.BindReg(d106.Reg2, &d445)
-					} else {
-						d445 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d106}, 1)
-						d445.Type = tagFloat
-						ctx.BindReg(d445.Reg, &d445)
-					}
+					d445 = ctx.EmitFloatDesc(d106)
 					ctx.StabilizeDescForControlFlow(&d445)
 					ctx.EnsureDesc(&d445)
 					var d446 JITValueDesc
@@ -20005,23 +19893,7 @@ func init_alu() {
 						ctx.UnprotectReg(d5.Reg)
 						d567 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(dynamicArgOff568), Rooted: true}
 					}
-					var d569 JITValueDesc
-					if d567.Loc == LocImm {
-						d569 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d567.Imm.Float())}
-					} else if d567.Type == tagFloat && d567.Loc == LocReg {
-						d569 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d567.Reg}
-						ctx.BindReg(d567.Reg, &d569)
-						ctx.BindReg(d567.Reg, &d569)
-					} else if d567.Type == tagFloat && d567.Loc == LocRegPair {
-						ctx.FreeReg(d567.Reg)
-						d569 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d567.Reg2}
-						ctx.BindReg(d567.Reg2, &d569)
-						ctx.BindReg(d567.Reg2, &d569)
-					} else {
-						d569 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d567}, 1)
-						d569.Type = tagFloat
-						ctx.BindReg(d569.Reg, &d569)
-					}
+					d569 = ctx.EmitFloatDesc(d567)
 					ctx.EnsureDesc(&d6)
 					ctx.EnsureDesc(&d569)
 					ctx.EnsureDescsTogether(&d6, &d569)
@@ -22219,23 +22091,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d87 = args[0]
 					d87.ID = 0
-					var d88 JITValueDesc
-					if d87.Loc == LocImm {
-						d88 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d87.Imm.Float())}
-					} else if d87.Type == tagFloat && d87.Loc == LocReg {
-						d88 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d87.Reg}
-						ctx.BindReg(d87.Reg, &d88)
-						ctx.BindReg(d87.Reg, &d88)
-					} else if d87.Type == tagFloat && d87.Loc == LocRegPair {
-						ctx.FreeReg(d87.Reg)
-						d88 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d87.Reg2}
-						ctx.BindReg(d87.Reg2, &d88)
-						ctx.BindReg(d87.Reg2, &d88)
-					} else {
-						d88 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d87}, 1)
-						d88.Type = tagFloat
-						ctx.BindReg(d88.Reg, &d88)
-					}
+					d88 = ctx.EmitFloatDesc(d87)
 					ctx.StabilizeDescForControlFlow(&d88)
 					ctx.FreeDesc(&d87)
 					d89 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args) - 1))}
@@ -23082,23 +22938,7 @@ func init_alu() {
 						ctx.UnprotectReg(d97.Reg)
 						d172 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(dynamicArgOff173), Rooted: true}
 					}
-					var d174 JITValueDesc
-					if d172.Loc == LocImm {
-						d174 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d172.Imm.Float())}
-					} else if d172.Type == tagFloat && d172.Loc == LocReg {
-						d174 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d172.Reg}
-						ctx.BindReg(d172.Reg, &d174)
-						ctx.BindReg(d172.Reg, &d174)
-					} else if d172.Type == tagFloat && d172.Loc == LocRegPair {
-						ctx.FreeReg(d172.Reg)
-						d174 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d172.Reg2}
-						ctx.BindReg(d172.Reg2, &d174)
-						ctx.BindReg(d172.Reg2, &d174)
-					} else {
-						d174 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d172}, 1)
-						d174.Type = tagFloat
-						ctx.BindReg(d174.Reg, &d174)
-					}
+					d174 = ctx.EmitFloatDesc(d172)
 					ctx.EnsureDesc(&d2)
 					ctx.EnsureDesc(&d174)
 					ctx.EnsureDescsTogether(&d2, &d174)
@@ -24511,23 +24351,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d127 = args[1]
 					d127.ID = 0
-					var d128 JITValueDesc
-					if d127.Loc == LocImm {
-						d128 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d127.Imm.Float())}
-					} else if d127.Type == tagFloat && d127.Loc == LocReg {
-						d128 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d127.Reg}
-						ctx.BindReg(d127.Reg, &d128)
-						ctx.BindReg(d127.Reg, &d128)
-					} else if d127.Type == tagFloat && d127.Loc == LocRegPair {
-						ctx.FreeReg(d127.Reg)
-						d128 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d127.Reg2}
-						ctx.BindReg(d127.Reg2, &d128)
-						ctx.BindReg(d127.Reg2, &d128)
-					} else {
-						d128 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d127}, 1)
-						d128.Type = tagFloat
-						ctx.BindReg(d128.Reg, &d128)
-					}
+					d128 = ctx.EmitFloatDesc(d127)
 					ctx.StabilizeDescForControlFlow(&d128)
 					ctx.FreeDesc(&d127)
 					ctx.EnsureDesc(&d128)
@@ -26700,23 +26524,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d404 = args[0]
 					d404.ID = 0
-					var d405 JITValueDesc
-					if d404.Loc == LocImm {
-						d405 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d404.Imm.Float())}
-					} else if d404.Type == tagFloat && d404.Loc == LocReg {
-						d405 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d404.Reg}
-						ctx.BindReg(d404.Reg, &d405)
-						ctx.BindReg(d404.Reg, &d405)
-					} else if d404.Type == tagFloat && d404.Loc == LocRegPair {
-						ctx.FreeReg(d404.Reg)
-						d405 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d404.Reg2}
-						ctx.BindReg(d404.Reg2, &d405)
-						ctx.BindReg(d404.Reg2, &d405)
-					} else {
-						d405 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d404}, 1)
-						d405.Type = tagFloat
-						ctx.BindReg(d405.Reg, &d405)
-					}
+					d405 = ctx.EmitFloatDesc(d404)
 					ctx.FreeDesc(&d404)
 					ctx.EnsureDesc(&d405)
 					ctx.EnsureDesc(&d128)
@@ -30000,23 +29808,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d127 = args[1]
 					d127.ID = 0
-					var d128 JITValueDesc
-					if d127.Loc == LocImm {
-						d128 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d127.Imm.Float())}
-					} else if d127.Type == tagFloat && d127.Loc == LocReg {
-						d128 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d127.Reg}
-						ctx.BindReg(d127.Reg, &d128)
-						ctx.BindReg(d127.Reg, &d128)
-					} else if d127.Type == tagFloat && d127.Loc == LocRegPair {
-						ctx.FreeReg(d127.Reg)
-						d128 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d127.Reg2}
-						ctx.BindReg(d127.Reg2, &d128)
-						ctx.BindReg(d127.Reg2, &d128)
-					} else {
-						d128 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d127}, 1)
-						d128.Type = tagFloat
-						ctx.BindReg(d128.Reg, &d128)
-					}
+					d128 = ctx.EmitFloatDesc(d127)
 					ctx.StabilizeDescForControlFlow(&d128)
 					ctx.FreeDesc(&d127)
 					ctx.EnsureDesc(&d128)
@@ -31155,23 +30947,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d246 = args[0]
 					d246.ID = 0
-					var d247 JITValueDesc
-					if d246.Loc == LocImm {
-						d247 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d246.Imm.Float())}
-					} else if d246.Type == tagFloat && d246.Loc == LocReg {
-						d247 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d246.Reg}
-						ctx.BindReg(d246.Reg, &d247)
-						ctx.BindReg(d246.Reg, &d247)
-					} else if d246.Type == tagFloat && d246.Loc == LocRegPair {
-						ctx.FreeReg(d246.Reg)
-						d247 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d246.Reg2}
-						ctx.BindReg(d246.Reg2, &d247)
-						ctx.BindReg(d246.Reg2, &d247)
-					} else {
-						d247 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d246}, 1)
-						d247.Type = tagFloat
-						ctx.BindReg(d247.Reg, &d247)
-					}
+					d247 = ctx.EmitFloatDesc(d246)
 					ctx.FreeDesc(&d246)
 					ctx.EnsureDesc(&d247)
 					ctx.EnsureDesc(&d247)
@@ -42815,23 +42591,7 @@ func init_alu() {
 				}
 				d0 := args[0]
 				d0.ID = 0
-				var d1 JITValueDesc
-				if d0.Loc == LocImm {
-					d1 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d0.Imm.Float())}
-				} else if d0.Type == tagFloat && d0.Loc == LocReg {
-					d1 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d0.Reg}
-					ctx.BindReg(d0.Reg, &d1)
-					ctx.BindReg(d0.Reg, &d1)
-				} else if d0.Type == tagFloat && d0.Loc == LocRegPair {
-					ctx.FreeReg(d0.Reg)
-					d1 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d0.Reg2}
-					ctx.BindReg(d0.Reg2, &d1)
-					ctx.BindReg(d0.Reg2, &d1)
-				} else {
-					d1 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d0}, 1)
-					d1.Type = tagFloat
-					ctx.BindReg(d1.Reg, &d1)
-				}
+				d1 := ctx.EmitFloatDesc(d0)
 				ctx.FreeDesc(&d0)
 				ctx.EnsureDesc(&d1)
 				var d2 JITValueDesc
@@ -42899,23 +42659,7 @@ func init_alu() {
 				}
 				d0 := args[0]
 				d0.ID = 0
-				var d1 JITValueDesc
-				if d0.Loc == LocImm {
-					d1 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d0.Imm.Float())}
-				} else if d0.Type == tagFloat && d0.Loc == LocReg {
-					d1 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d0.Reg}
-					ctx.BindReg(d0.Reg, &d1)
-					ctx.BindReg(d0.Reg, &d1)
-				} else if d0.Type == tagFloat && d0.Loc == LocRegPair {
-					ctx.FreeReg(d0.Reg)
-					d1 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d0.Reg2}
-					ctx.BindReg(d0.Reg2, &d1)
-					ctx.BindReg(d0.Reg2, &d1)
-				} else {
-					d1 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d0}, 1)
-					d1.Type = tagFloat
-					ctx.BindReg(d1.Reg, &d1)
-				}
+				d1 := ctx.EmitFloatDesc(d0)
 				ctx.FreeDesc(&d0)
 				ctx.EnsureDesc(&d1)
 				var d2 JITValueDesc
@@ -42983,23 +42727,7 @@ func init_alu() {
 				}
 				d0 := args[0]
 				d0.ID = 0
-				var d1 JITValueDesc
-				if d0.Loc == LocImm {
-					d1 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d0.Imm.Float())}
-				} else if d0.Type == tagFloat && d0.Loc == LocReg {
-					d1 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d0.Reg}
-					ctx.BindReg(d0.Reg, &d1)
-					ctx.BindReg(d0.Reg, &d1)
-				} else if d0.Type == tagFloat && d0.Loc == LocRegPair {
-					ctx.FreeReg(d0.Reg)
-					d1 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d0.Reg2}
-					ctx.BindReg(d0.Reg2, &d1)
-					ctx.BindReg(d0.Reg2, &d1)
-				} else {
-					d1 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d0}, 1)
-					d1.Type = tagFloat
-					ctx.BindReg(d1.Reg, &d1)
-				}
+				d1 := ctx.EmitFloatDesc(d0)
 				ctx.FreeDesc(&d0)
 				if d1.Loc == LocRegPair || d1.Loc == LocStackPair || d1.Loc == LocRegTriple || d1.Loc == LocStackTriple {
 					panic("jit: generic call arg expects 1-word value")
@@ -44101,23 +43829,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d54 = args[0]
 					d54.ID = 0
-					var d55 JITValueDesc
-					if d54.Loc == LocImm {
-						d55 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d54.Imm.Float())}
-					} else if d54.Type == tagFloat && d54.Loc == LocReg {
-						d55 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d54.Reg}
-						ctx.BindReg(d54.Reg, &d55)
-						ctx.BindReg(d54.Reg, &d55)
-					} else if d54.Type == tagFloat && d54.Loc == LocRegPair {
-						ctx.FreeReg(d54.Reg)
-						d55 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d54.Reg2}
-						ctx.BindReg(d54.Reg2, &d55)
-						ctx.BindReg(d54.Reg2, &d55)
-					} else {
-						d55 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d54}, 1)
-						d55.Type = tagFloat
-						ctx.BindReg(d55.Reg, &d55)
-					}
+					d55 = ctx.EmitFloatDesc(d54)
 					ctx.StabilizeDescForControlFlow(&d55)
 					ctx.FreeDesc(&d54)
 					ctx.EnsureDesc(&d55)
@@ -50777,23 +50489,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d23 = args[0]
 					d23.ID = 0
-					var d24 JITValueDesc
-					if d23.Loc == LocImm {
-						d24 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d23.Imm.Float())}
-					} else if d23.Type == tagFloat && d23.Loc == LocReg {
-						d24 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d23.Reg}
-						ctx.BindReg(d23.Reg, &d24)
-						ctx.BindReg(d23.Reg, &d24)
-					} else if d23.Type == tagFloat && d23.Loc == LocRegPair {
-						ctx.FreeReg(d23.Reg)
-						d24 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d23.Reg2}
-						ctx.BindReg(d23.Reg2, &d24)
-						ctx.BindReg(d23.Reg2, &d24)
-					} else {
-						d24 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d23}, 1)
-						d24.Type = tagFloat
-						ctx.BindReg(d24.Reg, &d24)
-					}
+					d24 = ctx.EmitFloatDesc(d23)
 					ctx.StabilizeDescForControlFlow(&d24)
 					ctx.FreeDesc(&d23)
 					ctx.EnsureDesc(&d24)
@@ -51951,23 +51647,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d137 = args[0]
 					d137.ID = 0
-					var d138 JITValueDesc
-					if d137.Loc == LocImm {
-						d138 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d137.Imm.Float())}
-					} else if d137.Type == tagFloat && d137.Loc == LocReg {
-						d138 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d137.Reg}
-						ctx.BindReg(d137.Reg, &d138)
-						ctx.BindReg(d137.Reg, &d138)
-					} else if d137.Type == tagFloat && d137.Loc == LocRegPair {
-						ctx.FreeReg(d137.Reg)
-						d138 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d137.Reg2}
-						ctx.BindReg(d137.Reg2, &d138)
-						ctx.BindReg(d137.Reg2, &d138)
-					} else {
-						d138 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d137}, 1)
-						d138.Type = tagFloat
-						ctx.BindReg(d138.Reg, &d138)
-					}
+					d138 = ctx.EmitFloatDesc(d137)
 					ctx.FreeDesc(&d137)
 					ctx.EnsureDesc(&d138)
 					ctx.EnsureDesc(&d1)
@@ -52649,23 +52329,7 @@ func init_alu() {
 					ctx.ReclaimUntrackedRegs()
 					d19 = args[0]
 					d19.ID = 0
-					var d20 JITValueDesc
-					if d19.Loc == LocImm {
-						d20 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d19.Imm.Float())}
-					} else if d19.Type == tagFloat && d19.Loc == LocReg {
-						d20 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d19.Reg}
-						ctx.BindReg(d19.Reg, &d20)
-						ctx.BindReg(d19.Reg, &d20)
-					} else if d19.Type == tagFloat && d19.Loc == LocRegPair {
-						ctx.FreeReg(d19.Reg)
-						d20 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d19.Reg2}
-						ctx.BindReg(d19.Reg2, &d20)
-						ctx.BindReg(d19.Reg2, &d20)
-					} else {
-						d20 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d19}, 1)
-						d20.Type = tagFloat
-						ctx.BindReg(d20.Reg, &d20)
-					}
+					d20 = ctx.EmitFloatDesc(d19)
 					ctx.StabilizeDescForControlFlow(&d20)
 					ctx.FreeDesc(&d19)
 					ctx.EnsureDesc(&d20)

--- a/scm/compare.go
+++ b/scm/compare.go
@@ -2450,21 +2450,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 			ctx.BindReg(r6, &d208)
 		}
 		ctx.FreeDesc(&d207)
-		var d209 JITValueDesc
-		if args[1].Loc == LocImm {
-			d209 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(args[1].Imm.Float())}
-		} else if args[1].Type == tagFloat && args[1].Loc == LocReg {
-			d209 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg}
-			ctx.BindReg(args[1].Reg, &d209)
-		} else if args[1].Type == tagFloat && args[1].Loc == LocRegPair {
-			ctx.FreeReg(args[1].Reg)
-			d209 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg2}
-			ctx.BindReg(args[1].Reg2, &d209)
-		} else {
-			d209 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{args[1]}, 1)
-			d209.Type = tagFloat
-			ctx.BindReg(d209.Reg, &d209)
-		}
+		d209 = ctx.EmitFloatDesc(args[1])
 		ctx.EnsureDesc(&d208)
 		resultTarget210 := false
 		_ = resultTarget210
@@ -3492,21 +3478,7 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 			ctx.BindReg(r11, &d343)
 		}
 		ctx.FreeDesc(&d342)
-		var d344 JITValueDesc
-		if args[1].Loc == LocImm {
-			d344 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(args[1].Imm.Float())}
-		} else if args[1].Type == tagFloat && args[1].Loc == LocReg {
-			d344 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg}
-			ctx.BindReg(args[1].Reg, &d344)
-		} else if args[1].Type == tagFloat && args[1].Loc == LocRegPair {
-			ctx.FreeReg(args[1].Reg)
-			d344 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg2}
-			ctx.BindReg(args[1].Reg2, &d344)
-		} else {
-			d344 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{args[1]}, 1)
-			d344.Type = tagFloat
-			ctx.BindReg(d344.Reg, &d344)
-		}
+		d344 = ctx.EmitFloatDesc(args[1])
 		ctx.EnsureDesc(&d343)
 		resultTarget345 := false
 		_ = resultTarget345
@@ -4401,36 +4373,8 @@ func jitEmitLess(ctx *JITContext, args []JITValueDesc, result JITValueDesc) JITV
 			d429 = ps.OverlayValues[429]
 		}
 		ctx.ReclaimUntrackedRegs()
-		var d430 JITValueDesc
-		if args[0].Loc == LocImm {
-			d430 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(args[0].Imm.Float())}
-		} else if args[0].Type == tagFloat && args[0].Loc == LocReg {
-			d430 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[0].Reg}
-			ctx.BindReg(args[0].Reg, &d430)
-		} else if args[0].Type == tagFloat && args[0].Loc == LocRegPair {
-			ctx.FreeReg(args[0].Reg)
-			d430 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[0].Reg2}
-			ctx.BindReg(args[0].Reg2, &d430)
-		} else {
-			d430 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{args[0]}, 1)
-			d430.Type = tagFloat
-			ctx.BindReg(d430.Reg, &d430)
-		}
-		var d431 JITValueDesc
-		if args[1].Loc == LocImm {
-			d431 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(args[1].Imm.Float())}
-		} else if args[1].Type == tagFloat && args[1].Loc == LocReg {
-			d431 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg}
-			ctx.BindReg(args[1].Reg, &d431)
-		} else if args[1].Type == tagFloat && args[1].Loc == LocRegPair {
-			ctx.FreeReg(args[1].Reg)
-			d431 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: args[1].Reg2}
-			ctx.BindReg(args[1].Reg2, &d431)
-		} else {
-			d431 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{args[1]}, 1)
-			d431.Type = tagFloat
-			ctx.BindReg(d431.Reg, &d431)
-		}
+		d430 = ctx.EmitFloatDesc(args[0])
+		d431 = ctx.EmitFloatDesc(args[1])
 		ctx.EnsureDesc(&d430)
 		resultTarget432 := false
 		_ = resultTarget432

--- a/scm/jit_storage_abi_test.go
+++ b/scm/jit_storage_abi_test.go
@@ -27,6 +27,82 @@ import (
 	"unsafe"
 )
 
+func TestJITTypedFloatConversionLocations(t *testing.T) {
+	for _, value := range []Scmer{NewInt(-7), NewInt(1<<53 + 1), NewInt(math.MinInt64), NewInt(math.MaxInt64), NewFloat(math.Copysign(0, -1)), NewFloat(math.Inf(1)), NewFloat(math.NaN()), NewFloat(1.25)} {
+		for _, location := range []string{"scalar", "pair", "stack", "stack-pair", "fp", "fp-stack"} {
+			if (location == "fp" || location == "fp-stack") && !value.IsFloat() {
+				continue
+			}
+			for _, preserve := range []bool{false, true} {
+				fn := CompileJITStorageGetValue(func(ctx *JITContext, input, target JITValueDesc) JITValueDesc {
+					input.Type = value.GetTag()
+					var bits uint64
+					if value.IsFloat() {
+						bits = math.Float64bits(value.Float())
+					} else {
+						bits = uint64(value.Int())
+					}
+					ctx.EmitMovRegImm64(input.Reg, bits)
+					if location == "fp" || location == "fp-stack" {
+						// Standalone storage emitters normally reserve only GPRs.
+						// Enable one native FP home to exercise the shared Proc path.
+						ctx.AllFPRegs = 1 << uint(RegX2)
+						ctx.FreeFPRegs = ctx.AllFPRegs
+						ctx.EnsureFPReg(&input)
+					}
+					if location == "pair" || location == "stack-pair" {
+						input = jitCopyScmerToPair(ctx, input)
+					}
+					if location == "stack" || location == "stack-pair" || location == "fp-stack" {
+						ctx.StabilizeDescForControlFlow(&input)
+					}
+					before := len(ctx.Safepoints)
+					converted := ctx.EmitFloatDesc(input)
+					if len(ctx.Safepoints) != before {
+						t.Errorf("%v/%s: typed conversion emitted a Go call", value, location)
+					}
+					if preserve {
+						ctx.FreeDesc(&converted)
+						return jitPlaceIntoPair(ctx, &input, target)
+					}
+					ctx.EmitMakeFloat(target, converted)
+					return target
+				})
+				if fn == nil {
+					t.Fatalf("%v/%s/preserve=%v: compile failed", value, location, preserve)
+				}
+				got, want := fn(0), NewFloat(value.Float())
+				if preserve {
+					want = value
+				}
+				if got != want {
+					t.Fatalf("%v/%s/preserve=%v: got %#v, want %#v", value, location, preserve, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestJITFloatConversionDynamicFallback(t *testing.T) {
+	for _, value := range []Scmer{NewInt(-7), NewFloat(1.25), NewString("12.5"), NewBool(true), NewNil()} {
+		fn := CompileJITStorageGetValue(func(ctx *JITContext, input, target JITValueDesc) JITValueDesc {
+			ctx.TrackImm(value)
+			input = jitCopyScmerToPair(ctx, JITValueDesc{Loc: LocImm, Type: value.GetTag(), Imm: value})
+			input.Type = JITTypeUnknown
+			ctx.StabilizeDescForControlFlow(&input)
+			converted := ctx.EmitFloatDesc(input)
+			ctx.EmitMakeFloat(target, converted)
+			return target
+		})
+		if fn == nil {
+			t.Fatal("dynamic conversion did not compile")
+		}
+		if got, want := fn(0), NewFloat(value.Float()); got != want {
+			t.Fatalf("%v: got %#v, want %#v", value, got, want)
+		}
+	}
+}
+
 func TestEmitCmpFloat64AvoidsDuplicateSameOperandMove(t *testing.T) {
 	code := make([]byte, 16)
 	ctx := &JITContext{

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -2138,6 +2138,47 @@ func (ctx *JITContext) EmitTagEqualsBorrowed(src *JITValueDesc, tag uint8, resul
 	return ctx.EmitTagEquals(&tmp, tag, result)
 }
 
+// EmitFloatDesc borrows a Scmer descriptor and returns raw float64 bits.
+// Known numeric types retain their conversion after spills; only unknown or
+// coercible nonnumeric values need the general runtime conversion helper.
+func (ctx *JITContext) EmitFloatDesc(src JITValueDesc) JITValueDesc {
+	ctx.SyncDesc(&src)
+	if src.Loc == LocImm {
+		return JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(src.Imm.Float())}
+	}
+	if src.Type != tagInt && src.Type != tagFloat {
+		out := ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{src}, 1)
+		out.Type = tagFloat
+		ctx.BindReg(out.Reg, &out)
+		return out
+	}
+	ctx.EnsureDesc(&src)
+	ctx.ProtectReg(src.Reg)
+	if src.Loc == LocRegPair {
+		ctx.ProtectReg(src.Reg2)
+	}
+	out := JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: ctx.AllocReg()}
+	if src.Loc == LocRegPair {
+		ctx.UnprotectReg(src.Reg2)
+	}
+	ctx.UnprotectReg(src.Reg)
+	ctx.BindReg(out.Reg, &out)
+	switch src.Loc {
+	case LocReg:
+		ctx.EmitMovRegReg(out.Reg, src.Reg)
+	case LocRegPair:
+		ctx.EmitMovRegReg(out.Reg, src.Reg2)
+	case LocFPReg:
+		ctx.EmitMovFPToGPR(out.Reg, src.Reg)
+	default:
+		panic("jit: numeric conversion requires a materialized value")
+	}
+	if src.Type == tagInt {
+		ctx.EmitCvtInt64ToFloat64(RegX0, out.Reg)
+	}
+	return out
+}
+
 // EmitBoolDesc evaluates Scmer truthiness equivalent to (Scmer).Bool().
 // It consumes src and returns a bool descriptor (LocImm or LocReg).
 // Fast paths are emitted for compile-time constants and known primitive types;

--- a/scm/list.go
+++ b/scm/list.go
@@ -67844,40 +67844,8 @@ func init_list() {
 						d304 = ps.OverlayValues[304]
 					}
 					ctx.ReclaimUntrackedRegs()
-					var d305 JITValueDesc
-					if d1.Loc == LocImm {
-						d305 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d1.Imm.Float())}
-					} else if d1.Type == tagFloat && d1.Loc == LocReg {
-						d305 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d1.Reg}
-						ctx.BindReg(d1.Reg, &d305)
-						ctx.BindReg(d1.Reg, &d305)
-					} else if d1.Type == tagFloat && d1.Loc == LocRegPair {
-						ctx.FreeReg(d1.Reg)
-						d305 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d1.Reg2}
-						ctx.BindReg(d1.Reg2, &d305)
-						ctx.BindReg(d1.Reg2, &d305)
-					} else {
-						d305 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d1}, 1)
-						d305.Type = tagFloat
-						ctx.BindReg(d305.Reg, &d305)
-					}
-					var d306 JITValueDesc
-					if d67.Loc == LocImm {
-						d306 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d67.Imm.Float())}
-					} else if d67.Type == tagFloat && d67.Loc == LocReg {
-						d306 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d67.Reg}
-						ctx.BindReg(d67.Reg, &d306)
-						ctx.BindReg(d67.Reg, &d306)
-					} else if d67.Type == tagFloat && d67.Loc == LocRegPair {
-						ctx.FreeReg(d67.Reg)
-						d306 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d67.Reg2}
-						ctx.BindReg(d67.Reg2, &d306)
-						ctx.BindReg(d67.Reg2, &d306)
-					} else {
-						d306 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d67}, 1)
-						d306.Type = tagFloat
-						ctx.BindReg(d306.Reg, &d306)
-					}
+					d305 = ctx.EmitFloatDesc(d1)
+					d306 = ctx.EmitFloatDesc(d67)
 					ctx.EnsureDesc(&d305)
 					ctx.EnsureDesc(&d306)
 					ctx.EnsureDescsTogether(&d305, &d306)
@@ -69000,23 +68968,7 @@ func init_list() {
 					_ = stackArray13
 					d14 = args[2]
 					d14.ID = 0
-					var d15 JITValueDesc
-					if d14.Loc == LocImm {
-						d15 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d14.Imm.Float())}
-					} else if d14.Type == tagFloat && d14.Loc == LocReg {
-						d15 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d14.Reg}
-						ctx.BindReg(d14.Reg, &d15)
-						ctx.BindReg(d14.Reg, &d15)
-					} else if d14.Type == tagFloat && d14.Loc == LocRegPair {
-						ctx.FreeReg(d14.Reg)
-						d15 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d14.Reg2}
-						ctx.BindReg(d14.Reg2, &d15)
-						ctx.BindReg(d14.Reg2, &d15)
-					} else {
-						d15 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d14}, 1)
-						d15.Type = tagFloat
-						ctx.BindReg(d15.Reg, &d15)
-					}
+					d15 = ctx.EmitFloatDesc(d14)
 					ctx.StabilizeDescForControlFlow(&d15)
 					ctx.FreeDesc(&d14)
 					d16 = args[2]
@@ -71109,23 +71061,7 @@ func init_list() {
 						d273 = ps.OverlayValues[273]
 					}
 					ctx.ReclaimUntrackedRegs()
-					var d274 JITValueDesc
-					if d102.Loc == LocImm {
-						d274 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d102.Imm.Float())}
-					} else if d102.Type == tagFloat && d102.Loc == LocReg {
-						d274 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d102.Reg}
-						ctx.BindReg(d102.Reg, &d274)
-						ctx.BindReg(d102.Reg, &d274)
-					} else if d102.Type == tagFloat && d102.Loc == LocRegPair {
-						ctx.FreeReg(d102.Reg)
-						d274 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d102.Reg2}
-						ctx.BindReg(d102.Reg2, &d274)
-						ctx.BindReg(d102.Reg2, &d274)
-					} else {
-						d274 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d102}, 1)
-						d274.Type = tagFloat
-						ctx.BindReg(d274.Reg, &d274)
-					}
+					d274 = ctx.EmitFloatDesc(d102)
 					ctx.EnsureDesc(&d5)
 					ctx.EnsureDesc(&d274)
 					d275 = ctx.EmitFloatBinary(&d5, &d274, JITFloatAdd)

--- a/scm/vector.go
+++ b/scm/vector.go
@@ -3112,23 +3112,7 @@ func init_vector() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					var d272 JITValueDesc
-					if d271.Loc == LocImm {
-						d272 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d271.Imm.Float())}
-					} else if d271.Type == tagFloat && d271.Loc == LocReg {
-						d272 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d271.Reg}
-						ctx.BindReg(d271.Reg, &d272)
-						ctx.BindReg(d271.Reg, &d272)
-					} else if d271.Type == tagFloat && d271.Loc == LocRegPair {
-						ctx.FreeReg(d271.Reg)
-						d272 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d271.Reg2}
-						ctx.BindReg(d271.Reg2, &d272)
-						ctx.BindReg(d271.Reg2, &d272)
-					} else {
-						d272 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d271}, 1)
-						d272.Type = tagFloat
-						ctx.BindReg(d272.Reg, &d272)
-					}
+					d272 = ctx.EmitFloatDesc(d271)
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d272)
 					ctx.FreeDesc(&d269)
@@ -3153,23 +3137,7 @@ func init_vector() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					var d276 JITValueDesc
-					if d275.Loc == LocImm {
-						d276 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d275.Imm.Float())}
-					} else if d275.Type == tagFloat && d275.Loc == LocReg {
-						d276 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d275.Reg}
-						ctx.BindReg(d275.Reg, &d276)
-						ctx.BindReg(d275.Reg, &d276)
-					} else if d275.Type == tagFloat && d275.Loc == LocRegPair {
-						ctx.FreeReg(d275.Reg)
-						d276 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d275.Reg2}
-						ctx.BindReg(d275.Reg2, &d276)
-						ctx.BindReg(d275.Reg2, &d276)
-					} else {
-						d276 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d275}, 1)
-						d276.Type = tagFloat
-						ctx.BindReg(d276.Reg, &d276)
-					}
+					d276 = ctx.EmitFloatDesc(d275)
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d276)
 					ctx.FreeDesc(&d273)
@@ -6408,23 +6376,7 @@ func init_vector() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					var d653 JITValueDesc
-					if d652.Loc == LocImm {
-						d653 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d652.Imm.Float())}
-					} else if d652.Type == tagFloat && d652.Loc == LocReg {
-						d653 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d652.Reg}
-						ctx.BindReg(d652.Reg, &d653)
-						ctx.BindReg(d652.Reg, &d653)
-					} else if d652.Type == tagFloat && d652.Loc == LocRegPair {
-						ctx.FreeReg(d652.Reg)
-						d653 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d652.Reg2}
-						ctx.BindReg(d652.Reg2, &d653)
-						ctx.BindReg(d652.Reg2, &d653)
-					} else {
-						d653 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d652}, 1)
-						d653.Type = tagFloat
-						ctx.BindReg(d653.Reg, &d653)
-					}
+					d653 = ctx.EmitFloatDesc(d652)
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d653)
 					ctx.FreeDesc(&d650)
@@ -6449,23 +6401,7 @@ func init_vector() {
 					ctx.ResolveFixups()
 					ctx.ReclaimUntrackedRegs()
 					ctx.ReclaimUntrackedRegs()
-					var d657 JITValueDesc
-					if d656.Loc == LocImm {
-						d657 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d656.Imm.Float())}
-					} else if d656.Type == tagFloat && d656.Loc == LocReg {
-						d657 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d656.Reg}
-						ctx.BindReg(d656.Reg, &d657)
-						ctx.BindReg(d656.Reg, &d657)
-					} else if d656.Type == tagFloat && d656.Loc == LocRegPair {
-						ctx.FreeReg(d656.Reg)
-						d657 = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: d656.Reg2}
-						ctx.BindReg(d656.Reg2, &d657)
-						ctx.BindReg(d656.Reg2, &d657)
-					} else {
-						d657 = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{d656}, 1)
-						d657.Type = tagFloat
-						ctx.BindReg(d657.Reg, &d657)
-					}
+					d657 = ctx.EmitFloatDesc(d656)
 					ctx.ReclaimUntrackedRegs()
 					ctx.EnsureDesc(&d657)
 					ctx.FreeDesc(&d654)

--- a/storage/scan_column_cost_bench_test.go
+++ b/storage/scan_column_cost_bench_test.go
@@ -494,14 +494,18 @@ func BenchmarkFilterBufferLocalScan(b *testing.B) {
 	if !scm.JITEnabled() {
 		b.Skip("requires JIT")
 	}
-	shard := benchmarkMapReduceFusionShard(60000)
-	cols := []string{"amount", "quantity", "factor"}
-	readers := make([]ColumnReader, len(cols))
-	emitters := make([]scm.JITStorageGetValueEmitter, len(cols))
-	for i, col := range cols {
-		storage := shard.getColumnStorageOrPanic(col, false, nil)
+	readers := make([]ColumnReader, 16)
+	emitters := make([]scm.JITStorageGetValueEmitter, len(readers))
+	valueTypes := make([]uint8, len(readers))
+	for i := range readers {
+		values := make([]scm.Scmer, 60000)
+		for row := range values {
+			values[row] = scm.NewInt(int64(row + i))
+		}
+		storage := buildStorageInt(values)
 		readers[i] = newCachedColumnReaderTx(storage, nil)
 		emitters[i] = storage.JITEmit
+		valueTypes[i] = storage.JITValueType()
 	}
 	for _, shape := range []struct {
 		name, source string
@@ -509,6 +513,7 @@ func BenchmarkFilterBufferLocalScan(b *testing.B) {
 	}{
 		{"simple", "(lambda (a) (> a 127))", 1},
 		{"arithmetic", "(lambda (a b c) (> (+ a (* b c)) 127))", 3},
+		{"distinct16", "(lambda (c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15) (and (> c0 -1) (< c1 60001) (> c2 -3) (< c3 60003) (> c4 -5) (< c5 60005) (> c6 -7) (< c7 60007) (> c8 -9) (< c9 60009) (> c10 -11) (< c11 60011) (> c12 -13) (< c13 60013) (> c14 -15) (< c15 60015)))", 16},
 	} {
 		proc := benchmarkMapReduceFusionProc(b, shape.source)
 		for _, rows := range []int{0, 1, 64, 1024, 8192, 60000} {
@@ -529,7 +534,7 @@ func BenchmarkFilterBufferLocalScan(b *testing.B) {
 					for i := range tags {
 						tags[i] = scm.JITTypeUnknown
 						if mode == "buffer-typed" || mode == "direct-typed" {
-							tags[i] = scm.TagInt
+							tags[i] = valueTypes[i]
 						}
 					}
 					b.ReportAllocs()
@@ -582,6 +587,58 @@ func BenchmarkFilterBufferLocalScan(b *testing.B) {
 				})
 			}
 		}
+	}
+}
+
+func TestFilterBufferComparisonWidths(t *testing.T) {
+	if !scm.JITEnabled() {
+		t.Skip("requires JIT")
+	}
+	for width := 1; width <= 16; width++ {
+		t.Run(fmt.Sprint(width), func(t *testing.T) {
+			params, terms := make([]string, width), make([]string, width)
+			tags := make([]uint8, width)
+			for i := range params {
+				params[i] = fmt.Sprintf("c%d", i)
+				terms[i] = fmt.Sprintf("(> c%d %d)", i, -i-1)
+				if i%2 == 1 {
+					terms[i] = fmt.Sprintf("(< c%d %d)", i, 60000+i)
+				}
+				tags[i] = scm.TagInt
+			}
+			proc := benchmarkMapReduceFusionProc(t, fmt.Sprintf("(lambda (%s) (and %s))", strings.Join(params, " "), strings.Join(terms, " ")))
+			kernel := scm.CompileJITFilterBuffer(proc.Proc(), tags)
+			if kernel == nil {
+				t.Fatal("compile failed")
+			}
+			ids := make([]uint32, 1024)
+			batch := make([]scm.Scmer, len(ids)*width)
+			var want []uint32
+			for row := range ids {
+				ids[row] = uint32(row)
+				for col := range tags {
+					batch[row*width+col] = scm.NewInt(int64(row + col))
+				}
+				if row%3 == 0 {
+					col := (row / 3) % width
+					boundary := -col - 1
+					if col%2 == 1 {
+						boundary = 60000 + col
+					}
+					batch[row*width+col] = scm.NewInt(int64(boundary))
+				} else {
+					want = append(want, uint32(row))
+				}
+			}
+			if got := kernel(ids, batch); got != len(want) {
+				t.Fatalf("got %d, want %d", got, len(want))
+			}
+			for i, id := range want {
+				if ids[i] != id {
+					t.Fatalf("row %d: got ID %d, want %d", i, ids[i], id)
+				}
+			}
+		})
 	}
 }
 

--- a/tests/performance/typed-filter-buffer.yaml
+++ b/tests/performance/typed-filter-buffer.yaml
@@ -13,6 +13,15 @@ metadata:
   isolated: true
 
 setup:
+  - sql: "DROP TABLE IF EXISTS typed_filter_wide"
+  - sql: "CREATE TABLE typed_filter_wide (c0 INT, c1 INT, c2 INT, c3 INT, c4 INT, c5 INT, c6 INT, c7 INT, c8 INT, c9 INT, c10 INT, c11 INT, c12 INT, c13 INT, c14 INT, c15 INT) ENGINE=memory"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "typed_filter_wide")
+          (map (produceN 16) (lambda (c) (concat "c" c)))
+          (map (produceN 60000) (lambda (i)
+            (map (produceN 16) (lambda (c) (+ (mod (* i i 7919) 60000) c))))))
+        (rebuild))
   - sql: "DROP TABLE IF EXISTS typed_filter_buffer"
   - sql: "CREATE TABLE typed_filter_buffer (a INT, b INT, c INT) ENGINE=memory"
   - scm: |
@@ -23,6 +32,30 @@ setup:
         (rebuild))
 
 test_cases:
+  - name: "Sixteen bound integer columns preserve comparison results"
+    sql: "SELECT COUNT(*) AS n FROM typed_filter_wide WHERE c0<c1 AND c2<c3 AND c4<c5 AND c6<c7 AND c8<c9 AND c10<c11 AND c12<c13 AND c14<c15"
+    timing_samples: 5
+    expect:
+      data: [{n: 60000}]
+  - name: "Wide integer filter and arithmetic reducer performance"
+    sql: "SELECT SUM(c0+c1*c2) AS total FROM typed_filter_wide WHERE c0<c1 AND c2<c3 AND c4<c5 AND c6<c7 AND c8<c9 AND c10<c11 AND c12<c13 AND c14<c15"
+    threshold_ms: 1000
+    performance_rows: 60000
+    # Measure the first fill, not repeated reads of the aggregate cache.
+    warmup: 0
+    timing_samples: 1
+    expect:
+      data: [{total: 74211485358000}]
+  - name: "Point aggregate stays correct"
+    sql: "SELECT SUM(a+b*c) AS total FROM typed_filter_buffer WHERE a=42"
+    timing_samples: 5
+    expect:
+      data: [{total: 48}]
+  - name: "Small range aggregate stays correct"
+    sql: "SELECT SUM(a+b*c) AS total FROM typed_filter_buffer WHERE a>=1000 AND a<1064"
+    timing_samples: 5
+    expect:
+      data: [{total: 66400}]
   - name: "Full main shard arithmetic aggregate"
     sql: "SELECT SUM(a+b*c) AS total FROM typed_filter_buffer"
     timing_samples: 5
@@ -48,4 +81,5 @@ test_cases:
     expect: {error: true}
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS typed_filter_wide"
   - sql: "DROP TABLE IF EXISTS typed_filter_buffer"

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -7490,21 +7490,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			// (Scmer).Float() — extract float64 from Scmer.
 			arg := g.vals[v.Call.Args[0].Name()]
 			dv := g.allocDesc()
-			g.emit("var %s JITValueDesc", dv)
-			g.emit("if %s.Loc == LocImm {", arg.goVar)
-			g.emit("\t%s = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(%s.Imm.Float())}", dv, arg.goVar)
-			g.emit("} else if %s.Type == tagFloat && %s.Loc == LocReg {", arg.goVar, arg.goVar)
-			g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: %s.Reg}", dv, arg.goVar)
-			g.emit("\tctx.BindReg(%s.Reg, &%s)", arg.goVar, dv)
-			g.emit("} else if %s.Type == tagFloat && %s.Loc == LocRegPair {", arg.goVar, arg.goVar)
-			g.emit("\tctx.FreeReg(%s.Reg)", arg.goVar) // free ptr, keep aux (float bits)
-			g.emit("\t%s = JITValueDesc{Loc: LocReg, Type: tagFloat, Reg: %s.Reg2}", dv, arg.goVar)
-			g.emit("\tctx.BindReg(%s.Reg2, &%s)", arg.goVar, dv)
-			g.emit("} else {")
-			g.emit("\t%s = ctx.EmitGoCallScalar(GoFuncAddr(JITScmerToFloatBits), []JITValueDesc{%s}, 1)", dv, arg.goVar)
-			g.emit("\t%s.Type = tagFloat", dv)
-			g.emit("\tctx.BindReg(%s.Reg, &%s)", dv, dv)
-			g.emit("}")
+			g.emit("%s := ctx.EmitFloatDesc(%s)", dv, arg.goVar)
 			g.vals[name] = genVal{goVar: dv, isDesc: true}
 		case "String":
 			// (Scmer).String() string — extract Go string from Scmer

--- a/tools/jitgen/main_test.go
+++ b/tools/jitgen/main_test.go
@@ -219,6 +219,22 @@ func choose(a ...Scmer) Scmer {
 	}
 }
 
+func TestFloatConversionUsesSharedTypedLowering(t *testing.T) {
+	fn := buildTestSSAFunction(t, `package sample
+type Scmer struct{}
+func (Scmer) Float() float64
+func NewFloat(float64) Scmer
+func convert(a ...Scmer) Scmer { return NewFloat(a[0].Float()) }
+`, "convert")
+	code, errMsg := generateClosure("convert", fn, nil)
+	if errMsg != "" {
+		t.Fatal(errMsg)
+	}
+	if !strings.Contains(code, "ctx.EmitFloatDesc(") || strings.Contains(code, "GoFuncAddr(JITScmerToFloatBits)") {
+		t.Fatalf("conversion bypasses shared typed lowering:\n%s", code)
+	}
+}
+
 func TestIsNaNConsumedByBranchKeepsParityFlag(t *testing.T) {
 	fn := buildTestSSAFunction(t, `package sample
 import "math"


### PR DESCRIPTION
## What and why

Follow-up to #827 and the disassembly investigation of the 60k arithmetic / 16-distinct-column cases.

- Lower `(Scmer).Float()` through one shared, borrowing `EmitFloatDesc` operation. Known integer descriptors emit the existing signed int64-to-float64 conversion; known float descriptors extract their payload, including spilled and FP-register locations. Unknown/coercible values retain the runtime helper.
- Preserve existing float-based comparison semantics, including rounding above 2^53. This is **not** an integer-CMP substitution.
- Regenerate the affected emitters with `make jitgen`; remove duplicated conversion dispatch from arithmetic, comparisons, lists and vectors.
- No new kernel caches, mutexes, storage lifetime changes or hard-coded row thresholds. Kernels remain scan-local. Startup calibration still compiles/measures the current emitter; the cost-model formula is unchanged.

## Experiments / best-of

1. **Retained:** shared typed numeric conversion.
2. **Rejected:** additionally load just the payload directly from a typed stack slot, bypassing pair materialization. It produced the same 5,406-byte kernel for this workload; its 60k median was 5,809.083 µs versus 5,835.450 µs for variant 1 (0.45%, not an established additional win). Do not add the extra specialization on this evidence.

The forced 16-column typed kernel changes from **5,766 to 5,406 bytes** (-6.24%). Disassembly has **26 → 18 CALL instructions** (including the common stack-growth call), and **8 → 16 CVTSI2SD instructions**: eight conversion helper calls are replaced with direct conversions. The fixed frame remains 336 bytes. Per-scan allocations decrease **502 → 482**. Remaining boolean helper calls, eager argument homes and generic arithmetic are not claimed to be solved.

## Manual A/B: scan-local compilation + integer storage decoding + filtering

Baseline: freshly fetched `origin/master` **50fc99d40**, also this branch's base. Both binaries use the same patched Go JIT toolchain, `GOEXPERIMENT=jit`, Ryzen 9 7900X3D, `GOMAXPROCS=1`, CPU affinity 10. No profiler/disassembly dumping during measurements. Identical extended benchmark fixture applied to the detached baseline worktree before building it.

`BenchmarkFilterBufferLocalScan`: 60k values per column, `StorageInt`, `value[row,col]=row+col`; type tags come from **JITValueType**, not SQL type names. Batches of 1,024; the kernel is compiled and disposed on **every timed scan**, with reader setup outside timing. Scalar expected results are checked. Three interleaved rounds of baseline / conversion / payload, `-test.benchtime=250ms -test.count=2`, median of six Go benchmark samples; the benchmark harness performs its usual iteration calibration. Zero rows measures compilation/setup, not steady-state execution.

| Shape | Rows examined | master µs/scan | PR µs/scan | Change |
|---|---:|---:|---:|---:|
| arithmetic | 0 | 263.552 | 261.860 | -0.6% |
| arithmetic | 1 | 269.206 | 268.291 | -0.3% |
| arithmetic | 64 | 272.551 | 270.986 | -0.6% |
| arithmetic | 1,024 | 308.854 | 306.171 | -0.9% |
| arithmetic | 8,192 | 529.596 | 523.869 | -1.1% |
| arithmetic | 60,000 | 2,102.186 | 2,089.244 | -0.6% |
| distinct16 | 0 | 320.925 | 311.242 | -3.0% |
| distinct16 | 1 | 323.675 | 311.529 | -3.8% |
| distinct16 | 64 | 332.414 | 323.448 | -2.7% |
| distinct16 | 1,024 | 496.084 | 472.081 | -4.8% |
| distinct16 | 8,192 | 1,272.129 | 1,128.598 | -11.3% |
| distinct16 | 60,000 | 6,847.566 | 5,835.450 | **-14.8%** |

These are **forced typed-kernel** measurements, not evidence that compiling is profitable for a point query. The row-zero compile cost makes that distinction especially clear. A preliminary sequence-compressed (float-valued) fixture showed essentially unchanged timings. The initial attempt incorrectly supplied integer tags to sequence storage; its failed correctness checks were discarded, and the benchmark now obtains storage-proven tags.

Reproduce the timed spectrum after building matching storage test binaries:

```sh
GOMAXPROCS=1 taskset -c 10 ./storage.test -test.run='^$' \
  -test.bench='^BenchmarkFilterBufferLocalScan/(arithmetic|distinct16)/rows=(0|1|64|1024|8192|60000)/buffer-typed$' \
  -test.benchtime=250ms -test.count=2
```

## Manual A/B: automatically selected paths

Same CPU/toolchain, three alternating A/B rounds, two 250ms samples each, median of six. These use the existing whole-scan / mapper benchmarks, not forced fusion.

| Benchmark, 60k rows | master µs | PR µs | Change |
|---|---:|---:|---:|
| ScanFilterSpectrum, arithmetic | 6,542.745 | 6,720.370 | +2.7% |
| ScanFilterExpressionCost, distinct_columns / terms=16 | 32,199.664 | 31,728.336 | -1.5% |
| MapReduceBufferedBestOf, ExpressionSum | 1,657.183 | 1,564.414 | -5.6% |

The original historical regressions used an older baseline and predominantly scalar predicate paths. This patch improves generated conversion code; it does **not** establish a fix for every historical percentage or guarantee that automatic selection uses the improved kernel.

## Manual A/B: SQL → HTTP end to end

Same binaries/CPU, separate local servers and identical fixtures from `tests/performance/typed-filter-buffer.yaml`. Each table has 60k rows. `PartitionMaxDimensions=0` on these disposable test servers keeps a single main shard. The wide fixture uses `r=(i*i*7919)%60000`, columns `cN=r+N`, verified as `StorageInt[16]`; the three-column fixture uses `(i,2,3)`. EXPLAIN, EXPLAIN IR, EXPLAIN PHYSICAL and EXPLAIN REORDER were inspected on both sides.

Two warm-up executions per query/side, then **nine alternating A/B sample groups of 20 requests each**, median of group means. Timing includes the HTTP request, SQL execution, aggregate-cache fill and response; excludes fixture creation and cache removal. Before **each** request, only the `.grp:typed_filter_*` relation identified by that query's EXPLAIN is dropped outside timing, ensuring the aggregate scans again rather than reporting a warm cached result. Every response is checked against the expected result. Default GC remains enabled.

| Query | master ms/request | PR ms/request | Change |
|---|---:|---:|---:|
| 16 bound columns, eight column-pair comparisons, COUNT | 27.277 | 24.338 | -10.8% |
| Same filter, SUM(c0+c1*c2) | 27.464 | 29.689 | **+8.1%** |
| Point: SUM(a+b*c), a=42 | 4.581 | 4.464 | -2.6% |
| 64-row indexed range: SUM(a+b*c) | 4.592 | 4.914 | **+7.0%** |
| Full shard: SUM(a+b*c) | 11.093 | 10.443 | -5.9% |
| Half-range: COUNT + SUM(a+b*c), a+0>=30000 | 15.737 | 16.807 | **+6.8%** |
| Empty filtered COUNT | 16.189 | 15.900 | -1.8% |

These noisier HTTP/cold-cache results are deliberately included, including regressions. An exploratory run with only five requests/group changed several signs (e.g. wide SUM -2.2%, point +19.0%); do not interpret small E2E differences as established wins. The robust, attributable improvement is the typed wide-filter kernel and removal of its conversion calls, not an across-the-board SQL speedup.

An explicit transaction was also tried to bypass global aggregate caching: the wide SUM returned NULL **on unmodified master as well**. That unrelated planner path was not modified here; the reported E2E measurements use the verified autocommit path above. The committed performance case uses a single cold fill, no warmup, and declares `performance_rows: 60000`.

## Validation

- JIT `go test ./scm ./storage`: pass.
- Stock `go test ./scm ./storage ./tools/jitgen`: pass.
- `make jitgen`: regenerated consistently; `git diff --check`: pass.
- Expanded typed-filter SQL suite with `PERF_TEST=1`, `--fail-fast`: **10/10 pass**, including the cold aggregate performance case.
- New conversion tests cover int64 extrema, >2^53 rounding, NaN, infinity, negative zero, scalar/pair/spilled/native-FP locations, source preservation and dynamic string/bool/nil fallback. Known-type conversion must not emit a Go safepoint/call.
- New filter tests exercise 1–16 bound columns with mixed accepting/rejecting rows and exact record-ID compaction.
- No storage format, shard synchronization, planner or dependency changes. Full integration/architecture CI runs on the PR; not yet claimed green.
