### PR TITLE
perf(optimizer): fold singleton merges to unblock native join reordering

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -185901,6 +185901,38 @@ func optimizeMerge(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Typ
 	if !ok || len(rv) < 2 {
 		return result, td
 	}
+	// Flattening a base list followed by a freshly constructed singleton is
+	// append, regardless of whether the base can be transferred. Keep the
+	// non-mutating form for borrowed bases. Besides avoiding the temporary list,
+	// this removes the general merge loop from nested native expressions.
+	// Both forms evaluate base then item exactly once before validating the
+	// base as a list. Direct list/list concatenation keeps its flattening rule
+	// below, which can eliminate the copy altogether.
+	if len(rv) == 2 {
+		if outer, ok := scmerSlice(rv[1]); ok {
+			var parts []Scmer
+			if len(outer) == 3 && scmerIsSymbol(outer[0], "list") {
+				parts = outer[1:]
+			} else if len(outer) == 5 && scmerIsSymbol(outer[0], "!list") && outer[2].IsInt() && outer[2].Int() == 2 {
+				parts = outer[3:]
+			}
+			if len(parts) == 2 {
+				base, constructed := scmerSlice(parts[0])
+				constructed = constructed && len(base) > 0 && (scmerIsSymbol(base[0], "list") || scmerIsSymbol(base[0], "!list"))
+				if item, ok := optimizedSingletonListItem(parts[1]); ok && !constructed {
+					baseType := tiZero
+					if outerType := optimizedArgumentType(argumentTypes, 1); outerType.Extra != nil && outerType.Extra.Keys != nil {
+						baseType = TypeInfoFromTD(outerType.Extra.Keys["0"])
+					}
+					length := exactOptimizedListArgumentLength(parts[0], baseType)
+					if length >= 0 {
+						length++
+					}
+					return NewSlice([]Scmer{NewSymbol("append"), parts[0], item}), descriptorWithLength(FreshAlloc, length)
+				}
+			}
+		}
+	}
 	if len(rv) == 3 && optimizedArgumentType(argumentTypes, 1).Transfer() {
 		if singleton, ok := optimizedSingletonListItem(rv[2]); ok {
 			length := UnknownLength

--- a/tests/sql/expressions/merge-singleton-append.yaml
+++ b/tests/sql/expressions/merge-singleton-append.yaml
@@ -1,0 +1,51 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "Singleton concatenation avoids intermediate lists and preserves ownership"
+setup: []
+test_cases:
+  - name: "Join source selector remains compilable with nested merge control flow"
+    scm: |
+      (if (equal? (jit? (jit join_optimizer_reorder_sources)) (jit-enabled?))
+        true (error "join source selector exhausted JIT registers"))
+  - name: "Nested merge preserves empty arms and escaped list results"
+    scm: |
+      (begin
+        (define build (jit (lambda (xs x)
+          (if (empty_list? xs) (list)
+            (list (list 'ordered (merge (list xs (list x)))))))))
+        (define results (map (produceN 100) (lambda (i) (build (list i) (+ i 1)))))
+        (if (and (equal? (build (list) 1) (list))
+                 (equal? results (map (produceN 100) (lambda (i)
+                   (list (list 'ordered (list i (+ i 1))))))))
+          true (error "nested list result or empty branch was corrupted")))
+  - name: "Nested list lengths and payloads survive repeated calls"
+    scm: |
+      (begin
+        (define build (jit (lambda (parts marker)
+          (list marker (merge parts) marker (count (merge parts))))))
+        (define results (map (produceN 100) (lambda (i)
+          (build (list (produceN i) (list "tail" nil true)) (list i "kept")))))
+        (define expected (map (produceN 100) (lambda (i)
+          (list (list i "kept") (append (produceN i) "tail" nil true)
+                (list i "kept") (+ i 3)))))
+        (if (equal? results expected) true
+          (error "spilled slice lengths or pointer-bearing siblings changed")))
+  - name: "Invalid merge item still raises an error"
+    scm: |
+      ((jit (lambda (base) (merge (list base (list 2))))) 3)
+    expect:
+      error: true
+  - name: "Singleton concatenation does not mutate a borrowed base"
+    scm: |
+      (begin
+        (define build (jit (lambda (base item)
+          (list (merge (list base (list item))) base))))
+        (define base (list 1 "two" nil))
+        (if (and
+              (equal? (build base 4) (list (list 1 "two" nil 4) (list 1 "two" nil)))
+              (equal? (build base 5) (list (list 1 "two" nil 5) (list 1 "two" nil)))
+              (equal? base (list 1 "two" nil)))
+          true (error "singleton concatenation mutated its borrowed input")))
+cleanup: []


### PR DESCRIPTION
## Summary

Fold `(merge (list base (list item)))` into the functional `(append base item)`.
The rule also recognizes the optimizer's frame-local `!list` constructor. It
does not mutate a borrowed base, reorder/evaluate arguments twice, introduce a
builtin, or change SQL planning decisions. Existing list/list flattening keeps
priority; known result lengths are retained.

This is the measured expression preventing `join_optimizer_reorder_sources`
from compiling natively: its general merge emitter exhausted the register bank.
Removing the unnecessary outer/singleton list construction and general merge
loop lets the existing JIT compile the complete procedure.

## Scope and discarded experiments

The final patch changes only the existing Scheme optimizer hook and YAML tests.
There are **no register-allocator, planner, cost-model, JIT-disable, or CI changes**.

An attempted allocator change returned sibling registers after spilling a pair
or triple. Although it made the coverage test green and improved small cases,
it regressed the existing UNION suite and crashed compilation of the large
query on the offline data copy. That experiment was discarded completely.
Register ownership, borrowed descriptor views, and deferred copies need a
separate correctness investigation; this PR does not claim to solve spilling.

## Manual A/B measurements

Baseline: `ad3b88b1c` (master including #833). Same JIT compiler, same host,
same fixtures, 3 warmups and 30 measured samples per side. Small-case samples
alternate A/B and B/A. Latencies below are medians, not best samples.

| Measurement | Master | Patch | Change |
| --- | ---: | ---: | ---: |
| Source reordering, 1,000 calls/sample | 68.92 us/call | 56.71 us/call | -17.7% |
| Scalar lookup + ordered join, entire EXPLAIN COMPILE | 1.989 ms | 1.821 ms | -8.4% |
| Nullable scalar WHERE + join, entire EXPLAIN COMPILE | 1.825 ms | 1.729 ms | -5.3% |
| Large saved search/ACL list, reordering phase | 56.174 ms | 52.559 ms | -6.4% |
| Large saved search/ACL list, entire EXPLAIN COMPILE | 200.808 ms | 200.430 ms | -0.2% |

The small SQL fixtures are the first two queries and setup from
`tests/planner/subqueries/decorrelated-join-reordering.yaml`. The isolated
function benchmark uses those document/tenant tables, two sources, an equality
join, LIMIT 72, a prebuilt query block/hypergraph and a per-sample planning
session. Each sample checks the result count from all 1,000 calls.

The large-query measurements use sequential baseline/candidate processes on
the **same offline data copy**, not the live service. Its overall median
difference is small enough to be noise: this is **not** a claim of a large
end-to-end SQL execution speedup. Total compile p95 was 234.45 -> 215.61 ms;
reorder p95 was 95.42 -> 59.77 ms, but those tails need more independent runs.
An earlier candidate run measured 199.74 ms total / 53.40 ms reorder; both
runs support treating total compile latency as effectively unchanged.
The complete physical EXPLAIN response was byte-for-byte identical (84,107
bytes); EXPLAIN COMPILE reports the same 57,328-byte physical plan.

As a control, a bare singleton-merge benchmark (10,000 calls/sample) measured
267.6 -> 274.7 ns/call (+2.6%). The gain is native reachability in the larger
function, not a demonstrated standalone-append throughput improvement.
The CI performance comparison remains enabled and unchanged.

## Tests

The new YAML suite was written before the fix. On baseline, the native
reorder-coverage assertion fails; the other four cases pass. With the patch,
all five pass, including escaped results, mixed payloads/lengths, borrowed-base
immutability, and invalid-input errors. Non-JIT builds expect interpreter
coverage instead of pretending to exercise native code.

Targeted checks include startup Scheme tests, traced UNION/scalar probes,
decorrelated join reordering, join multiplicity/NULL behavior, and callback
ownership tests. The deep-correlation suite has the same three pre-existing
noncritical failures on baseline and candidate; no expectations or criticality
were changed.

No local full-suite run: full SQL/JIT and performance A/B validation belongs to CI.
