### PR TITLE
perf(jit): cost scan-local fusion and preserve callback captures

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -727,6 +727,66 @@ type JITMapReduceBufferFunc func(Scmer, []Scmer, int) Scmer
 // are compile-time properties of the function.
 type JITFilterBufferFunc func([]uint32, []Scmer) int
 
+// JITBufferProbeSafe proves that replaying a numeric reducer cannot mutate its
+// accumulator or invoke callbacks. Const alone is insufficient: aggregate
+// containers can have ownership-based mutable implementations.
+func JITBufferProbeSafe(proc *Proc, arity int) bool {
+	if proc == nil || arity < 1 {
+		return false
+	}
+	var safe func(Scmer) bool
+	safe = func(expr Scmer) bool {
+		for expr.GetTag() == tagSourceInfo {
+			expr = expr.SourceInfo().value
+		}
+		switch expr.GetTag() {
+		case tagNil, tagInt, tagFloat:
+			return true
+		case tagNthLocalVar:
+			return int(expr.NthLocalVar()) < arity
+		case tagSymbol:
+			if proc.Params.GetTag() == tagSlice {
+				for _, param := range proc.Params.Slice() {
+					if param.GetTag() == tagSymbol && param.Symbol() == expr.Symbol() {
+						return true
+					}
+				}
+			}
+			return false
+		case tagSlice:
+			list := expr.Slice()
+			if len(list) == 0 {
+				return false
+			}
+			decl := DeclarationForValue(list[0])
+			if decl == nil || decl.RetainsCallArgs || decl.Type == nil || !decl.Type.Const || decl.Type.Return == nil {
+				return false
+			}
+			switch decl.Type.Return.Kind {
+			case "number", "number|nil", "int", "int|nil":
+			default:
+				return false
+			}
+			for _, param := range decl.Type.Params {
+				switch param.Kind {
+				case "number", "number|nil", "int", "int|nil":
+				default:
+					return false
+				}
+			}
+			for _, arg := range list[1:] {
+				if !safe(arg) {
+					return false
+				}
+			}
+			return true
+		default:
+			return false
+		}
+	}
+	return safe(proc.Body)
+}
+
 // PrepareJITBufferProc returns source suitable for typed buffer-loop inlining.
 // Native declarations with a JIT emitter are wrapped in a procedure so physical
 // operators can specialize the same implementation without teaching the

--- a/scm/jit_calibration.go
+++ b/scm/jit_calibration.go
@@ -53,6 +53,8 @@ type JITCostCalibration struct {
 	BufferCurrentNS           float64
 	BufferFusedNS             float64
 	BufferSavedNS             float64
+	BufferProbeCurrentNS      float64
+	BufferProbeFusedNS        float64
 	BufferMaxUnits            int
 	FilterBufferCompileNS     float64
 	FilterBufferCompileUnitNS float64
@@ -110,13 +112,18 @@ func (calibration JITCostCalibration) MapReduceBufferBreakEven(expressionCost, c
 	return int(math.Ceil(2 * calibration.BufferCompileNS / calibration.BufferSavedNS))
 }
 
-// MapReduceBufferProbeBreakEven bounds the one-time cost of compiling and
-// comparing an uncalibrated reducer shape to one percent of the whole scan.
+// MapReduceBufferProbeBreakEven amortizes compilation and duplicate probe work
+// against the measured buffer-loop saving, not against one percent of a scan.
 // Unlike MapReduceBufferBreakEven, this admits arbitrary callback arity and
 // expression complexity: the actual reducer decides its own best path on its
 // first representative buffer.
 func (calibration JITCostCalibration) MapReduceBufferProbeBreakEven(expressionCost, columnCount, probeRows int) int {
-	if !calibration.Enabled || expressionCost < 0 || columnCount < 0 || calibration.BufferCurrentNS <= 0 {
+	// This is admission for a bounded trial, not a promise of a speedup. A
+	// noisy complex calibration must not hide the measured opportunity to
+	// remove one callback boundary; the scan-local probe still has to repay
+	// its actual compilation cost before its kernel is retained.
+	savedNS := math.Max(calibration.DirectCallNS, calibration.BufferProbeCurrentNS-calibration.BufferProbeFusedNS)
+	if !calibration.Enabled || expressionCost < 0 || columnCount < 0 || probeRows < 0 || savedNS <= 0 {
 		return math.MaxInt
 	}
 	compileNS := calibration.BufferCompileNS
@@ -126,8 +133,8 @@ func (calibration JITCostCalibration) MapReduceBufferProbeBreakEven(expressionCo
 		}
 		compileNS += float64(expressionCost-calibration.BufferMaxUnits) * calibration.BufferCompileUnitNS
 	}
-	probeNS := float64(probeRows) * (calibration.BufferCurrentNS + calibration.BufferFusedNS)
-	return int(math.Ceil(100 * (compileNS + probeNS) / calibration.BufferCurrentNS))
+	probeNS := float64(probeRows) * calibration.BufferProbeFusedNS
+	return probeRows + int(math.Ceil(2*(compileNS+probeNS)/savedNS))
 }
 
 // FilterBufferBreakEven returns the number of rows needed to amortize a typed
@@ -181,8 +188,12 @@ func CalibrateJITCosts() JITCostCalibration {
 				return measureJITCalibrationShapes()
 			}()
 			calibration = summarizeJITCalibration(observations)
-			calibration.BufferCompileNS, calibration.BufferCurrentNS, calibration.BufferFusedNS, calibration.BufferMaxUnits = measureMapReduceBufferCalibration()
-			calibration.BufferCompileUnitNS = measureMapReduceBufferCompileUnit(calibration.BufferCompileNS, calibration.BufferMaxUnits)
+			calibration.BufferCompileNS, calibration.BufferCurrentNS, calibration.BufferFusedNS, calibration.BufferMaxUnits = measureMapReduceBufferCalibration("(lambda (acc value) (sql_sum_reduce acc value))", 1)
+			complexCompileNS, complexCurrentNS, complexFusedNS, complexUnits := measureMapReduceBufferCalibration("(lambda (acc a b c) (+ acc (+ a (* b c))))", 3)
+			calibration.BufferProbeCurrentNS, calibration.BufferProbeFusedNS = complexCurrentNS, complexFusedNS
+			if complexUnits > calibration.BufferMaxUnits {
+				calibration.BufferCompileUnitNS = math.Max(0, (complexCompileNS-calibration.BufferCompileNS)/float64(complexUnits-calibration.BufferMaxUnits))
+			}
 			calibration.BufferSavedNS = math.Max(0, calibration.BufferCurrentNS-calibration.BufferFusedNS)
 			calibration.FilterBufferCompileNS, calibration.FilterBufferCurrentNS, calibration.FilterBufferFusedNS, calibration.FilterBufferMaxUnits = measureFilterBufferCalibration()
 			calibration.FilterBufferCompileUnitNS = measureFilterBufferCompileUnit(calibration.FilterBufferCompileNS, calibration.FilterBufferMaxUnits)
@@ -276,8 +287,8 @@ func measureFilterBufferCompileUnit(simpleNS float64, simpleUnits int) float64 {
 	return math.Max(0, (medianFloat64(samples)-simpleNS)/float64(units-simpleUnits))
 }
 
-func measureMapReduceBufferCalibration() (compileNS, currentNS, fusedNS float64, expressionUnits int) {
-	template := calibrationProcedure(`(lambda (acc value) (sql_sum_reduce acc value))`)
+func measureMapReduceBufferCalibration(source string, width int) (compileNS, currentNS, fusedNS float64, expressionUnits int) {
+	template := calibrationProcedure(source)
 	compiled := CompileJIT(NewProcStruct(*cloneCalibrationProcedure(template)), true)
 	proc := compiled.Proc()
 	if proc == nil || proc.Compiled == nil {
@@ -286,34 +297,40 @@ func measureMapReduceBufferCalibration() (compileNS, currentNS, fusedNS float64,
 	expressionUnits = JITExpressionCost(proc.Body)
 	compileSamples := make([]float64, jitCalibrationSamples)
 	var fused JITMapReduceBufferFunc
+	valueTypes := make([]uint8, width)
+	for index := range valueTypes {
+		valueTypes[index] = tagInt
+	}
 	for sample := range compileSamples {
 		started := time.Now()
-		fused = CompileJITMapReduceBuffer(proc, []uint8{tagInt})
+		fused = CompileJITMapReduceBuffer(proc, valueTypes)
 		compileSamples[sample] = float64(time.Since(started).Nanoseconds())
 	}
 	if fused == nil {
 		return 0, 0, 0, 0
 	}
-	values := make([]Scmer, 16*1024)
+	const rows = 16 * 1024
+	values := make([]Scmer, rows*width)
 	for index := range values {
 		values[index] = NewInt(int64(index & 255))
 	}
 	currentSamples := make([]float64, jitCalibrationSamples)
 	fusedSamples := make([]float64, jitCalibrationSamples)
-	args := []Scmer{NewInt(0), NewInt(0)}
+	args := make([]Scmer, width+1)
 	for sample := range currentSamples {
 		started := time.Now()
 		acc := NewInt(0)
-		for _, value := range values {
-			args[0], args[1] = acc, value
+		for offset := 0; offset < len(values); offset += width {
+			args[0] = acc
+			copy(args[1:], values[offset:offset+width])
 			acc = proc.Compiled.Native(args...)
 		}
-		currentSamples[sample] = float64(time.Since(started).Nanoseconds()) / float64(len(values))
+		currentSamples[sample] = float64(time.Since(started).Nanoseconds()) / rows
 		jitCalibrationSink = acc
 
 		started = time.Now()
-		acc = fused(NewInt(0), values, len(values))
-		fusedSamples[sample] = float64(time.Since(started).Nanoseconds()) / float64(len(values))
+		acc = fused(NewInt(0), values, rows)
+		fusedSamples[sample] = float64(time.Since(started).Nanoseconds()) / rows
 		jitCalibrationSink = acc
 	}
 	compileNS = medianFloat64(compileSamples)
@@ -322,30 +339,6 @@ func measureMapReduceBufferCalibration() (compileNS, currentNS, fusedNS float64,
 	runtime.KeepAlive(compiled)
 	runtime.KeepAlive(fused)
 	return compileNS, currentNS, fusedNS, expressionUnits
-}
-
-func measureMapReduceBufferCompileUnit(simpleNS float64, simpleUnits int) float64 {
-	template := calibrationProcedure("(lambda (acc a b c) (+ acc (+ a (* b c))))")
-	compiled := CompileJIT(NewProcStruct(*cloneCalibrationProcedure(template)), true)
-	proc := compiled.Proc()
-	if proc == nil || proc.Compiled == nil {
-		return 0
-	}
-	units := JITExpressionCost(proc.Body)
-	if units <= simpleUnits {
-		return 0
-	}
-	samples := make([]float64, jitCalibrationSamples)
-	for sample := range samples {
-		started := time.Now()
-		kernel := CompileJITMapReduceBuffer(proc, []uint8{tagInt, tagInt, tagInt})
-		samples[sample] = float64(time.Since(started).Nanoseconds())
-		if kernel == nil {
-			return 0
-		}
-		runtime.KeepAlive(kernel)
-	}
-	return math.Max(0, (medianFloat64(samples)-simpleNS)/float64(units-simpleUnits))
 }
 
 // CurrentJITCosts returns a value copy so callers cannot mutate the globally

--- a/scm/jit_calibration.go
+++ b/scm/jit_calibration.go
@@ -128,7 +128,7 @@ func (calibration JITCostCalibration) MapReduceBufferProbeBreakEven(expressionCo
 	}
 	compileNS := calibration.BufferCompileNS
 	if expressionCost > calibration.BufferMaxUnits {
-		if calibration.BufferCompileUnitNS <= 0 {
+		if calibration.BufferCompileUnitNS < 0 {
 			return math.MaxInt
 		}
 		compileNS += float64(expressionCost-calibration.BufferMaxUnits) * calibration.BufferCompileUnitNS
@@ -147,7 +147,7 @@ func (calibration JITCostCalibration) FilterBufferBreakEven(expressionCost, colu
 	}
 	compileNS := calibration.FilterBufferCompileNS
 	if expressionCost > calibration.FilterBufferMaxUnits {
-		if calibration.FilterBufferCompileUnitNS <= 0 {
+		if calibration.FilterBufferCompileUnitNS < 0 {
 			return math.MaxInt
 		}
 		compileNS += float64(expressionCost-calibration.FilterBufferMaxUnits) * calibration.FilterBufferCompileUnitNS
@@ -191,6 +191,7 @@ func CalibrateJITCosts() JITCostCalibration {
 			calibration.BufferCompileNS, calibration.BufferCurrentNS, calibration.BufferFusedNS, calibration.BufferMaxUnits = measureMapReduceBufferCalibration("(lambda (acc value) (sql_sum_reduce acc value))", 1)
 			complexCompileNS, complexCurrentNS, complexFusedNS, complexUnits := measureMapReduceBufferCalibration("(lambda (acc a b c) (+ acc (+ a (* b c))))", 3)
 			calibration.BufferProbeCurrentNS, calibration.BufferProbeFusedNS = complexCurrentNS, complexFusedNS
+			calibration.BufferCompileUnitNS = -1
 			if complexUnits > calibration.BufferMaxUnits {
 				calibration.BufferCompileUnitNS = math.Max(0, (complexCompileNS-calibration.BufferCompileNS)/float64(complexUnits-calibration.BufferMaxUnits))
 			}
@@ -268,11 +269,11 @@ func measureFilterBufferCompileUnit(simpleNS float64, simpleUnits int) float64 {
 	compiled := CompileJIT(NewProcStruct(*cloneCalibrationProcedure(template)), true)
 	proc := compiled.Proc()
 	if proc == nil || proc.Compiled == nil {
-		return 0
+		return -1
 	}
 	units := JITExpressionCost(proc.Body)
 	if units <= simpleUnits {
-		return 0
+		return -1
 	}
 	samples := make([]float64, jitCalibrationSamples)
 	for sample := range samples {
@@ -280,7 +281,7 @@ func measureFilterBufferCompileUnit(simpleNS float64, simpleUnits int) float64 {
 		kernel := CompileJITFilterBuffer(proc, []uint8{tagInt, tagInt, tagInt})
 		samples[sample] = float64(time.Since(started).Nanoseconds())
 		if kernel == nil {
-			return 0
+			return -1
 		}
 		runtime.KeepAlive(kernel)
 	}

--- a/scm/jit_calibration_test.go
+++ b/scm/jit_calibration_test.go
@@ -128,6 +128,14 @@ func TestJITCalibrationFilterBufferBestOf(t *testing.T) {
 	if got := calibration.FilterBufferBreakEven(20, 0); got != math.MaxInt {
 		t.Fatalf("zero-column filter break-even = %d, want MaxInt", got)
 	}
+	calibration.FilterBufferCompileUnitNS = 0
+	if got := calibration.FilterBufferBreakEven(100, 16); got != 40 {
+		t.Fatalf("a measured flat compile slope disabled wide filters: %d", got)
+	}
+	calibration.FilterBufferCompileUnitNS = -1
+	if got := calibration.FilterBufferBreakEven(100, 16); got != math.MaxInt {
+		t.Fatalf("an unavailable compile slope admitted wide filters: %d", got)
+	}
 }
 
 func TestJITCalibrationAnchorsCallBoundaryToTrivialShapes(t *testing.T) {

--- a/scm/jit_calibration_test.go
+++ b/scm/jit_calibration_test.go
@@ -51,13 +51,15 @@ func TestJITCalibrationBreakEvenHasNoHiddenSafetyFactor(t *testing.T) {
 
 func TestJITCalibrationMapReduceBufferBestOf(t *testing.T) {
 	calibration := JITCostCalibration{
-		Enabled:             true,
-		BufferCompileNS:     100,
-		BufferCompileUnitNS: 4,
-		BufferCurrentNS:     10,
-		BufferFusedNS:       5,
-		BufferSavedNS:       2,
-		BufferMaxUnits:      40,
+		Enabled:              true,
+		BufferCompileNS:      100,
+		BufferCompileUnitNS:  4,
+		BufferCurrentNS:      10,
+		BufferFusedNS:        5,
+		BufferSavedNS:        2,
+		BufferProbeCurrentNS: 7,
+		BufferProbeFusedNS:   5,
+		BufferMaxUnits:       40,
 	}
 	if got := calibration.MapReduceBufferBreakEven(40, 1); got != 100 {
 		t.Fatalf("buffer break-even rows = %d, want 100", got)
@@ -74,6 +76,38 @@ func TestJITCalibrationMapReduceBufferBestOf(t *testing.T) {
 	}
 	if got := calibration.MapReduceBufferProbeBreakEven(80, 3, 1024); got == math.MaxInt {
 		t.Fatal("arbitrary-arity expression was not admitted for an adaptive probe")
+	}
+	// 260ns compilation + 5120ns duplicate execution, twice amortized at
+	// 2ns/row, plus the probe rows themselves. No hidden >60k floor.
+	if got := calibration.MapReduceBufferProbeBreakEven(80, 3, 1024); got != 6404 {
+		t.Fatalf("probe break-even = %d, want 6404", got)
+	}
+	calibration.BufferProbeFusedNS = 9
+	if got := calibration.MapReduceBufferProbeBreakEven(80, 3, 1024); got != math.MaxInt {
+		t.Fatal("a losing probe with no measured call saving was admitted")
+	}
+	calibration.DirectCallNS = 2
+	if got := calibration.MapReduceBufferProbeBreakEven(80, 3, 1024); got != 10500 {
+		t.Fatalf("call-boundary trial break-even = %d, want 10500", got)
+	}
+}
+
+func TestJITBufferProbeRequiresPureNumericExpression(t *testing.T) {
+	for _, test := range []struct {
+		source string
+		arity  int
+		want   bool
+	}{
+		{"(lambda (acc a b c) (+ acc (+ a (* b c))))", 4, true},
+		{"(lambda (acc a) (sql_sum_reduce acc a))", 2, true},
+		{"(lambda (acc a) (set_assoc acc a true))", 2, false},
+		{"(lambda (acc a) (begin (print a) (+ acc a)))", 2, false},
+		{"(lambda (acc a) (a acc))", 2, false},
+	} {
+		proc := calibrationProcedure(test.source)
+		if got := JITBufferProbeSafe(proc, test.arity); got != test.want {
+			t.Errorf("probe safety %s = %v, want %v; body=%s", test.source, got, test.want, String(proc.Body))
+		}
 	}
 }
 

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -2919,7 +2919,10 @@ func jitGeneratedEmitterInline(ctx *JITContext, declaration *Declaration, args [
 			inline = true
 		case declaration.Type.JITVirtualArgs && hasVirtualArgs && cost <= 32:
 			inline = true
-		case len(args) > 0 && knownTypes == len(args) && cost <= 256:
+		// Known tags do not eliminate dynamic variadic loops. Keep the
+		// generated body bounded even when every argument has a known type;
+		// larger bodies retain their native boundary inside the fused loop.
+		case len(args) > 0 && knownTypes == len(args) && cost <= 48:
 			inline = true
 		case knownShapes == len(args) && knownArgs == len(args) && cost <= 32:
 			inline = true

--- a/scm/jit_storage_abi_test.go
+++ b/scm/jit_storage_abi_test.go
@@ -38,6 +38,35 @@ func TestJITTypedInliningKeepsLargeNativeBoundaries(t *testing.T) {
 	}
 }
 
+func TestJITBufferLoopsPreserveClosureCaptures(t *testing.T) {
+	values := []Scmer{NewInt(6), NewInt(9)}
+	for _, source := range []string{
+		"(lambda (limit) (lambda (a) (> a limit)))",
+		"(lambda (limit) (lambda (unused) (lambda (a) (> a limit))))",
+	} {
+		producer := CompileJIT(NewProcStruct(*calibrationProcedure(source)), true)
+		callback := Apply(producer, NewInt(7))
+		if len(callback.Proc().Params.Slice()) == 1 && callback.Proc().Params.Slice()[0].SymbolEquals("unused") {
+			callback = Apply(callback, NewNil())
+		}
+		_, captures := callback.Proc().JITCapturedLocals()
+		if len(captures) == 0 {
+			t.Fatal("test did not produce an inline closure capture")
+		}
+		kernel := CompileJITFilterBuffer(callback.Proc(), []uint8{tagInt})
+		ids := []uint32{0, 1}
+		if kernel == nil || kernel(ids, values) != 1 || ids[0] != 1 {
+			t.Fatalf("filter lost captured limit: %s", source)
+		}
+	}
+	producer := CompileJIT(NewProcStruct(*calibrationProcedure("(lambda (factor) (lambda (acc a) (+ acc (* a factor))))")), true)
+	callback := Apply(producer, NewInt(2))
+	reduce := CompileJITMapReduceBuffer(callback.Proc(), []uint8{tagInt})
+	if reduce == nil || !Equal(reduce(NewInt(0), values, 2), NewInt(30)) {
+		t.Fatal("reducer lost captured multiplier")
+	}
+}
+
 func TestJITTypedFloatConversionLocations(t *testing.T) {
 	for _, value := range []Scmer{NewInt(-7), NewInt(1<<53 + 1), NewInt(math.MinInt64), NewInt(math.MaxInt64), NewFloat(math.Copysign(0, -1)), NewFloat(math.Inf(1)), NewFloat(math.NaN()), NewFloat(1.25)} {
 		for _, location := range []string{"scalar", "pair", "stack", "stack-pair", "fp", "fp-stack"} {

--- a/scm/jit_storage_abi_test.go
+++ b/scm/jit_storage_abi_test.go
@@ -27,6 +27,17 @@ import (
 	"unsafe"
 )
 
+func TestJITTypedInliningKeepsLargeNativeBoundaries(t *testing.T) {
+	for _, cost := range []uint16{18, 38, 48, 49, 57, 256} {
+		ctx := &JITContext{}
+		decl := &Declaration{Type: &TypeDescriptor{JITInlineCost: cost}}
+		args := []JITValueDesc{{Type: tagInt, Loc: LocStack}, {Type: tagInt, Loc: LocStack}}
+		if got := jitGeneratedEmitterInline(ctx, decl, args); got != (cost <= 48) {
+			t.Errorf("typed inline cost %d = %v", cost, got)
+		}
+	}
+}
+
 func TestJITTypedFloatConversionLocations(t *testing.T) {
 	for _, value := range []Scmer{NewInt(-7), NewInt(1<<53 + 1), NewInt(math.MinInt64), NewInt(math.MaxInt64), NewFloat(math.Copysign(0, -1)), NewFloat(math.Inf(1)), NewFloat(math.NaN()), NewFloat(1.25)} {
 		for _, location := range []string{"scalar", "pair", "stack", "stack-pair", "fp", "fp-stack"} {

--- a/scm/jit_storage_amd64.go
+++ b/scm/jit_storage_amd64.go
@@ -259,7 +259,7 @@ func emitJITFilterBuffer(ctx *JITContext, proc *Proc, valueTypes []uint8, reader
 		}
 		ctx.FreeDesc(&address)
 	}
-	predicate := JITEmitProcInline(ctx, proc, args, RegR12, JITValueDesc{Loc: LocAny})
+	predicate := jitEmitStorageProc(ctx, proc, args)
 	boolean := ctx.EmitBoolDesc(&predicate, JITValueDesc{Loc: LocAny})
 	ctx.FreeDesc(&predicate)
 	if boolean.Loc == LocImm {
@@ -315,6 +315,35 @@ func emitJITFilterBuffer(ctx *JITContext, proc *Proc, valueTypes []uint8, reader
 	ctx.EmitLoadFromStack(RegRAX, outOff)
 }
 
+// jitEmitStorageProc binds the concrete callback, not the storage emitter's
+// lexical frame. Compiled closures keep captured numbered locals in their
+// ProcJIT tail; treating those slots as fresh nil locals changes SQL filters.
+func jitEmitStorageProc(ctx *JITContext, proc *Proc, args []JITValueDesc) JITValueDesc {
+	base, captures := proc.JITCapturedLocals()
+	if len(captures) != 0 {
+		if base < len(args) {
+			panic("jit: storage callback captures overlap arguments")
+		}
+		locals := make([]JITValueDesc, base+len(captures))
+		copy(locals, args)
+		for index := len(args); index < base; index++ {
+			locals[index] = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+		}
+		for index, value := range captures {
+			ctx.TrackImm(value)
+			locals[base+index] = JITValueDesc{Loc: LocImm, Type: value.GetTag(), Imm: value}
+		}
+		args = locals
+	}
+	runtimeEnv := proc.En
+	if runtimeEnv == nil {
+		runtimeEnv = &Globalenv
+	}
+	ctx.RuntimeEnv = NewAny(runtimeEnv)
+	ctx.TrackImm(ctx.RuntimeEnv)
+	return JITEmitProcInlineWithOuter(ctx, proc, jitCapturedEnv(proc.En), args, RegR12, JITValueDesc{Loc: LocAny})
+}
+
 func emitJITMapReduceBuffer(ctx *JITContext, proc *Proc, valueTypes []uint8) {
 	// The accumulator is the loop-carried phi. Its canonical home is a rooted
 	// stack pair so calls, type changes and stack growth remain safe. Physical
@@ -366,7 +395,7 @@ func emitJITMapReduceBuffer(ctx *JITContext, proc *Proc, valueTypes []uint8) {
 		}
 		ctx.FreeDesc(&address)
 	}
-	newAccumulator := JITEmitProcInline(ctx, proc, args, RegR12, JITValueDesc{Loc: LocAny})
+	newAccumulator := jitEmitStorageProc(ctx, proc, args)
 	ctx.EmitStoreScmerToStack(newAccumulator, accumulator.StackOff)
 	ctx.FreeDesc(&newAccumulator)
 

--- a/storage/mapreduce_fusion_bench_test.go
+++ b/storage/mapreduce_fusion_bench_test.go
@@ -26,6 +26,26 @@ import (
 
 const mapReduceFusionBenchmarkRows = 1_000_000
 
+func TestJITBufferCostThresholds(t *testing.T) {
+	if !scm.JITEnabled() {
+		t.Skip("JIT")
+	}
+	costs := scm.CurrentJITCosts()
+	t.Logf("calibration %+v", costs)
+	for _, shape := range []struct {
+		source string
+		width  int
+	}{
+		{"(lambda (acc a) (+ acc a))", 1},
+		{"(lambda (acc a) (+ acc (* a 3)))", 1},
+		{"(lambda (acc a b c) (+ acc (+ a (* b c))))", 3},
+	} {
+		proc := benchmarkMapReduceFusionProc(t, shape.source)
+		units := scm.JITExpressionCost(proc.Proc().Body)
+		t.Logf("%s units=%d direct_min=%d probe_min=%d", shape.source, units, costs.MapReduceBufferBreakEven(units, shape.width), costs.MapReduceBufferProbeBreakEven(units, shape.width, defaultScanBufferSize))
+	}
+}
+
 func TestJITMapReduceBufferBestOf(t *testing.T) {
 	if !scm.JITEnabled() {
 		t.Skip("requires the JIT experiment")
@@ -59,7 +79,7 @@ func TestJITMapReduceBufferBestOf(t *testing.T) {
 		t.Fatalf("fused reduction = %s, want %d", scm.String(got), want)
 	}
 	if mapper.bufferReduceFn == nil {
-		t.Fatalf("profitable reducer did not compile after its break-even: seen=%d min=%d columns=%d kind=%d", mapper.bufferSeenRows, mapper.bufferMinRows, mapper.bufferColumnCount, mapper.mapReduceProgram.Kind)
+		t.Fatalf("profitable reducer did not compile: min=%d columns=%d kind=%d", mapper.bufferMinRows, mapper.bufferColumnCount, mapper.mapReduceProgram.Kind)
 	}
 	count := benchmarkMapReduceFusionProc(t, "(lambda (acc) (+ acc 1))")
 	countMapper := shard.OpenMapReducer(nil, count, false, 0, nil, nil)
@@ -137,6 +157,55 @@ func TestJITMapReduceBufferBestOf(t *testing.T) {
 	lifecycleMapper.Close()
 	if lifecycleMapper.mainBulkValues != nil || lifecycleMapper.bufferReduceProc != nil || lifecycleMapper.bufferValueTypes != nil {
 		t.Fatal("Close retained query-local map-reduce buffer state")
+	}
+}
+
+func TestJITMapReduceCompilationUsesRemainingRows(t *testing.T) {
+	if !scm.JITEnabled() {
+		t.Skip("requires the JIT experiment")
+	}
+	shard := benchmarkMapReduceFusionShard(60000)
+	callback := benchmarkMapReduceFusionProc(t, "(lambda (acc amount) (+ acc amount))")
+	unsafeProbe := ShardMapReducer{bufferReduceProc: callback.Proc(), bufferProbe: true, bufferMinRows: 1}
+	container := scm.NewSlice([]scm.Scmer{scm.NewInt(1)})
+	if _, processed := unsafeProbe.processJITBuffer(container, []uint32{0}); processed || !unsafeProbe.bufferRejected || unsafeProbe.bufferReduceFn != nil {
+		t.Fatal("a mutable accumulator entered the replay probe")
+	}
+	mapper := shard.OpenMapReducer([]string{"amount"}, callback, false, 0, nil, nil)
+	defer mapper.Close()
+	// Force a deterministic threshold, independent of startup timer noise.
+	mapper.bufferReduceProc = callback.Proc()
+	mapper.bufferColumnCount = 1
+	mapper.bufferMinRows = 128
+	mapper.bufferProbe = false
+	ids := make([]uint32, 64)
+	for index := range ids {
+		ids[index] = uint32(index)
+	}
+	if got := mapper.Stream(scm.NewInt(0), ids, nil); !scm.Equal(got, scm.NewInt(2080)) {
+		t.Fatal("64-row callback changed the result")
+	}
+	if mapper.bufferReduceFn != nil {
+		t.Fatal("64 candidates inherited the containing shard's 60000-row horizon")
+	}
+	mapper.bufferMinRows = 8
+	for range 16 {
+		mapper.Stream(scm.NewInt(0), []uint32{0}, nil)
+	}
+	if got := mapper.Stream(scm.NewInt(0), []uint32{0}, nil); !scm.Equal(got, scm.NewInt(1)) {
+		t.Fatal("last-batch callback changed the result")
+	}
+	if mapper.bufferReduceFn != nil {
+		t.Fatal("already processed rows justified a last-batch compilation")
+	}
+	mapper.bufferRemainingRows = 60000
+	mapper.Stream(scm.NewInt(0), []uint32{0}, nil)
+	if mapper.bufferReduceFn == nil {
+		t.Fatal("known remaining work did not enable early compilation")
+	}
+	mapper.Close()
+	if mapper.bufferReduceFn != nil || mapper.bufferReduceProc != nil || mapper.mainBulkValues != nil {
+		t.Fatal("scan-local specialization survived Close")
 	}
 }
 
@@ -297,8 +366,8 @@ func BenchmarkMapReduceBufferedBestOf(b *testing.B) {
 	if !scm.JITEnabled() {
 		b.Skip("requires the JIT experiment")
 	}
-	shard := benchmarkMapReduceFusionShard(mapReduceFusionBenchmarkRows)
-	recids := make([]uint32, mapReduceFusionBenchmarkRows)
+	shard := benchmarkMapReduceFusionShard(60000)
+	recids := make([]uint32, 60000)
 	for index := range recids {
 		recids[index] = uint32(index)
 	}
@@ -316,29 +385,53 @@ func BenchmarkMapReduceBufferedBestOf(b *testing.B) {
 	}
 	for _, shape := range shapes {
 		callback := benchmarkMapReduceFusionProc(b, shape.source)
-		for _, rowCount := range []int{1, 8, 1_024, 60_000, mapReduceFusionBenchmarkRows} {
-			for _, bestOf := range []bool{false, true} {
-				mode := "Baseline"
-				if bestOf {
-					mode = "BestOf"
-				}
+		for _, rowCount := range []int{0, 1, 64, 1024, 8192, 60000} {
+			for _, mode := range []string{"Baseline", "BestOf", "Forced"} {
 				b.Run(fmt.Sprintf("%s/Rows%d/%s", shape.name, rowCount, mode), func(b *testing.B) {
 					b.ReportAllocs()
 					b.ReportMetric(float64(rowCount), "rows/op")
 					var result scm.Scmer
+					fusedScans := 0
+					want := shape.neutral
+					args := make([]scm.Scmer, len(shape.cols)+1)
+					for _, id := range recids[:rowCount] {
+						args[0] = want
+						for col, name := range shape.cols {
+							args[col+1] = shard.getColumnStorageOrPanic(name, false, nil).GetValue(id)
+						}
+						want = scm.Apply(callback, args...)
+					}
+					b.ResetTimer()
 					for sample := 0; sample < b.N; sample++ {
 						mapper := shard.OpenMapReducer(shape.cols, callback, false, 0, nil, nil)
-						if !bestOf {
+						if mode == "Baseline" {
 							mapper.bufferReduceProc = nil
+						}
+						if mode == "Forced" {
+							mapper.bufferReduceProc = callback.Proc()
+							mapper.bufferMinRows = 0
+							mapper.bufferColumnCount = len(shape.cols)
+							mapper.bufferProbe = false
 						}
 						result = shape.neutral
 						for offset := 0; offset < rowCount; offset += defaultScanBufferSize {
 							end := min(offset+defaultScanBufferSize, rowCount)
+							mapper.bufferRemainingRows = rowCount - offset
 							result = mapper.Stream(result, recids[offset:end], nil)
 						}
+						if mode == "Forced" && rowCount > 0 && mapper.bufferReduceFn == nil {
+							b.Fatal("forced kernel did not compile")
+						}
+						if mapper.bufferReduceFn != nil && !mapper.bufferRejected {
+							fusedScans++
+						}
 						mapper.Close()
+						if !scm.Equal(result, want) {
+							b.Fatal("incorrect fused result")
+						}
 					}
 					runtime.KeepAlive(result)
+					b.ReportMetric(float64(fusedScans)/float64(b.N), "fused/op")
 				})
 			}
 		}

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -2365,6 +2365,13 @@ func (t *storageShard) scan(access scanAccess, conditionCols []string, condition
 					locked = false
 				}
 				outCount += int64(outN)
+				if access.len() == 0 && candidateCount > 0 {
+					// Full scans have a known candidate horizon. Estimate accepted
+					// remaining rows from observed selectivity; index/RecSet scans
+					// must not use the population of the containing shard.
+					remaining := max(int64(0), int64(mapper.mainCount)-candidateCount)
+					mapper.bufferRemainingRows = outN + int(remaining*outCount/candidateCount)
+				}
 				akkumulator = mapper.Stream(akkumulator, batch[:outN], nil)
 				hadValue = true
 				if !skipShardReadLock {

--- a/storage/scan_column_cost_bench_test.go
+++ b/storage/scan_column_cost_bench_test.go
@@ -517,7 +517,7 @@ func BenchmarkFilterBufferLocalScan(b *testing.B) {
 	} {
 		proc := benchmarkMapReduceFusionProc(b, shape.source)
 		for _, rows := range []int{0, 1, 64, 1024, 8192, 60000} {
-			for _, mode := range []string{"lambda", "buffer-dynamic", "buffer-typed", "direct-typed"} {
+			for _, mode := range []string{"lambda", "buffer-dynamic", "buffer-mixed", "buffer-typed", "direct-typed"} {
 				b.Run(fmt.Sprintf("%s/rows=%d/%s", shape.name, rows, mode), func(b *testing.B) {
 					ids := make([]uint32, defaultScanBufferSize)
 					args := make([]scm.Scmer, shape.width)
@@ -533,7 +533,7 @@ func BenchmarkFilterBufferLocalScan(b *testing.B) {
 					tags := make([]uint8, shape.width)
 					for i := range tags {
 						tags[i] = scm.JITTypeUnknown
-						if mode == "buffer-typed" || mode == "direct-typed" {
+						if mode == "buffer-typed" || mode == "direct-typed" || (mode == "buffer-mixed" && i%2 == 0) {
 							tags[i] = valueTypes[i]
 						}
 					}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1609,28 +1609,27 @@ type ShardMapReducer struct {
 	isBreak            []bool // true for $break column
 	hasBreakCol        bool
 	// tagClosure hoisted fn ptrs — allocated once per mapper, reused per row
-	setClosureFn       []*func(uint32, ...scm.Scmer) scm.Scmer // per $set col
-	incrClosureFn      []*func(uint32, ...scm.Scmer) scm.Scmer // per $increment col
-	invClosureFn       []*func(uint32, ...scm.Scmer) scm.Scmer // per $invalidate col
-	noopClosureFn      *func(uint32, ...scm.Scmer) scm.Scmer   // shared noop
-	breakClosureFn     *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
-	args               []scm.Scmer                             // pre-allocated [accumulator, column...] buffer
-	mapProgram         scm.SerialProc
-	mapReduceProgram   scm.SerialProc
-	mapReduceScmer     scm.Scmer // original Scmer for network serialization
-	bufferReduceProc   *scm.Proc // source retained for a profitable typed main-buffer specialization
-	bufferReduceFn     scm.JITMapReduceBufferFunc
-	bufferValueTypes   []uint8
-	bufferColumnCount  int
-	bufferMinRows      int
-	bufferSeenRows     int
-	bufferProbe        bool
-	bufferRejected     bool
-	bufferProbeCount   int
-	bufferProbeFused   int64
-	bufferProbeCurrent int64
-	deleteBatch        *triggerBatch // when set, DELETE triggers are batched instead of per-row
-	deletedRows        uint64        // applied DELETEs, published once when the mapper flushes
+	setClosureFn      []*func(uint32, ...scm.Scmer) scm.Scmer // per $set col
+	incrClosureFn     []*func(uint32, ...scm.Scmer) scm.Scmer // per $increment col
+	invClosureFn      []*func(uint32, ...scm.Scmer) scm.Scmer // per $invalidate col
+	noopClosureFn     *func(uint32, ...scm.Scmer) scm.Scmer   // shared noop
+	breakClosureFn    *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
+	args              []scm.Scmer                             // pre-allocated [accumulator, column...] buffer
+	mapProgram        scm.SerialProc
+	mapReduceProgram  scm.SerialProc
+	mapReduceScmer    scm.Scmer // original Scmer for network serialization
+	bufferReduceProc  *scm.Proc // source retained for a profitable typed main-buffer specialization
+	bufferReduceFn    scm.JITMapReduceBufferFunc
+	bufferValueTypes  []uint8
+	bufferColumnCount int
+	bufferMinRows     int
+	// Scan-local estimate including the current batch. Zero means that only
+	// this batch is known; never infer remaining work from shard population.
+	bufferRemainingRows int
+	bufferProbe         bool
+	bufferRejected      bool
+	deleteBatch         *triggerBatch // when set, DELETE triggers are batched instead of per-row
+	deletedRows         uint64        // applied DELETEs, published once when the mapper flushes
 	// Batched side effects: collected during scan, flushed after lock release.
 	// $increment calls are aggregated per (proxy, recid) → one update per unique target.
 	incrementBatch  map[*StorageComputeProxy]map[uint32]scm.Scmer // proxy → recid → accumulated delta
@@ -1737,7 +1736,7 @@ func (m *ShardMapReducer) prepareJITBufferReducer() {
 	minimumRows := costs.MapReduceBufferBreakEven(expressionCost, len(m.mainCols))
 	probe := minimumRows == math.MaxInt
 	if probe {
-		minimumRows = costs.MapReduceBufferProbeBreakEven(expressionCost, len(m.mainCols), 3*defaultScanBufferSize)
+		minimumRows = costs.MapReduceBufferProbeBreakEven(expressionCost, len(m.mainCols), defaultScanBufferSize)
 	}
 	if minimumRows > int(m.mainCount) {
 		return
@@ -2168,9 +2167,29 @@ func (m *ShardMapReducer) processJITBuffer(acc scm.Scmer, recids []uint32) (scm.
 	if m.bufferReduceProc == nil || m.bufferRejected {
 		return acc, false
 	}
-	m.bufferSeenRows += len(recids)
-	if m.bufferReduceFn == nil && m.bufferSeenRows >= m.bufferMinRows {
+	remaining := max(len(recids), m.bufferRemainingRows)
+	var compileNS int64
+	if m.bufferReduceFn == nil && remaining >= m.bufferMinRows {
+		if m.bufferProbe {
+			// Do not walk the expression or validate replay types for short
+			// scans that cannot amortize a compilation in the first place.
+			if (!acc.IsNil() && !acc.IsInt() && !acc.IsFloat()) || !scm.JITBufferProbeSafe(m.bufferReduceProc, m.bufferColumnCount+1) {
+				m.bufferRejected = true
+				return acc, false
+			}
+			for _, valueType := range m.bufferValueTypes {
+				if valueType != scm.NewInt(0).GetTag() && valueType != scm.NewFloat(0).GetTag() {
+					m.bufferRejected = true
+					return acc, false
+				}
+			}
+		}
+		started := time.Now()
 		m.bufferReduceFn = scm.CompileJITMapReduceBuffer(m.bufferReduceProc, m.bufferValueTypes)
+		compileNS = time.Since(started).Nanoseconds()
+		if m.bufferReduceFn == nil {
+			m.bufferRejected = true
+		}
 	}
 	if m.bufferReduceFn == nil {
 		return acc, false
@@ -2182,26 +2201,23 @@ func (m *ShardMapReducer) processJITBuffer(acc scm.Scmer, recids []uint32) (scm.
 		started = time.Now()
 		current := m.reducePreparedBuffer(acc, len(recids))
 		currentNS := time.Since(started).Nanoseconds()
-		m.bufferProbeCount++
-		m.bufferProbeFused += fusedNS
-		m.bufferProbeCurrent += currentNS
-		if !scm.Equal(fused, current) {
+		if fused.GetTag() != current.GetTag() || !scm.Equal(fused, current) {
 			m.bufferRejected = true
 			m.bufferProbe = false
 			m.bufferReduceFn = nil
 			return current, true
 		}
-		if m.bufferProbeCount < 3 {
-			return current, true
-		}
-		if m.bufferProbeFused*100 >= m.bufferProbeCurrent*98 {
+		// The startup model admits the trial; this actual expression must also
+		// repay compilation and duplicate work over the remaining accepted rows.
+		savedNS := float64(currentNS-fusedNS) / float64(len(recids))
+		if fusedNS*100 >= currentNS*98 || savedNS*float64(remaining-len(recids)) <= 2*float64(compileNS+fusedNS) {
 			m.bufferRejected = true
 			m.bufferProbe = false
 			m.bufferReduceFn = nil
 			return current, true
 		}
 		m.bufferProbe = false
-		return fused, true
+		return current, true
 	}
 	acc = m.bufferReduceFn(acc, m.mainBulkValues, len(recids))
 	runtime.KeepAlive(m.bufferReduceProc)
@@ -2302,6 +2318,7 @@ func (m *ShardMapReducer) Stream(acc scm.Scmer, recids []uint32, batchids []uint
 			} else {
 				acc = m.processMainBlockBatch(acc, recids[i:j], batchids[i:j])
 			}
+			m.bufferRemainingRows = max(0, m.bufferRemainingRows-(j-i))
 		} else {
 			for j < n && recids[j] >= m.mainCount {
 				j++

--- a/tests/performance/typed-filter-buffer.yaml
+++ b/tests/performance/typed-filter-buffer.yaml
@@ -61,6 +61,14 @@ test_cases:
     timing_samples: 5
     expect:
       data: [{total: 1800330000}]
+  - name: "One batch range aggregate"
+    sql: "SELECT SUM(a+b*c) AS total FROM typed_filter_buffer WHERE a>=0 AND a<1024"
+    expect:
+      data: [{total: 529920}]
+  - name: "Medium range aggregate"
+    sql: "SELECT SUM(a+b*c) AS total FROM typed_filter_buffer WHERE a>=0 AND a<8192"
+    expect:
+      data: [{total: 33599488}]
   - name: "Residual filter before arithmetic aggregate"
     sql: "SELECT COUNT(*) AS n, SUM(a+b*c) AS total FROM typed_filter_buffer WHERE a+0 >= 30000"
     timing_samples: 5
@@ -70,6 +78,17 @@ test_cases:
     sql: "SELECT COUNT(*) AS n FROM typed_filter_buffer WHERE a+0 < 0"
     expect:
       data: [{n: 0}]
+  - name: "Uncached arithmetic aggregate performance"
+    setup:
+      # Invalidate the aggregate previously filled by correctness cases.
+      - sql: "UPDATE typed_filter_buffer SET b=4 WHERE a=0"
+    sql: "SELECT SUM(a+b*c) AS total FROM typed_filter_buffer"
+    threshold_ms: 1000
+    performance_rows: 60000
+    warmup: 0
+    timing_samples: 1
+    expect:
+      data: [{total: 1800330006}]
   - name: "Add delta row"
     sql: "INSERT INTO typed_filter_buffer (a,b,c) VALUES (60000,2,3)"
   - name: "Main and delta use the same predicate semantics"


### PR DESCRIPTION
## Summary

Developed in `.worktrees/jit-fusion-potential`, based on current master `ce26bfb3d`. This is a new PR.

- Bound the common generated, fully typed inlining policy by `JITInlineCost` (48 units instead of 256), without an operator-name blacklist. Larger native calls remain inside the fused loop; storage type information is retained.
- Decide reducer compilation from remaining accepted work, not rows already processed. Full scans supply an observed-selectivity estimate; index/RecSet/other callers without a horizon only count their current batch. Small requests do not inherit their containing shard's population.
- Replace the unreachable >307,200-row probe floor with compile/probe amortization. Startup calibration measures both simple SUM and three-column arithmetic. The measured removable callback boundary also admits a trial when the complex timing difference is noisy. The actual callback must then repay compilation plus duplicate execution with a 2x reserve over the remaining rows.
- Only replay proven pure numeric reducers with scalar accumulators and numeric storage inputs. Defer that expression analysis until the row-cost test passes. Reject failed compilation once; no repeated attempts, scan caches, or new synchronization.
- Distinguish a measured flat compile-cost slope (`0`) from unavailable calibration (`-1`). A smaller complex emitter must not silently disable complex filters.
- Preserve concrete ProcJIT capture-tail values and lexical environments in both filter and mapreduce buffer kernels. The SQL end-to-end measurement exposed a previously hidden failure: a captured group key became a nil local, so an activated wide filter returned zero rows. Forced closure regression tests cover filters, nested captures and reducers.
- Keep buffers and specialization references scan-local and release them in `Close`. Delta execution is unchanged.

## Manual A/B (before PR creation)

Baseline: master `ce26bfb3d`; proposed: `41cc680b7`. Same patched Go JIT toolchain (`84fe25ee45468f5e3920c11c24e2bbb926fc3a72`), Ryzen 9 7900X3D, `GOMAXPROCS=1`, CPU affinity 10. Separate HTTP servers and private data directories; only `memcp-tests` fixtures are modified.

SQL fixture: `tests/performance/typed-filter-buffer.yaml`, 60,000 rows, including 16 bound integer columns and `SUM(a+b*c)`. Two warmups, nine alternating A/B batches of 20 requests per query; report the median batch mean. Drop only the matching test aggregate-cache table before each timed request (drop excluded from timing), so results measure scan/cache fill rather than a warm aggregate lookup. SQL parsing/planning, execution, allocation/GC and HTTP roundtrip are included. Result rows are checked on every request; EXPLAIN, IR, PHYSICAL and REORDER are recorded for both variants. `PartitionMaxDimensions=0` is set for both measurement instances.

Complete SQL results (milliseconds, negative is faster):

| SQL case | master | PR | change |
|---|---:|---:|---:|
| 16-column comparison filter / COUNT | 46.932 | 37.660 | -19.8% |
| 16-column filter / three-column arithmetic SUM | 52.342 | 41.360 | -21.0% |
| Point arithmetic aggregate | 25.056 | 25.451 | +1.6% |
| 64-row range aggregate | 27.131 | 26.142 | -3.6% |
| Full 60k arithmetic aggregate | 36.288 | 36.483 | +0.5% |
| 1024-row range aggregate | 28.167 | 28.031 | -0.5% |
| 8192-row range aggregate | 28.072 | 28.800 | +2.6% |
| Residual filter / COUNT and SUM | 40.948 | 40.863 | -0.2% |
| Empty filtered aggregate | 31.308 | 31.159 | -0.5% |

All nine queries returned the expected rows throughout this run. The wide-filter improvements are visible end-to-end; the standalone SUM gain is not established in this loaded-host SQL run. Earlier exploration results are not substituted for final-branch measurements. Host load is variable, so small differences should not be interpreted as established speedups.

### Scan-level confirmation

Matched benchmark instrumentation on both sides, including the `fused/op` counter. Baseline uses the same benchmark functions/fixtures but omits the new remaining-row hint assignment. A/B/B/A order, two samples of 500ms per process: four samples per variant. Medians in microseconds, including scan-local compilation, gather/decoder work and teardown (fixture construction and startup calibration excluded):

| Case | master | PR | change |
|---|---:|---:|---:|
| `acc += a+b*c`, 64 candidates, automatic selection | 5.928 | 5.864 | -1.1% |
| `acc += a+b*c`, 60k candidates, automatic selection | 1620.967 | 1264.594 | -22.0% |
| Arithmetic filter, 60k, typed buffer kernel | 2144.613 | 1617.793 | -24.6% |
| Unchanged 16-column comparison kernel, 60k, typed buffer | 6020.337 | 6131.010 | +1.8% |

Both variants compile **zero** specialized kernels for the 64-row reducer. The small difference there is not evidence of a speedup. An earlier large microbenchmark discrepancy disappeared when the instrumentation was made identical; those unmatched numbers are not used here. Earlier SQL repeats put the 64-row end-to-end difference at +12.3% and +5.7%; the final complete run is -3.6%. That variability must not be attributed to a fusion that is not selected.

### Complete 0–60k investigation grid

Same fixtures and instrumentation, A/B/B/A with one 100ms sample per process (two samples per variant). This broader grid is exploratory; the selected cases above have longer confirmation samples. All outputs are checked. Expression reducer medians in microseconds:

| Candidates | master automatic | PR automatic | PR forced fusion |
|---:|---:|---:|---:|
| 0 | 0.641 | 0.652 | 0.653 |
| 1 | 3.886 | 3.599 | 20.210 |
| 64 | 6.133 | 6.064 | 22.767 |
| 1024 | 35.409 | 33.330 | 47.248 |
| 8192 | 239.923 | 238.602 | 189.930 |
| 60000 | 1616.569 | 1240.399 | 1212.454 |

The zero-row forced case does not compile: no batch is executed. At 8192 rows forced fusion wins in this fixture, but the automatic policy conservatively keeps the direct loop because compilation **plus the extra replay probe** has to amortize. This is a documented remaining opportunity, not a claim of an exact universal crossover.

Other 60k automatic reducers from the same grid:

| Shape | master µs | PR µs | change |
|---|---:|---:|---:|
| COUNT | 500.676 | 433.678 | -13.4% |
| SUM | 558.623 | 495.257 | -11.3% |
| `acc += a*3` | 1210.207 | 948.947 | -21.6% |
| `acc += a*b` | 1480.723 | 1044.135 | -29.5% |

Final-branch filter alternatives, 60k rows, milliseconds including per-scan compilation:

| Filter | Lambda calls | Dynamic buffer | Half-known types | Typed buffer | Direct storage fusion |
|---|---:|---:|---:|---:|---:|
| Simple comparison | 1.106 | 0.726 | 0.466 | 0.467 | 0.515 |
| `a+b*c` comparison | 2.250 | 1.682 | 1.711 | 1.577 | 1.696 |
| 16 bound columns | 13.428 | 11.074 | 8.600 | 6.256 | 7.978 |

The half-known variant intentionally erases every second column's type fact. Direct storage fusion inlines the getters into the filter loop; it is not lazily decoding columns along short-circuit branches. It does not beat typed buffers in this set, so this PR does not add a blanket full-fusion switch. The grid covers five reducer shapes, three filter shapes and 0/1/64/1024/8192/60000 candidates. The SQL table separately covers actual point/range access; a short sequential ID list alone is not presented as an indexed SQL query.

## Validation and limits

- JIT Go tests: `go test ./scm ./storage` passed after the capture fix.
- Targeted SQL/performance suite: 13/13 passed, including full arithmetic, 1/64/1024/8192-row candidate cases, empty output, main+delta and invalid binding.
- Regression tests cover remaining-row decisions, no compilation for 64 candidates in a 60k shard, scalar-only replay, flat/unavailable calibration, closure capture preservation, and scan-local teardown.
- Full integration suite was delegated to CI as requested. **All nine checks are green**, including Go, JIT Go, SQL, JIT SQL (with dump/restore), performance A/B, packaging, S3/recovery and both policy checks.
- This is a bounded cost heuristic plus a scan-local timing trial, not an oracle or a claim that every query is faster. A rejected trial still costs time; selectivity can change after the observed prefix. Direct storage/filter fusion is retained as a measured alternative, not enabled merely because a shard has 60k rows. Unknown storage types and unproved callback shapes retain conservative paths.

Raw local evidence: `/tmp/jit-fusion-e2e-capture.log`, `/tmp/jit-fusion-capture-go.log`, `/tmp/jit-fusion-capture-sql.log`, `/tmp/jit-fusion-complete-{1,2,3,4}-{cost-base,bestof}.log`, `/tmp/jit-fusion-confirmed-{1,2,3,4}-{cost-base,bestof}.log`. The final SQL driver is `/tmp/jit-values-e2e.py`. Production binaries: master SHA256 `0a401438d5805fd2b3b7869c3f515d02d3c15aa9d017de58ce943436f3b8cc3e`, PR `674cbb520cc2f27fa77706f7010b2ca5eadeeae0f5134ffb7d1e19d042b40620`.
