### PR TITLE
fix(storage): recover index-build panics and protect shared blobs

### DIFF
--- a/storage/blob-refcount.go
+++ b/storage/blob-refcount.go
@@ -177,7 +177,13 @@ func (db *database) IncrBlobRefcount(hash string) {
 }
 
 // DecrBlobRefcount decrements the reference count for a blob hash in db.`.blobs`.
-// If the count reaches 0, the row is deleted and the blob file is removed.
+// If the count reaches 0, only the operational counter row is deleted.
+// A counter can undercount committed owners after a crash or an interrupted
+// lifecycle update. It is therefore NEVER authority to delete payload data.
+// CleanDatabase reclaims unowned files using the complete committed-generation
+// manifests under persistenceLifecycle. Do not scan those manifests here:
+// callers can already hold schema/shard lifecycle locks, and doing so would
+// introduce lock inversions as well as a full catalog walk per decrement.
 func (db *database) DecrBlobRefcount(hash string) {
 	defer db.lockBlobRef(hash)()
 	state := db.blobRefState()
@@ -220,15 +226,10 @@ func (db *database) DecrBlobRefcount(hash string) {
 	})
 
 	aggr := sumProc()
-	result := t.scan(
+	t.scan(
 		nil, newScanAccessSchema(scanAccessConsumerScan, nil, -1), nil,
 		[]string{"hash"}, blobCondition(hashVal),
 		[]string{"refcount", "$update"}, callback,
 		scm.NewInt(0), aggr, false,
 	)
-
-	// If row was deleted (RC was <=1), remove the blob file
-	if scm.ToInt(result) > 0 && db.persistence != nil {
-		db.persistence.DeleteBlob(hash)
-	}
 }

--- a/storage/blob_refcount_test.go
+++ b/storage/blob_refcount_test.go
@@ -468,6 +468,8 @@ func TestBlobDeleteRowsAndRebuild(t *testing.T) {
 
 	// Rebuild: old shard (3 blobs) replaced by new shard (1 blob: longA)
 	Rebuild(true, true)
+	// Reclamation requires committed-generation evidence, not an RC decrement.
+	CleanDatabase(db)
 
 	// Only blob A should remain
 	if n := countBlobFiles(t, "tdb4"); n != 1 {
@@ -547,8 +549,9 @@ func TestBlobDropTableReleasesBlobs(t *testing.T) {
 		t.Fatalf("expected 3 blob refs before drop, got %d", len(refs))
 	}
 
-	// Drop table should release blob refcounts and delete blob files
+	// Drop retires ownership; only generation-based cleanup may delete files.
 	DropTable("tdb2", "docs", false)
+	CleanDatabase(db)
 
 	if n := countBlobFiles(t, "tdb2"); n != 0 {
 		t.Fatalf("expected 0 blob files after drop, got %d", n)
@@ -642,8 +645,9 @@ func TestBlobSharedAcrossTables(t *testing.T) {
 		t.Fatalf("t2 content after t1 drop: expected %d, got %d", len(shared), readLen)
 	}
 
-	// Drop second table: blobs should be deleted
+	// Drop second table, then reclaim the now-unowned files by generation proof.
 	DropTable("tdb3", "t2", false)
+	CleanDatabase(db)
 
 	if n := countBlobFiles(t, "tdb3"); n != 0 {
 		t.Fatalf("after dropping both tables: expected 0 blob files, got %d", n)
@@ -859,6 +863,7 @@ func TestOverlayBlobLoadedReferenceLifecycle(t *testing.T) {
 		t.Fatal("v1 release removed legacy owner's blob")
 	}
 	legacy.ReleaseBlobs(1) // Known build/migration ownership is unambiguous.
+	CleanDatabase(db)
 	if countBlobFiles(t, "gcdb") != 0 {
 		t.Fatal("last known owner failed to release blob")
 	}

--- a/storage/index.go
+++ b/storage/index.go
@@ -1035,6 +1035,22 @@ func (s *StorageIndex) fullScan(maxInsertIndex int, buf []uint32, matchers []Ind
 // cols must contain value getters for each index column in order.
 // The caller must hold s.mu.Lock() or have exclusive access.
 func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx *TxContext) {
+	// A reader, comparator or hook may panic (for example on a missing blob).
+	// Never publish or retain a partially constructed index as usable state.
+	// The caller owns mu throughout construction and failure cleanup.
+	complete := false
+	state.active = false
+	defer func() {
+		if !complete {
+			state.mainIndexes = StorageInt{}
+			state.mainIndexPositions = StorageInt{}
+			state.deltaBtree = nil
+			state.minVals, state.maxVals = nil, nil
+			state.indexHooks = nil
+			state.indexHookBytes.Store(0)
+			state.computedRevisions = nil
+		}
+	}()
 	startRevisions := s.computedRevisionsRLocked()
 	if !s.Native {
 		// main storage: build sort-order index
@@ -1229,6 +1245,7 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 	endRevisions := s.computedRevisionsRLocked()
 	state.computedRevisions = endRevisions
 	state.active = sameComputedRevisions(startRevisions, endRevisions)
+	complete = true
 }
 
 // buildMainIndexPositionsLocked lazily constructs the inverse of mainIndexes
@@ -1727,8 +1744,12 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, indexBoundsValu
 				s.mu.Unlock()
 				goto start_scan
 			}
-			s.buildIndex(state, cols, tx)
-			s.mu.Unlock()
+			func() {
+				// Error propagation must not strand the shared index mutex:
+				// every later scan snapshots state under this same lock.
+				defer s.mu.Unlock()
+				s.buildIndex(state, cols, tx)
+			}()
 			// register with CacheManager
 			GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeIndex, indexCleanup, indexLastUsed, indexGetScore)
 		}

--- a/tests/storage/formats/blob-undercount-recovery.yaml
+++ b/tests/storage/formats/blob-undercount-recovery.yaml
@@ -1,0 +1,34 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "An undercounted blob must survive retirement of another owner"
+setup:
+  - sql: "DROP TABLE IF EXISTS blob_owner_a"
+  - sql: "DROP TABLE IF EXISTS blob_owner_b"
+  - sql: "CREATE TABLE blob_owner_a (id INT, payload TEXT)"
+  - sql: "CREATE TABLE blob_owner_b (id INT, payload TEXT)"
+  - sql: "INSERT INTO blob_owner_a VALUES (1, REPEAT('A', 6000)), (2, REPEAT('B', 6000)), (3, REPEAT('C', 6000))"
+  - sql: "INSERT INTO blob_owner_b SELECT * FROM blob_owner_a"
+  - scm: '(rebuild (table "memcp-tests" "blob_owner_a") true false)'
+  - scm: '(rebuild (table "memcp-tests" "blob_owner_b") true false)'
+test_cases:
+  - name: "Fixture has externally stored payloads with two owners"
+    sql: "SELECT COUNT(*) AS n FROM `.blobs` WHERE hash IN ('f5ddb39412a9924f220f6c16749f0ca53083cf2aa56c4e4ca3d8994141bee964','344edcc59c0872f3a6dff5edd2a586226d0f11faf6dcee6783d3a91dcbfe072b','1658327e53de73a559075f5a4edf9784fd1930cde3ea4f0db91367910f3a57ce') AND refcount >= 2"
+    expect:
+      data: [{n: 3}]
+  - name: "Simulate stale operational counters for only this fixture"
+    sql: "UPDATE `.blobs` SET refcount = 1 WHERE hash IN ('f5ddb39412a9924f220f6c16749f0ca53083cf2aa56c4e4ca3d8994141bee964','344edcc59c0872f3a6dff5edd2a586226d0f11faf6dcee6783d3a91dcbfe072b','1658327e53de73a559075f5a4edf9784fd1930cde3ea4f0db91367910f3a57ce')"
+  - name: "Retire one warm owner"
+    sql: "DROP TABLE blob_owner_a"
+  - name: "Surviving owner retains every payload despite stale counters"
+    sql: "SELECT id, payload = REPEAT(CASE id WHEN 1 THEN 'A' WHEN 2 THEN 'B' ELSE 'C' END, 6000) AS intact FROM blob_owner_b ORDER BY id"
+    expect:
+      data: [{id: 1, intact: true}, {id: 2, intact: true}, {id: 3, intact: true}]
+  - name: "Repeated payload reads remain intact"
+    sql: "SELECT id, LENGTH(payload) AS bytes FROM blob_owner_b ORDER BY id"
+    expect:
+      data: [{id: 1, bytes: 6000}, {id: 2, bytes: 6000}, {id: 3, bytes: 6000}]
+cleanup:
+  - sql: "DROP TABLE IF EXISTS blob_owner_a"
+  - sql: "DROP TABLE IF EXISTS blob_owner_b"

--- a/tests/storage/indexes/index-build-panic-recovery.yaml
+++ b/tests/storage/indexes/index-build-panic-recovery.yaml
@@ -1,0 +1,42 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "Failed index construction releases ownership and permits retry"
+setup:
+  - sql: "DROP TABLE IF EXISTS index_panic_rows"
+  - sql: "CREATE TABLE index_panic_rows (id INT, value INT) ENGINE=memory"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "index_panic_rows") '("id" "value")
+          (map (produceN 128) (lambda (i) (list i (- 128 i)))))
+        (rebuild (table "memcp-tests" "index_panic_rows") true false))
+test_cases:
+  - name: "Repeated column-read failures do not poison the index lock"
+    timeout: 10
+    scm: |
+      (begin
+        (define fail (newsession))
+        (fail "enabled" true)
+        (createcolumn (table "memcp-tests" "index_panic_rows")
+          "computed_value" "INT" '() (list "temp" true "filtercols" (list) "filter" (lambda () false))
+          '("value") (lambda (value)
+            (if (and (fail "enabled") (equal? value 64))
+              (error "intentional index column failure") value)))
+        (define access (compile_scan_access '() (lambda () true)))
+        (define query (lambda ()
+          (scan_order nil (table "memcp-tests" "index_panic_rows")
+            (car access) (cadr access) '() (lambda () true)
+            '("computed_value") '(<) 0 0 3 '("id")
+            (lambda (acc id) (+ acc id)) 0 false)))
+        (define failures (reduce (produceN 4) (lambda (n i)
+          (+ n (try (lambda () (begin (query) 0)) (lambda (e) 1)))) 0))
+        (fail "enabled" false)
+        (if (and (equal? failures 4) (equal? (query) 378) (equal? (query) 378))
+          true (error "index retry lost rows or swallowed a build failure")))
+  - name: "Rows remain intact after failed index construction"
+    sql: "SELECT COUNT(*) AS n, SUM(id) AS total FROM index_panic_rows"
+    expect:
+      data: [{n: 128, total: 8128}]
+cleanup:
+  - sql: "DROP TABLE IF EXISTS index_panic_rows"


### PR DESCRIPTION
## Summary

Fix two independently reproduced storage failures:

* A column read can panic while an auto-index is built. The index mutex previously remained locked, so later scans waited forever. Release it on unwinding and discard partial build state; preserve the original error and permit a clean retry.
* Operational blob refcounts can undercount committed owners. Dropping one owner previously deleted a shared payload when the counter reached zero. Decrements now retire only the counter row. Physical reclamation belongs exclusively to the existing committed-generation cleanup proof.

No planner/cost-model changes, no suppression of missing-blob errors, and no return-NULL fallback.

## Regression evidence

New permanent YAML tests, written before their respective fixes:

* `index-build-panic-recovery.yaml`: on the master binary the retry times out after 10 seconds; fixed binary passes repeated injected failures followed by correct successful reads. The error is injected through a computed-column reader used by the ordinary ordered auto-index path, not a new production fault hook.
* `blob-undercount-recovery.yaml`: three externally stored payloads are shared by two tables. After deliberately undercounting only those hashes and dropping one table, the unfixed implementation raises `OverlayBlob: missing blob`. The fixed implementation retains all three exact values.

Both suites pass with the ordinary and JIT builds. Existing warm-index-hook consumer YAML: 8/8. Targeted existing blob lifecycle and cleanup Go tests pass.

The existing file-reclamation tests retain their exact assertions; they now explicitly invoke `CleanDatabase` after owner retirement, reflecting the intentional contract that a counter decrement is not deletion authority. Reclamation is deferred, not disabled. This may retain orphaned payloads until cleanup runs.

Full SQL/JIT/performance suites are delegated to CI; no local full-suite run and no relaxed test expectations or timing thresholds.

## Incident attribution

The lock leak and undercount data-loss mechanism are reproducible. They do not prove which historical operation removed a particular payload from an external deployment. Missing payloads must be restored from hash-verified copies separately; this patch cannot recreate lost contents.
