### PR TITLE
feat: add explicit metadata-only blob inventory audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,31 @@ another column's blob. Generation-based cleanup can reclaim these retained blobs
 once no active or recoverable generation references them. Version 1 has no such
 ambiguity, including for hashes beginning with `!`.
 
+### Explicit blob inventory check
+
+Run `(blob_inventory "my_database")` in the administrative Scheme interface to
+compare committed blob references with backend object names. The result is an
+association list with `referenced_blobs`, `listed_blobs`, `unreferenced_blobs`
+(counts), and a sorted `missing_blobs` list of hashes. An empty missing list means
+all discovered references were listed; it does not prove payload readability,
+checksums, or integrity. Legacy ambiguous references are conservative candidates.
+Incomplete generation metadata or backend listing errors raise an error instead
+of returning a partial success report.
+
+The audit does not fetch blob payloads, delete objects, repair reference counts,
+or publish legacy manifest backfills. It is explicit maintenance, not part of
+startup cleanup or ordinary queries. It reads generation manifests (or reconstructs references from committed column
+files for legacy generations) and traverses the backend listing once (filesystem traversal, paginated S3 listing, or Ceph
+object iteration). Ceph may enumerate the wider pool before prefix filtering.
+Memory grows with the reference set and reported missing hashes. The database's
+lifecycle lock prevents concurrent publication and cleanup during the audit;
+rebuilds, backend migration, and some DDL can wait, and resource contention can
+indirectly affect queries. Schedule large inventories accordingly.
+
+Automatic cleanup continues to delete only objects proven unreferenced by all
+active generations. It does not run this availability audit. A missing live blob
+does not prevent collecting a separate, proven-unreferenced object.
+
 ### Storage failure notifications
 
 Administrators can register named Scheme callbacks for persistence failures.

--- a/storage/blob-refcount.go
+++ b/storage/blob-refcount.go
@@ -177,7 +177,10 @@ func (db *database) IncrBlobRefcount(hash string) {
 }
 
 // DecrBlobRefcount decrements the reference count for a blob hash in db.`.blobs`.
-// If the count reaches 0, the row is deleted and the blob file is removed.
+// If the count reaches 0, remove only the operational row. Its absence makes
+// the blob a cleanup candidate, never a deletion proof: counts can lag committed
+// owners after a crash. CleanDatabase alone may delete the file after checking
+// all active generations under the publication barrier.
 func (db *database) DecrBlobRefcount(hash string) {
 	defer db.lockBlobRef(hash)()
 	state := db.blobRefState()
@@ -220,15 +223,10 @@ func (db *database) DecrBlobRefcount(hash string) {
 	})
 
 	aggr := sumProc()
-	result := t.scan(
+	t.scan(
 		nil, newScanAccessSchema(scanAccessConsumerScan, nil, -1), nil,
 		[]string{"hash"}, blobCondition(hashVal),
 		[]string{"refcount", "$update"}, callback,
 		scm.NewInt(0), aggr, false,
 	)
-
-	// If row was deleted (RC was <=1), remove the blob file
-	if scm.ToInt(result) > 0 && db.persistence != nil {
-		db.persistence.DeleteBlob(hash)
-	}
 }

--- a/storage/blob_refcount_test.go
+++ b/storage/blob_refcount_test.go
@@ -469,6 +469,9 @@ func TestBlobDeleteRowsAndRebuild(t *testing.T) {
 	// Rebuild: old shard (3 blobs) replaced by new shard (1 blob: longA)
 	Rebuild(true, true)
 
+	// Physical deletion waits for the complete generation ownership check.
+	CleanDatabase(db)
+
 	// Only blob A should remain
 	if n := countBlobFiles(t, "tdb4"); n != 1 {
 		t.Fatalf("after delete+rebuild: expected 1 blob file, got %d", n)
@@ -547,8 +550,9 @@ func TestBlobDropTableReleasesBlobs(t *testing.T) {
 		t.Fatalf("expected 3 blob refs before drop, got %d", len(refs))
 	}
 
-	// Drop table should release blob refcounts and delete blob files
+	// Drop releases counts; cleanup proves the files are unowned.
 	DropTable("tdb2", "docs", false)
+	CleanDatabase(db)
 
 	if n := countBlobFiles(t, "tdb2"); n != 0 {
 		t.Fatalf("expected 0 blob files after drop, got %d", n)
@@ -642,8 +646,9 @@ func TestBlobSharedAcrossTables(t *testing.T) {
 		t.Fatalf("t2 content after t1 drop: expected %d, got %d", len(shared), readLen)
 	}
 
-	// Drop second table: blobs should be deleted
+	// Drop second table, then collect the now-unowned blobs.
 	DropTable("tdb3", "t2", false)
+	CleanDatabase(db)
 
 	if n := countBlobFiles(t, "tdb3"); n != 0 {
 		t.Fatalf("after dropping both tables: expected 0 blob files, got %d", n)
@@ -859,6 +864,10 @@ func TestOverlayBlobLoadedReferenceLifecycle(t *testing.T) {
 		t.Fatal("v1 release removed legacy owner's blob")
 	}
 	legacy.ReleaseBlobs(1) // Known build/migration ownership is unambiguous.
+	if countBlobFiles(t, "gcdb") != 1 {
+		t.Fatal("last decrement deleted blob before ownership check")
+	}
+	CleanDatabase(db)
 	if countBlobFiles(t, "gcdb") != 0 {
 		t.Fatal("last known owner failed to release blob")
 	}

--- a/storage/gc.go
+++ b/storage/gc.go
@@ -61,6 +61,10 @@ func CleanDatabase(db *database) (blobsDeleted, shardsDeleted int) {
 func cleanBlobs(db *database) int {
 	references, complete := activeBlobReferences(db)
 	if !complete {
+		fmt.Printf("blob cleanup %s: ownership check incomplete; retaining all blobs\n", db.Name)
+		return 0
+	}
+	if !checkReferencedBlobFiles(db, references) {
 		return 0
 	}
 
@@ -73,6 +77,26 @@ func cleanBlobs(db *database) int {
 		}
 	})
 	return deleted
+}
+
+// Check the reverse direction too: every committed reference must have a file.
+// This checks availability, not payload integrity, and never loads/decompresses
+// payloads. Continue after missing files so one run reports the entire inventory.
+// The caller holds persistenceLifecycle exclusively throughout the check.
+func checkReferencedBlobFiles(db *database, references map[string]struct{}) bool {
+	complete := true
+	for hash := range references {
+		reader := db.persistence.ReadBlob(hash)
+		if readErr, failed := reader.(ErrorReader); failed {
+			complete = false
+			fmt.Printf("blob cleanup %s: referenced blob %s unavailable: %v\n", db.Name, hash, readErr.e)
+		}
+		if err := reader.Close(); err != nil {
+			complete = false
+			fmt.Printf("blob cleanup %s: referenced blob %s close failed: %v\n", db.Name, hash, err)
+		}
+	}
+	return complete
 }
 
 func activeBlobReferences(db *database) (map[string]struct{}, bool) {

--- a/storage/gc.go
+++ b/storage/gc.go
@@ -59,12 +59,9 @@ func CleanDatabase(db *database) (blobsDeleted, shardsDeleted int) {
 // safe. Missing legacy manifests are reconstructed from committed column files;
 // corrupt manifests and all ambiguous I/O failures remain a fail-closed no-op.
 func cleanBlobs(db *database) int {
-	references, complete := activeBlobReferences(db)
+	references, complete := activeBlobReferences(db, true)
 	if !complete {
 		fmt.Printf("blob cleanup %s: ownership check incomplete; retaining all blobs\n", db.Name)
-		return 0
-	}
-	if !checkReferencedBlobFiles(db, references) {
 		return 0
 	}
 
@@ -79,27 +76,53 @@ func cleanBlobs(db *database) int {
 	return deleted
 }
 
-// Check the reverse direction too: every committed reference must have a file.
-// This checks availability, not payload integrity, and never loads/decompresses
-// payloads. Continue after missing files so one run reports the entire inventory.
-// The caller holds persistenceLifecycle exclusively throughout the check.
-func checkReferencedBlobFiles(db *database, references map[string]struct{}) bool {
-	complete := true
-	for hash := range references {
-		reader := db.persistence.ReadBlob(hash)
-		if readErr, failed := reader.(ErrorReader); failed {
-			complete = false
-			fmt.Printf("blob cleanup %s: referenced blob %s unavailable: %v\n", db.Name, hash, readErr.e)
-		}
-		if err := reader.Close(); err != nil {
-			complete = false
-			fmt.Printf("blob cleanup %s: referenced blob %s close failed: %v\n", db.Name, hash, err)
-		}
-	}
-	return complete
+// BlobInventory describes listed objects, not payload readability or integrity.
+// Missing hashes are sorted for deterministic diagnostics. An incomplete scan
+// raises an error instead of returning a potentially misleading partial report.
+type BlobInventory struct {
+	Referenced   int
+	Listed       int
+	Unreferenced int
+	Missing      []string
 }
 
-func activeBlobReferences(db *database) (map[string]struct{}, bool) {
+// AuditBlobInventory is an explicit maintenance operation. It reads generation
+// metadata and lists object names, never fetching blob payloads or deleting data.
+// The exclusive lifecycle capability keeps publication and cleanup out of the
+// snapshot. Ordinary row reads/writes do not participate in this lock.
+func AuditBlobInventory(db *database) BlobInventory {
+	db.ensureLoaded()
+	db.persistenceLifecycle.Lock()
+	defer db.persistenceLifecycle.Unlock()
+	references, complete := activeBlobReferences(db, false)
+	if !complete {
+		panic("blob inventory: incomplete generation references for database " + db.Name)
+	}
+	result := BlobInventory{Referenced: len(references)}
+	// Keep the reference set intact: repeated backend listings must not turn a
+	// live object into an apparent orphan. The bool only records whether seen.
+	seen := make(map[string]bool, len(references))
+	for hash := range references {
+		seen[hash] = false
+	}
+	db.persistence.WalkBlobs(func(hash string) {
+		result.Listed++
+		if _, live := seen[hash]; live {
+			seen[hash] = true
+		} else {
+			result.Unreferenced++
+		}
+	})
+	for hash, present := range seen {
+		if !present {
+			result.Missing = append(result.Missing, hash)
+		}
+	}
+	sort.Strings(result.Missing)
+	return result
+}
+
+func activeBlobReferences(db *database, persistManifests bool) (map[string]struct{}, bool) {
 	db.schemalock.RLock()
 	defer db.schemalock.RUnlock()
 	references := make(map[string]struct{})
@@ -117,7 +140,7 @@ func activeBlobReferences(db *database) (map[string]struct{}, bool) {
 				if !readErr.Missing() {
 					return nil, false
 				}
-				legacyReferences, ok := backfillBlobManifest(shard)
+				legacyReferences, ok := backfillBlobManifest(shard, persistManifests)
 				if !ok {
 					return nil, false
 				}
@@ -167,8 +190,9 @@ func readBlobManifest(reader io.ReadCloser) (map[string]struct{}, bool) {
 // backfillBlobManifest upgrades one legacy active generation without loading
 // blob payloads or forcing a rebuild. It inspects only committed column files,
 // deserializes reference-bearing OverlayBlob/compute-proxy columns, and then
-// publishes the same checksummed manifest used by new generations.
-func backfillBlobManifest(shard *storageShard) (references map[string]struct{}, ok bool) {
+// optionally publishes the same checksummed manifest used by new generations.
+// Explicit inventory audits only inspect metadata and do not publish a backfill.
+func backfillBlobManifest(shard *storageShard, persistManifest bool) (references map[string]struct{}, ok bool) {
 	if shard == nil || shard.t == nil || shard.t.schema == nil {
 		return nil, false
 	}
@@ -209,7 +233,7 @@ func backfillBlobManifest(shard *storageShard) (references map[string]struct{}, 
 		}
 		appendColumnBlobReferences(storage, references, count)
 	}
-	if !tryWriteBlobManifestReferences(shard, references) {
+	if persistManifest && !tryWriteBlobManifestReferences(shard, references) {
 		return nil, false
 	}
 	return references, true

--- a/storage/gc_test.go
+++ b/storage/gc_test.go
@@ -598,3 +598,114 @@ func TestBlobManifestSurvivesUnchangedColdRebuild(t *testing.T) {
 		t.Fatalf("cold rebuild lost %d live blobs", deleted)
 	}
 }
+
+// A crash may leave the operational count below the number of committed owners.
+// Releasing one owner must never remove another owner's payload.
+func TestBlobUndercountRetainsCommittedOwners(t *testing.T) {
+	for _, scenario := range []string{"shared", "restart", "rebuild", "failed-publication"} {
+		t.Run(scenario, func(t *testing.T) {
+			defer setupGCTest(t)()
+			CreateDatabase("gcdb", false)
+			payloads := []string{strings.Repeat("a", maxInlineBlobBytes+1), strings.Repeat("b", maxInlineBlobBytes+1), strings.Repeat("c", maxInlineBlobBytes+1)}
+			for _, name := range []string{"first", "second"} {
+				tbl, _ := CreateTable("gcdb", name, Safe, false)
+				tbl.CreateColumn("id", "INT", nil, nil)
+				tbl.CreateColumn("content", "TEXT", nil, nil)
+				insertLongRows(t, tbl, payloads)
+			}
+			db := GetDatabase("gcdb")
+			for hash, count := range queryBlobsTable(t, db) {
+				if count != 2 {
+					t.Fatalf("fixture count = %d, want 2", count)
+				}
+				db.DecrBlobRefcount(hash)
+			}
+			if scenario == "restart" {
+				Rebuild(true, true)
+				databases.Remove("gcdb")
+				LoadDatabases()
+				db = GetDatabase("gcdb")
+				db.ensureLoaded()
+			}
+			if scenario == "rebuild" {
+				Rebuild(true, true)
+			}
+			if scenario == "failed-publication" {
+				persistence := db.persistence
+				failing := &failSchemaWritePersistence{PersistenceEngine: persistence, failAt: 1}
+				db.persistence = failing
+				tbl := db.tables.Get("second")
+				tbl.Insert([]string{"id", "content"}, [][]scm.Scmer{{scm.NewInt(4), scm.NewString(payloads[0])}}, nil, scm.NewNil(), false, nil)
+				result := Rebuild(true, true)
+				db.persistence = persistence
+				if !strings.Contains(result, "schema publication failure") {
+					t.Fatalf("missing injected failure: %s", result)
+				}
+			}
+			DropTable("gcdb", "first", false)
+			if got := len(blobFiles(t, "gcdb")); got != 3 {
+				t.Fatalf("decrement deleted committed blobs: got %d, want 3", got)
+			}
+			if deleted, _ := CleanDatabase(db); deleted != 0 {
+				t.Fatalf("cleanup deleted %d owned blobs", deleted)
+			}
+			references, complete := activeBlobReferences(db)
+			if !complete || len(references) != 3 {
+				t.Fatalf("references = %v, complete = %v", references, complete)
+			}
+			for _, payload := range payloads {
+				hash := fmt.Sprintf("%x", sha256.Sum256([]byte(payload)))
+				reader := db.persistence.ReadBlob(hash)
+				value, ok := gunzipReader(reader)
+				reader.Close()
+				if !ok || value.String() != payload {
+					t.Fatalf("surviving payload %s unreadable", hash)
+				}
+			}
+			DropTable("gcdb", "second", false)
+			if got := len(blobFiles(t, "gcdb")); got != 3 {
+				t.Fatalf("drop deleted blobs before ownership check: %d", got)
+			}
+			if deleted, _ := CleanDatabase(db); deleted != 3 {
+				t.Fatalf("cleanup deleted %d orphans, want 3", deleted)
+			}
+		})
+	}
+}
+
+func TestCleanReportsMissingReferencesAndRetainsOrphans(t *testing.T) {
+	defer setupGCTest(t)()
+	CreateDatabase("gcdb", false)
+	tbl, _ := CreateTable("gcdb", "docs", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("content", "TEXT", nil, nil)
+	insertLongRows(t, tbl, []string{strings.Repeat("x", maxInlineBlobBytes+1), strings.Repeat("y", maxInlineBlobBytes+1), strings.Repeat("z", maxInlineBlobBytes+1)})
+	db := GetDatabase("gcdb")
+	references, complete := activeBlobReferences(db)
+	if !complete || len(references) != 3 {
+		t.Fatal("incomplete fixture")
+	}
+	if !checkReferencedBlobFiles(db, references) {
+		t.Fatal("healthy inventory rejected")
+	}
+	for hash := range references {
+		db.persistence.DeleteBlob(hash)
+	}
+	orphan := strings.Repeat("ab", 32)
+	writer := db.persistence.WriteBlob(orphan)
+	if _, err := writer.Write([]byte("orphan")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if checkReferencedBlobFiles(db, references) {
+		t.Fatal("missing referenced blobs accepted")
+	}
+	if deleted, _ := CleanDatabase(db); deleted != 0 {
+		t.Fatalf("deleted %d blobs with incomplete inventory", deleted)
+	}
+	if got := len(blobFiles(t, "gcdb")); got != 1 {
+		t.Fatalf("orphan not retained: %d files", got)
+	}
+}

--- a/storage/gc_test.go
+++ b/storage/gc_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -649,7 +650,7 @@ func TestBlobUndercountRetainsCommittedOwners(t *testing.T) {
 			if deleted, _ := CleanDatabase(db); deleted != 0 {
 				t.Fatalf("cleanup deleted %d owned blobs", deleted)
 			}
-			references, complete := activeBlobReferences(db)
+			references, complete := activeBlobReferences(db, true)
 			if !complete || len(references) != 3 {
 				t.Fatalf("references = %v, complete = %v", references, complete)
 			}
@@ -673,7 +674,27 @@ func TestBlobUndercountRetainsCommittedOwners(t *testing.T) {
 	}
 }
 
-func TestCleanReportsMissingReferencesAndRetainsOrphans(t *testing.T) {
+// Audits must work even on backends whose ReadBlob eagerly loads the payload.
+type inventoryMetadataOnlyPersistence struct {
+	PersistenceEngine
+	failList bool
+}
+
+func (p *inventoryMetadataOnlyPersistence) ReadBlob(string) io.ReadCloser {
+	panic("inventory fetched payload")
+}
+func (p *inventoryMetadataOnlyPersistence) WriteColumn(string, string) io.WriteCloser {
+	panic("inventory wrote column metadata")
+}
+func (p *inventoryMetadataOnlyPersistence) DeleteBlob(string) { panic("inventory deleted blob") }
+func (p *inventoryMetadataOnlyPersistence) WalkBlobs(fn func(string)) {
+	if p.failList {
+		panic("injected inventory listing failure")
+	}
+	p.PersistenceEngine.WalkBlobs(fn)
+}
+
+func TestBlobInventoryListsMissingReferencesWithoutFetchingPayloads(t *testing.T) {
 	defer setupGCTest(t)()
 	CreateDatabase("gcdb", false)
 	tbl, _ := CreateTable("gcdb", "docs", Safe, false)
@@ -681,15 +702,36 @@ func TestCleanReportsMissingReferencesAndRetainsOrphans(t *testing.T) {
 	tbl.CreateColumn("content", "TEXT", nil, nil)
 	insertLongRows(t, tbl, []string{strings.Repeat("x", maxInlineBlobBytes+1), strings.Repeat("y", maxInlineBlobBytes+1), strings.Repeat("z", maxInlineBlobBytes+1)})
 	db := GetDatabase("gcdb")
-	references, complete := activeBlobReferences(db)
+	references, complete := activeBlobReferences(db, true)
 	if !complete || len(references) != 3 {
 		t.Fatal("incomplete fixture")
 	}
-	if !checkReferencedBlobFiles(db, references) {
-		t.Fatal("healthy inventory rejected")
+	backend := db.persistence
+	db.persistence = &inventoryMetadataOnlyPersistence{PersistenceEngine: backend}
+	report := AuditBlobInventory(db)
+	if report.Referenced != 3 || report.Listed != 3 || len(report.Missing) != 0 || report.Unreferenced != 0 {
+		t.Fatalf("healthy inventory: %+v", report)
+	}
+	if deleted, _ := CleanDatabase(db); deleted != 0 {
+		t.Fatalf("cleanup deleted %d live blobs", deleted)
+	}
+	// Missing legacy manifests are discovered without publishing a backfill.
+	for _, shard := range tbl.ActiveShards() {
+		backend.RemoveColumn(shard.uuid.String(), blobManifestColumn)
+	}
+	legacy := AuditBlobInventory(db)
+	if legacy.Referenced != 3 || len(legacy.Missing) != 0 {
+		t.Fatalf("legacy inventory: %+v", legacy)
+	}
+	for _, shard := range tbl.ActiveShards() {
+		reader := backend.ReadColumn(shard.uuid.String(), blobManifestColumn)
+		reader.Close()
+		if missing, ok := reader.(ErrorReader); !ok || !missing.Missing() {
+			t.Fatal("audit published legacy manifest")
+		}
 	}
 	for hash := range references {
-		db.persistence.DeleteBlob(hash)
+		backend.DeleteBlob(hash)
 	}
 	orphan := strings.Repeat("ab", 32)
 	writer := db.persistence.WriteBlob(orphan)
@@ -699,13 +741,87 @@ func TestCleanReportsMissingReferencesAndRetainsOrphans(t *testing.T) {
 	if err := writer.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if checkReferencedBlobFiles(db, references) {
-		t.Fatal("missing referenced blobs accepted")
+	report = AuditBlobInventory(db)
+	if report.Referenced != 3 || report.Listed != 1 || len(report.Missing) != 3 || report.Unreferenced != 1 {
+		t.Fatalf("damaged inventory: %+v", report)
 	}
-	if deleted, _ := CleanDatabase(db); deleted != 0 {
-		t.Fatalf("deleted %d blobs with incomplete inventory", deleted)
+	for _, hash := range report.Missing {
+		if _, expected := references[hash]; !expected {
+			t.Fatalf("unexpected missing hash %s", hash)
+		}
 	}
-	if got := len(blobFiles(t, "gcdb")); got != 1 {
-		t.Fatalf("orphan not retained: %d files", got)
+	if len(blobFiles(t, "gcdb")) != 1 {
+		t.Fatal("audit deleted the orphan")
+	}
+	db.persistence = backend
+	if deleted, _ := CleanDatabase(db); deleted != 1 {
+		t.Fatalf("cleanup retained an unowned blob because another file is missing: deleted %d", deleted)
+	}
+	if got := len(blobFiles(t, "gcdb")); got != 0 {
+		t.Fatalf("orphan not collected: %d files", got)
+	}
+}
+
+func TestBlobInventoryRejectsIncompleteSnapshotsAndReleasesLock(t *testing.T) {
+	for _, failure := range []string{"manifest", "listing"} {
+		t.Run(failure, func(t *testing.T) {
+			defer setupGCTest(t)()
+			CreateDatabase("gcdb", false)
+			tbl, _ := CreateTable("gcdb", "docs", Safe, false)
+			tbl.CreateColumn("id", "INT", nil, nil)
+			tbl.CreateColumn("content", "TEXT", nil, nil)
+			insertLongRows(t, tbl, []string{strings.Repeat("a", maxInlineBlobBytes+1), strings.Repeat("b", maxInlineBlobBytes+1), strings.Repeat("c", maxInlineBlobBytes+1)})
+			db := GetDatabase("gcdb")
+			if failure == "manifest" {
+				writer := db.persistence.WriteColumn(tbl.ActiveShards()[0].uuid.String(), blobManifestColumn)
+				if _, err := writer.Write([]byte("corrupt")); err != nil {
+					t.Fatal(err)
+				}
+				if err := writer.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			db.persistence = &inventoryMetadataOnlyPersistence{PersistenceEngine: db.persistence, failList: failure == "listing"}
+			var caught any
+			func() { defer func() { caught = recover() }(); AuditBlobInventory(db) }()
+			expected := "incomplete generation references"
+			if failure == "listing" {
+				expected = "injected inventory listing failure"
+			}
+			if !strings.Contains(fmt.Sprint(caught), expected) {
+				t.Fatalf("unexpected error: %v", caught)
+			}
+			if !db.persistenceLifecycle.TryLock() {
+				t.Fatal("audit retained lifecycle lock after failure")
+			}
+			db.persistenceLifecycle.Unlock()
+			if len(blobFiles(t, "gcdb")) != 3 {
+				t.Fatal("failed audit changed files")
+			}
+		})
+	}
+}
+
+func TestBlobInventoryWaitsForGenerationPublication(t *testing.T) {
+	defer setupGCTest(t)()
+	CreateDatabase("gcdb", false)
+	db := GetDatabase("gcdb")
+	db.persistenceLifecycle.RLock()
+	done := make(chan BlobInventory, 1)
+	go func() { done <- AuditBlobInventory(db) }()
+	select {
+	case <-done:
+		db.persistenceLifecycle.RUnlock()
+		t.Fatal("audit entered an unpublished generation")
+	case <-time.After(25 * time.Millisecond):
+	}
+	db.persistenceLifecycle.RUnlock()
+	select {
+	case report := <-done:
+		if report.Referenced != 0 || report.Listed != 0 {
+			t.Fatalf("empty inventory: %+v", report)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("audit did not resume after publication")
 	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3613,6 +3613,31 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "blob_inventory",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			db := GetDatabase(scm.String(a[0]))
+			if db == nil {
+				panic("blob_inventory: database does not exist: " + scm.String(a[0]))
+			}
+			report := AuditBlobInventory(db)
+			missing := make([]scm.Scmer, len(report.Missing))
+			for i, hash := range report.Missing {
+				missing[i] = scm.NewString(hash)
+			}
+			return scm.NewSlice([]scm.Scmer{
+				scm.NewString("referenced_blobs"), scm.NewInt(int64(report.Referenced)),
+				scm.NewString("listed_blobs"), scm.NewInt(int64(report.Listed)),
+				scm.NewString("unreferenced_blobs"), scm.NewInt(int64(report.Unreferenced)),
+				scm.NewString("missing_blobs"), scm.NewSlice(missing),
+			})
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", HasSideEffects: true,
+			Description: "Explicit maintenance audit of committed blob references against backend object names; no payload reads or deletion. Incomplete scans raise an error.",
+			Params:      []*scm.TypeDescriptor{{Kind: "string", Label: "database"}},
+			Return:      &scm.TypeDescriptor{Kind: "list"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "stat",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if len(a) == 0 {

--- a/tests/storage/formats/blob-undercount-recovery.yaml
+++ b/tests/storage/formats/blob-undercount-recovery.yaml
@@ -13,6 +13,18 @@ setup:
   - scm: '(rebuild (table "memcp-tests" "blob_owner_a") true false)'
   - scm: '(rebuild (table "memcp-tests" "blob_owner_b") true false)'
 test_cases:
+  - name: "Explicit inventory reports shared blob references without missing files"
+    scm: |
+      (begin
+        (define report (blob_inventory "memcp-tests"))
+        (and (>= (get_assoc report "referenced_blobs") 3)
+             (equal? (get_assoc report "missing_blobs") (list))))
+    expect:
+      data: [true]
+  - name: "Inventory rejects an unknown database"
+    scm: '(blob_inventory "memcp-tests-inventory-missing")'
+    expect:
+      error: true
   - name: "Fixture has externally stored payloads with two owners"
     sql: "SELECT COUNT(*) AS n FROM `.blobs` WHERE hash IN ('f5ddb39412a9924f220f6c16749f0ca53083cf2aa56c4e4ca3d8994141bee964','344edcc59c0872f3a6dff5edd2a586226d0f11faf6dcee6783d3a91dcbfe072b','1658327e53de73a559075f5a4edf9784fd1930cde3ea4f0db91367910f3a57ce') AND refcount >= 2"
     expect:


### PR DESCRIPTION
Adds an explicit Scheme maintenance command, `(blob_inventory "database")`, to compare active committed-generation blob references with backend object names. The report contains `referenced_blobs`, `listed_blobs`, `unreferenced_blobs`, and a sorted `missing_blobs` hash list. Incomplete generation metadata or listing failures raise an error instead of returning a misleading partial report.

The audit performs no blob payload reads, deletions, reference-count repairs, or legacy manifest-backfill writes. It uses `WalkBlobs`: filesystem traversal, paginated S3 object listing, or Ceph object iteration. Missing legacy manifests are inspected through committed column files without publishing a replacement manifest. Listing proves presence only, not readability, checksums, or payload integrity; ambiguous legacy references remain conservative candidates.

Automatic startup cleanup does not invoke the audit. It retains the ownership proof already on master through #838: a counter decrement cannot delete a file, and incomplete ownership evidence prevents blob deletion. A missing live blob does not block collection of a separate object proven unreferenced. Cleanup logs incomplete ownership checks explicitly.

Performance and maintenance costs:

| Path | Work introduced by this PR |
| --- | --- |
| Ordinary SELECT/DML and refcount changes | No inventory call or per-row/per-blob availability request. |
| Automatic cleanup | No added availability pass or payload requests; the existing manifest discovery, listing, and ownership-based reclamation remain. An incomplete ownership check gains a diagnostic. |
| Explicit `blob_inventory` | Read generation metadata, traverse the backend object listing once, compare names, and sort missing hashes. No per-blob `ReadBlob`, S3 GET, Ceph payload read, or decompression. |

For B unique referenced hashes, L listed objects, and M missing hashes, the explicit comparison requires O(B + L + M log M) bookkeeping and O(B + M) memory, in addition to manifest discovery. Ceph currently iterates the wider pool before filtering the database's blob prefix. Legacy discovery can require reading reference-bearing column files. The audit holds the database's exclusive lifecycle lock across discovery and listing to exclude generation publication and cleanup: rebuild/repartition, migration, and some DDL can wait. Ordinary row operations do not take this lock directly, but may see resource contention or wait if they require one of those maintenance/catalog operations. Operators choose when to pay this cost; it is not scheduled at startup or periodically.

Regression coverage preserves the shared-owner/undercount, reload, rebuild, failed-publication, and deferred-reclamation tests, and adds:

- metadata-only backend guards that panic on any blob read, column write, or blob deletion;
- missing files and unreferenced objects in one inventory, followed by independent safe orphan reclamation;
- legacy reference discovery without manifest writes;
- incomplete manifests and failed listings, including panic-safe lifecycle-lock release;
- publication-barrier waiting and an empty inventory;
- the Scheme command and rejection of an unknown database.

Validation:
- `go test ./storage ./scm` passes; targeted inventory tests pass after the final test addition.
- Extended `blob-undercount-recovery.yaml`: 7/7 cases pass.

No on-disk format, external dependency, shard-eviction, or trigger-policy changes. No production data was modified or audited. No large-inventory/cold-cache/remote-backend timing benchmark is claimed; the no-payload-I/O property is enforced by tests, and the complexity/locking statements are from the implementation.

Full SQL/JIT/performance validation is delegated to CI. The local full-suite run was stopped at the user's request; it is not claimed as completed for this revision.
