### PR TITLE
fix(planner): cost exact observations before replacing ordered batches

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -3667,6 +3667,19 @@ below it remain guarded, but do not precompute an exact projection merely to
 choose between alternatives whose complete runtime is already negligible. */
 (define planner_adaptive_observation_budget_ns 100000000)
 
+/* Exact preparation is an executed plan prefix, not free statistics. Once it
+has run, candidate consumption wins by reuse, but that conditional dominance
+does NOT justify paying for the prefix. Compare preparation plus consumption
+with the executable no-observation winner using the same calibrated costs.
+Uncertainty and the risk budget alone must not erase LIMIT's early braking.
+Unknown costs cannot prove that adding a complete scan is beneficial. A prefix
+already required by the selected consumer is shared work, not an added scan:
+its exact count can still guard against projection skew. */
+(define membership_observation_cost_preferred? (lambda (prepared_cost unprepared_cost preparation_shared)
+	(or preparation_shared (and (not (nil? prepared_cost))
+		(and (not (nil? unprepared_cost))
+			(not (planner_cost_better? unprepared_cost prepared_cost)))))))
+
 /* A prepared exact candidate is already the strongest reusable boundary for
 an ordered scan. The storage operator adapts its traversal to the RecSet's
 runtime cardinality, so rebuilding cumulative prefixes cannot win afterward. */
@@ -3841,7 +3854,7 @@ candidate RecSet. */
 /* Cost one physical tree edge once and return (strategy RecSet-expression).
 Consumers decide whether that RecSet is their scan carrier or a membership
 filter; they must not reconstruct the choice from enclosing block facts. */
-(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch prefiltered_driver_expr downstream_probe_branches allow_driver_probe driver_order_partitioning decision_scope planning_session tx)
+(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch batch_prepares_candidate prefiltered_driver_expr downstream_probe_branches allow_driver_probe driver_order_partitioning decision_scope planning_session tx)
 	(begin
 		(define stage (nth membership 0))
 		(define driver_order_partitioned (if (nil? driver_order_partitioning)
@@ -4089,8 +4102,20 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 						(qassoc_get lower_best_cost (quote total_ns) 0)
 						(qassoc_get upper_best_cost (quote total_ns) 0))
 					0))
+				/* The emitter owns this topology fact: some batch consumers already
+				use the complete candidate as their input, others project only each
+				window. Counting an already required input adds no relational work.
+				Do not infer that from the operator name or SQL shape. Conversely,
+				availability of such a carrier does not make preparation free when
+				the actual no-observation winner uses another topology. */
+				(define observation_preparation_shared (and batch_prepares_candidate
+					(equal? estimated_normal_choice "ordered_batch_accept")))
+				(define observation_cost_preferred (membership_observation_cost_preferred?
+					candidate_cost (if (nil? cost_choice) nil (cadr cost_choice))
+					observation_preparation_shared))
 				(define observe_projection (and interval_crosses
-					(> interval_worst_ns planner_adaptive_observation_budget_ns)))
+					(and (> interval_worst_ns planner_adaptive_observation_budget_ns)
+						observation_cost_preferred)))
 				(define observation_keys (if observe_projection
 					(planner_register_queryplan_observation decision_id raw_expr
 						(list (quote recset_count) (symbol "__queryplan_observed_value")) planning_session)
@@ -4220,6 +4245,8 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 							(list "projection_interval_upper_rows" (if observation_supported source_rows nil))
 							(list "projection_crossover_rows" crossover)
 							(list "adaptive_observation_required" observe_projection)
+							(list "adaptive_observation_cost_preferred" observation_cost_preferred)
+							(list "adaptive_observation_preparation_shared" observation_preparation_shared)
 							(list "adaptive_observation_budget_ns" planner_adaptive_observation_budget_ns)
 							(list "expected_driver_rows_visited" (membership_expected_driver_rows_visited
 								candidate_input_rows candidate_rows driver_rows facts))
@@ -4287,7 +4314,7 @@ candidate-keyset choice replaces the marker with a projected RecSet carrier. */
 (define recset_project_join_expr_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch)
 	(begin
 		(define plan (recset_project_join_plan_for_membership_using
-			src membership consumer driver_rows_override allow_ordered_batch nil 0 true nil
+			src membership consumer driver_rows_override allow_ordered_batch false nil 0 true nil
 			(quote expression) nil nil))
 		(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
 			(cadr plan)
@@ -5944,7 +5971,7 @@ state through an assoc and one-element payload lists adds no semantics. */
 						/* This marker runs in the group fill's input filter, before
 						the residual predicates. The output LIMIT does not bound its
 						probes: every input row can reach this call. */
-						src term (quote aggregate) (planner_source_row_count src) false nil 0 true nil
+						src term (quote aggregate) (planner_source_row_count src) false false nil 0 true nil
 						(quote group_fill) (planner_context_session facts) (planner_context_tx facts)))
 					(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
 						(list term (membership_recset_var src term) (cadr plan)) nil))))
@@ -5957,7 +5984,7 @@ state through an assoc and one-element payload lists adds no semantics. */
 				nil
 				(begin
 					(define plan (recset_project_join_plan_for_membership_using
-						src membership (quote aggregate) (planner_source_row_count src) false nil 0 true nil
+						src membership (quote aggregate) (planner_source_row_count src) false false nil 0 true nil
 						(quote group_fill) (planner_context_session facts) (planner_context_tx facts)))
 					(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
 						(cadr plan) nil)))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4133,6 +4133,10 @@ plan construction or timing during compilation. */
 								(probe_limit_work_rows (qb_limit block)
 									(planner_context_session (qb_facts block))) nil)
 							allow_ordered_batch_binding
+							/* An implied membership becomes batch_membership_table_expr
+							below. Its complete preparation is shared with observation;
+							branch-local OR memberships remain window-local instead. */
+							(equal? membership implied_membership)
 							(prefiltered_driver_recset_expr_for_membership
 								src source_table raw_condition membership)
 							(+ (count (acceptance_required_sources
@@ -5308,6 +5312,7 @@ until the caller has selected this physical alternative. */
 				(if (query_limit_active? offset_value limit_value)
 					(probe_limit_work_rows limit_value planning_session) nil)
 				allow_ordered_batch
+				false
 				(prefiltered_driver_recset_expr_for_membership
 					src (source_table_expr_using stages src) raw_condition membership)
 				(+ (count (acceptance_required_sources
@@ -6966,6 +6971,7 @@ carrier remains on the measured direct path and is never built eagerly. */
 							(query_limit_active? offset_value limit_value))
 							(probe_limit_work_rows limit_value planning_session) nil)
 						allow_ordered_batch
+						false
 						(prefiltered_driver_recset_expr_for_membership
 							src (source_table_expr_using stages src) condition membership)
 						(+ (count (acceptance_required_sources

--- a/tests/performance/batch-observation-cost.yaml
+++ b/tests/performance/batch-observation-cost.yaml
@@ -1,0 +1,126 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "Exact observations must pay their full preparation cost before displacing LIMIT batching"
+
+setup:
+  - sql: "DROP TABLE IF EXISTS boc_document"
+  - sql: "DROP TABLE IF EXISTS boc_file"
+  - sql: "DROP TABLE IF EXISTS boc_acl"
+  - sql: "CREATE TABLE boc_file (id INT PRIMARY KEY, filename TEXT, body TEXT) ENGINE=memory"
+  - sql: "CREATE TABLE boc_document (id INT PRIMARY KEY, file_id INT, rank_value INT, domain_id INT) ENGINE=memory"
+  - sql: "CREATE TABLE boc_acl (id INT PRIMARY KEY, allowed INT) ENGINE=memory"
+  - scm: |
+      (begin
+        (define hit (string_repeat "commonneedle-" 512))
+        (define miss (string_repeat "co--om--mm--mo--on--nn--ne--ee--ed--dl--le--" 170))
+        (insert (table "memcp-tests" "boc_file") '("id" "filename" "body")
+          (map (produceN 20000) (lambda (i)
+            (list i "file" (if (equal? (mod i 2) 0) hit miss)))))
+        (insert (table "memcp-tests" "boc_document") '("id" "file_id" "rank_value" "domain_id")
+          (map (produceN 20000) (lambda (i) (list i i i (mod i 16)))))
+        (insert (table "memcp-tests" "boc_acl") '("id" "allowed")
+          (map (produceN 16) (lambda (i) (list i 1))))
+        (rebuild (table "memcp-tests" "boc_file") true false)
+        (rebuild (table "memcp-tests" "boc_document") true false)
+        (rebuild (table "memcp-tests" "boc_acl") true false))
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS boc_document"
+  - sql: "DROP TABLE IF EXISTS boc_file"
+  - sql: "DROP TABLE IF EXISTS boc_acl"
+
+test_cases:
+  - name: "Observation admission charges complete execution and preserves cheaper exact paths"
+    scm: |
+      (begin
+        (define cheap (list (list (quote total_ns) 100) (list (quote memory_bytes) 10)))
+        (define expensive (list (list (quote total_ns) 1000) (list (quote memory_bytes) 100)))
+        (if (and
+          (not (membership_observation_cost_preferred? expensive cheap false))
+          (membership_observation_cost_preferred? cheap expensive false)
+          (membership_observation_cost_preferred? cheap cheap false)
+          (membership_observation_cost_preferred? expensive cheap true)
+          (not (membership_observation_cost_preferred? nil cheap false))
+          (not (membership_observation_cost_preferred? cheap nil false)))
+          true (error "exact observation admission ignored its full cost")))
+
+  - name: "Cached LIMIT plan retains batching without a full search observation"
+    scm: &boc_cached_plan |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (define query "SELECT d.id, label.allowed FROM boc_document d LEFT JOIN boc_acl label ON label.id = d.domain_id WHERE d.file_id IN (SELECT id FROM boc_file WHERE filename LIKE '%alternate%' UNION SELECT id FROM boc_file WHERE body LIKE '%commonneedle%') AND EXISTS (SELECT 1 FROM boc_acl a WHERE a.id = d.domain_id AND a.allowed = 1) ORDER BY d.rank_value DESC LIMIT 5")
+        (define formula (with_autocommit sess nil 1 query (lambda (tx)
+          (cached_parse cache (list parse_sql) "memcp-tests" query
+            (sql_policy "root") "root" sess true tx))))
+        (define code (serialize formula))
+        (if (and (strlike code "%scan_order_batch_accept%")
+          (not (strlike code "%__memcp_queryplan_observation_value_%")))
+          true (error "cached plan replaced LIMIT batching with an expensive exact observation")))
+
+  - name: "Batch search with ACL returns the exact ordered page"
+    sql: &boc_query |
+      SELECT d.id, label.allowed FROM boc_document d
+      LEFT JOIN boc_acl label ON label.id = d.domain_id
+      WHERE d.file_id IN (
+        SELECT id FROM boc_file WHERE filename LIKE '%alternate%'
+        UNION SELECT id FROM boc_file WHERE body LIKE '%commonneedle%'
+      ) AND EXISTS (SELECT 1 FROM boc_acl a WHERE a.id = d.domain_id AND a.allowed = 1)
+      ORDER BY d.rank_value DESC LIMIT 5
+    expect: &boc_page
+      data: [{id: 19998, allowed: 1}, {id: 19996, allowed: 1}, {id: 19994, allowed: 1}, {id: 19992, allowed: 1}, {id: 19990, allowed: 1}]
+
+  - name: "Repeated cached broad search does not pay for the full text population"
+    performance_rows: 20000
+    warmup: 3
+    timing_samples: 9
+    threshold_ms: 5000
+    sql: *boc_query
+    expect: *boc_page
+
+  - name: "OFFSET is applied after membership and ACL filtering"
+    sql: |
+      SELECT d.id FROM boc_document d
+      LEFT JOIN boc_acl label ON label.id = d.domain_id
+      WHERE d.file_id IN (
+        SELECT id FROM boc_file WHERE filename LIKE '%alternate%'
+        UNION SELECT id FROM boc_file WHERE body LIKE '%commonneedle%'
+      ) AND EXISTS (SELECT 1 FROM boc_acl a WHERE a.id = d.domain_id AND a.allowed = 1)
+      ORDER BY d.rank_value DESC LIMIT 2 OFFSET 1
+    expect:
+      data: [{id: 19996}, {id: 19994}]
+
+  - name: "Absent search exhausts candidates without manufacturing a page"
+    sql: |
+      SELECT d.id, label.allowed FROM boc_document d
+      LEFT JOIN boc_acl label ON label.id = d.domain_id
+      WHERE d.file_id IN (
+        SELECT id FROM boc_file WHERE filename LIKE '%absent%'
+        UNION SELECT id FROM boc_file WHERE body LIKE '%absent%'
+      ) AND EXISTS (SELECT 1 FROM boc_acl a WHERE a.id = d.domain_id AND a.allowed = 1)
+      ORDER BY d.rank_value DESC LIMIT 5
+    expect:
+      rows: 0
+
+  - name: "A complete scan learns the source LIKE selectivity"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "boc_file"))
+        (define callback (list 'lambda (list 'x)
+          (list 'strlike 'x "%commonneedle%" "utf8mb4_general_ci")))
+        (define access (compile_scan_access '("body") callback))
+        (define values (map (nth access 1) (lambda (v) (eval v))))
+        /* A complete ordinary scan can train table feedback; a restricted
+        batch cannot. Prove that this test really has the new learned input. */
+        (define matched (scan nil tbl (nth access 0) values '("body")
+          (eval callback) '() scan_count 0 + false))
+        (define estimate (table_filter_selectivity tbl (nth access 0) values))
+        (if (and (equal? matched 10000)
+          (equal? (qassoc_get estimate 'source nil) 'scan_feedback)
+          (equal? (qassoc_get estimate 'value nil) 0.5))
+          true (error "complete LIKE scan did not publish the expected selectivity")))
+
+  - name: "Learned LIKE selectivity retains the cheap cached batch plan"
+    scm: *boc_cached_plan


### PR DESCRIPTION
## Problem

An ordered membership plan can win the calibrated cost comparison as `ordered_batch_accept`, yet the cached query formula executes a complete projected search RecSet before dispatching its guards. Once that preparation has run, reuse correctly favors `candidate_keyset` — but that does not justify executing the expensive preparation in the first place. EXPLAIN's provisional operator choice alone did not catch this difference.

The old observation admission checked an uncertain projection interval and a 100 ms risk budget, but did not compare the cost of the prepared plan against the executable plan without observation.

## Change

- Admit an additional full observation only when the existing calibrated preparation-plus-consumption cost is no worse than the cheapest executable alternative. Unknown costs do not establish this benefit.
- Preserve shared preparation: a consumer which already takes the full candidate RecSet as its scan input can count that required input without adding a relational scan. The emitter supplies this topology property; it is not inferred from SQL spelling, table names, or the presence of an index. It applies only when that consumer is the selected alternative.
- Keep the interval/risk checks, ordinary statistics and growth guards, and reuse of already prepared values. This does **not** always select batching or disable adaptive observations.
- Expose admission and shared-preparation facts in EXPLAIN PHYSICAL.

No logical/decorrelation changes, new physical operators, coefficient changes, or hand calibration. Reviewed the existing `tools/costgen` candidate and batch feature equations: this change consumes their existing cost comparison at observation admission rather than changing their operator-work features or fits.

## Regression coverage

New `tests/performance/batch-observation-cost.yaml` uses 20,000 documents and files with a UNION search, long text with bigram false positives, ACL EXISTS, a nullable lookup projection, ORDER and LIMIT. It checks the **actual cached formula**, ordered result values, OFFSET, empty results, cost admission, and learned LIKE statistics. Its timed case is under `tests/performance/` for performance-CI discovery.

The cached-formula assertion fails on master `6a8642977`: the full observation replaces the bounded batch. Correctness checks pass on that baseline. The new helper's unit check additionally fails there because the helper does not yet exist; that is not the evidence of reproduction.

An initial overly restrictive admission failed the existing projection-skew assertion in `in-subquery.yaml`. The final patch accounts for the consumer's shared preparation, and the existing assertion passes **unchanged**. No existing tests or limits were relaxed.

## Manual A/B

Baseline: master `6a8642977`, including filter-selectivity learning (#837). Candidate: this patch on the same base. Same JIT binary/build, separate local test instances, identical deterministic 20,000-row fixtures. Three warmups per side, 15 samples each, alternating A/B then B/A. Times below are complete SQL HTTP round-trip medians; every response was byte-identical.

| Statistics state | Master | Patch | Reduction |
| --- | ---: | ---: | ---: |
| Before explicit complete-scan feedback | 384.93 ms | 2.89 ms | 99.25%, 133× |
| After verified LIKE feedback (50% matching rows) | 423.31 ms | 3.25 ms | 99.23%, 130× |

Before-feedback sample ranges: master 366.75–480.11 ms, patch 2.37–4.00 ms. After-feedback ranges: master 383.91–466.26 ms, patch 2.47–4.01 ms. Learning alone does not eliminate the bad observation decision; source-local selectivity also does not prove FK projection overlap.

Independent diagnosis on the full real-data query, on the running pre-#837 build, used the existing calibration facility to execute both physical alternatives, with identical results (72 rows and identical result hash): ordered batch 68.96/69.67/77.15 ms versus full candidate 640.97/652.94/649.90 ms. This establishes the operator opportunity, **not** an end-to-end deployment measurement of this patch. The live service has not been restarted or modified for this PR.

## Validation

- JIT startup: 1276/1276 runtime tests.
- New suite including its timed case and learned-statistics checks: 8/8.
- `in-subquery.yaml`: 73/73.
- `indexed-membership-costing.yaml`: 20/20.
- `order-limit.yaml`: 56/56, including its performance cases.
- `like-acl-query-shapes.yaml`: 11/11, including its performance cases.
- Scheme formatting checks and `git diff --check` pass.
- Full functional/JIT/performance A/B suites are delegated to CI as requested.
