### PR TITLE
Cache repeatedly decoded blobs within the existing RAM hierarchy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,13 @@ curl -s -u root:admin "http://localhost:[PORT]/sql/DBNAME" -d "SELECT 1"
 - `storageShard.filterFeedback` contains immutable observations published with one best-effort CAS after a complete shard scan. Readers may load these atomics without shard locks or concurrency rights; they must not inspect shard containers. `table.filterFeedback` publishes an immutable, bounded merged snapshot. Generation IDs are scalar planner-statistics tokens, never retained shard/topology pointers. No feedback synchronization or publication is permitted inside element or filter-batch loops.
 - When adding new storage fields, document the locking discipline and update this section.
 
+- `OverlayBlob.ram` belongs to one immutable column generation. Its `blobRAMCache.mu`
+  protects admission metadata, decoded strings, and byte/benefit accounting;
+  `lastUsed` is atomic and updated once per read batch. Cache callbacks use
+  `TryLock` and never acquire shard/table locks or call public CacheManager APIs.
+  Generation construction and `SetSchema` replace the cache under the existing
+  exclusive column lifecycle. Cache registrations retain no shard/database.
+
 ### Scheme AST and Codegen Quoting (lib/queryplan.scm and lib/queryplan-*.scm)
 - Build AST as data: most builder blocks use a single leading quote `'(...)` so nested lists are data, not executed at construction.
 - Lambdas: embed as `'((quote lambda) (param-list) body)` where:

--- a/storage/blob-ram.go
+++ b/storage/blob-ram.go
@@ -1,0 +1,229 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "fmt"
+import "sync"
+import "time"
+import "strings"
+import "sync/atomic"
+import "github.com/launix-de/memcp/scm"
+
+// One optional RAM owner per immutable OverlayBlob generation. It deliberately
+// has no pointer back to its column/shard/database: a soft registration cannot
+// keep a retired persisted generation alive. Hashes deduplicate within an owner;
+// different owners charge their own copies. No reference count authorizes I/O.
+//
+// Existing cachemap entries admit on the first access, expire by idle time when
+// configured, and have per-key synchronization/registrations. A single partial
+// cacheObject instead batches synchronization and owns probation metadata too.
+// mu protects everything except lastUsed (published once per batch). Eviction
+// only TryLocks: readers may publish to CacheManager while holding storage locks.
+type blobRAMCache struct {
+	requestedBytes int64 // largest denied admission in this batch, under mu
+	mu             sync.Mutex
+	entries        map[[32]byte]blobRAMEntry
+	payloadBytes   int64
+	savedWork      float64
+	registered     bool
+	lastUsed       atomic.Int64
+}
+
+// Queue publication under mu to preserve mutation order, but let the manager
+// process it only after Unlock. Otherwise a newly registered probation owner
+// is ineligible (busy) and pressure steals a warm owner's contents instead.
+func (c *blobRAMCache) endBatch(before int64) {
+	requested := c.requestedBytes
+	c.requestedBytes = 0
+	size := c.size()
+	var ready, done chan struct{}
+	if size > 0 && (!c.registered || size != before) {
+		ready, done = make(chan struct{}), make(chan struct{})
+		op := cacheOp{ready: ready, done: done}
+		if !c.registered {
+			c.registered = true
+			op.add = newSoftItem(c, size, TypeCacheEntry, nil, blobRAMLastUsed, blobRAMScore, 0, 0)
+		} else {
+			op.updatePtr, op.updateDelta = c, size-before
+		}
+		GlobalCache.opChan <- op
+	}
+	c.mu.Unlock()
+	if ready != nil {
+		close(ready)
+		<-done
+	}
+	if requested > 0 {
+		GlobalCache.CheckPressure(requested)
+	}
+}
+
+type blobRAMEntry struct {
+	value    string // empty on probation; external blobs cannot have empty contents
+	decodeNS float64
+	reuses   uint8 // saturates; historical popularity cannot grow without bound
+}
+
+// Conservative allocation estimates include map load factor, growth/overflow,
+// string headers, allocator rounding, and the global softItem/map/heap slot.
+// Map entries are never deleted individually, so this bound does not shrink
+// while Go retains buckets. Payload strings are cloned to exact-length storage;
+// temporary gzip/Builder buffers belong to the executing reader, not the cache.
+const blobRAMEntryBytes = 256
+const blobRAMRegistrationBytes = 512
+
+// Account for allocator size classes, not just logical string length. Small
+// objects reserve a conservative 25% allowance; larger objects round to Go's
+// 8 KiB heap pages. String headers are already in blobRAMEntryBytes.
+func blobRAMStringBytes(length int) int64 {
+	bytes := int64(length)
+	if bytes <= 32768 {
+		return (bytes + bytes/4 + 63) &^ 63
+	}
+	return (bytes + 8191) &^ 8191
+}
+
+func (c *blobRAMCache) size() int64 {
+	if c.entries == nil {
+		return 0
+	}
+	return blobRAMRegistrationBytes + int64(len(c.entries))*blobRAMEntryBytes + c.payloadBytes
+}
+
+func blobRAMLastUsed(pointer any) time.Time {
+	return time.Unix(0, pointer.(*blobRAMCache).lastUsed.Load())
+}
+
+// Saved decode nanoseconds per resident byte supplies reuse/work-per-space
+// telemetry to the existing heuristic (without changing type weights).
+// Only successful measured reloads train decode cost. At most eight reuses are
+// credited, and every pressure-driven partial eviction halves the history.
+func blobRAMScore(pointer any) float64 {
+	c := pointer.(*blobRAMCache)
+	if !c.mu.TryLock() {
+		return 0
+	}
+	defer c.mu.Unlock()
+	if size := c.size(); size > 0 {
+		return c.savedWork / float64(size)
+	}
+	return 0
+}
+
+func (c *blobRAMCache) read(s *OverlayBlob, hash [32]byte, limit *int64) scm.Scmer {
+	e, seen := c.entries[hash]
+	if e.value != "" {
+		if e.reuses < 8 {
+			e.reuses++
+			c.savedWork += e.decodeNS
+			c.entries[hash] = e
+		}
+		return scm.NewString(e.value)
+	}
+	if *limit < 0 {
+		*limit = GlobalCache.Stat().MemoryBudget
+	}
+	start := time.Now()
+	value, found := s.readBlob(hash)
+	if !found {
+		panic("OverlayBlob: missing blob " + fmt.Sprintf("%x", hash))
+	}
+	elapsed := float64(time.Since(start).Nanoseconds())
+	if c.entries == nil {
+		c.entries = make(map[[32]byte]blobRAMEntry)
+	}
+	if seen && e.decodeNS > 0 {
+		e.decodeNS = (e.decodeNS + elapsed) / 2
+		bytes := blobRAMStringBytes(len(value.String()))
+		if *limit > 0 && c.size()+bytes > *limit {
+			if bytes+blobRAMRegistrationBytes+blobRAMEntryBytes <= *limit {
+				c.requestedBytes = max(c.requestedBytes, bytes)
+			}
+			c.entries[hash] = e
+			return value
+		}
+		e.value = strings.Clone(value.String())
+		e.reuses = 1
+		c.payloadBytes += blobRAMStringBytes(len(e.value))
+		c.savedWork += e.decodeNS
+		value = scm.NewString(e.value)
+	} else {
+		e.decodeNS = elapsed // first read records evidence, never retains payload
+	}
+	c.entries[hash] = e
+	return value
+}
+
+func (c *blobRAMCache) evictionOffer(size int64) evictionOffer {
+	if !c.mu.TryLock() {
+		return evictionOffer{}
+	}
+	defer c.mu.Unlock()
+	if c.payloadBytes == 0 {
+		// Probation contains no useful decoded representation to preserve.
+		return evictionOffer{partialBytes: size, fullBytes: size}
+	}
+	return evictionOffer{partialBytes: c.payloadBytes, fullBytes: size}
+}
+
+func (c *blobRAMCache) evict(mode evictionMode, size int64, _ *[numEvictableTypes]int64) evictionResult {
+	if !c.mu.TryLock() {
+		return evictionResult{}
+	}
+	defer c.mu.Unlock()
+	if mode == evictFull || c.payloadBytes == 0 {
+		c.entries = nil
+		c.payloadBytes = 0
+		c.savedWork = 0
+		c.registered = false
+		return evictionResult{freedBytes: size, fullyEvicted: true, success: true}
+	}
+	// Shed the lower-benefit payloads first. Keep metadata until full eviction;
+	// successful readers hold ordinary immutable Go strings through reclamation.
+	threshold := c.savedWork / float64(c.payloadBytes)
+	before := c.payloadBytes
+	c.savedWork = 0
+	for hash, e := range c.entries {
+		if e.value != "" {
+			bytes := blobRAMStringBytes(len(e.value))
+			if e.decodeNS*float64(e.reuses)/float64(bytes) <= threshold {
+				c.payloadBytes -= bytes
+				e.value = ""
+				e.reuses = 0
+				e.decodeNS = 0 // require fresh evidence before readmission
+			} else {
+				e.reuses = (e.reuses + 1) / 2
+				c.savedWork += e.decodeNS * float64(e.reuses)
+			}
+			c.entries[hash] = e
+		}
+	}
+	return evictionResult{freedBytes: before - c.payloadBytes, success: before > c.payloadBytes}
+}
+
+// Called only by exclusive generation construction/source replacement.
+func (s *OverlayBlob) resetBlobRAM() {
+	if old := s.ram; old != nil {
+		old.mu.Lock()
+		registered := old.registered
+		old.mu.Unlock()
+		if registered {
+			GlobalCache.Remove(old)
+		}
+	}
+	s.ram = &blobRAMCache{}
+}

--- a/storage/blob-ram.md
+++ b/storage/blob-ram.md
@@ -1,0 +1,230 @@
+<!-- Copyright (C) 2026 MemCP Contributors; SPDX-License-Identifier: GPL-3.0-or-later -->
+
+# Adaptive decoded blob RAM
+
+External values remain gzip-compressed in the existing content-addressed format.
+The 2 KiB inline boundary, planner, query-cache guards and costgen weights are
+unchanged. `OverlayBlob` optionally retains successfully decoded strings.
+
+## Existing hierarchy and admission
+
+Index Savings already expresses reuse, and CacheManager provides budgets,
+telemetry and partial/full eviction. Ordinary cachemap entries admit on first
+access and synchronize/register each entry. Materialized string dictionaries
+also decode completely on first access. Neither implements blob admission. The
+existing `OverlayBlob.values` map contains serialized gzip/build data, so decoded
+RAM values cannot reuse it without mixing representation and persistence.
+
+One column-generation-local `cacheObject` therefore owns decoded values and
+probation metadata. It registers as one ordinary `CacheEntry` in the existing
+manager. The first successful read records the hash and measured reload time,
+without retaining the payload. A second read can retain it. Repeated identical
+hashes within a batch are actual reuse and deduplicate within that owner; a
+scan of distinct new hashes retains only metadata.
+
+Telemetry is bounded reuses × measured reload nanoseconds / charged resident
+bytes. Reload measurements include file access, gzip and allocation. Failed
+reloads never train the estimate. At most eight reuses are credited. Partial
+eviction drops payloads at or below the owner's mean benefit/byte, halves the
+retained histories and requires fresh evidence for readmission. Full eviction
+also releases the map and probation metadata.
+
+There is no idle expiry or time-based cooling of blob admission history. Warm
+entries survive an idle weekend without pressure. Under pressure the existing
+manager still combines idle age and telemetry. This remains a heuristic across
+cache types, not a globally optimal common latency model.
+
+The manager now collects at least 16 available candidates before comparing
+scores. Previously one large warm owner could alone fill the byte target,
+preventing comparison with much cheaper small probation owners. Probation-only
+owners offer complete release in the partial pass because they have no decoded
+representation to preserve. Type weights and expiry settings are unchanged.
+
+## Concurrency, lifetime and memory
+
+Synchronization and usage publication happen once per batch of at most 256
+rows; a scalar point read is a one-value batch. Inline-only reads avoid cache
+locking. Generated JIT bulk getters use the same resolver. Cold decoding is
+serialized per column owner, without a database-wide lock.
+
+Size publication is queued while locked, but the manager processes it only
+after unlock. Otherwise a newly added, busy probation owner could be skipped
+and warm contents stolen instead. Callbacks use `TryLock`, acquire no shard or
+table locks and call no public CacheManager methods. Panic cleanup publishes
+previous successful admissions and releases the lock.
+
+Owners retain no source-column, shard, database or persistence pointer. Updates
+use the existing delta/generation visibility rules; exclusive source replacement
+resets the owner. Different owners charge their own copies rather than assuming
+shared lifetime from a hash. Retired owners remain charged until pressure removes
+them, but cannot keep a persistent generation alive. Returned immutable Go
+strings remain valid for active readers after eviction.
+
+Payloads are charged separately from base-column storage. Each hash reserves
+256 bytes for entry/map capacity and growth; each registration reserves 512
+bytes for manager/map overhead. Partial release never subtracts buckets Go
+still retains. Cloned strings avoid retaining excess Builder capacity. Small
+strings reserve a conservative 25% allocator allowance rounded to 64 bytes;
+strings above 32 KiB round to 8 KiB heap pages. The fixed cache header is in the
+parent-column estimate.
+
+A miss samples the configured RAM budget once per batch. Admission cannot grow
+one owner's payload beyond that entire configured budget. Denied reusable
+values request room through the existing manager after unlock. Probation and
+concurrent batches still follow its soft-budget semantics. Gzip/Builder buffers,
+output buffers and active-reader references are query working memory. Physical
+reclamation follows reader release and Go collection; cache ownership is not an
+RSS limit. Memory measurements below distinguish these quantities.
+
+No cache operation deletes a persistent blob or changes its reference count.
+Complete reference proof remains the deletion authority. Misses still report
+missing or corrupt payloads and can succeed after repair. Hits return previously
+fully decoded content; they do not reopen immutable files to detect external
+filesystem changes. Legacy ambiguous references retain their original verified
+path. Recovery never depends on the RAM cache.
+
+Partial streaming decode and early comparison/matcher exit require a separate
+checksum/error contract and are outside this implementation.
+
+## Validation and A/B method
+
+Baseline: master `6a8642977`, including blob safety fix #838. All fixtures are
+synthetic; no live service or production data was used. Full tests run in CI.
+
+Permanent cases extend `tests/storage/formats/blob-storage.yaml`: actual external
+overlays, repeated text/binary reads, shared hashes in rows/tables, update and
+failed-write visibility, surviving ownership, restart, parallel readers and RAM
+pressure. Performance cases project LIKE/length per row, avoiding aggregate
+keytables which would bypass content reads on warm runs.
+
+Temporary Go probes additionally checked admission, a one-shot scan against a
+warm owner, source replacement, missing/corrupt gzip followed by repair, and
+concurrent admission/eviction with the race detector. The one-shot reproducer
+originally displaced about three quarters of a warm owner's payload charge;
+the corrected comparison/publication protocol preserves it.
+
+Microbenchmarks use Go 1.24, linux/amd64, GOMAXPROCS=4 and 128 distinct strings
+of 512 B, 4 KiB or 64 KiB. Strings have `row-%08d:` prefixes and either repeated
+ASCII or deterministic pseudorandom printable ASCII (seed 42). External values
+use the normal default gzip encoder and filesystem blobs. Both revisions use
+the same files/seed, three warmups and 32 measured iterations per case, run in
+A/B/B/A order. Tables report the mean of each revision's two blocks. Separate
+inline checks use two blocks of 10,000 iterations. “Cold” means a fresh decoded
+owner before each iteration, with filesystem pages already warm.
+
+Workloads are scalar point reads, range scans, scans with a changing literal
+search term, alternating two owners, and cold scans. Budgets are 128 KiB and
+64 MiB. Allocation metrics include the benchmark's small search-pattern string.
+Memory probes perform twelve scans, sample heap/RSS every millisecond and drop
+caller-owned output before measuring retained heap. Sampled peaks are observed
+lower bounds, not exact maxima. CPU includes the sampler's overhead.
+
+JIT SQL measurements use the existing jit-foreign-frames Go toolchain, the same
+256-row fixture as the YAML suite, three warmups and seven measured queries per
+case, again in A/B/B/A order. The fixture contains numeric prefixes followed by
+8 KiB of repeated text. HTTP and result encoding are included.
+
+## Results (2026-09-09)
+
+AMD Ryzen 9 7900X3D. Values below are baseline → candidate. The matrix had no
+external-blob case slower by 20% or more; tiny inline point reads added about
+1.5 ns in the longer verification. HTTP point-read changes remain noise-sized.
+
+### JIT SQL, milliseconds per query
+
+| Projection | Master | Candidate | Change |
+|---|---:|---:|---:|
+| Repeated LIKE projection over external blobs | 5.448 | 1.155 | -78.8% |
+| Repeated full content length projection | 5.605 | 1.011 | -82.0% |
+| A different LIKE pattern reuses decoded content | 8.763 | 4.397 | -49.8% |
+| Repeated point read of external content | 0.796 | 0.818 | +2.7% |
+
+Each SQL block uses the median of seven queries; the table averages the two
+blocks for each revision. The fixed fixture always has 256 rows.
+
+### Blob reader matrix
+
+Point times are **µs**, all scan times are **ms**. “Change” scans include literal
+matching with a different row-prefix search string each iteration; “alternate”
+switches two independent column owners. “Cold” does not include disk-page eviction.
+
+| Text | Budget | Point µs | Range ms | Change ms | Alternate ms | Cold ms |
+|---|---|---:|---:|---:|---:|---:|
+| 4 KiB repeated | 128 KiB | 25.665 → 0.093 | 2.258 → 1.746 | 2.309 → 1.682 | 2.155 → 1.919 | 1.977 → 1.854 |
+| 4 KiB repeated | 64 MiB | 14.774 → 0.099 | 2.091 → 0.003 | 2.309 → 0.008 | 1.934 → 0.003 | 2.055 → 1.838 |
+| 4 KiB random | 128 KiB | 41.566 → 0.075 | 4.664 → 4.302 | 4.771 → 4.493 | 4.739 → 4.627 | 4.840 → 4.684 |
+| 4 KiB random | 64 MiB | 36.157 → 0.095 | 5.073 → 0.002 | 5.157 → 0.039 | 4.928 → 0.003 | 4.696 → 4.654 |
+| 64 KiB repeated | 128 KiB | 51.621 → 0.099 | 5.820 → 5.639 | 6.378 → 5.287 | 5.334 → 5.206 | 5.425 → 6.122 |
+| 64 KiB repeated | 64 MiB | 46.239 → 0.079 | 5.144 → 0.003 | 5.673 → 0.090 | 5.228 → 0.003 | 5.107 → 6.077 |
+| 64 KiB random | 128 KiB | 374.779 → 0.073 | 48.584 → 49.455 | 50.305 → 50.459 | 48.922 → 48.853 | 49.589 → 49.143 |
+| 64 KiB random | 64 MiB | 390.627 → 0.075 | 48.875 → 0.002 | 50.219 → 1.243 | 48.986 → 0.003 | 49.355 → 49.264 |
+
+The weakest cold result above is 64 KiB repeated text with a 64 MiB budget:
+5.107 → 6.077 ms (+19.0%). A longer, identical 128-iteration A/B/B/A follow-up
+measured 7.014 → 6.963 ms (-0.7%). Cold timings are noisy on this shared host;
+there is no claim of a cold-read speedup, and first-read metadata has a cost.
+
+For the 512 B inline verification, median point/range/change/alternate times
+were respectively 9.36/813.85/4275.5/843.45 ns on master and
+10.90/677.8/3914.0/659.85 ns on the candidate. Inline cache charge stayed zero.
+
+### Range-scan allocations and cache charge
+
+Allocation bytes are MiB per operation, followed by allocation count. The cache
+charge is a conservative owner estimate after the measured block, not RSS.
+
+| Text | Budget | Allocation MiB / count, A → B | Candidate cache KiB |
+|---|---|---:|---:|
+| 4 KiB repeated | 128 KiB | 5.128 / 1694 → 4.888 / 1650 | 75.0 |
+| 4 KiB repeated | 64 MiB | 5.128 / 1694 → 0.000 / 0 | 672.5 |
+| 4 KiB random | 128 KiB | 5.101 / 1712 → 4.841 / 1658 | 75.0 |
+| 4 KiB random | 64 MiB | 5.116 / 1715 → 0.000 / 0 | 672.5 |
+| 64 KiB repeated | 128 KiB | 18.615 / 1828 → 18.695 / 1868 | 32.5 |
+| 64 KiB repeated | 64 MiB | 18.625 / 1828 → 0.000 / 0 | 8224.5 |
+| 64 KiB random | 128 KiB | 18.589 / 1944 → 18.654 / 1982 | 32.5 |
+| 64 KiB random | 64 MiB | 18.588 / 1942 → 0.000 / 0 | 8224.5 |
+
+### CPU and resident/peak memory for twelve scans
+
+Heap values are MiB above the pre-read baseline; retained heap is sampled after
+clearing caller output and running GC. Peak heap/RSS are sampled during reads.
+RSS columns show the whole process after output release and the sampled peak.
+
+| Text | Budget | CPU ms A → B | Retained heap MiB A → B | Peak heap Δ MiB A → B | RSS after MiB A → B | Peak RSS MiB A → B |
+|---|---|---:|---:|---:|---:|---:|
+| 4 KiB repeated | 128 KiB | 49.99 → 49.74 | 0.13 → 0.14 | 3.06 → 3.14 | 23.47 → 22.98 | 23.65 → 23.47 |
+| 4 KiB repeated | 64 MiB | 50.07 → 10.15 | 0.09 → 0.60 | 2.97 → 2.26 | 24.10 → 22.77 | 24.10 → 22.73 |
+| 4 KiB random | 128 KiB | 109.66 → 83.62 | 0.04 → 0.10 | 2.64 → 3.00 | 22.51 → 22.64 | 22.76 → 23.26 |
+| 4 KiB random | 64 MiB | 92.14 → 18.05 | 0.04 → 0.60 | 2.58 → 2.21 | 22.29 → 22.85 | 22.75 → 22.85 |
+| 64 KiB repeated | 128 KiB | 141.67 → 125.66 | 0.04 → 0.06 | 19.87 → 20.92 | 33.48 → 33.20 | 40.75 → 40.94 |
+| 64 KiB repeated | 64 MiB | 111.43 → 32.26 | 0.09 → 8.11 | 19.15 → 17.31 | 36.16 → 32.88 | 39.75 → 37.88 |
+| 64 KiB random | 128 KiB | 652.71 → 683.44 | 0.04 → 0.06 | 20.76 → 20.61 | 34.16 → 33.26 | 41.60 → 41.06 |
+| 64 KiB random | 64 MiB | 662.32 → 120.27 | 0.04 → 8.06 | 20.20 → 14.62 | 33.18 → 32.29 | 40.26 → 34.89 |
+
+Pre-read RSS was 19.3–19.8 MiB across these processes. Warm cache residency trades
+additional retained heap for much less decode/GC churn: the 64 KiB random, 64 MiB
+budget probe retained about 8 MiB more heap, while twelve-scan CPU fell from
+662 to 120 ms and sampled peak RSS from 40.3 to 34.9 MiB. At 128 KiB, those large
+scans remain effectively uncached; no whole 8 MiB decoded scan is admitted.
+
+These measurements do not imply the same speedup for a complete application:
+LIKE/collation work, network output, already cached aggregates, and planner choices
+can dominate. Simultaneous owners still compete through a bounded candidate
+window, and a first scan has nonzero metadata cost.
+
+To reproduce the permanent JIT integration cases with an existing `./memcp` build:
+
+```sh
+PERF_TEST=1 python3 run_sql_tests.py tests/storage/formats/blob-storage.yaml 18494 --fail-fast
+```
+
+
+Local final checks: 83/83 blob YAML cases with JIT, 5/5 undercount-recovery
+cases, 32/32 memory-pressure cases, targeted existing Go blob/cache tests, and
+the temporary race/admission/fault-repair probes passed. All four JIT A/B
+projection cases passed on both revisions in both orderings.
+
+`EXPLAIN`, `EXPLAIN IR`, `EXPLAIN PHYSICAL` and `EXPLAIN REORDER` were checked
+for the length projection: the logical form is one query-block and the lowered
+code is one scan reading `id` and `payload`, with `strlen` in the output mapping.
+There is no aggregate keytable bypassing payload access in that measurement.

--- a/storage/cache.go
+++ b/storage/cache.go
@@ -16,19 +16,16 @@ Copyright (C) 2025-2026  MemCP Contributors
 */
 package storage
 
-import (
-	"container/heap"
-	"fmt"
-	"github.com/carli2/hybridsort"
-	"log"
-	"os"
-	"strings"
-	"sync/atomic"
-	"syscall"
-	"time"
-
-	units "github.com/docker/go-units"
-)
+import "os"
+import "fmt"
+import "log"
+import "time"
+import "strings"
+import "syscall"
+import "sync/atomic"
+import "container/heap"
+import units "github.com/docker/go-units"
+import "github.com/carli2/hybridsort"
 
 // EvictableType identifies the kind of cached object for factor lookup and stat reporting.
 type EvictableType uint8
@@ -249,6 +246,7 @@ type CacheManager struct {
 }
 
 type cacheOp struct {
+	ready              <-chan struct{} // optional: owner released its lock after enqueueing
 	add                *softItem
 	del                any
 	updatePtr          any
@@ -509,6 +507,9 @@ func (cm *CacheManager) run() {
 			if !ok {
 				return
 			}
+			if op.ready != nil {
+				<-op.ready
+			}
 			if op.add != nil {
 				cm.addInternal(op.add)
 			} else if op.del != nil {
@@ -753,7 +754,10 @@ func (cm *CacheManager) evict(currentUsage, budget, additionalSize int64, typeFi
 		}
 		var candidates []evictionCandidate
 		var candidateSum int64
-		for candidateSum < candidateTarget && cm.h.Len() > 0 {
+		// A single large owner can exceed the byte target by itself. Still
+		// collect a bounded comparison window: otherwise telemetry never gets
+		// to compare that warm owner with small, low-benefit probation caches.
+		for (candidateSum < candidateTarget || len(candidates) < 16) && cm.h.Len() > 0 {
 			item := heap.Pop(&cm.h).(*softItem)
 			if typeFilter != nil && !typeFilter(item.evictType) {
 				skipped = append(skipped, item)

--- a/storage/jit_getters.go
+++ b/storage/jit_getters.go
@@ -117039,72 +117039,34 @@ func (s *StorageComputeProxy) JITEmitGetValueMulti(ctx *scm.JITContext, recids, 
 	return result
 }
 func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, target, stride, result scm.JITValueDesc) scm.JITValueDesc {
+	var d2 scm.JITValueDesc
+	_ = d2
+	var d3 scm.JITValueDesc
+	_ = d3
+	var d5 scm.JITValueDesc
+	_ = d5
 	var d7 scm.JITValueDesc
 	_ = d7
-	var d8 scm.JITValueDesc
-	_ = d8
-	var d10 scm.JITValueDesc
-	_ = d10
-	var d12 scm.JITValueDesc
-	_ = d12
-	var d21 scm.JITValueDesc
-	_ = d21
-	var d24 scm.JITValueDesc
-	_ = d24
-	var d36 scm.JITValueDesc
-	_ = d36
-	var d37 scm.JITValueDesc
-	_ = d37
-	var d38 scm.JITValueDesc
-	_ = d38
-	var d40 scm.JITValueDesc
-	_ = d40
-	var d41 scm.JITValueDesc
-	_ = d41
-	var d42 scm.JITValueDesc
-	_ = d42
-	var d43 scm.JITValueDesc
-	_ = d43
-	var d44 scm.JITValueDesc
-	_ = d44
-	var d45 scm.JITValueDesc
-	_ = d45
-	var d48 scm.JITValueDesc
-	_ = d48
-	var d49 scm.JITValueDesc
-	_ = d49
-	var d94 scm.JITValueDesc
-	_ = d94
-	var d95 scm.JITValueDesc
-	_ = d95
-	var d96 scm.JITValueDesc
-	_ = d96
-	var d97 scm.JITValueDesc
-	_ = d97
-	var d98 scm.JITValueDesc
-	_ = d98
-	var d99 scm.JITValueDesc
-	_ = d99
-	var d100 scm.JITValueDesc
-	_ = d100
-	var d101 scm.JITValueDesc
-	_ = d101
-	var d102 scm.JITValueDesc
-	_ = d102
-	var d104 scm.JITValueDesc
-	_ = d104
-	var d105 scm.JITValueDesc
-	_ = d105
+	var d14 scm.JITValueDesc
+	_ = d14
+	var d17 scm.JITValueDesc
+	_ = d17
+	var d27 scm.JITValueDesc
+	_ = d27
+	var d28 scm.JITValueDesc
+	_ = d28
+	var d29 scm.JITValueDesc
+	_ = d29
+	var d30 scm.JITValueDesc
+	_ = d30
 	/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 	ctx.TrackPointer(unsafe.Pointer(s))
 	thisptr := scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uintptr(unsafe.Pointer(s)))), NoHeapPointer: true}
 	standaloneFrame := ctx.BeginStandaloneFrame()
-	phiBase0 := ctx.AllocStack(int32(48))
-	var bbs [6]scm.BBDescriptor
+	phiBase0 := ctx.AllocStack(int32(16))
+	var bbs [3]scm.BBDescriptor
 	bbs[2].PhiBase = int32(phiBase0) + int32(0)
 	bbs[2].PhiCount = uint16(1)
-	bbs[3].PhiBase = int32(phiBase0) + int32(16)
-	bbs[3].PhiCount = uint16(2)
 	var storageRecidHome scm.JITValueDesc
 	var storageCountHome scm.JITValueDesc
 	var storageTargetHome scm.JITValueDesc
@@ -117135,34 +117097,8 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 	} else {
 		ctx.StabilizeDescForControlFlow(&storageStrideHome)
 	}
-	registerHomes1 := ctx.AllocRegisterHomes(scm.JITRegisterPlan{Slots: [16]scm.JITRegisterSlot{{Color: 0, Width: 1, Cost: 22}, {Color: 1, Width: 1, Cost: 17}}, Count: 2})
-	defer ctx.ReleaseRegisterHomes(registerHomes1)
-	var r0 scm.Reg
-	phiHomeOK2 := registerHomes1.Available&(uint16(1)<<0) == uint16(1)<<0
-	if phiHomeOK2 {
-		r0 = registerHomes1.Registers[0]
-	}
-	var r1 scm.Reg
-	phiHomeOK3 := registerHomes1.Available&(uint16(1)<<1) == uint16(1)<<1
-	if phiHomeOK3 {
-		r1 = registerHomes1.Registers[1]
-	}
-	d4 := scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-	_ = d4
-	var d5 scm.JITValueDesc
-	if phiHomeOK2 {
-		d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-	} else {
-		d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-	}
-	_ = d5
-	var d6 scm.JITValueDesc
-	if phiHomeOK3 {
-		d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-	} else {
-		d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-	}
-	_ = d6
+	d1 := scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
+	_ = d1
 	lbl0 := ctx.ReserveLabel()
 	bbpos_0_0 := int32(-1)
 	_ = bbpos_0_0
@@ -117176,18 +117112,6 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 	_ = bbpos_0_2
 	lbl3 := ctx.ReserveLabel()
 	_ = lbl3
-	bbpos_0_3 := int32(-1)
-	_ = bbpos_0_3
-	lbl4 := ctx.ReserveLabel()
-	_ = lbl4
-	bbpos_0_4 := int32(-1)
-	_ = bbpos_0_4
-	lbl5 := ctx.ReserveLabel()
-	_ = lbl5
-	bbpos_0_5 := int32(-1)
-	_ = bbpos_0_5
-	lbl6 := ctx.ReserveLabel()
-	_ = lbl6
 	bbs[0].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
 		if !ps.General {
 			if bbs[0].VisitCount >= 0 {
@@ -117208,25 +117132,9 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 			ctx.MarkLabel(lbl1)
 			ctx.ResolveFixups()
 		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
-		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
-			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
+		d1 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
+		if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != scm.LocNone {
+			d1 = ps.OverlayValues[1]
 		}
 		recid = storageRecidHome
 		count = storageCountHome
@@ -117234,142 +117142,124 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 		stride = storageStrideHome
 		ctx.ReclaimUntrackedRegs()
 		ctx.EnsureDesc(&stride)
-		var d7 scm.JITValueDesc
+		var d2 scm.JITValueDesc
 		if stride.Loc == scm.LocImm {
-			d7 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewBool(stride.Imm.Int() <= 0)}
+			d2 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewBool(stride.Imm.Int() <= 0)}
 		} else {
-			r2 := ctx.AllocRegExcept(stride.Reg)
+			r0 := ctx.AllocRegExcept(stride.Reg)
 			ctx.EmitCmpRegImm32(stride.Reg, 0)
-			d7 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r2, Condition: scm.CondSignedLessOrEqual}
-			ctx.BindReg(r2, &d7)
+			d2 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r0, Condition: scm.CondSignedLessOrEqual}
+			ctx.BindReg(r0, &d2)
 		}
-		d8 = d7
-		ctx.EnsureDesc(&d8)
-		if d8.Loc != scm.LocImm && d8.Loc != scm.LocFlags {
+		d3 = d2
+		ctx.EnsureDesc(&d3)
+		if d3.Loc != scm.LocImm && d3.Loc != scm.LocFlags {
 			panic("jit: fused If condition is neither scm.LocImm nor scm.LocFlags")
 		}
-		if d8.Loc == scm.LocImm {
-			if d8.Imm.Bool() {
+		if d3.Loc == scm.LocImm {
+			if d3.Imm.Bool() {
 				if ps.General {
 				}
-				ps9 := scm.PhiState{General: ps.General}
-				ps9.OverlayValues = make([]scm.JITValueDesc, 9)
-				ps9.OverlayValues[4] = d4
-				ps9.OverlayValues[5] = d5
-				ps9.OverlayValues[6] = d6
-				ps9.OverlayValues[7] = d7
-				ps9.OverlayValues[8] = d8
-				return bbs[1].RenderPS(ps9)
+				ps4 := scm.PhiState{General: ps.General}
+				ps4.OverlayValues = make([]scm.JITValueDesc, 4)
+				ps4.OverlayValues[1] = d1
+				ps4.OverlayValues[2] = d2
+				ps4.OverlayValues[3] = d3
+				return bbs[1].RenderPS(ps4)
 			}
 			if ps.General {
-				d10 = stride
-				if d10.Loc == scm.LocNone {
+				d5 = stride
+				if d5.Loc == scm.LocNone {
 					panic("jit: phi source has no location")
 				}
-				ctx.EnsureDesc(&d10)
-				ctx.EmitStoreToStack(d10, int32(bbs[2].PhiBase)+int32(0))
+				ctx.EnsureDesc(&d5)
+				ctx.EmitStoreToStack(d5, int32(bbs[2].PhiBase)+int32(0))
 			}
-			ps11 := scm.PhiState{General: ps.General}
-			ps11.OverlayValues = make([]scm.JITValueDesc, 11)
-			ps11.OverlayValues[4] = d4
-			ps11.OverlayValues[5] = d5
-			ps11.OverlayValues[6] = d6
-			ps11.OverlayValues[7] = d7
-			ps11.OverlayValues[8] = d8
-			ps11.OverlayValues[10] = d10
-			ps11.PhiValues = make([]scm.JITValueDesc, 1)
-			d12 = stride
-			ps11.PhiValues[0] = d12
-			return bbs[2].RenderPS(ps11)
+			ps6 := scm.PhiState{General: ps.General}
+			ps6.OverlayValues = make([]scm.JITValueDesc, 6)
+			ps6.OverlayValues[1] = d1
+			ps6.OverlayValues[2] = d2
+			ps6.OverlayValues[3] = d3
+			ps6.OverlayValues[5] = d5
+			ps6.PhiValues = make([]scm.JITValueDesc, 1)
+			d7 = stride
+			ps6.PhiValues[0] = d7
+			return bbs[2].RenderPS(ps6)
 		}
 		if !ps.General {
 			ps.General = true
 			return bbs[0].RenderPS(ps)
 		}
-		lbl7 := ctx.ReserveLabel()
-		ctx.EmitJump(d8.Condition, lbl2)
-		ctx.EmitJmp(lbl7)
-		ctx.FreeDesc(&d7)
-		snap13 := d4
-		snap14 := d5
-		snap15 := d6
-		snap16 := d7
-		snap17 := d8
-		snap18 := d10
-		snap19 := d12
-		alloc20 := ctx.SnapshotAllocState()
-		ctx.RestoreAllocState(alloc20)
-		d4 = snap13
-		d5 = snap14
-		d6 = snap15
-		d7 = snap16
-		d8 = snap17
-		d10 = snap18
-		d12 = snap19
-		ctx.MarkLabel(lbl7)
-		d21 = stride
-		if d21.Loc == scm.LocNone {
+		lbl4 := ctx.ReserveLabel()
+		ctx.EmitJump(d3.Condition, lbl2)
+		ctx.EmitJmp(lbl4)
+		ctx.FreeDesc(&d2)
+		snap8 := d1
+		snap9 := d2
+		snap10 := d3
+		snap11 := d5
+		snap12 := d7
+		alloc13 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc13)
+		d1 = snap8
+		d2 = snap9
+		d3 = snap10
+		d5 = snap11
+		d7 = snap12
+		ctx.MarkLabel(lbl4)
+		d14 = stride
+		if d14.Loc == scm.LocNone {
 			panic("jit: phi source has no location")
 		}
-		ctx.EnsureDesc(&d21)
-		ctx.EmitStoreToStack(d21, int32(bbs[2].PhiBase)+int32(0))
+		ctx.EnsureDesc(&d14)
+		ctx.EmitStoreToStack(d14, int32(bbs[2].PhiBase)+int32(0))
 		ctx.EmitJmp(lbl3)
-		ctx.RestoreAllocState(alloc20)
-		d4 = snap13
-		d5 = snap14
-		d6 = snap15
-		d7 = snap16
-		d8 = snap17
-		d10 = snap18
-		d12 = snap19
-		ps22 := scm.PhiState{General: true}
-		ps22.OverlayValues = make([]scm.JITValueDesc, 22)
-		ps22.OverlayValues[4] = d4
-		ps22.OverlayValues[5] = d5
-		ps22.OverlayValues[6] = d6
-		ps22.OverlayValues[7] = d7
-		ps22.OverlayValues[8] = d8
-		ps22.OverlayValues[10] = d10
-		ps22.OverlayValues[12] = d12
-		ps22.OverlayValues[21] = d21
-		ps23 := scm.PhiState{General: true}
-		ps23.OverlayValues = make([]scm.JITValueDesc, 22)
-		ps23.OverlayValues[4] = d4
-		ps23.OverlayValues[5] = d5
-		ps23.OverlayValues[6] = d6
-		ps23.OverlayValues[7] = d7
-		ps23.OverlayValues[8] = d8
-		ps23.OverlayValues[10] = d10
-		ps23.OverlayValues[12] = d12
-		ps23.OverlayValues[21] = d21
-		ps23.PhiValues = make([]scm.JITValueDesc, 1)
-		d24 = stride
-		ps23.PhiValues[0] = d24
-		snap25 := d4
-		snap26 := d5
-		snap27 := d6
-		snap28 := d7
-		snap29 := d8
-		snap30 := d10
-		snap31 := d12
-		snap32 := d21
-		snap33 := d24
-		alloc34 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc13)
+		d1 = snap8
+		d2 = snap9
+		d3 = snap10
+		d5 = snap11
+		d7 = snap12
+		ps15 := scm.PhiState{General: true}
+		ps15.OverlayValues = make([]scm.JITValueDesc, 15)
+		ps15.OverlayValues[1] = d1
+		ps15.OverlayValues[2] = d2
+		ps15.OverlayValues[3] = d3
+		ps15.OverlayValues[5] = d5
+		ps15.OverlayValues[7] = d7
+		ps15.OverlayValues[14] = d14
+		ps16 := scm.PhiState{General: true}
+		ps16.OverlayValues = make([]scm.JITValueDesc, 15)
+		ps16.OverlayValues[1] = d1
+		ps16.OverlayValues[2] = d2
+		ps16.OverlayValues[3] = d3
+		ps16.OverlayValues[5] = d5
+		ps16.OverlayValues[7] = d7
+		ps16.OverlayValues[14] = d14
+		ps16.PhiValues = make([]scm.JITValueDesc, 1)
+		d17 = stride
+		ps16.PhiValues[0] = d17
+		snap18 := d1
+		snap19 := d2
+		snap20 := d3
+		snap21 := d5
+		snap22 := d7
+		snap23 := d14
+		snap24 := d17
+		alloc25 := ctx.SnapshotAllocState()
 		if !bbs[2].Rendered {
-			bbs[2].RenderPS(ps23)
+			bbs[2].RenderPS(ps16)
 		}
-		ctx.RestoreAllocState(alloc34)
-		d4 = snap25
-		d5 = snap26
-		d6 = snap27
-		d7 = snap28
-		d8 = snap29
-		d10 = snap30
-		d12 = snap31
-		d21 = snap32
-		d24 = snap33
+		ctx.RestoreAllocState(alloc25)
+		d1 = snap18
+		d2 = snap19
+		d3 = snap20
+		d5 = snap21
+		d7 = snap22
+		d14 = snap23
+		d17 = snap24
 		if !bbs[1].Rendered {
-			return bbs[1].RenderPS(ps22)
+			return bbs[1].RenderPS(ps15)
 		}
 		return result
 		return result
@@ -117394,43 +117284,27 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 			ctx.MarkLabel(lbl2)
 			ctx.ResolveFixups()
 		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
+		d1 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
+		if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != scm.LocNone {
+			d1 = ps.OverlayValues[1]
 		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != scm.LocNone {
+			d2 = ps.OverlayValues[2]
 		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != scm.LocNone {
+			d3 = ps.OverlayValues[3]
 		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
 			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
 		}
 		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
 			d7 = ps.OverlayValues[7]
 		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
+		if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != scm.LocNone {
+			d14 = ps.OverlayValues[14]
 		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
-		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
-		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
+		if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != scm.LocNone {
+			d17 = ps.OverlayValues[17]
 		}
 		recid = storageRecidHome
 		count = storageCountHome
@@ -117440,33 +117314,31 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 		if ps.General {
 			ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 		}
-		ps35 := scm.PhiState{General: ps.General}
-		ps35.OverlayValues = make([]scm.JITValueDesc, 25)
-		ps35.OverlayValues[4] = d4
-		ps35.OverlayValues[5] = d5
-		ps35.OverlayValues[6] = d6
-		ps35.OverlayValues[7] = d7
-		ps35.OverlayValues[8] = d8
-		ps35.OverlayValues[10] = d10
-		ps35.OverlayValues[12] = d12
-		ps35.OverlayValues[21] = d21
-		ps35.OverlayValues[24] = d24
-		ps35.PhiValues = make([]scm.JITValueDesc, 1)
-		d36 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(1)}
-		ps35.PhiValues[0] = d36
-		if ps35.General && bbs[2].Rendered {
+		ps26 := scm.PhiState{General: ps.General}
+		ps26.OverlayValues = make([]scm.JITValueDesc, 18)
+		ps26.OverlayValues[1] = d1
+		ps26.OverlayValues[2] = d2
+		ps26.OverlayValues[3] = d3
+		ps26.OverlayValues[5] = d5
+		ps26.OverlayValues[7] = d7
+		ps26.OverlayValues[14] = d14
+		ps26.OverlayValues[17] = d17
+		ps26.PhiValues = make([]scm.JITValueDesc, 1)
+		d27 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(1)}
+		ps26.PhiValues[0] = d27
+		if ps26.General && bbs[2].Rendered {
 			ctx.EmitJmp(lbl3)
 			return result
 		}
-		return bbs[2].RenderPS(ps35)
+		return bbs[2].RenderPS(ps26)
 		return result
 	}
 	bbs[2].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
 		if !ps.General {
 			if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-				d37 := ps.PhiValues[0]
-				ctx.EnsureDesc(&d37)
-				ctx.EmitStoreToStack(d37, int32(bbs[2].PhiBase)+int32(0))
+				d28 := ps.PhiValues[0]
+				ctx.EnsureDesc(&d28)
+				ctx.EmitStoreToStack(d28, int32(bbs[2].PhiBase)+int32(0))
 			}
 			if bbs[2].VisitCount >= 0 {
 				ps.General = true
@@ -117486,947 +117358,98 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 			ctx.MarkLabel(lbl3)
 			ctx.ResolveFixups()
 		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
+		d1 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
+		if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != scm.LocNone {
+			d1 = ps.OverlayValues[1]
 		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != scm.LocNone {
+			d2 = ps.OverlayValues[2]
 		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != scm.LocNone {
+			d3 = ps.OverlayValues[3]
 		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
 			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
 		}
 		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
 			d7 = ps.OverlayValues[7]
 		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
+		if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != scm.LocNone {
+			d14 = ps.OverlayValues[14]
 		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
+		if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != scm.LocNone {
+			d17 = ps.OverlayValues[17]
 		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
+		if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != scm.LocNone {
+			d27 = ps.OverlayValues[27]
 		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
-		}
-		if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != scm.LocNone {
-			d36 = ps.OverlayValues[36]
-		}
-		if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != scm.LocNone {
-			d37 = ps.OverlayValues[37]
+		if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != scm.LocNone {
+			d28 = ps.OverlayValues[28]
 		}
 		if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-			d4 = ps.PhiValues[0]
+			d1 = ps.PhiValues[0]
 		}
 		recid = storageRecidHome
 		count = storageCountHome
 		target = storageTargetHome
 		stride = storageStrideHome
 		ctx.ReclaimUntrackedRegs()
-		ctx.StabilizeDescForControlFlow(&d4)
-		var d38 scm.JITValueDesc
+		var d29 scm.JITValueDesc
 		if thisptr.Loc == scm.LocImm {
 			fieldAddr := uintptr(thisptr.Imm.Int()) + unsafe.Offsetof((*OverlayBlob)(nil).Base)
-			r3 := ctx.AllocReg()
-			r4 := ctx.AllocRegExcept(r3)
-			ctx.EmitMovRegMem64(r3, fieldAddr)
-			ctx.EmitMovRegMem64(r4, fieldAddr+8)
-			d38 = scm.JITValueDesc{Loc: scm.LocRegPair, Reg: r3, Reg2: r4}
-			ctx.BindReg(r3, &d38)
-			ctx.BindReg(r4, &d38)
+			r1 := ctx.AllocReg()
+			r2 := ctx.AllocRegExcept(r1)
+			ctx.EmitMovRegMem64(r1, fieldAddr)
+			ctx.EmitMovRegMem64(r2, fieldAddr+8)
+			d29 = scm.JITValueDesc{Loc: scm.LocRegPair, Reg: r1, Reg2: r2}
+			ctx.BindReg(r1, &d29)
+			ctx.BindReg(r2, &d29)
 		} else {
 			off := int32(unsafe.Offsetof((*OverlayBlob)(nil).Base))
-			r5 := ctx.AllocReg()
-			r6 := ctx.AllocRegExcept(r5)
-			ctx.EmitMovRegMem(r5, thisptr.Reg, off)
-			ctx.EmitMovRegMem(r6, thisptr.Reg, off+8)
-			d38 = scm.JITValueDesc{Loc: scm.LocRegPair, Reg: r5, Reg2: r6}
-			ctx.BindReg(r5, &d38)
-			ctx.BindReg(r6, &d38)
+			r3 := ctx.AllocReg()
+			r4 := ctx.AllocRegExcept(r3)
+			ctx.EmitMovRegMem(r3, thisptr.Reg, off)
+			ctx.EmitMovRegMem(r4, thisptr.Reg, off+8)
+			d29 = scm.JITValueDesc{Loc: scm.LocRegPair, Reg: r3, Reg2: r4}
+			ctx.BindReg(r3, &d29)
+			ctx.BindReg(r4, &d29)
 		}
-		ctx.EnsureDesc(&d38)
+		ctx.EnsureDesc(&d29)
 		ctx.EnsureDesc(&recid)
 		ctx.EnsureDesc(&count)
 		ctx.EnsureDesc(&target)
-		ctx.EnsureDesc(&d4)
+		ctx.EnsureDesc(&d1)
 		ctx.EmitGoCallVoid(scm.GoFuncAddr(func(receiver ColumnStorage, arg0 uint32, arg1 uint32, arg2 []scm.Scmer, arg3 int) {
 			receiver.GetValueRange(arg0, arg1, arg2, arg3)
-		}), []scm.JITValueDesc{d38, recid, count, target, d4})
+		}), []scm.JITValueDesc{d29, recid, count, target, d1})
 		ctx.FreeDesc(&recid)
-		if ps.General {
-			if phiHomeOK2 {
-				ctx.EmitMovToReg(r0, scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)})
-			} else {
-				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}, int32(bbs[3].PhiBase)+int32(0))
-			}
-			if phiHomeOK3 {
-				ctx.EmitMovToReg(r1, scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)})
-			} else {
-				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}, int32(bbs[3].PhiBase)+int32(16))
-			}
-		}
-		ps39 := scm.PhiState{General: ps.General}
-		ps39.OverlayValues = make([]scm.JITValueDesc, 39)
-		ps39.OverlayValues[4] = d4
-		ps39.OverlayValues[5] = d5
-		ps39.OverlayValues[6] = d6
-		ps39.OverlayValues[7] = d7
-		ps39.OverlayValues[8] = d8
-		ps39.OverlayValues[10] = d10
-		ps39.OverlayValues[12] = d12
-		ps39.OverlayValues[21] = d21
-		ps39.OverlayValues[24] = d24
-		ps39.OverlayValues[36] = d36
-		ps39.OverlayValues[37] = d37
-		ps39.OverlayValues[38] = d38
-		ps39.PhiValues = make([]scm.JITValueDesc, 2)
-		d40 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}
-		ps39.PhiValues[0] = d40
-		d41 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}
-		ps39.PhiValues[1] = d41
-		if ps39.General && bbs[3].Rendered {
-			ctx.EmitJmp(lbl4)
-			return result
-		}
-		return bbs[3].RenderPS(ps39)
-		return result
-	}
-	bbs[3].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
-		if !ps.General {
-			if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-				d42 := ps.PhiValues[0]
-				ctx.EnsureDesc(&d42)
-				if phiHomeOK2 {
-					ctx.EmitMovToReg(r0, d42)
-				} else {
-					ctx.EmitStoreToStack(d42, int32(bbs[3].PhiBase)+int32(0))
-				}
-			}
-			if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != scm.LocNone {
-				d43 := ps.PhiValues[1]
-				ctx.EnsureDesc(&d43)
-				if phiHomeOK3 {
-					ctx.EmitMovToReg(r1, d43)
-				} else {
-					ctx.EmitStoreToStack(d43, int32(bbs[3].PhiBase)+int32(16))
-				}
-			}
-			if bbs[3].VisitCount >= 0 {
-				ps.General = true
-				return bbs[3].RenderPS(ps)
-			}
-		}
-		bbs[3].VisitCount++
-		if ps.General {
-			if bbs[3].Rendered {
-				ctx.EmitJmp(lbl4)
-				return result
-			}
-			bbs[3].Rendered = true
-			ctx.FlushRegisterMoves()
-			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-			bbpos_0_3 = bbs[3].Address
-			ctx.MarkLabel(lbl4)
-			ctx.ResolveFixups()
-		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
-		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
-			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
-		}
-		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
-			d7 = ps.OverlayValues[7]
-		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
-		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
-		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
-		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
-		}
-		if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != scm.LocNone {
-			d36 = ps.OverlayValues[36]
-		}
-		if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != scm.LocNone {
-			d37 = ps.OverlayValues[37]
-		}
-		if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != scm.LocNone {
-			d38 = ps.OverlayValues[38]
-		}
-		if len(ps.OverlayValues) > 40 && ps.OverlayValues[40].Loc != scm.LocNone {
-			d40 = ps.OverlayValues[40]
-		}
-		if len(ps.OverlayValues) > 41 && ps.OverlayValues[41].Loc != scm.LocNone {
-			d41 = ps.OverlayValues[41]
-		}
-		if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != scm.LocNone {
-			d42 = ps.OverlayValues[42]
-		}
-		if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != scm.LocNone {
-			d43 = ps.OverlayValues[43]
-		}
-		if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-			d5 = ps.PhiValues[0]
-		}
-		if !ps.General && len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != scm.LocNone {
-			d6 = ps.PhiValues[1]
-		}
-		recid = storageRecidHome
-		count = storageCountHome
-		target = storageTargetHome
-		stride = storageStrideHome
-		if phiHomeOK2 && d5.Loc == scm.LocReg {
-			ctx.BindReg(r0, &d5)
-		}
-		if phiHomeOK3 && d6.Loc == scm.LocReg {
-			ctx.BindReg(r1, &d6)
-		}
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d6)
 		ctx.EnsureDesc(&count)
-		ctx.EnsureDescsTogether(&d6, &count)
-		var d44 scm.JITValueDesc
-		if d6.Loc == scm.LocImm && count.Loc == scm.LocImm {
-			d44 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewBool(uint64(d6.Imm.Int()) < uint64(count.Imm.Int()))}
-		} else if count.Loc == scm.LocImm {
-			r7 := ctx.AllocRegExcept(d6.Reg)
-			if count.Imm.Int() >= -2147483648 && count.Imm.Int() <= 2147483647 {
-				ctx.EmitCmpRegImm32(d6.Reg, int32(count.Imm.Int()))
-			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(count.Imm.Int()))
-				ctx.EmitCmpInt64(d6.Reg, scm.RegR11)
-			}
-			d44 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r7, Condition: scm.CondUnsignedBelow}
-			ctx.BindReg(r7, &d44)
-		} else if d6.Loc == scm.LocImm {
-			r8 := ctx.AllocReg()
-			ctx.EmitMovRegImm64(scm.RegR11, uint64(d6.Imm.Int()))
-			ctx.EmitCmpInt64(scm.RegR11, count.Reg)
-			d44 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r8, Condition: scm.CondUnsignedBelow}
-			ctx.BindReg(r8, &d44)
-		} else {
-			r9 := ctx.AllocRegExcept(d6.Reg)
-			ctx.EmitCmpInt64(d6.Reg, count.Reg)
-			d44 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r9, Condition: scm.CondUnsignedBelow}
-			ctx.BindReg(r9, &d44)
-		}
-		ctx.FreeDesc(&count)
-		d45 = d44
-		ctx.EnsureDesc(&d45)
-		if d45.Loc != scm.LocImm && d45.Loc != scm.LocFlags {
-			panic("jit: fused If condition is neither scm.LocImm nor scm.LocFlags")
-		}
-		if d45.Loc == scm.LocImm {
-			if d45.Imm.Bool() {
-				if ps.General {
-				}
-				ps46 := scm.PhiState{General: ps.General}
-				ps46.OverlayValues = make([]scm.JITValueDesc, 46)
-				ps46.OverlayValues[4] = d4
-				ps46.OverlayValues[5] = d5
-				ps46.OverlayValues[6] = d6
-				ps46.OverlayValues[7] = d7
-				ps46.OverlayValues[8] = d8
-				ps46.OverlayValues[10] = d10
-				ps46.OverlayValues[12] = d12
-				ps46.OverlayValues[21] = d21
-				ps46.OverlayValues[24] = d24
-				ps46.OverlayValues[36] = d36
-				ps46.OverlayValues[37] = d37
-				ps46.OverlayValues[38] = d38
-				ps46.OverlayValues[40] = d40
-				ps46.OverlayValues[41] = d41
-				ps46.OverlayValues[42] = d42
-				ps46.OverlayValues[43] = d43
-				ps46.OverlayValues[44] = d44
-				ps46.OverlayValues[45] = d45
-				return bbs[4].RenderPS(ps46)
-			}
-			if ps.General {
-			}
-			ps47 := scm.PhiState{General: ps.General}
-			ps47.OverlayValues = make([]scm.JITValueDesc, 46)
-			ps47.OverlayValues[4] = d4
-			ps47.OverlayValues[5] = d5
-			ps47.OverlayValues[6] = d6
-			ps47.OverlayValues[7] = d7
-			ps47.OverlayValues[8] = d8
-			ps47.OverlayValues[10] = d10
-			ps47.OverlayValues[12] = d12
-			ps47.OverlayValues[21] = d21
-			ps47.OverlayValues[24] = d24
-			ps47.OverlayValues[36] = d36
-			ps47.OverlayValues[37] = d37
-			ps47.OverlayValues[38] = d38
-			ps47.OverlayValues[40] = d40
-			ps47.OverlayValues[41] = d41
-			ps47.OverlayValues[42] = d42
-			ps47.OverlayValues[43] = d43
-			ps47.OverlayValues[44] = d44
-			ps47.OverlayValues[45] = d45
-			return bbs[5].RenderPS(ps47)
-		}
-		if !ps.General {
-			if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-				d48 := ps.PhiValues[0]
-				ctx.EnsureDesc(&d48)
-				if phiHomeOK2 {
-					ctx.EmitMovToReg(r0, d48)
-				} else {
-					ctx.EmitStoreToStack(d48, int32(bbs[3].PhiBase)+int32(0))
-				}
-			}
-			if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != scm.LocNone {
-				d49 := ps.PhiValues[1]
-				ctx.EnsureDesc(&d49)
-				if phiHomeOK3 {
-					ctx.EmitMovToReg(r1, d49)
-				} else {
-					ctx.EmitStoreToStack(d49, int32(bbs[3].PhiBase)+int32(16))
-				}
-			}
-			ps.General = true
-			return bbs[3].RenderPS(ps)
-		}
-		ctx.EmitJump(d45.Condition, lbl5)
-		if bbs[5].Rendered {
-			ctx.EmitJmp(lbl6)
-		}
-		ctx.FreeDesc(&d44)
-		snap50 := d4
-		snap51 := d5
-		snap52 := d6
-		snap53 := d7
-		snap54 := d8
-		snap55 := d10
-		snap56 := d12
-		snap57 := d21
-		snap58 := d24
-		snap59 := d36
-		snap60 := d37
-		snap61 := d38
-		snap62 := d40
-		snap63 := d41
-		snap64 := d42
-		snap65 := d43
-		snap66 := d44
-		snap67 := d45
-		snap68 := d48
-		snap69 := d49
-		alloc70 := ctx.SnapshotAllocState()
-		ctx.RestoreAllocState(alloc70)
-		d4 = snap50
-		d5 = snap51
-		d6 = snap52
-		d7 = snap53
-		d8 = snap54
-		d10 = snap55
-		d12 = snap56
-		d21 = snap57
-		d24 = snap58
-		d36 = snap59
-		d37 = snap60
-		d38 = snap61
-		d40 = snap62
-		d41 = snap63
-		d42 = snap64
-		d43 = snap65
-		d44 = snap66
-		d45 = snap67
-		d48 = snap68
-		d49 = snap69
-		ctx.RestoreAllocState(alloc70)
-		d4 = snap50
-		d5 = snap51
-		d6 = snap52
-		d7 = snap53
-		d8 = snap54
-		d10 = snap55
-		d12 = snap56
-		d21 = snap57
-		d24 = snap58
-		d36 = snap59
-		d37 = snap60
-		d38 = snap61
-		d40 = snap62
-		d41 = snap63
-		d42 = snap64
-		d43 = snap65
-		d44 = snap66
-		d45 = snap67
-		d48 = snap68
-		d49 = snap69
-		ps71 := scm.PhiState{General: true}
-		ps71.OverlayValues = make([]scm.JITValueDesc, 50)
-		ps71.OverlayValues[4] = d4
-		ps71.OverlayValues[5] = d5
-		ps71.OverlayValues[6] = d6
-		ps71.OverlayValues[7] = d7
-		ps71.OverlayValues[8] = d8
-		ps71.OverlayValues[10] = d10
-		ps71.OverlayValues[12] = d12
-		ps71.OverlayValues[21] = d21
-		ps71.OverlayValues[24] = d24
-		ps71.OverlayValues[36] = d36
-		ps71.OverlayValues[37] = d37
-		ps71.OverlayValues[38] = d38
-		ps71.OverlayValues[40] = d40
-		ps71.OverlayValues[41] = d41
-		ps71.OverlayValues[42] = d42
-		ps71.OverlayValues[43] = d43
-		ps71.OverlayValues[44] = d44
-		ps71.OverlayValues[45] = d45
-		ps71.OverlayValues[48] = d48
-		ps71.OverlayValues[49] = d49
-		ps72 := scm.PhiState{General: true}
-		ps72.OverlayValues = make([]scm.JITValueDesc, 50)
-		ps72.OverlayValues[4] = d4
-		ps72.OverlayValues[5] = d5
-		ps72.OverlayValues[6] = d6
-		ps72.OverlayValues[7] = d7
-		ps72.OverlayValues[8] = d8
-		ps72.OverlayValues[10] = d10
-		ps72.OverlayValues[12] = d12
-		ps72.OverlayValues[21] = d21
-		ps72.OverlayValues[24] = d24
-		ps72.OverlayValues[36] = d36
-		ps72.OverlayValues[37] = d37
-		ps72.OverlayValues[38] = d38
-		ps72.OverlayValues[40] = d40
-		ps72.OverlayValues[41] = d41
-		ps72.OverlayValues[42] = d42
-		ps72.OverlayValues[43] = d43
-		ps72.OverlayValues[44] = d44
-		ps72.OverlayValues[45] = d45
-		ps72.OverlayValues[48] = d48
-		ps72.OverlayValues[49] = d49
-		snap73 := d4
-		snap74 := d5
-		snap75 := d6
-		snap76 := d7
-		snap77 := d8
-		snap78 := d10
-		snap79 := d12
-		snap80 := d21
-		snap81 := d24
-		snap82 := d36
-		snap83 := d37
-		snap84 := d38
-		snap85 := d40
-		snap86 := d41
-		snap87 := d42
-		snap88 := d43
-		snap89 := d44
-		snap90 := d45
-		snap91 := d48
-		snap92 := d49
-		alloc93 := ctx.SnapshotAllocState()
-		if !bbs[5].Rendered {
-			bbs[5].RenderPS(ps72)
-		}
-		ctx.RestoreAllocState(alloc93)
-		d4 = snap73
-		d5 = snap74
-		d6 = snap75
-		d7 = snap76
-		d8 = snap77
-		d10 = snap78
-		d12 = snap79
-		d21 = snap80
-		d24 = snap81
-		d36 = snap82
-		d37 = snap83
-		d38 = snap84
-		d40 = snap85
-		d41 = snap86
-		d42 = snap87
-		d43 = snap88
-		d44 = snap89
-		d45 = snap90
-		d48 = snap91
-		d49 = snap92
-		if !bbs[4].Rendered {
-			return bbs[4].RenderPS(ps71)
-		}
-		return result
-		return result
-	}
-	bbs[4].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
-		if !ps.General {
-			if bbs[4].VisitCount >= 0 {
-				ps.General = true
-				return bbs[4].RenderPS(ps)
-			}
-		}
-		bbs[4].VisitCount++
-		if ps.General {
-			if bbs[4].Rendered {
-				ctx.EmitJmp(lbl5)
-				return result
-			}
-			bbs[4].Rendered = true
-			ctx.FlushRegisterMoves()
-			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-			bbpos_0_4 = bbs[4].Address
-			ctx.MarkLabel(lbl5)
-			ctx.ResolveFixups()
-		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
-		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
-			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
-		}
-		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
-			d7 = ps.OverlayValues[7]
-		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
-		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
-		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
-		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
-		}
-		if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != scm.LocNone {
-			d36 = ps.OverlayValues[36]
-		}
-		if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != scm.LocNone {
-			d37 = ps.OverlayValues[37]
-		}
-		if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != scm.LocNone {
-			d38 = ps.OverlayValues[38]
-		}
-		if len(ps.OverlayValues) > 40 && ps.OverlayValues[40].Loc != scm.LocNone {
-			d40 = ps.OverlayValues[40]
-		}
-		if len(ps.OverlayValues) > 41 && ps.OverlayValues[41].Loc != scm.LocNone {
-			d41 = ps.OverlayValues[41]
-		}
-		if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != scm.LocNone {
-			d42 = ps.OverlayValues[42]
-		}
-		if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != scm.LocNone {
-			d43 = ps.OverlayValues[43]
-		}
-		if len(ps.OverlayValues) > 44 && ps.OverlayValues[44].Loc != scm.LocNone {
-			d44 = ps.OverlayValues[44]
-		}
-		if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != scm.LocNone {
-			d45 = ps.OverlayValues[45]
-		}
-		if len(ps.OverlayValues) > 48 && ps.OverlayValues[48].Loc != scm.LocNone {
-			d48 = ps.OverlayValues[48]
-		}
-		if len(ps.OverlayValues) > 49 && ps.OverlayValues[49].Loc != scm.LocNone {
-			d49 = ps.OverlayValues[49]
-		}
-		recid = storageRecidHome
-		count = storageCountHome
-		target = storageTargetHome
-		stride = storageStrideHome
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d5)
-		d95 = ctx.EmitSliceElementAddress(&target, &d5, 16)
-		ctx.EnsureDesc(&d95)
-		r10 := ctx.AllocRegExcept(d95.Reg)
-		ctx.EmitMovRegMem(r10, d95.Reg, 8)
-		ctx.EmitMovRegMem(d95.Reg, d95.Reg, 0)
-		d94 = scm.JITValueDesc{Loc: scm.LocRegPair, Type: scm.JITTypeUnknown, Reg: d95.Reg, Reg2: r10}
-		ctx.BindReg(d95.Reg, &d94)
-		ctx.BindReg(r10, &d94)
+		ctx.EnsureDesc(&count)
 		if thisptr.Loc == scm.LocRegPair || thisptr.Loc == scm.LocStackPair || thisptr.Loc == scm.LocRegTriple || thisptr.Loc == scm.LocStackTriple {
 			panic("jit: generic call arg expects 1-word value")
 		}
-		d94 = scm.JITPrepareScmerGoArg(ctx, d94)
+		target = scm.JITPrepareGoSliceArg(ctx, target)
+		if target.Loc != scm.LocRegTriple && target.Loc != scm.LocStackTriple {
+			panic("jit: generic call arg expects 3-word Go slice ((*OverlayBlob).resolveBlobBatch arg1)")
+		}
+		if count.Loc == scm.LocRegPair || count.Loc == scm.LocStackPair || count.Loc == scm.LocRegTriple || count.Loc == scm.LocStackTriple {
+			panic("jit: generic call arg expects 1-word value")
+		}
+		if d1.Loc == scm.LocRegPair || d1.Loc == scm.LocStackPair || d1.Loc == scm.LocRegTriple || d1.Loc == scm.LocStackTriple {
+			panic("jit: generic call arg expects 1-word value")
+		}
 		ctx.SyncDesc(&thisptr)
-		ctx.SyncDesc(&d94)
-		d96 = ctx.EmitGoCallScalar(scm.GoFuncAddr((*OverlayBlob).resolveBlob), []scm.JITValueDesc{thisptr, d94}, 2)
-		d96.NoHeapPointer = false
-		ctx.BindReg(d96.Reg, &d96)
-		ctx.BindReg(d96.Reg2, &d96)
-		ctx.FreeDesc(&d94)
-		ctx.EnsureDesc(&d5)
-		ctx.SyncDesc(&d96)
-		d97 = target
-		d97.ID = 0
-		d98 = d5
-		d98.ID = 0
-		if !ctx.TryEmitStoreScmerSliceElement(&d97, &d98, &d96, int32(16)) {
-			ctx.StabilizeDescAcrossNestedCall(&d5)
-			d98 = d5
-			d98.ID = 0
-			ctx.EmitStoreScmerSliceElement(&d97, &d98, &d96, int32(16))
-		}
-		ctx.FreeDesc(&d98)
-		ctx.FreeDesc(&d96)
-		ctx.EnsureDesc(&d5)
-		ctx.EnsureDesc(&d4)
-		ctx.EnsureDescsTogether(&d5, &d4)
-		var d99 scm.JITValueDesc
-		if d5.Loc == scm.LocImm && d4.Loc == scm.LocImm {
-			d99 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d5.Imm.Int() + d4.Imm.Int())}
-		} else if d4.Loc == scm.LocImm && d4.Imm.Int() == 0 {
-			var r11 scm.Reg
-			if phiHomeOK2 {
-				r11 = r0
-			} else {
-				r11 = ctx.AllocRegExcept(d5.Reg)
-			}
-			ctx.EmitMovRegReg(r11, d5.Reg)
-			d99 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r11}
-			ctx.BindReg(r11, &d99)
-		} else if d5.Loc == scm.LocImm && d5.Imm.Int() == 0 {
-			d99 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d4.Reg}
-			ctx.BindReg(d4.Reg, &d99)
-		} else if d5.Loc == scm.LocImm {
-			var scratch scm.Reg
-			if phiHomeOK2 && r0 != d4.Reg {
-				scratch = r0
-			} else {
-				scratch = ctx.AllocRegExcept(d4.Reg)
-			}
-			ctx.EmitMovRegImm64(scratch, uint64(d5.Imm.Int()))
-			ctx.EmitAddInt64(scratch, d4.Reg)
-			d99 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d99)
-		} else if d4.Loc == scm.LocImm {
-			var scratch scm.Reg
-			if phiHomeOK2 {
-				scratch = r0
-			} else {
-				scratch = ctx.AllocRegExcept(d5.Reg)
-			}
-			ctx.EmitMovRegReg(scratch, d5.Reg)
-			if d4.Imm.Int() >= -2147483648 && d4.Imm.Int() <= 2147483647 {
-				ctx.EmitAddRegImm32(scratch, int32(d4.Imm.Int()))
-			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d4.Imm.Int()))
-				ctx.EmitAddInt64(scratch, scm.RegR11)
-			}
-			d99 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d99)
-		} else {
-			var r12 scm.Reg
-			if phiHomeOK2 && r0 != d4.Reg {
-				r12 = r0
-			} else {
-				r12 = ctx.AllocRegExcept(d5.Reg, d4.Reg)
-			}
-			ctx.EmitMovRegReg(r12, d5.Reg)
-			ctx.EmitAddInt64(r12, d4.Reg)
-			d99 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r12}
-			ctx.BindReg(r12, &d99)
-		}
-		if d99.Loc == scm.LocReg && d5.Loc == scm.LocReg && d99.Reg == d5.Reg {
-			ctx.TransferReg(d5.Reg)
-			d5.Loc = scm.LocNone
-		}
-		ctx.EnsureDesc(&d6)
-		ctx.EnsureDesc(&d6)
-		var d100 scm.JITValueDesc
-		if d6.Loc == scm.LocImm {
-			d100 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d6.Imm.Int() + 1)}
-		} else {
-			var scratch scm.Reg
-			if phiHomeOK3 {
-				scratch = r1
-			} else {
-				scratch = ctx.AllocRegExcept(d6.Reg)
-			}
-			ctx.EmitMovRegReg(scratch, d6.Reg)
-			ctx.EmitAddRegImm32Low(scratch, int32(1))
-			d100 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d100)
-		}
-		if d100.Loc == scm.LocReg && d6.Loc == scm.LocReg && d100.Reg == d6.Reg {
-			ctx.TransferReg(d6.Reg)
-			d6.Loc = scm.LocNone
-		}
-		if ps.General {
-			ctx.SyncDesc(&d99)
-			if d99.Loc == scm.LocReg || d99.Loc == scm.LocFPReg {
-				ctx.ProtectReg(d99.Reg)
-			} else if d99.Loc == scm.LocRegPair {
-				ctx.ProtectReg(d99.Reg)
-				ctx.ProtectReg(d99.Reg2)
-			}
-			ctx.SyncDesc(&d100)
-			if d100.Loc == scm.LocReg || d100.Loc == scm.LocFPReg {
-				ctx.ProtectReg(d100.Reg)
-			} else if d100.Loc == scm.LocRegPair {
-				ctx.ProtectReg(d100.Reg)
-				ctx.ProtectReg(d100.Reg2)
-			}
-			d101 = d99
-			if d101.Loc == scm.LocNone {
-				panic("jit: phi source has no location")
-			}
-			ctx.EnsureDesc(&d101)
-			if phiHomeOK2 {
-				ctx.EmitMovToReg(r0, d101)
-			} else {
-				ctx.EmitStoreToStack(d101, int32(bbs[3].PhiBase)+int32(0))
-			}
-			d102 = d100
-			if d102.Loc == scm.LocNone {
-				panic("jit: phi source has no location")
-			}
-			ctx.EnsureDesc(&d102)
-			if phiHomeOK3 {
-				ctx.EmitMovToReg(r1, d102)
-			} else {
-				ctx.EmitStoreToStack(d102, int32(bbs[3].PhiBase)+int32(16))
-			}
-			if d99.Loc == scm.LocReg || d99.Loc == scm.LocFPReg {
-				ctx.UnprotectReg(d99.Reg)
-			} else if d99.Loc == scm.LocRegPair {
-				ctx.UnprotectReg(d99.Reg)
-				ctx.UnprotectReg(d99.Reg2)
-			}
-			if d100.Loc == scm.LocReg || d100.Loc == scm.LocFPReg {
-				ctx.UnprotectReg(d100.Reg)
-			} else if d100.Loc == scm.LocRegPair {
-				ctx.UnprotectReg(d100.Reg)
-				ctx.UnprotectReg(d100.Reg2)
-			}
-		}
-		ps103 := scm.PhiState{General: ps.General}
-		ps103.OverlayValues = make([]scm.JITValueDesc, 103)
-		ps103.OverlayValues[4] = d4
-		ps103.OverlayValues[5] = d5
-		ps103.OverlayValues[6] = d6
-		ps103.OverlayValues[7] = d7
-		ps103.OverlayValues[8] = d8
-		ps103.OverlayValues[10] = d10
-		ps103.OverlayValues[12] = d12
-		ps103.OverlayValues[21] = d21
-		ps103.OverlayValues[24] = d24
-		ps103.OverlayValues[36] = d36
-		ps103.OverlayValues[37] = d37
-		ps103.OverlayValues[38] = d38
-		ps103.OverlayValues[40] = d40
-		ps103.OverlayValues[41] = d41
-		ps103.OverlayValues[42] = d42
-		ps103.OverlayValues[43] = d43
-		ps103.OverlayValues[44] = d44
-		ps103.OverlayValues[45] = d45
-		ps103.OverlayValues[48] = d48
-		ps103.OverlayValues[49] = d49
-		ps103.OverlayValues[94] = d94
-		ps103.OverlayValues[95] = d95
-		ps103.OverlayValues[96] = d96
-		ps103.OverlayValues[97] = d97
-		ps103.OverlayValues[98] = d98
-		ps103.OverlayValues[99] = d99
-		ps103.OverlayValues[100] = d100
-		ps103.OverlayValues[101] = d101
-		ps103.OverlayValues[102] = d102
-		ps103.PhiValues = make([]scm.JITValueDesc, 2)
-		d104 = d99
-		ps103.PhiValues[0] = d104
-		d105 = d100
-		ps103.PhiValues[1] = d105
-		if ps103.General && bbs[3].Rendered {
-			ctx.EmitJmp(lbl4)
-			return result
-		}
-		return bbs[3].RenderPS(ps103)
-		return result
-	}
-	bbs[5].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
-		if !ps.General {
-			if bbs[5].VisitCount >= 0 {
-				ps.General = true
-				return bbs[5].RenderPS(ps)
-			}
-		}
-		bbs[5].VisitCount++
-		if ps.General {
-			if bbs[5].Rendered {
-				ctx.EmitJmp(lbl6)
-				return result
-			}
-			bbs[5].Rendered = true
-			ctx.FlushRegisterMoves()
-			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-			bbpos_0_5 = bbs[5].Address
-			ctx.MarkLabel(lbl6)
-			ctx.ResolveFixups()
-		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
-		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
-			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
-		}
-		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
-			d7 = ps.OverlayValues[7]
-		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
-		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
-		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
-		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
-		}
-		if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != scm.LocNone {
-			d36 = ps.OverlayValues[36]
-		}
-		if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != scm.LocNone {
-			d37 = ps.OverlayValues[37]
-		}
-		if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != scm.LocNone {
-			d38 = ps.OverlayValues[38]
-		}
-		if len(ps.OverlayValues) > 40 && ps.OverlayValues[40].Loc != scm.LocNone {
-			d40 = ps.OverlayValues[40]
-		}
-		if len(ps.OverlayValues) > 41 && ps.OverlayValues[41].Loc != scm.LocNone {
-			d41 = ps.OverlayValues[41]
-		}
-		if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != scm.LocNone {
-			d42 = ps.OverlayValues[42]
-		}
-		if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != scm.LocNone {
-			d43 = ps.OverlayValues[43]
-		}
-		if len(ps.OverlayValues) > 44 && ps.OverlayValues[44].Loc != scm.LocNone {
-			d44 = ps.OverlayValues[44]
-		}
-		if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != scm.LocNone {
-			d45 = ps.OverlayValues[45]
-		}
-		if len(ps.OverlayValues) > 48 && ps.OverlayValues[48].Loc != scm.LocNone {
-			d48 = ps.OverlayValues[48]
-		}
-		if len(ps.OverlayValues) > 49 && ps.OverlayValues[49].Loc != scm.LocNone {
-			d49 = ps.OverlayValues[49]
-		}
-		if len(ps.OverlayValues) > 94 && ps.OverlayValues[94].Loc != scm.LocNone {
-			d94 = ps.OverlayValues[94]
-		}
-		if len(ps.OverlayValues) > 95 && ps.OverlayValues[95].Loc != scm.LocNone {
-			d95 = ps.OverlayValues[95]
-		}
-		if len(ps.OverlayValues) > 96 && ps.OverlayValues[96].Loc != scm.LocNone {
-			d96 = ps.OverlayValues[96]
-		}
-		if len(ps.OverlayValues) > 97 && ps.OverlayValues[97].Loc != scm.LocNone {
-			d97 = ps.OverlayValues[97]
-		}
-		if len(ps.OverlayValues) > 98 && ps.OverlayValues[98].Loc != scm.LocNone {
-			d98 = ps.OverlayValues[98]
-		}
-		if len(ps.OverlayValues) > 99 && ps.OverlayValues[99].Loc != scm.LocNone {
-			d99 = ps.OverlayValues[99]
-		}
-		if len(ps.OverlayValues) > 100 && ps.OverlayValues[100].Loc != scm.LocNone {
-			d100 = ps.OverlayValues[100]
-		}
-		if len(ps.OverlayValues) > 101 && ps.OverlayValues[101].Loc != scm.LocNone {
-			d101 = ps.OverlayValues[101]
-		}
-		if len(ps.OverlayValues) > 102 && ps.OverlayValues[102].Loc != scm.LocNone {
-			d102 = ps.OverlayValues[102]
-		}
-		if len(ps.OverlayValues) > 104 && ps.OverlayValues[104].Loc != scm.LocNone {
-			d104 = ps.OverlayValues[104]
-		}
-		if len(ps.OverlayValues) > 105 && ps.OverlayValues[105].Loc != scm.LocNone {
-			d105 = ps.OverlayValues[105]
-		}
-		recid = storageRecidHome
-		count = storageCountHome
-		target = storageTargetHome
-		stride = storageStrideHome
-		ctx.ReclaimUntrackedRegs()
+		ctx.SyncDesc(&target)
+		ctx.SyncDesc(&count)
+		ctx.SyncDesc(&d1)
+		ctx.EmitGoCallVoid(scm.GoFuncAddr((*OverlayBlob).resolveBlobBatch), []scm.JITValueDesc{thisptr, target, count, d1})
+		ctx.FreeDesc(&count)
+		ctx.FreeDesc(&d1)
 		ctx.EmitJmp(lbl0)
 		return result
 	}
-	ps106 := scm.PhiState{General: false}
-	_ = bbs[0].RenderPS(ps106)
+	ps31 := scm.PhiState{General: false}
+	_ = bbs[0].RenderPS(ps31)
 	ctx.MarkLabel(lbl0)
 	ctx.ResolveFixups()
 	if storageInputsProtected {
@@ -118445,74 +117468,34 @@ func (s *OverlayBlob) JITEmitGetValueRange(ctx *scm.JITContext, recid, count, ta
 	return result
 }
 func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, stride, result scm.JITValueDesc) scm.JITValueDesc {
+	var d2 scm.JITValueDesc
+	_ = d2
+	var d3 scm.JITValueDesc
+	_ = d3
+	var d5 scm.JITValueDesc
+	_ = d5
 	var d7 scm.JITValueDesc
 	_ = d7
-	var d8 scm.JITValueDesc
-	_ = d8
-	var d10 scm.JITValueDesc
-	_ = d10
-	var d12 scm.JITValueDesc
-	_ = d12
-	var d21 scm.JITValueDesc
-	_ = d21
-	var d24 scm.JITValueDesc
-	_ = d24
-	var d36 scm.JITValueDesc
-	_ = d36
-	var d37 scm.JITValueDesc
-	_ = d37
-	var d38 scm.JITValueDesc
-	_ = d38
-	var d39 scm.JITValueDesc
-	_ = d39
-	var d41 scm.JITValueDesc
-	_ = d41
-	var d42 scm.JITValueDesc
-	_ = d42
-	var d43 scm.JITValueDesc
-	_ = d43
-	var d44 scm.JITValueDesc
-	_ = d44
-	var d45 scm.JITValueDesc
-	_ = d45
-	var d46 scm.JITValueDesc
-	_ = d46
-	var d47 scm.JITValueDesc
-	_ = d47
-	var d50 scm.JITValueDesc
-	_ = d50
-	var d51 scm.JITValueDesc
-	_ = d51
-	var d100 scm.JITValueDesc
-	_ = d100
-	var d101 scm.JITValueDesc
-	_ = d101
-	var d102 scm.JITValueDesc
-	_ = d102
-	var d103 scm.JITValueDesc
-	_ = d103
-	var d104 scm.JITValueDesc
-	_ = d104
-	var d105 scm.JITValueDesc
-	_ = d105
-	var d106 scm.JITValueDesc
-	_ = d106
-	var d107 scm.JITValueDesc
-	_ = d107
-	var d109 scm.JITValueDesc
-	_ = d109
-	var d110 scm.JITValueDesc
-	_ = d110
+	var d14 scm.JITValueDesc
+	_ = d14
+	var d17 scm.JITValueDesc
+	_ = d17
+	var d27 scm.JITValueDesc
+	_ = d27
+	var d28 scm.JITValueDesc
+	_ = d28
+	var d29 scm.JITValueDesc
+	_ = d29
+	var d30 scm.JITValueDesc
+	_ = d30
 	/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
 	ctx.TrackPointer(unsafe.Pointer(s))
 	thisptr := scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(uintptr(unsafe.Pointer(s)))), NoHeapPointer: true}
 	standaloneFrame := ctx.BeginStandaloneFrame()
-	phiBase0 := ctx.AllocStack(int32(48))
-	var bbs [6]scm.BBDescriptor
+	phiBase0 := ctx.AllocStack(int32(16))
+	var bbs [3]scm.BBDescriptor
 	bbs[2].PhiBase = int32(phiBase0) + int32(0)
 	bbs[2].PhiCount = uint16(1)
-	bbs[3].PhiBase = int32(phiBase0) + int32(16)
-	bbs[3].PhiCount = uint16(2)
 	var storageRecidsHome scm.JITValueDesc
 	var storageTargetHome scm.JITValueDesc
 	var storageStrideHome scm.JITValueDesc
@@ -118537,34 +117520,8 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 	} else {
 		ctx.StabilizeDescForControlFlow(&storageStrideHome)
 	}
-	registerHomes1 := ctx.AllocRegisterHomes(scm.JITRegisterPlan{Slots: [16]scm.JITRegisterSlot{{Color: 0, Width: 1, Cost: 22}, {Color: 1, Width: 1, Cost: 12}}, Count: 2})
-	defer ctx.ReleaseRegisterHomes(registerHomes1)
-	var r0 scm.Reg
-	phiHomeOK2 := registerHomes1.Available&(uint16(1)<<0) == uint16(1)<<0
-	if phiHomeOK2 {
-		r0 = registerHomes1.Registers[0]
-	}
-	var r1 scm.Reg
-	phiHomeOK3 := registerHomes1.Available&(uint16(1)<<1) == uint16(1)<<1
-	if phiHomeOK3 {
-		r1 = registerHomes1.Registers[1]
-	}
-	d4 := scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-	_ = d4
-	var d5 scm.JITValueDesc
-	if phiHomeOK2 {
-		d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-	} else {
-		d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-	}
-	_ = d5
-	var d6 scm.JITValueDesc
-	if phiHomeOK3 {
-		d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-	} else {
-		d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-	}
-	_ = d6
+	d1 := scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
+	_ = d1
 	lbl0 := ctx.ReserveLabel()
 	bbpos_0_0 := int32(-1)
 	_ = bbpos_0_0
@@ -118578,18 +117535,6 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 	_ = bbpos_0_2
 	lbl3 := ctx.ReserveLabel()
 	_ = lbl3
-	bbpos_0_3 := int32(-1)
-	_ = bbpos_0_3
-	lbl4 := ctx.ReserveLabel()
-	_ = lbl4
-	bbpos_0_4 := int32(-1)
-	_ = bbpos_0_4
-	lbl5 := ctx.ReserveLabel()
-	_ = lbl5
-	bbpos_0_5 := int32(-1)
-	_ = bbpos_0_5
-	lbl6 := ctx.ReserveLabel()
-	_ = lbl6
 	bbs[0].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
 		if !ps.General {
 			if bbs[0].VisitCount >= 0 {
@@ -118610,167 +117555,133 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 			ctx.MarkLabel(lbl1)
 			ctx.ResolveFixups()
 		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
-		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
-			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
+		d1 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
+		if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != scm.LocNone {
+			d1 = ps.OverlayValues[1]
 		}
 		recids = storageRecidsHome
 		target = storageTargetHome
 		stride = storageStrideHome
 		ctx.ReclaimUntrackedRegs()
 		ctx.EnsureDesc(&stride)
-		var d7 scm.JITValueDesc
+		var d2 scm.JITValueDesc
 		if stride.Loc == scm.LocImm {
-			d7 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewBool(stride.Imm.Int() <= 0)}
+			d2 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewBool(stride.Imm.Int() <= 0)}
 		} else {
-			r2 := ctx.AllocRegExcept(stride.Reg)
+			r0 := ctx.AllocRegExcept(stride.Reg)
 			ctx.EmitCmpRegImm32(stride.Reg, 0)
-			d7 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r2, Condition: scm.CondSignedLessOrEqual}
-			ctx.BindReg(r2, &d7)
+			d2 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r0, Condition: scm.CondSignedLessOrEqual}
+			ctx.BindReg(r0, &d2)
 		}
-		d8 = d7
-		ctx.EnsureDesc(&d8)
-		if d8.Loc != scm.LocImm && d8.Loc != scm.LocFlags {
+		d3 = d2
+		ctx.EnsureDesc(&d3)
+		if d3.Loc != scm.LocImm && d3.Loc != scm.LocFlags {
 			panic("jit: fused If condition is neither scm.LocImm nor scm.LocFlags")
 		}
-		if d8.Loc == scm.LocImm {
-			if d8.Imm.Bool() {
+		if d3.Loc == scm.LocImm {
+			if d3.Imm.Bool() {
 				if ps.General {
 				}
-				ps9 := scm.PhiState{General: ps.General}
-				ps9.OverlayValues = make([]scm.JITValueDesc, 9)
-				ps9.OverlayValues[4] = d4
-				ps9.OverlayValues[5] = d5
-				ps9.OverlayValues[6] = d6
-				ps9.OverlayValues[7] = d7
-				ps9.OverlayValues[8] = d8
-				return bbs[1].RenderPS(ps9)
+				ps4 := scm.PhiState{General: ps.General}
+				ps4.OverlayValues = make([]scm.JITValueDesc, 4)
+				ps4.OverlayValues[1] = d1
+				ps4.OverlayValues[2] = d2
+				ps4.OverlayValues[3] = d3
+				return bbs[1].RenderPS(ps4)
 			}
 			if ps.General {
-				d10 = stride
-				if d10.Loc == scm.LocNone {
+				d5 = stride
+				if d5.Loc == scm.LocNone {
 					panic("jit: phi source has no location")
 				}
-				ctx.EnsureDesc(&d10)
-				ctx.EmitStoreToStack(d10, int32(bbs[2].PhiBase)+int32(0))
+				ctx.EnsureDesc(&d5)
+				ctx.EmitStoreToStack(d5, int32(bbs[2].PhiBase)+int32(0))
 			}
-			ps11 := scm.PhiState{General: ps.General}
-			ps11.OverlayValues = make([]scm.JITValueDesc, 11)
-			ps11.OverlayValues[4] = d4
-			ps11.OverlayValues[5] = d5
-			ps11.OverlayValues[6] = d6
-			ps11.OverlayValues[7] = d7
-			ps11.OverlayValues[8] = d8
-			ps11.OverlayValues[10] = d10
-			ps11.PhiValues = make([]scm.JITValueDesc, 1)
-			d12 = stride
-			ps11.PhiValues[0] = d12
-			return bbs[2].RenderPS(ps11)
+			ps6 := scm.PhiState{General: ps.General}
+			ps6.OverlayValues = make([]scm.JITValueDesc, 6)
+			ps6.OverlayValues[1] = d1
+			ps6.OverlayValues[2] = d2
+			ps6.OverlayValues[3] = d3
+			ps6.OverlayValues[5] = d5
+			ps6.PhiValues = make([]scm.JITValueDesc, 1)
+			d7 = stride
+			ps6.PhiValues[0] = d7
+			return bbs[2].RenderPS(ps6)
 		}
 		if !ps.General {
 			ps.General = true
 			return bbs[0].RenderPS(ps)
 		}
-		lbl7 := ctx.ReserveLabel()
-		ctx.EmitJump(d8.Condition, lbl2)
-		ctx.EmitJmp(lbl7)
-		ctx.FreeDesc(&d7)
-		snap13 := d4
-		snap14 := d5
-		snap15 := d6
-		snap16 := d7
-		snap17 := d8
-		snap18 := d10
-		snap19 := d12
-		alloc20 := ctx.SnapshotAllocState()
-		ctx.RestoreAllocState(alloc20)
-		d4 = snap13
-		d5 = snap14
-		d6 = snap15
-		d7 = snap16
-		d8 = snap17
-		d10 = snap18
-		d12 = snap19
-		ctx.MarkLabel(lbl7)
-		d21 = stride
-		if d21.Loc == scm.LocNone {
+		lbl4 := ctx.ReserveLabel()
+		ctx.EmitJump(d3.Condition, lbl2)
+		ctx.EmitJmp(lbl4)
+		ctx.FreeDesc(&d2)
+		snap8 := d1
+		snap9 := d2
+		snap10 := d3
+		snap11 := d5
+		snap12 := d7
+		alloc13 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc13)
+		d1 = snap8
+		d2 = snap9
+		d3 = snap10
+		d5 = snap11
+		d7 = snap12
+		ctx.MarkLabel(lbl4)
+		d14 = stride
+		if d14.Loc == scm.LocNone {
 			panic("jit: phi source has no location")
 		}
-		ctx.EnsureDesc(&d21)
-		ctx.EmitStoreToStack(d21, int32(bbs[2].PhiBase)+int32(0))
+		ctx.EnsureDesc(&d14)
+		ctx.EmitStoreToStack(d14, int32(bbs[2].PhiBase)+int32(0))
 		ctx.EmitJmp(lbl3)
-		ctx.RestoreAllocState(alloc20)
-		d4 = snap13
-		d5 = snap14
-		d6 = snap15
-		d7 = snap16
-		d8 = snap17
-		d10 = snap18
-		d12 = snap19
-		ps22 := scm.PhiState{General: true}
-		ps22.OverlayValues = make([]scm.JITValueDesc, 22)
-		ps22.OverlayValues[4] = d4
-		ps22.OverlayValues[5] = d5
-		ps22.OverlayValues[6] = d6
-		ps22.OverlayValues[7] = d7
-		ps22.OverlayValues[8] = d8
-		ps22.OverlayValues[10] = d10
-		ps22.OverlayValues[12] = d12
-		ps22.OverlayValues[21] = d21
-		ps23 := scm.PhiState{General: true}
-		ps23.OverlayValues = make([]scm.JITValueDesc, 22)
-		ps23.OverlayValues[4] = d4
-		ps23.OverlayValues[5] = d5
-		ps23.OverlayValues[6] = d6
-		ps23.OverlayValues[7] = d7
-		ps23.OverlayValues[8] = d8
-		ps23.OverlayValues[10] = d10
-		ps23.OverlayValues[12] = d12
-		ps23.OverlayValues[21] = d21
-		ps23.PhiValues = make([]scm.JITValueDesc, 1)
-		d24 = stride
-		ps23.PhiValues[0] = d24
-		snap25 := d4
-		snap26 := d5
-		snap27 := d6
-		snap28 := d7
-		snap29 := d8
-		snap30 := d10
-		snap31 := d12
-		snap32 := d21
-		snap33 := d24
-		alloc34 := ctx.SnapshotAllocState()
+		ctx.RestoreAllocState(alloc13)
+		d1 = snap8
+		d2 = snap9
+		d3 = snap10
+		d5 = snap11
+		d7 = snap12
+		ps15 := scm.PhiState{General: true}
+		ps15.OverlayValues = make([]scm.JITValueDesc, 15)
+		ps15.OverlayValues[1] = d1
+		ps15.OverlayValues[2] = d2
+		ps15.OverlayValues[3] = d3
+		ps15.OverlayValues[5] = d5
+		ps15.OverlayValues[7] = d7
+		ps15.OverlayValues[14] = d14
+		ps16 := scm.PhiState{General: true}
+		ps16.OverlayValues = make([]scm.JITValueDesc, 15)
+		ps16.OverlayValues[1] = d1
+		ps16.OverlayValues[2] = d2
+		ps16.OverlayValues[3] = d3
+		ps16.OverlayValues[5] = d5
+		ps16.OverlayValues[7] = d7
+		ps16.OverlayValues[14] = d14
+		ps16.PhiValues = make([]scm.JITValueDesc, 1)
+		d17 = stride
+		ps16.PhiValues[0] = d17
+		snap18 := d1
+		snap19 := d2
+		snap20 := d3
+		snap21 := d5
+		snap22 := d7
+		snap23 := d14
+		snap24 := d17
+		alloc25 := ctx.SnapshotAllocState()
 		if !bbs[2].Rendered {
-			bbs[2].RenderPS(ps23)
+			bbs[2].RenderPS(ps16)
 		}
-		ctx.RestoreAllocState(alloc34)
-		d4 = snap25
-		d5 = snap26
-		d6 = snap27
-		d7 = snap28
-		d8 = snap29
-		d10 = snap30
-		d12 = snap31
-		d21 = snap32
-		d24 = snap33
+		ctx.RestoreAllocState(alloc25)
+		d1 = snap18
+		d2 = snap19
+		d3 = snap20
+		d5 = snap21
+		d7 = snap22
+		d14 = snap23
+		d17 = snap24
 		if !bbs[1].Rendered {
-			return bbs[1].RenderPS(ps22)
+			return bbs[1].RenderPS(ps15)
 		}
 		return result
 		return result
@@ -118795,43 +117706,27 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 			ctx.MarkLabel(lbl2)
 			ctx.ResolveFixups()
 		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
+		d1 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
+		if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != scm.LocNone {
+			d1 = ps.OverlayValues[1]
 		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != scm.LocNone {
+			d2 = ps.OverlayValues[2]
 		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != scm.LocNone {
+			d3 = ps.OverlayValues[3]
 		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
 			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
 		}
 		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
 			d7 = ps.OverlayValues[7]
 		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
+		if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != scm.LocNone {
+			d14 = ps.OverlayValues[14]
 		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
-		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
-		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
+		if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != scm.LocNone {
+			d17 = ps.OverlayValues[17]
 		}
 		recids = storageRecidsHome
 		target = storageTargetHome
@@ -118840,33 +117735,31 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 		if ps.General {
 			ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(1)}, int32(bbs[2].PhiBase)+int32(0))
 		}
-		ps35 := scm.PhiState{General: ps.General}
-		ps35.OverlayValues = make([]scm.JITValueDesc, 25)
-		ps35.OverlayValues[4] = d4
-		ps35.OverlayValues[5] = d5
-		ps35.OverlayValues[6] = d6
-		ps35.OverlayValues[7] = d7
-		ps35.OverlayValues[8] = d8
-		ps35.OverlayValues[10] = d10
-		ps35.OverlayValues[12] = d12
-		ps35.OverlayValues[21] = d21
-		ps35.OverlayValues[24] = d24
-		ps35.PhiValues = make([]scm.JITValueDesc, 1)
-		d36 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(1)}
-		ps35.PhiValues[0] = d36
-		if ps35.General && bbs[2].Rendered {
+		ps26 := scm.PhiState{General: ps.General}
+		ps26.OverlayValues = make([]scm.JITValueDesc, 18)
+		ps26.OverlayValues[1] = d1
+		ps26.OverlayValues[2] = d2
+		ps26.OverlayValues[3] = d3
+		ps26.OverlayValues[5] = d5
+		ps26.OverlayValues[7] = d7
+		ps26.OverlayValues[14] = d14
+		ps26.OverlayValues[17] = d17
+		ps26.PhiValues = make([]scm.JITValueDesc, 1)
+		d27 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(1)}
+		ps26.PhiValues[0] = d27
+		if ps26.General && bbs[2].Rendered {
 			ctx.EmitJmp(lbl3)
 			return result
 		}
-		return bbs[2].RenderPS(ps35)
+		return bbs[2].RenderPS(ps26)
 		return result
 	}
 	bbs[2].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
 		if !ps.General {
 			if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-				d37 := ps.PhiValues[0]
-				ctx.EnsureDesc(&d37)
-				ctx.EmitStoreToStack(d37, int32(bbs[2].PhiBase)+int32(0))
+				d28 := ps.PhiValues[0]
+				ctx.EnsureDesc(&d28)
+				ctx.EmitStoreToStack(d28, int32(bbs[2].PhiBase)+int32(0))
 			}
 			if bbs[2].VisitCount >= 0 {
 				ps.General = true
@@ -118886,986 +117779,110 @@ func (s *OverlayBlob) JITEmitGetValueMulti(ctx *scm.JITContext, recids, target, 
 			ctx.MarkLabel(lbl3)
 			ctx.ResolveFixups()
 		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
+		d1 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
+		if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != scm.LocNone {
+			d1 = ps.OverlayValues[1]
 		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
+		if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != scm.LocNone {
+			d2 = ps.OverlayValues[2]
 		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
+		if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != scm.LocNone {
+			d3 = ps.OverlayValues[3]
 		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
+		if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
 			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
 		}
 		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
 			d7 = ps.OverlayValues[7]
 		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
+		if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != scm.LocNone {
+			d14 = ps.OverlayValues[14]
 		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
+		if len(ps.OverlayValues) > 17 && ps.OverlayValues[17].Loc != scm.LocNone {
+			d17 = ps.OverlayValues[17]
 		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
+		if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != scm.LocNone {
+			d27 = ps.OverlayValues[27]
 		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
-		}
-		if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != scm.LocNone {
-			d36 = ps.OverlayValues[36]
-		}
-		if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != scm.LocNone {
-			d37 = ps.OverlayValues[37]
+		if len(ps.OverlayValues) > 28 && ps.OverlayValues[28].Loc != scm.LocNone {
+			d28 = ps.OverlayValues[28]
 		}
 		if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-			d4 = ps.PhiValues[0]
+			d1 = ps.PhiValues[0]
 		}
 		recids = storageRecidsHome
 		target = storageTargetHome
 		stride = storageStrideHome
 		ctx.ReclaimUntrackedRegs()
-		ctx.StabilizeDescForControlFlow(&d4)
-		var d38 scm.JITValueDesc
+		var d29 scm.JITValueDesc
 		if thisptr.Loc == scm.LocImm {
 			fieldAddr := uintptr(thisptr.Imm.Int()) + unsafe.Offsetof((*OverlayBlob)(nil).Base)
-			r3 := ctx.AllocReg()
-			r4 := ctx.AllocRegExcept(r3)
-			ctx.EmitMovRegMem64(r3, fieldAddr)
-			ctx.EmitMovRegMem64(r4, fieldAddr+8)
-			d38 = scm.JITValueDesc{Loc: scm.LocRegPair, Reg: r3, Reg2: r4}
-			ctx.BindReg(r3, &d38)
-			ctx.BindReg(r4, &d38)
+			r1 := ctx.AllocReg()
+			r2 := ctx.AllocRegExcept(r1)
+			ctx.EmitMovRegMem64(r1, fieldAddr)
+			ctx.EmitMovRegMem64(r2, fieldAddr+8)
+			d29 = scm.JITValueDesc{Loc: scm.LocRegPair, Reg: r1, Reg2: r2}
+			ctx.BindReg(r1, &d29)
+			ctx.BindReg(r2, &d29)
 		} else {
 			off := int32(unsafe.Offsetof((*OverlayBlob)(nil).Base))
-			r5 := ctx.AllocReg()
-			r6 := ctx.AllocRegExcept(r5)
-			ctx.EmitMovRegMem(r5, thisptr.Reg, off)
-			ctx.EmitMovRegMem(r6, thisptr.Reg, off+8)
-			d38 = scm.JITValueDesc{Loc: scm.LocRegPair, Reg: r5, Reg2: r6}
-			ctx.BindReg(r5, &d38)
-			ctx.BindReg(r6, &d38)
+			r3 := ctx.AllocReg()
+			r4 := ctx.AllocRegExcept(r3)
+			ctx.EmitMovRegMem(r3, thisptr.Reg, off)
+			ctx.EmitMovRegMem(r4, thisptr.Reg, off+8)
+			d29 = scm.JITValueDesc{Loc: scm.LocRegPair, Reg: r3, Reg2: r4}
+			ctx.BindReg(r3, &d29)
+			ctx.BindReg(r4, &d29)
 		}
-		ctx.EnsureDesc(&d38)
+		ctx.EnsureDesc(&d29)
 		ctx.EnsureDesc(&recids)
 		ctx.EnsureDesc(&target)
-		ctx.EnsureDesc(&d4)
+		ctx.EnsureDesc(&d1)
 		ctx.EmitGoCallVoid(scm.GoFuncAddr(func(receiver ColumnStorage, arg0 []uint32, arg1 []scm.Scmer, arg2 int) {
 			receiver.GetValueMulti(arg0, arg1, arg2)
-		}), []scm.JITValueDesc{d38, recids, target, d4})
-		var d39 scm.JITValueDesc
+		}), []scm.JITValueDesc{d29, recids, target, d1})
+		var d30 scm.JITValueDesc
 		if recids.SliceSizeKnown {
-			d39 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(recids.KnownSliceLen))}
+			d30 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(recids.KnownSliceLen))}
 		} else if recids.Loc == scm.LocImm {
-			d39 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(recids.StackOff))}
+			d30 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(int64(recids.StackOff))}
 		} else if recids.Loc == scm.LocStackTriple {
-			d39 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: recids.StackOff + 8, NoHeapPointer: true}
+			d30 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: recids.StackOff + 8, NoHeapPointer: true}
 		} else {
 			ctx.EnsureDesc(&recids)
 			if recids.Loc == scm.LocRegPair || recids.Loc == scm.LocRegTriple {
-				d39 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: recids.Reg2, ID: 0}
+				d30 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: recids.Reg2, ID: 0}
 			} else if recids.Loc == scm.LocReg {
-				d39 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: recids.Reg, ID: 0}
+				d30 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: recids.Reg, ID: 0}
 			} else {
 				panic("len on unsupported descriptor location")
 			}
 		}
-		ctx.StabilizeDescForControlFlow(&d39)
-		if ps.General {
-			if phiHomeOK2 {
-				ctx.EmitMovToReg(r0, scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)})
-			} else {
-				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}, int32(bbs[3].PhiBase)+int32(0))
-			}
-			if phiHomeOK3 {
-				ctx.EmitMovToReg(r1, scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(-1)})
-			} else {
-				ctx.EmitStoreToStack(scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(-1)}, int32(bbs[3].PhiBase)+int32(16))
-			}
-		}
-		ps40 := scm.PhiState{General: ps.General}
-		ps40.OverlayValues = make([]scm.JITValueDesc, 40)
-		ps40.OverlayValues[4] = d4
-		ps40.OverlayValues[5] = d5
-		ps40.OverlayValues[6] = d6
-		ps40.OverlayValues[7] = d7
-		ps40.OverlayValues[8] = d8
-		ps40.OverlayValues[10] = d10
-		ps40.OverlayValues[12] = d12
-		ps40.OverlayValues[21] = d21
-		ps40.OverlayValues[24] = d24
-		ps40.OverlayValues[36] = d36
-		ps40.OverlayValues[37] = d37
-		ps40.OverlayValues[38] = d38
-		ps40.OverlayValues[39] = d39
-		ps40.PhiValues = make([]scm.JITValueDesc, 2)
-		d41 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(0)}
-		ps40.PhiValues[0] = d41
-		d42 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(-1)}
-		ps40.PhiValues[1] = d42
-		if ps40.General && bbs[3].Rendered {
-			ctx.EmitJmp(lbl4)
-			return result
-		}
-		return bbs[3].RenderPS(ps40)
-		return result
-	}
-	bbs[3].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
-		if !ps.General {
-			if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-				d43 := ps.PhiValues[0]
-				ctx.EnsureDesc(&d43)
-				if phiHomeOK2 {
-					ctx.EmitMovToReg(r0, d43)
-				} else {
-					ctx.EmitStoreToStack(d43, int32(bbs[3].PhiBase)+int32(0))
-				}
-			}
-			if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != scm.LocNone {
-				d44 := ps.PhiValues[1]
-				ctx.EnsureDesc(&d44)
-				if phiHomeOK3 {
-					ctx.EmitMovToReg(r1, d44)
-				} else {
-					ctx.EmitStoreToStack(d44, int32(bbs[3].PhiBase)+int32(16))
-				}
-			}
-			if bbs[3].VisitCount >= 0 {
-				ps.General = true
-				return bbs[3].RenderPS(ps)
-			}
-		}
-		bbs[3].VisitCount++
-		if ps.General {
-			if bbs[3].Rendered {
-				ctx.EmitJmp(lbl4)
-				return result
-			}
-			bbs[3].Rendered = true
-			ctx.FlushRegisterMoves()
-			bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-			bbpos_0_3 = bbs[3].Address
-			ctx.MarkLabel(lbl4)
-			ctx.ResolveFixups()
-		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
-		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
-			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
-		}
-		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
-			d7 = ps.OverlayValues[7]
-		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
-		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
-		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
-		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
-		}
-		if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != scm.LocNone {
-			d36 = ps.OverlayValues[36]
-		}
-		if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != scm.LocNone {
-			d37 = ps.OverlayValues[37]
-		}
-		if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != scm.LocNone {
-			d38 = ps.OverlayValues[38]
-		}
-		if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != scm.LocNone {
-			d39 = ps.OverlayValues[39]
-		}
-		if len(ps.OverlayValues) > 41 && ps.OverlayValues[41].Loc != scm.LocNone {
-			d41 = ps.OverlayValues[41]
-		}
-		if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != scm.LocNone {
-			d42 = ps.OverlayValues[42]
-		}
-		if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != scm.LocNone {
-			d43 = ps.OverlayValues[43]
-		}
-		if len(ps.OverlayValues) > 44 && ps.OverlayValues[44].Loc != scm.LocNone {
-			d44 = ps.OverlayValues[44]
-		}
-		if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-			d5 = ps.PhiValues[0]
-		}
-		if !ps.General && len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != scm.LocNone {
-			d6 = ps.PhiValues[1]
-		}
-		recids = storageRecidsHome
-		target = storageTargetHome
-		stride = storageStrideHome
-		if phiHomeOK2 && d5.Loc == scm.LocReg {
-			ctx.BindReg(r0, &d5)
-		}
-		if phiHomeOK3 && d6.Loc == scm.LocReg {
-			ctx.BindReg(r1, &d6)
-		}
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d6)
-		ctx.EnsureDesc(&d6)
-		var d45 scm.JITValueDesc
-		if d6.Loc == scm.LocImm {
-			d45 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d6.Imm.Int() + 1)}
-		} else {
-			scratch := ctx.AllocRegExcept(d6.Reg)
-			ctx.EmitMovRegReg(scratch, d6.Reg)
-			ctx.EmitAddRegImm32(scratch, int32(1))
-			d45 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d45)
-		}
-		if d45.Loc == scm.LocReg && d6.Loc == scm.LocReg && d45.Reg == d6.Reg {
-			ctx.TransferReg(d6.Reg)
-			d6.Loc = scm.LocNone
-		}
-		ctx.FreeDesc(&d6)
-		ctx.EnsureDesc(&d45)
-		ctx.EnsureDesc(&d39)
-		ctx.EnsureDescsTogether(&d45, &d39)
-		var d46 scm.JITValueDesc
-		if d45.Loc == scm.LocImm && d39.Loc == scm.LocImm {
-			d46 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagBool, Imm: scm.NewBool(d45.Imm.Int() < d39.Imm.Int())}
-		} else if d39.Loc == scm.LocImm {
-			r7 := ctx.AllocRegExcept(d45.Reg)
-			if d39.Imm.Int() >= -2147483648 && d39.Imm.Int() <= 2147483647 {
-				ctx.EmitCmpRegImm32(d45.Reg, int32(d39.Imm.Int()))
-			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d39.Imm.Int()))
-				ctx.EmitCmpInt64(d45.Reg, scm.RegR11)
-			}
-			d46 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r7, Condition: scm.CondSignedLess}
-			ctx.BindReg(r7, &d46)
-		} else if d45.Loc == scm.LocImm {
-			r8 := ctx.AllocReg()
-			ctx.EmitMovRegImm64(scm.RegR11, uint64(d45.Imm.Int()))
-			ctx.EmitCmpInt64(scm.RegR11, d39.Reg)
-			d46 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r8, Condition: scm.CondSignedLess}
-			ctx.BindReg(r8, &d46)
-		} else {
-			r9 := ctx.AllocRegExcept(d45.Reg)
-			ctx.EmitCmpInt64(d45.Reg, d39.Reg)
-			d46 = scm.JITValueDesc{Loc: scm.LocFlags, Type: scm.TagBool, Reg: r9, Condition: scm.CondSignedLess}
-			ctx.BindReg(r9, &d46)
-		}
-		d47 = d46
-		ctx.EnsureDesc(&d47)
-		if d47.Loc != scm.LocImm && d47.Loc != scm.LocFlags {
-			panic("jit: fused If condition is neither scm.LocImm nor scm.LocFlags")
-		}
-		if d47.Loc == scm.LocImm {
-			if d47.Imm.Bool() {
-				if ps.General {
-				}
-				ps48 := scm.PhiState{General: ps.General}
-				ps48.OverlayValues = make([]scm.JITValueDesc, 48)
-				ps48.OverlayValues[4] = d4
-				ps48.OverlayValues[5] = d5
-				ps48.OverlayValues[6] = d6
-				ps48.OverlayValues[7] = d7
-				ps48.OverlayValues[8] = d8
-				ps48.OverlayValues[10] = d10
-				ps48.OverlayValues[12] = d12
-				ps48.OverlayValues[21] = d21
-				ps48.OverlayValues[24] = d24
-				ps48.OverlayValues[36] = d36
-				ps48.OverlayValues[37] = d37
-				ps48.OverlayValues[38] = d38
-				ps48.OverlayValues[39] = d39
-				ps48.OverlayValues[41] = d41
-				ps48.OverlayValues[42] = d42
-				ps48.OverlayValues[43] = d43
-				ps48.OverlayValues[44] = d44
-				ps48.OverlayValues[45] = d45
-				ps48.OverlayValues[46] = d46
-				ps48.OverlayValues[47] = d47
-				return bbs[4].RenderPS(ps48)
-			}
-			if ps.General {
-			}
-			ps49 := scm.PhiState{General: ps.General}
-			ps49.OverlayValues = make([]scm.JITValueDesc, 48)
-			ps49.OverlayValues[4] = d4
-			ps49.OverlayValues[5] = d5
-			ps49.OverlayValues[6] = d6
-			ps49.OverlayValues[7] = d7
-			ps49.OverlayValues[8] = d8
-			ps49.OverlayValues[10] = d10
-			ps49.OverlayValues[12] = d12
-			ps49.OverlayValues[21] = d21
-			ps49.OverlayValues[24] = d24
-			ps49.OverlayValues[36] = d36
-			ps49.OverlayValues[37] = d37
-			ps49.OverlayValues[38] = d38
-			ps49.OverlayValues[39] = d39
-			ps49.OverlayValues[41] = d41
-			ps49.OverlayValues[42] = d42
-			ps49.OverlayValues[43] = d43
-			ps49.OverlayValues[44] = d44
-			ps49.OverlayValues[45] = d45
-			ps49.OverlayValues[46] = d46
-			ps49.OverlayValues[47] = d47
-			return bbs[5].RenderPS(ps49)
-		}
-		if !ps.General {
-			if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != scm.LocNone {
-				d50 := ps.PhiValues[0]
-				ctx.EnsureDesc(&d50)
-				if phiHomeOK2 {
-					ctx.EmitMovToReg(r0, d50)
-				} else {
-					ctx.EmitStoreToStack(d50, int32(bbs[3].PhiBase)+int32(0))
-				}
-			}
-			if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != scm.LocNone {
-				d51 := ps.PhiValues[1]
-				ctx.EnsureDesc(&d51)
-				if phiHomeOK3 {
-					ctx.EmitMovToReg(r1, d51)
-				} else {
-					ctx.EmitStoreToStack(d51, int32(bbs[3].PhiBase)+int32(16))
-				}
-			}
-			ps.General = true
-			return bbs[3].RenderPS(ps)
-		}
-		ctx.EmitJump(d47.Condition, lbl5)
-		if bbs[5].Rendered {
-			ctx.EmitJmp(lbl6)
-		}
-		ctx.FreeDesc(&d46)
-		snap52 := d4
-		snap53 := d5
-		snap54 := d6
-		snap55 := d7
-		snap56 := d8
-		snap57 := d10
-		snap58 := d12
-		snap59 := d21
-		snap60 := d24
-		snap61 := d36
-		snap62 := d37
-		snap63 := d38
-		snap64 := d39
-		snap65 := d41
-		snap66 := d42
-		snap67 := d43
-		snap68 := d44
-		snap69 := d45
-		snap70 := d46
-		snap71 := d47
-		snap72 := d50
-		snap73 := d51
-		alloc74 := ctx.SnapshotAllocState()
-		ctx.RestoreAllocState(alloc74)
-		d4 = snap52
-		d5 = snap53
-		d6 = snap54
-		d7 = snap55
-		d8 = snap56
-		d10 = snap57
-		d12 = snap58
-		d21 = snap59
-		d24 = snap60
-		d36 = snap61
-		d37 = snap62
-		d38 = snap63
-		d39 = snap64
-		d41 = snap65
-		d42 = snap66
-		d43 = snap67
-		d44 = snap68
-		d45 = snap69
-		d46 = snap70
-		d47 = snap71
-		d50 = snap72
-		d51 = snap73
-		ctx.RestoreAllocState(alloc74)
-		d4 = snap52
-		d5 = snap53
-		d6 = snap54
-		d7 = snap55
-		d8 = snap56
-		d10 = snap57
-		d12 = snap58
-		d21 = snap59
-		d24 = snap60
-		d36 = snap61
-		d37 = snap62
-		d38 = snap63
-		d39 = snap64
-		d41 = snap65
-		d42 = snap66
-		d43 = snap67
-		d44 = snap68
-		d45 = snap69
-		d46 = snap70
-		d47 = snap71
-		d50 = snap72
-		d51 = snap73
-		ps75 := scm.PhiState{General: true}
-		ps75.OverlayValues = make([]scm.JITValueDesc, 52)
-		ps75.OverlayValues[4] = d4
-		ps75.OverlayValues[5] = d5
-		ps75.OverlayValues[6] = d6
-		ps75.OverlayValues[7] = d7
-		ps75.OverlayValues[8] = d8
-		ps75.OverlayValues[10] = d10
-		ps75.OverlayValues[12] = d12
-		ps75.OverlayValues[21] = d21
-		ps75.OverlayValues[24] = d24
-		ps75.OverlayValues[36] = d36
-		ps75.OverlayValues[37] = d37
-		ps75.OverlayValues[38] = d38
-		ps75.OverlayValues[39] = d39
-		ps75.OverlayValues[41] = d41
-		ps75.OverlayValues[42] = d42
-		ps75.OverlayValues[43] = d43
-		ps75.OverlayValues[44] = d44
-		ps75.OverlayValues[45] = d45
-		ps75.OverlayValues[46] = d46
-		ps75.OverlayValues[47] = d47
-		ps75.OverlayValues[50] = d50
-		ps75.OverlayValues[51] = d51
-		ps76 := scm.PhiState{General: true}
-		ps76.OverlayValues = make([]scm.JITValueDesc, 52)
-		ps76.OverlayValues[4] = d4
-		ps76.OverlayValues[5] = d5
-		ps76.OverlayValues[6] = d6
-		ps76.OverlayValues[7] = d7
-		ps76.OverlayValues[8] = d8
-		ps76.OverlayValues[10] = d10
-		ps76.OverlayValues[12] = d12
-		ps76.OverlayValues[21] = d21
-		ps76.OverlayValues[24] = d24
-		ps76.OverlayValues[36] = d36
-		ps76.OverlayValues[37] = d37
-		ps76.OverlayValues[38] = d38
-		ps76.OverlayValues[39] = d39
-		ps76.OverlayValues[41] = d41
-		ps76.OverlayValues[42] = d42
-		ps76.OverlayValues[43] = d43
-		ps76.OverlayValues[44] = d44
-		ps76.OverlayValues[45] = d45
-		ps76.OverlayValues[46] = d46
-		ps76.OverlayValues[47] = d47
-		ps76.OverlayValues[50] = d50
-		ps76.OverlayValues[51] = d51
-		snap77 := d4
-		snap78 := d5
-		snap79 := d6
-		snap80 := d7
-		snap81 := d8
-		snap82 := d10
-		snap83 := d12
-		snap84 := d21
-		snap85 := d24
-		snap86 := d36
-		snap87 := d37
-		snap88 := d38
-		snap89 := d39
-		snap90 := d41
-		snap91 := d42
-		snap92 := d43
-		snap93 := d44
-		snap94 := d45
-		snap95 := d46
-		snap96 := d47
-		snap97 := d50
-		snap98 := d51
-		alloc99 := ctx.SnapshotAllocState()
-		if !bbs[5].Rendered {
-			bbs[5].RenderPS(ps76)
-		}
-		ctx.RestoreAllocState(alloc99)
-		d4 = snap77
-		d5 = snap78
-		d6 = snap79
-		d7 = snap80
-		d8 = snap81
-		d10 = snap82
-		d12 = snap83
-		d21 = snap84
-		d24 = snap85
-		d36 = snap86
-		d37 = snap87
-		d38 = snap88
-		d39 = snap89
-		d41 = snap90
-		d42 = snap91
-		d43 = snap92
-		d44 = snap93
-		d45 = snap94
-		d46 = snap95
-		d47 = snap96
-		d50 = snap97
-		d51 = snap98
-		if !bbs[4].Rendered {
-			return bbs[4].RenderPS(ps75)
-		}
-		return result
-		return result
-	}
-	bbs[4].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
-		if !ps.General {
-			if bbs[4].VisitCount >= 0 {
-				ps.General = true
-				return bbs[4].RenderPS(ps)
-			}
-		}
-		bbs[4].VisitCount++
-		if ps.General {
-			if bbs[4].Rendered {
-				ctx.EmitJmp(lbl5)
-				return result
-			}
-			bbs[4].Rendered = true
-			ctx.FlushRegisterMoves()
-			bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-			bbpos_0_4 = bbs[4].Address
-			ctx.MarkLabel(lbl5)
-			ctx.ResolveFixups()
-		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
-		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
-			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
-		}
-		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
-			d7 = ps.OverlayValues[7]
-		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
-		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
-		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
-		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
-		}
-		if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != scm.LocNone {
-			d36 = ps.OverlayValues[36]
-		}
-		if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != scm.LocNone {
-			d37 = ps.OverlayValues[37]
-		}
-		if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != scm.LocNone {
-			d38 = ps.OverlayValues[38]
-		}
-		if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != scm.LocNone {
-			d39 = ps.OverlayValues[39]
-		}
-		if len(ps.OverlayValues) > 41 && ps.OverlayValues[41].Loc != scm.LocNone {
-			d41 = ps.OverlayValues[41]
-		}
-		if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != scm.LocNone {
-			d42 = ps.OverlayValues[42]
-		}
-		if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != scm.LocNone {
-			d43 = ps.OverlayValues[43]
-		}
-		if len(ps.OverlayValues) > 44 && ps.OverlayValues[44].Loc != scm.LocNone {
-			d44 = ps.OverlayValues[44]
-		}
-		if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != scm.LocNone {
-			d45 = ps.OverlayValues[45]
-		}
-		if len(ps.OverlayValues) > 46 && ps.OverlayValues[46].Loc != scm.LocNone {
-			d46 = ps.OverlayValues[46]
-		}
-		if len(ps.OverlayValues) > 47 && ps.OverlayValues[47].Loc != scm.LocNone {
-			d47 = ps.OverlayValues[47]
-		}
-		if len(ps.OverlayValues) > 50 && ps.OverlayValues[50].Loc != scm.LocNone {
-			d50 = ps.OverlayValues[50]
-		}
-		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != scm.LocNone {
-			d51 = ps.OverlayValues[51]
-		}
-		recids = storageRecidsHome
-		target = storageTargetHome
-		stride = storageStrideHome
-		ctx.ReclaimUntrackedRegs()
-		ctx.EnsureDesc(&d5)
-		d101 = ctx.EmitSliceElementAddress(&target, &d5, 16)
-		ctx.EnsureDesc(&d101)
-		r10 := ctx.AllocRegExcept(d101.Reg)
-		ctx.EmitMovRegMem(r10, d101.Reg, 8)
-		ctx.EmitMovRegMem(d101.Reg, d101.Reg, 0)
-		d100 = scm.JITValueDesc{Loc: scm.LocRegPair, Type: scm.JITTypeUnknown, Reg: d101.Reg, Reg2: r10}
-		ctx.BindReg(d101.Reg, &d100)
-		ctx.BindReg(r10, &d100)
 		if thisptr.Loc == scm.LocRegPair || thisptr.Loc == scm.LocStackPair || thisptr.Loc == scm.LocRegTriple || thisptr.Loc == scm.LocStackTriple {
 			panic("jit: generic call arg expects 1-word value")
 		}
-		d100 = scm.JITPrepareScmerGoArg(ctx, d100)
+		target = scm.JITPrepareGoSliceArg(ctx, target)
+		if target.Loc != scm.LocRegTriple && target.Loc != scm.LocStackTriple {
+			panic("jit: generic call arg expects 3-word Go slice ((*OverlayBlob).resolveBlobBatch arg1)")
+		}
+		if d30.Loc == scm.LocRegPair || d30.Loc == scm.LocStackPair || d30.Loc == scm.LocRegTriple || d30.Loc == scm.LocStackTriple {
+			panic("jit: generic call arg expects 1-word value")
+		}
+		if d1.Loc == scm.LocRegPair || d1.Loc == scm.LocStackPair || d1.Loc == scm.LocRegTriple || d1.Loc == scm.LocStackTriple {
+			panic("jit: generic call arg expects 1-word value")
+		}
 		ctx.SyncDesc(&thisptr)
-		ctx.SyncDesc(&d100)
-		d102 = ctx.EmitGoCallScalar(scm.GoFuncAddr((*OverlayBlob).resolveBlob), []scm.JITValueDesc{thisptr, d100}, 2)
-		d102.NoHeapPointer = false
-		ctx.BindReg(d102.Reg, &d102)
-		ctx.BindReg(d102.Reg2, &d102)
-		ctx.FreeDesc(&d100)
-		ctx.EnsureDesc(&d5)
-		ctx.SyncDesc(&d102)
-		d103 = target
-		d103.ID = 0
-		d104 = d5
-		d104.ID = 0
-		if !ctx.TryEmitStoreScmerSliceElement(&d103, &d104, &d102, int32(16)) {
-			ctx.StabilizeDescAcrossNestedCall(&d5)
-			d104 = d5
-			d104.ID = 0
-			ctx.EmitStoreScmerSliceElement(&d103, &d104, &d102, int32(16))
-		}
-		ctx.FreeDesc(&d104)
-		ctx.FreeDesc(&d102)
-		ctx.EnsureDesc(&d5)
-		ctx.EnsureDesc(&d4)
-		ctx.EnsureDescsTogether(&d5, &d4)
-		var d105 scm.JITValueDesc
-		if d5.Loc == scm.LocImm && d4.Loc == scm.LocImm {
-			d105 = scm.JITValueDesc{Loc: scm.LocImm, Type: scm.TagInt, Imm: scm.NewInt(d5.Imm.Int() + d4.Imm.Int())}
-		} else if d4.Loc == scm.LocImm && d4.Imm.Int() == 0 {
-			var r11 scm.Reg
-			if phiHomeOK2 {
-				r11 = r0
-			} else {
-				r11 = ctx.AllocRegExcept(d5.Reg)
-			}
-			ctx.EmitMovRegReg(r11, d5.Reg)
-			d105 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r11}
-			ctx.BindReg(r11, &d105)
-		} else if d5.Loc == scm.LocImm && d5.Imm.Int() == 0 {
-			d105 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: d4.Reg}
-			ctx.BindReg(d4.Reg, &d105)
-		} else if d5.Loc == scm.LocImm {
-			var scratch scm.Reg
-			if phiHomeOK2 && r0 != d4.Reg {
-				scratch = r0
-			} else {
-				scratch = ctx.AllocRegExcept(d4.Reg)
-			}
-			ctx.EmitMovRegImm64(scratch, uint64(d5.Imm.Int()))
-			ctx.EmitAddInt64(scratch, d4.Reg)
-			d105 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d105)
-		} else if d4.Loc == scm.LocImm {
-			var scratch scm.Reg
-			if phiHomeOK2 {
-				scratch = r0
-			} else {
-				scratch = ctx.AllocRegExcept(d5.Reg)
-			}
-			ctx.EmitMovRegReg(scratch, d5.Reg)
-			if d4.Imm.Int() >= -2147483648 && d4.Imm.Int() <= 2147483647 {
-				ctx.EmitAddRegImm32(scratch, int32(d4.Imm.Int()))
-			} else {
-				ctx.EmitMovRegImm64(scm.RegR11, uint64(d4.Imm.Int()))
-				ctx.EmitAddInt64(scratch, scm.RegR11)
-			}
-			d105 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: scratch}
-			ctx.BindReg(scratch, &d105)
-		} else {
-			var r12 scm.Reg
-			if phiHomeOK2 && r0 != d4.Reg {
-				r12 = r0
-			} else {
-				r12 = ctx.AllocRegExcept(d5.Reg, d4.Reg)
-			}
-			ctx.EmitMovRegReg(r12, d5.Reg)
-			ctx.EmitAddInt64(r12, d4.Reg)
-			d105 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r12}
-			ctx.BindReg(r12, &d105)
-		}
-		if d105.Loc == scm.LocReg && d5.Loc == scm.LocReg && d105.Reg == d5.Reg {
-			ctx.TransferReg(d5.Reg)
-			d5.Loc = scm.LocNone
-		}
-		if ps.General {
-			ctx.SyncDesc(&d45)
-			if d45.Loc == scm.LocReg || d45.Loc == scm.LocFPReg {
-				ctx.ProtectReg(d45.Reg)
-			} else if d45.Loc == scm.LocRegPair {
-				ctx.ProtectReg(d45.Reg)
-				ctx.ProtectReg(d45.Reg2)
-			}
-			ctx.SyncDesc(&d105)
-			if d105.Loc == scm.LocReg || d105.Loc == scm.LocFPReg {
-				ctx.ProtectReg(d105.Reg)
-			} else if d105.Loc == scm.LocRegPair {
-				ctx.ProtectReg(d105.Reg)
-				ctx.ProtectReg(d105.Reg2)
-			}
-			d106 = d105
-			if d106.Loc == scm.LocNone {
-				panic("jit: phi source has no location")
-			}
-			ctx.EnsureDesc(&d106)
-			if phiHomeOK2 {
-				ctx.EmitMovToReg(r0, d106)
-			} else {
-				ctx.EmitStoreToStack(d106, int32(bbs[3].PhiBase)+int32(0))
-			}
-			d107 = d45
-			if d107.Loc == scm.LocNone {
-				panic("jit: phi source has no location")
-			}
-			ctx.EnsureDesc(&d107)
-			if phiHomeOK3 {
-				ctx.EmitMovToReg(r1, d107)
-			} else {
-				ctx.EmitStoreToStack(d107, int32(bbs[3].PhiBase)+int32(16))
-			}
-			if d45.Loc == scm.LocReg || d45.Loc == scm.LocFPReg {
-				ctx.UnprotectReg(d45.Reg)
-			} else if d45.Loc == scm.LocRegPair {
-				ctx.UnprotectReg(d45.Reg)
-				ctx.UnprotectReg(d45.Reg2)
-			}
-			if d105.Loc == scm.LocReg || d105.Loc == scm.LocFPReg {
-				ctx.UnprotectReg(d105.Reg)
-			} else if d105.Loc == scm.LocRegPair {
-				ctx.UnprotectReg(d105.Reg)
-				ctx.UnprotectReg(d105.Reg2)
-			}
-		}
-		ps108 := scm.PhiState{General: ps.General}
-		ps108.OverlayValues = make([]scm.JITValueDesc, 108)
-		ps108.OverlayValues[4] = d4
-		ps108.OverlayValues[5] = d5
-		ps108.OverlayValues[6] = d6
-		ps108.OverlayValues[7] = d7
-		ps108.OverlayValues[8] = d8
-		ps108.OverlayValues[10] = d10
-		ps108.OverlayValues[12] = d12
-		ps108.OverlayValues[21] = d21
-		ps108.OverlayValues[24] = d24
-		ps108.OverlayValues[36] = d36
-		ps108.OverlayValues[37] = d37
-		ps108.OverlayValues[38] = d38
-		ps108.OverlayValues[39] = d39
-		ps108.OverlayValues[41] = d41
-		ps108.OverlayValues[42] = d42
-		ps108.OverlayValues[43] = d43
-		ps108.OverlayValues[44] = d44
-		ps108.OverlayValues[45] = d45
-		ps108.OverlayValues[46] = d46
-		ps108.OverlayValues[47] = d47
-		ps108.OverlayValues[50] = d50
-		ps108.OverlayValues[51] = d51
-		ps108.OverlayValues[100] = d100
-		ps108.OverlayValues[101] = d101
-		ps108.OverlayValues[102] = d102
-		ps108.OverlayValues[103] = d103
-		ps108.OverlayValues[104] = d104
-		ps108.OverlayValues[105] = d105
-		ps108.OverlayValues[106] = d106
-		ps108.OverlayValues[107] = d107
-		ps108.PhiValues = make([]scm.JITValueDesc, 2)
-		d109 = d105
-		ps108.PhiValues[0] = d109
-		d110 = d45
-		ps108.PhiValues[1] = d110
-		if ps108.General && bbs[3].Rendered {
-			ctx.EmitJmp(lbl4)
-			return result
-		}
-		return bbs[3].RenderPS(ps108)
-		return result
-	}
-	bbs[5].RenderPS = func(ps scm.PhiState) scm.JITValueDesc {
-		if !ps.General {
-			if bbs[5].VisitCount >= 0 {
-				ps.General = true
-				return bbs[5].RenderPS(ps)
-			}
-		}
-		bbs[5].VisitCount++
-		if ps.General {
-			if bbs[5].Rendered {
-				ctx.EmitJmp(lbl6)
-				return result
-			}
-			bbs[5].Rendered = true
-			ctx.FlushRegisterMoves()
-			bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-			bbpos_0_5 = bbs[5].Address
-			ctx.MarkLabel(lbl6)
-			ctx.ResolveFixups()
-		}
-		d4 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(0)}
-		if phiHomeOK2 {
-			d5 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r0, ID: 0}
-		} else {
-			d5 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(16)}
-		}
-		if phiHomeOK3 {
-			d6 = scm.JITValueDesc{Loc: scm.LocReg, Type: scm.TagInt, Reg: r1, ID: 0}
-		} else {
-			d6 = scm.JITValueDesc{Loc: scm.LocStack, Type: scm.TagInt, StackOff: int32(phiBase0) + int32(32)}
-		}
-		if !ps.General && len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != scm.LocNone {
-			d4 = ps.OverlayValues[4]
-		}
-		if !ps.General && len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != scm.LocNone {
-			d5 = ps.OverlayValues[5]
-		}
-		if !ps.General && len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != scm.LocNone {
-			d6 = ps.OverlayValues[6]
-		}
-		if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != scm.LocNone {
-			d7 = ps.OverlayValues[7]
-		}
-		if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != scm.LocNone {
-			d8 = ps.OverlayValues[8]
-		}
-		if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != scm.LocNone {
-			d10 = ps.OverlayValues[10]
-		}
-		if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != scm.LocNone {
-			d12 = ps.OverlayValues[12]
-		}
-		if len(ps.OverlayValues) > 21 && ps.OverlayValues[21].Loc != scm.LocNone {
-			d21 = ps.OverlayValues[21]
-		}
-		if len(ps.OverlayValues) > 24 && ps.OverlayValues[24].Loc != scm.LocNone {
-			d24 = ps.OverlayValues[24]
-		}
-		if len(ps.OverlayValues) > 36 && ps.OverlayValues[36].Loc != scm.LocNone {
-			d36 = ps.OverlayValues[36]
-		}
-		if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != scm.LocNone {
-			d37 = ps.OverlayValues[37]
-		}
-		if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != scm.LocNone {
-			d38 = ps.OverlayValues[38]
-		}
-		if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != scm.LocNone {
-			d39 = ps.OverlayValues[39]
-		}
-		if len(ps.OverlayValues) > 41 && ps.OverlayValues[41].Loc != scm.LocNone {
-			d41 = ps.OverlayValues[41]
-		}
-		if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != scm.LocNone {
-			d42 = ps.OverlayValues[42]
-		}
-		if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != scm.LocNone {
-			d43 = ps.OverlayValues[43]
-		}
-		if len(ps.OverlayValues) > 44 && ps.OverlayValues[44].Loc != scm.LocNone {
-			d44 = ps.OverlayValues[44]
-		}
-		if len(ps.OverlayValues) > 45 && ps.OverlayValues[45].Loc != scm.LocNone {
-			d45 = ps.OverlayValues[45]
-		}
-		if len(ps.OverlayValues) > 46 && ps.OverlayValues[46].Loc != scm.LocNone {
-			d46 = ps.OverlayValues[46]
-		}
-		if len(ps.OverlayValues) > 47 && ps.OverlayValues[47].Loc != scm.LocNone {
-			d47 = ps.OverlayValues[47]
-		}
-		if len(ps.OverlayValues) > 50 && ps.OverlayValues[50].Loc != scm.LocNone {
-			d50 = ps.OverlayValues[50]
-		}
-		if len(ps.OverlayValues) > 51 && ps.OverlayValues[51].Loc != scm.LocNone {
-			d51 = ps.OverlayValues[51]
-		}
-		if len(ps.OverlayValues) > 100 && ps.OverlayValues[100].Loc != scm.LocNone {
-			d100 = ps.OverlayValues[100]
-		}
-		if len(ps.OverlayValues) > 101 && ps.OverlayValues[101].Loc != scm.LocNone {
-			d101 = ps.OverlayValues[101]
-		}
-		if len(ps.OverlayValues) > 102 && ps.OverlayValues[102].Loc != scm.LocNone {
-			d102 = ps.OverlayValues[102]
-		}
-		if len(ps.OverlayValues) > 103 && ps.OverlayValues[103].Loc != scm.LocNone {
-			d103 = ps.OverlayValues[103]
-		}
-		if len(ps.OverlayValues) > 104 && ps.OverlayValues[104].Loc != scm.LocNone {
-			d104 = ps.OverlayValues[104]
-		}
-		if len(ps.OverlayValues) > 105 && ps.OverlayValues[105].Loc != scm.LocNone {
-			d105 = ps.OverlayValues[105]
-		}
-		if len(ps.OverlayValues) > 106 && ps.OverlayValues[106].Loc != scm.LocNone {
-			d106 = ps.OverlayValues[106]
-		}
-		if len(ps.OverlayValues) > 107 && ps.OverlayValues[107].Loc != scm.LocNone {
-			d107 = ps.OverlayValues[107]
-		}
-		if len(ps.OverlayValues) > 109 && ps.OverlayValues[109].Loc != scm.LocNone {
-			d109 = ps.OverlayValues[109]
-		}
-		if len(ps.OverlayValues) > 110 && ps.OverlayValues[110].Loc != scm.LocNone {
-			d110 = ps.OverlayValues[110]
-		}
-		recids = storageRecidsHome
-		target = storageTargetHome
-		stride = storageStrideHome
-		ctx.ReclaimUntrackedRegs()
+		ctx.SyncDesc(&target)
+		ctx.SyncDesc(&d30)
+		ctx.SyncDesc(&d1)
+		ctx.EmitGoCallVoid(scm.GoFuncAddr((*OverlayBlob).resolveBlobBatch), []scm.JITValueDesc{thisptr, target, d30, d1})
+		ctx.FreeDesc(&d30)
+		ctx.FreeDesc(&d1)
 		ctx.EmitJmp(lbl0)
 		return result
 	}
-	ps111 := scm.PhiState{General: false}
-	_ = bbs[0].RenderPS(ps111)
+	ps31 := scm.PhiState{General: false}
+	_ = bbs[0].RenderPS(ps31)
 	ctx.MarkLabel(lbl0)
 	ctx.ResolveFixups()
 	if storageInputsProtected {

--- a/storage/overlay-blob.go
+++ b/storage/overlay-blob.go
@@ -19,6 +19,7 @@ package storage
 import "io"
 import "fmt"
 import "sync"
+import "time"
 import "unsafe"
 import "reflect"
 import "strings"
@@ -37,6 +38,7 @@ type OverlayBlob struct {
 	schema *database       // reference to owning database
 	refs   map[string]bool // hex-hashes referenced in this build()
 	legacy bool            // v0/ASCII-49 base encoding; preserved until the next rebuild
+	ram    *blobRAMCache   // generation-local; its mutex protects decoded contents and admission
 }
 
 // Keep ordinary text values in the columnar string storage. Small text values
@@ -46,7 +48,7 @@ type OverlayBlob struct {
 const maxInlineBlobBytes = 2 * 1024
 
 func (s *OverlayBlob) ComputeSize() uint {
-	return 48 + s.Base.ComputeSize()
+	return uint(unsafe.Sizeof(*s)) + uint(unsafe.Sizeof(blobRAMCache{})) + s.size + s.Base.ComputeSize()
 }
 
 func (s *OverlayBlob) String() string {
@@ -184,6 +186,7 @@ func (s *OverlayBlob) deserializeBlobV0(f io.Reader) uint {
 	var size uint64
 	binary.Read(f, binary.LittleEndian, &size) // read size
 	s.values = make(map[[32]byte]string)
+	s.resetBlobRAM()
 
 	if size > 0 {
 		// LEGACY: read inline blobs (migration in SetPersistence)
@@ -208,6 +211,7 @@ func (s *OverlayBlob) deserializeBlobV0(f io.Reader) uint {
 // SetSchema sets the owning database and migrates legacy inline blobs.
 func (s *OverlayBlob) SetSchema(db *database) {
 	s.schema = db
+	s.resetBlobRAM() // source changed; never reuse a detached representation
 	s.refs = make(map[string]bool)
 	for hash, data := range s.values {
 		hexHash := fmt.Sprintf("%x", hash[:])
@@ -274,11 +278,7 @@ func (s *OverlayBlob) GetValueRange(recid uint32, count uint32, target []scm.Scm
 		stride = 1
 	}
 	s.Base.GetValueRange(recid, count, target, stride)
-	idx := 0
-	for k := uint32(0); k < count; k++ {
-		target[idx] = s.resolveBlob(target[idx])
-		idx += stride
-	}
+	s.resolveBlobBatch(target, int(count), stride)
 }
 
 //jitgen:control-flow-stable recids/2 target/1 stride
@@ -287,11 +287,7 @@ func (s *OverlayBlob) GetValueMulti(recids []uint32, target []scm.Scmer, stride 
 		stride = 1
 	}
 	s.Base.GetValueMulti(recids, target, stride)
-	idx := 0
-	for range recids {
-		target[idx] = s.resolveBlob(target[idx])
-		idx += stride
-	}
+	s.resolveBlobBatch(target, len(recids), stride)
 }
 
 // blobReference recognizes references without fetching payloads. For v0, a
@@ -337,6 +333,63 @@ func (s *OverlayBlob) readBlob(hash [32]byte) (scm.Scmer, bool) {
 // literal identical to a present blob reference cannot be distinguished in v0;
 // only a rebuild from an authoritative source can resolve that case.
 func (s *OverlayBlob) resolveBlob(v scm.Scmer) scm.Scmer {
+	if !v.IsString() || v.String() == "" || v.String()[0] != '!' {
+		return v
+	}
+	var values [1]scm.Scmer
+	values[0] = v
+	s.resolveBlobBatch(values[:], 1, 1)
+	return values[0]
+}
+
+// The base column is already fetched. Inline-only batches retain the old path;
+// external payloads synchronize once per batch, including scalar point reads.
+func (s *OverlayBlob) resolveBlobBatch(values []scm.Scmer, count, stride int) {
+	for i := 0; i < count; i++ {
+		v := values[i*stride]
+		if !v.IsString() {
+			continue
+		}
+		raw := v.String()
+		if raw == "" || raw[0] != '!' {
+			continue
+		}
+		_, reference, ambiguous := s.blobReference(raw)
+		if reference && !ambiguous && s.ram != nil && GlobalCache.opChan != nil && !GlobalCache.stopped.Load() {
+			// Bound cold-reader admission buffers and publication delay.
+			for i < count {
+				n := min(256, count-i)
+				s.resolveBlobRAMBatch(values[i*stride:], n, stride)
+				i += n
+			}
+			return
+		}
+		values[i*stride] = s.resolveBlobUncached(v)
+	}
+}
+
+func (s *OverlayBlob) resolveBlobRAMBatch(values []scm.Scmer, count, stride int) {
+	c := s.ram
+	c.mu.Lock()
+	before := c.size()
+	// Publish even on panic: successfully decoded earlier values still own RAM.
+	defer c.endBatch(before)
+	limit := int64(-1) // lazy budget snapshot, only when a batch actually misses
+	c.lastUsed.Store(time.Now().UnixNano())
+	for i := 0; i < count; i++ {
+		v := values[i*stride]
+		if v.IsString() {
+			hash, reference, ambiguous := s.blobReference(v.String())
+			if reference && !ambiguous {
+				values[i*stride] = c.read(s, hash, &limit)
+				continue
+			}
+		}
+		values[i*stride] = s.resolveBlobUncached(v)
+	}
+}
+
+func (s *OverlayBlob) resolveBlobUncached(v scm.Scmer) scm.Scmer {
 	if !v.IsString() {
 		return v
 	}
@@ -387,6 +440,7 @@ func (s *OverlayBlob) scan(i uint32, value scm.Scmer) {
 func (s *OverlayBlob) init(i uint32) {
 	s.legacy = false
 	s.values = make(map[[32]byte]string)
+	s.resetBlobRAM()
 	s.size = 0
 	s.refs = make(map[string]bool)
 	s.Base.init(i)

--- a/tests/storage/formats/blob-storage.yaml
+++ b/tests/storage/formats/blob-storage.yaml
@@ -7,6 +7,12 @@ metadata:
   isolated: true
 
 setup:
+  - sql: "DROP TABLE IF EXISTS blob_rc1"
+  - sql: "DROP TABLE IF EXISTS blob_shared1"
+  - sql: "DROP TABLE IF EXISTS blob_shared2"
+  - sql: "DROP TABLE IF EXISTS blob_rcpersist"
+  - sql: "DROP TABLE IF EXISTS blob_external"
+  - sql: "DROP TABLE IF EXISTS blob_ram_scan"
   - sql: "DROP TABLE IF EXISTS blob_bang"
   - sql: "DROP TABLE IF EXISTS blob_test"
 
@@ -297,14 +303,14 @@ test_cases:
       rows: 0
 
   - name: "Shared blob: insert long string in first"
-    sql: "INSERT INTO blob_shared1 (id, payload) VALUES (1, REPEAT('S', 1000))"
+    sql: "INSERT INTO blob_shared1 (id, payload) VALUES (1, REPEAT('S', 4096)), (2, REPEAT('T', 4096)), (3, REPEAT('V', 4096))"
     expect:
-      affected_rows: 1
+      affected_rows: 3
 
   - name: "Shared blob: insert same long string in second"
-    sql: "INSERT INTO blob_shared2 (id, payload) VALUES (1, REPEAT('S', 1000))"
+    sql: "INSERT INTO blob_shared2 (id, payload) VALUES (1, REPEAT('S', 4096)), (2, REPEAT('T', 4096)), (3, REPEAT('V', 4096))"
     expect:
-      affected_rows: 1
+      affected_rows: 3
 
   - name: "Shared blob: rebuild both tables concurrently"
     sql: "SHUTDOWN"
@@ -314,8 +320,8 @@ test_cases:
   - name: "Shared blob: both tables survive concurrent rebuild"
     sql: |
       SELECT
-        (SELECT payload = REPEAT('S', 1000) FROM blob_shared1 WHERE id = 1) AS first_ok,
-        (SELECT payload = REPEAT('S', 1000) FROM blob_shared2 WHERE id = 1) AS second_ok
+        (SELECT payload = REPEAT('S', 4096) FROM blob_shared1 WHERE id = 1) AS first_ok,
+        (SELECT payload = REPEAT('S', 4096) FROM blob_shared2 WHERE id = 1) AS second_ok
     expect:
       rows: 1
       data:
@@ -328,7 +334,7 @@ test_cases:
       rows: 0
 
   - name: "Shared blob: second table still has blob"
-    sql: "SELECT payload = REPEAT('S', 1000) AS ok FROM blob_shared2 WHERE id = 1"
+    sql: "SELECT payload = REPEAT('S', 4096) AS ok FROM blob_shared2 WHERE id = 1"
     expect:
       rows: 1
       data:
@@ -385,9 +391,11 @@ test_cases:
     sql: |
       INSERT INTO blob_external (id, payload) VALUES
       (1, REPEAT('E', 3000)),
-      (2, FROM_BASE64(REPEAT('AAAA', 1000)))
+      (2, FROM_BASE64(REPEAT('AAAA', 1000))),
+      (3, REPEAT('Q', 3000)),
+      (4, REPEAT('E', 3000))
     expect:
-      affected_rows: 2
+      affected_rows: 4
 
   - name: "Persist external blobs above 2 KiB"
     sql: "SHUTDOWN"
@@ -400,12 +408,64 @@ test_cases:
       FROM blob_external
       ORDER BY id
     expect:
-      rows: 2
+      rows: 4
       data:
         - id: 1
           len: 3000
         - id: 2
           len: 3000
+        - id: 3
+          len: 3000
+        - id: 4
+          len: 3000
+
+  - name: "Repeated external reads retain exact text and binary"
+    sql: "SELECT id, payload = CASE WHEN id = 1 OR id = 4 THEN REPEAT('E', 3000) WHEN id = 2 THEN FROM_BASE64(REPEAT('AAAA', 1000)) ELSE REPEAT('Q', 3000) END AS ok FROM blob_external ORDER BY id"
+    repetitions: 4
+    expect: {rows: 4, data: [{id: 1, ok: 1}, {id: 2, ok: 1}, {id: 3, ok: 1}, {id: 4, ok: 1}]}
+
+  - name: "Update warmed external content"
+    sql: "UPDATE blob_external SET payload = REPEAT('N', 4096) WHERE id = 1"
+    expect: {affected_rows: 1}
+
+  - name: "Warmed generation does not replace updated contents"
+    sql: "SELECT payload = REPEAT('N', 4096) AS ok FROM blob_external WHERE id = 1"
+    repetitions: 3
+    expect: {rows: 1, data: [{ok: 1}]}
+
+  - name: "Another row retains the shared original hash after update"
+    sql: "SELECT payload = REPEAT('E', 3000) AS ok FROM blob_external WHERE id = 4"
+    expect: {rows: 1, data: [{ok: 1}]}
+
+  - name: "Persist updated external contents"
+    sql: "SHUTDOWN"
+    expect: {rows: 0}
+
+  - name: "Updated external contents recover without RAM cache"
+    sql: "SELECT payload = REPEAT('N', 4096) AS ok FROM blob_external WHERE id = 1"
+    repetitions: 3
+    expect: {rows: 1, data: [{ok: 1}]}
+
+  - name: "Pressure during concurrent external reads"
+    parallel: blob_ram_pressure
+    scm: (settings "MaxRamBytes" 1024)
+    expect: {}
+
+  - name: "Concurrent reader preserves updated text under pressure"
+    parallel: blob_ram_pressure
+    sql: "SELECT payload = REPEAT('N', 4096) AS ok FROM blob_external WHERE id = 1"
+    repetitions: 12
+    expect: {rows: 1, data: [{ok: 1}]}
+
+  - name: "Concurrent reader preserves binary under pressure"
+    parallel: blob_ram_pressure
+    sql: "SELECT TO_BASE64(payload) = REPEAT('AAAA', 1000) AS ok FROM blob_external WHERE id = 2"
+    repetitions: 12
+    expect: {rows: 1, data: [{ok: 1}]}
+
+  - name: "Restore RAM budget after external read pressure"
+    scm: (settings "MaxRamBytes" 0)
+    expect: {}
 
   - name: "Drop external blob boundary table"
     sql: "DROP TABLE blob_external"
@@ -438,7 +498,56 @@ test_cases:
     sql: "SELECT LENGTH(payload) AS len, payload = CONCAT('blob-prefix-66:', REPEAT('x', 5300)) AS ok FROM blob_bang WHERE id = 1"
     expect: {rows: 1, data: [{len: 5315, ok: 1}]}
 
+  - name: "Create anonymous repeated blob scan fixture"
+    sql: "CREATE TABLE blob_ram_scan (id INT PRIMARY KEY, payload TEXT)"
+    expect: {rows: 0}
+  - name: "Populate anonymous repeated blob scan fixture"
+    scm: |
+      (begin
+        (set text (reduce (produceN 1024) (lambda (acc i) (concat acc "payload-")) ""))
+        (insert (table "memcp-tests" "blob_ram_scan") '("id" "payload")
+          (map (produceN 256) (lambda (i) (list i (concat i ":" text)))))
+        (rebuild (table "memcp-tests" "blob_ram_scan") true false))
+    expect: {}
+  # Per-row projections require reading payloads on every execution. Aggregates
+  # would reuse a group keytable and stop exercising blob decoding after warmup.
+  - name: "Repeated LIKE projection over external blobs"
+    sql: "SELECT id, payload LIKE '%payload%' AS matched FROM blob_ram_scan"
+    threshold_ms: 200
+    performance_rows: 256
+    warmup: 3
+    repetitions: 7
+    expect: {rows: 256}
+  - name: "Repeated full content length projection"
+    sql: "SELECT id, LENGTH(payload) AS bytes FROM blob_ram_scan"
+    threshold_ms: 200
+    performance_rows: 256
+    warmup: 3
+    repetitions: 7
+    expect: {rows: 256}
+  - name: "A different LIKE pattern reuses decoded content"
+    sql: "SELECT id, payload LIKE '%absent-pattern%' AS matched FROM blob_ram_scan"
+    threshold_ms: 200
+    performance_rows: 256
+    warmup: 3
+    repetitions: 7
+    expect: {rows: 256}
+  - name: "Repeated point read of external content"
+    sql: "SELECT LENGTH(payload) AS bytes FROM blob_ram_scan WHERE id = 123"
+    threshold_ms: 200
+    performance_rows: 1
+    warmup: 3
+    repetitions: 7
+    expect: {rows: 1, data: [{bytes: 8196}]}
+  - name: "Reject a conflicting write to a warmed blob row"
+    sql: "INSERT INTO blob_ram_scan (id, payload) VALUES (0, REPEAT('rejected', 1024))"
+    expect: {error: true}
+  - name: "Failed write preserves warmed committed content"
+    sql: "SELECT payload = CONCAT('0:', REPEAT('payload-', 1024)) AS ok FROM blob_ram_scan WHERE id = 0"
+    expect: {rows: 1, data: [{ok: 1}]}
+
 cleanup:
+  - sql: "DROP TABLE IF EXISTS blob_ram_scan"
   - sql: "DROP TABLE IF EXISTS blob_test"
   - sql: "DROP TABLE IF EXISTS blob_rc1"
   - sql: "DROP TABLE IF EXISTS blob_shared1"


### PR DESCRIPTION
Repeated reads of external text currently reopen and gunzip the same payload. This change admits decoded strings after observed reuse and lets the existing CacheManager shed them under RAM pressure. Reads synchronize at batch boundaries, including the generated JIT bulk getters.

Each immutable column generation owns its hashes, probation metadata and decoded allocations. Measured reload work per resident byte feeds bounded reuse telemetry; partial eviction ages retained histories. Blob entries have no idle expiry. The candidate comparison window and publication ordering also prevent a first scan's cheap probation metadata from displacing an established warm owner merely because that owner is large or the new owner is still locked.

Eviction releases RAM only. Source replacement resets the cache, active readers retain valid immutable strings, and failed reads do not install negative entries. The blob deletion proof from #838 remains intact.

### Manual A/B before this PR

Baseline: master `6a8642977`. Synthetic fixtures only; same setup, three warmups and seven measured JIT SQL queries per block, in A/B/B/A order. Fixture: 256 distinct rows with roughly 8 KiB of text each; per-row projections require content reads on every execution.

| JIT SQL projection | Master | Candidate | Change |
|---|---:|---:|---:|
| LIKE, matching literal | 5.448 ms | 1.155 ms | -78.8% |
| Complete content length | 5.605 ms | 1.011 ms | -82.0% |
| LIKE, absent literal | 8.763 ms | 4.397 ms | -49.8% |
| Point read including HTTP | 0.796 ms | 0.818 ms | +2.7% |

The separate 60-case reader matrix covers 512 B/4 KiB/64 KiB, repeated/random printable text, points/ranges/changing patterns/alternating owners/cold reads, and 128 KiB/64 MiB budgets. Both revisions use three warmups and 32 measured operations per case in A/B/B/A order. A warm 128-row 4 KiB range falls from 2.091 ms to 3.48 µs with zero steady-state allocation. Large scans under 128 KiB remain approximately baseline-speed.

Trade-offs: first reads retain metadata; owners keep separate copies; HTTP-bound points show no meaningful gain. The weakest cold case in the matrix was +19%; a longer 128-operation follow-up was -0.7%, so no cold-read speedup is claimed. In the 64 KiB random / 64 MiB twelve-scan probe, retained heap grows by about 8 MiB while CPU falls from 662 to 120 ms and sampled peak RSS from 40.3 to 34.9 MiB. Peak sampling is a lower bound, and the manager budget remains a soft ownership budget rather than an RSS cap.

[Design, complete latency/allocation/memory matrix, and reproduction details](https://github.com/launix-de/memcp/blob/blob-adaptive-ram/storage/blob-ram.md).

### Validation

- JIT blob YAML: **83/83**, including repeated text/binary reads, shared owners, updates, failed conflicting writes, restart, concurrent readers and RAM pressure.
- Undercount recovery: **5/5**; general memory pressure: **32/32**.
- Targeted existing Go blob/cache tests passed.
- Temporary admission, one-shot pollution, source replacement, missing/corrupt payload repair, and concurrent eviction probes passed, including `-race`.
- JIT getters regenerated; EXPLAIN/IR/PHYSICAL/REORDER confirm the measured length projection is a direct payload scan.

Full suites and performance gates remain enabled in CI. Local validation was targeted, as requested for this follow-up.
