### PR TITLE
ci: gate heavy workflows behind a path-relevance check

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,0 +1,88 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Reusable gate: decides whether a push or pull request touches build- or
+# test-relevant paths. Documentation-only changes (README, wiki, papers,
+# assets, *.md) return relevant=false so the callers can skip their heavy
+# jobs. A job skipped through `if:` reports "success", so required status
+# checks stay green for docs-only pull requests.
+
+name: Detect relevant changes
+
+on:
+  workflow_call:
+    outputs:
+      relevant:
+        description: "'true' unless the change set is documentation-only"
+        value: ${{ jobs.detect.outputs.relevant }}
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Classify changed files
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Any uncertainty about the diff errs on the side of running CI.
+          emit() { echo "relevant=$1" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request|pull_request_target)
+              base="$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")"
+              head="$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")"
+              ;;
+            push)
+              base="$(jq -r '.before' "$GITHUB_EVENT_PATH")"
+              head="${GITHUB_SHA}"
+              case "${base}" in ""|0000000000000000000000000000000000000000)
+                echo "New branch push; running the full CI." >&2; emit true ;;
+              esac
+              ;;
+            *)
+              emit true ;;
+          esac
+
+          # The compare API needs only `contents: read`; `...` is merge-base
+          # based, so this is exactly the change set the pull request adds.
+          compare="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${base}...${head}" 2>/dev/null || true)"
+          if [ -z "${compare}" ]; then
+            echo "Compare API unavailable; running the full CI." >&2; emit true
+          fi
+
+          mapfile -t files < <(jq -r '.files[]?.filename' <<<"${compare}")
+          nfiles="${#files[@]}"
+
+          # The compare response lists at most 300 files. Anything at or above
+          # that is certainly not a documentation-only change.
+          if [ "${nfiles}" -eq 0 ]; then
+            echo "No files in comparison; running the full CI." >&2; emit true
+          fi
+          if [ "${nfiles}" -ge 300 ]; then
+            echo "Comparison capped at 300 files; running the full CI." >&2; emit true
+          fi
+
+          printf 'changed: %s\n' "${files[@]}" >&2
+
+          relevant=false
+          for f in "${files[@]}"; do
+            case "${f}" in
+              tests/*|scm/*|storage/*|lib/*|tools/*|apps/*|corelib/*|packaging/*|debian/*|.github/*) relevant=true ;;
+              *.go|go.mod|go.sum|Makefile|Dockerfile|memcp.spec|memcp.service|git-pre-commit) relevant=true ;;
+              run_sql_tests.py|run_tests_unbuffered.py|CHANGELOG.md) relevant=true ;;
+            esac
+            [ "${relevant}" = true ] && break
+          done
+
+          echo "Relevant paths changed: ${relevant}" | tee -a "$GITHUB_STEP_SUMMARY" >&2
+          emit "${relevant}"

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -33,8 +33,13 @@ env:
   JIT_GO_REF: jit-foreign-frames-go1.27.0
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   go-test:
     name: go-test
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -52,6 +57,8 @@ jobs:
 
   jit-go-test:
     name: jit-go-test
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/jit-test.yml
+++ b/.github/workflows/jit-test.yml
@@ -19,8 +19,13 @@ env:
   JIT_GO_REF: jit-foreign-frames-go1.27.0
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   jit-test:
     name: jit-test
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -15,8 +15,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   performance-ab:
     name: performance-ab
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/.github/workflows/sql-time-limit-guard.yml
+++ b/.github/workflows/sql-time-limit-guard.yml
@@ -10,7 +10,12 @@ on:
     branches: [master]
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   sql-time-limit-guard:
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,12 @@ on:
     branches: [master]
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   test:
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     services:
@@ -65,7 +70,8 @@ jobs:
           --mysqldump=mariadb-dump
 
   packaging:
-    needs: test
+    needs: [changes, test]
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -100,7 +106,8 @@ jobs:
         run: docker build --check .
 
   alternative-storage:
-    needs: test
+    needs: [changes, test]
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Every change — bugfix, feature, refactor — must go through a **branch + PR**
 4. **CI must be green** (`test` GitHub Actions job) before the PR can be merged.
 5. **Merge the PR** on GitHub (or `gh pr merge`). Delete the branch and worktree afterwards.
 
+Each CI workflow first runs a small `changes` gate (`.github/workflows/detect-changes.yml`). When a pull request touches **only** documentation (`*.md`, `wiki/`, `papers/`, `assets/`, …) the build/test jobs — `test`, `performance-ab`, `sql-time-limit-guard`, the JIT jobs, packaging — are skipped and report success, so a docs-only PR is mergeable without a full run. Touching anything under `tests/`, `scm/`, `storage/`, `lib/`, `tools/`, `apps/`, `corelib/`, `.github/`, or any `*.go` / build file runs the full CI as before. When in doubt the gate runs everything.
+
 `git commit --no-verify` is allowed for intermediate commits on non-`master` branches, after a successful `make test` run in the current worktree/session to save iteration time, or for documentation-only changes (e.g. `README*`, docs, manuals) that do not modify executable code or tests. Before pushing/opening a PR, run the full hook-equivalent test suite (e.g. `make test`) again for any change set that includes code/test changes.
 
 ## Build, Test, and Dev Commands


### PR DESCRIPTION
## Problem

Every pull request — including ones that only touch `README.md` or `wiki/` — spins up the full matrix: `test` (build + MariaDB + `git-pre-commit` + dump/restore), `performance-ab` (~45 min A/B), the two JIT jobs (each builds a patched Go toolchain, 30–60 min), packaging, S3 reliability drills. For a docs change that is pure waste of runner minutes and wall-clock.

## Approach

Each gated workflow now starts with a small reusable gate — `.github/workflows/detect-changes.yml` — that reads the GitHub compare API for the push/PR and classifies the changed paths:

- **relevant** → anything under `tests/`, `scm/`, `storage/`, `lib/`, `tools/`, `apps/`, `corelib/`, `packaging/`, `debian/`, `.github/`, or any `*.go` / `go.mod` / `go.sum` / `Makefile` / `Dockerfile` / `memcp.spec` / `memcp.service` / `git-pre-commit` / `run_sql_tests.py` / `CHANGELOG.md`
- **not relevant** → everything else (`*.md`, `wiki/`, `papers/`, `assets/`, `LICENSE`, …)

The build/test jobs get `needs: changes` + `if: ${{ needs.changes.outputs.relevant == 'true' }}`.

### Why this keeps required checks working

`test`, `performance-ab` and `sql-time-limit-guard` are **required status checks** (and `enforce_admins` is on). A job skipped through a job-level `if:` [reports its status as *success*](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks), so a docs-only PR stays mergeable with those checks green. This is *not* a top-level `paths:` filter — those leave required checks stuck "Expected / pending" and would hard-block every docs PR.

The gate **fails open**: any event type it doesn't understand, an unreachable compare API, an empty or >300-file diff → `relevant=true`, full CI. It needs only `contents: read`.

## Scope

| Workflow | Gated jobs |
|---|---|
| `test.yml` | `test`, `packaging`, `alternative-storage` |
| `go-test.yml` | `go-test`, `jit-go-test` |
| `jit-test.yml` | `jit-test` |
| `performance.yml` | `performance-ab` |
| `sql-time-limit-guard.yml` | `sql-time-limit-guard` |
| `sql-regression-policy.yml` | **not gated** — protected policy path (the regression guard refuses edits to it), ~30 s, not a required check |
| `release.yml` | untouched (tag trigger) |
| `jit-performance.yml` | untouched (manual dispatch) |

This PR itself touches `.github/**`, so it runs the full CI.

## Testing

The path-classification shell logic was exercised locally against synthetic compare payloads (docs-only, mixed doc+go, `lib/*.scm`, empty diff, root `*.go`, workflow file) — results as expected. All workflow files parse as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)