### PR TITLE
Fix ordered joins with residual membership filters

### DIFF
--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -326,6 +326,37 @@ func TestCompileScanAccessKeepsCandidateHooksAfterSortedPrefix(t *testing.T) {
 	}
 }
 
+func TestPruneScanResidualListPreservesColumnData(t *testing.T) {
+	filters := scm.Read(t.Name(), `(list
+		(lambda () true)
+		(lambda (slug) (contains? (list "alpha") slug))
+		(lambda (id name) (and (equal? id 7) (strlike name "A%"))))`)
+	for _, source := range []string{
+		`(quote (() ("slug") ("id" "name")))`,
+		`(list (list) (list "slug") (list "id" "name"))`,
+		`(list (quote ()) (quote ("slug")) (quote ("id" "name")))`,
+	} {
+		t.Run(source, func(t *testing.T) {
+			columns := scm.Read(t.Name(), source)
+			_, _, compiled, _ := compileScanAccessList(columns, filters, false)
+			if len(compiled) != 3 || compiled[1] || !compiled[2] {
+				t.Fatalf("expected an uncompiled membership and a compiled equality: %v", compiled)
+			}
+			columnExpr, filterExpr := pruneScanResidualList(columns, filters, compiled, false)
+			actual := scm.Eval(columnExpr, &scm.Globalenv)
+			expected := scm.Eval(scm.Read(t.Name(), `(quote (() ("slug") ("name")))`), &scm.Globalenv)
+			if !scm.Equal(actual, expected) {
+				t.Fatalf("residual columns = %s, want %s", scm.SerializeToString(actual, &scm.Globalenv), scm.SerializeToString(expected, &scm.Globalenv))
+			}
+			callbacks := scm.Eval(filterExpr, &scm.Globalenv).Slice()
+			if !scm.ToBool(scm.Apply(callbacks[1], scm.NewString("alpha"))) ||
+				scm.ToBool(scm.Apply(callbacks[1], scm.NewString("beta"))) {
+				t.Fatal("uncompiled membership callback changed its result")
+			}
+		})
+	}
+}
+
 func TestPruneScanResidualDropsExactProbesAndKeepsLike(t *testing.T) {
 	columns := scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("list"), scm.NewString("id"), scm.NewString("age"), scm.NewString("name"),

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -363,8 +363,14 @@ func pruneScanResidualList(columnListsExpr, filtersExpr scm.Scmer, compiled []bo
 	prunedColumns[0], prunedFilters[0] = scm.NewSymbol("list"), scm.NewSymbol("list")
 	for i := range filters {
 		prunedColumns[i+1], prunedFilters[i+1] = columnLists[i], filters[i]
+		// A quoted outer list contains column data, not expressions. Quote each
+		// static column list before placing it in the executable list constructor,
+		// including entries whose filter cannot be compiled into scan boundaries.
+		if columns, static := scanStaticColumns(columnLists[i]); static {
+			prunedColumns[i+1] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice(columns)})
+		}
 		if compiled[i] {
-			prunedColumns[i+1], prunedFilters[i+1] = pruneScanResidual(columnLists[i], filters[i], allowBatch)
+			prunedColumns[i+1], prunedFilters[i+1] = pruneScanResidual(prunedColumns[i+1], filters[i], allowBatch)
 		}
 	}
 	return scm.NewSlice(prunedColumns), scm.NewSlice(prunedFilters)

--- a/tests/planner/order-window/order-limit.yaml
+++ b/tests/planner/order-window/order-limit.yaml
@@ -991,6 +991,80 @@ test_cases:
         - "scan_join_order"
         - "legacy_join_tree"
 
+  - name: "Ordered join retains an inner membership filter"
+    sql: |
+      SELECT d.id
+      FROM ord_join_order_driver d
+      JOIN ord_join_order_lookup l ON d.lookup_id = l.id
+      WHERE l.enabled IN (1)
+      ORDER BY d.score DESC
+      LIMIT 2
+    expect:
+      rows: 2
+      data:
+        - id: 3
+        - id: 1
+
+  - name: "Ordered join retains a driver membership filter"
+    sql: |
+      SELECT d.id
+      FROM ord_join_order_driver d
+      JOIN ord_join_order_lookup l ON d.lookup_id = l.id
+      WHERE d.score IN (10, 30)
+      ORDER BY d.score DESC
+      LIMIT 1 OFFSET 1
+    expect:
+      rows: 1
+      data:
+        - id: 1
+
+  - name: "Ordered join membership rejects nonmatching rows"
+    sql: |
+      SELECT d.id
+      FROM ord_join_order_driver d
+      JOIN ord_join_order_lookup l ON d.lookup_id = l.id
+      WHERE l.enabled IN (99)
+      ORDER BY d.score DESC
+      LIMIT 2
+    expect:
+      rows: 0
+
+  - name: "Ordered join membership preserves NULL semantics"
+    sql: |
+      SELECT d.id
+      FROM ord_join_order_driver d
+      JOIN ord_join_order_lookup l ON d.lookup_id = l.id
+      WHERE l.enabled IN (1, NULL)
+      ORDER BY d.score DESC
+      LIMIT 2
+    expect:
+      rows: 2
+      data:
+        - id: 3
+        - id: 1
+
+  - name: "Ordered join NOT IN with NULL rejects unknown results"
+    sql: |
+      SELECT d.id
+      FROM ord_join_order_driver d
+      JOIN ord_join_order_lookup l ON d.lookup_id = l.id
+      WHERE l.enabled NOT IN (1, NULL)
+      ORDER BY d.score DESC
+      LIMIT 2
+    expect:
+      rows: 0
+
+  - name: "Ordered join still rejects unknown filter columns"
+    sql: |
+      SELECT d.id
+      FROM ord_join_order_driver d
+      JOIN ord_join_order_lookup l ON d.lookup_id = l.id
+      WHERE l.missing IN (1)
+      ORDER BY d.score DESC
+      LIMIT 2
+    expect:
+      error: true
+
   - name: "Sparse ordered join costs all visited driver rows"
     setup:
       - sql: "DROP TABLE IF EXISTS ord_join_order_driver"


### PR DESCRIPTION
Ordered joins with local membership filters could fail with errors such as `Unknown function: slug` instead of returning rows. A reproducer is a two-table join with `WHERE t.slug IN ('alpha') ORDER BY t.id LIMIT 1`.

The shared multi-scan compiler now preserves static filter-column lists as quoted data when assembling the executable argument list, including filters that cannot become scan boundaries. This fixes the cause without disabling ordered joins or rewriting application SQL.

Validation:
- Added SQL regressions for driver/inner filters, pagination, empty results, NULL membership, and invalid columns. Before the fix: 53/58 passed, with all five new valid-query cases failing. After: 58/58 passed.
- Added a Go regression that evaluates the emitted column lists and residual callback for quoted and constructed input lists; focused residual-filter tests pass.
- Full `make test` passed: 308 suite summaries, 6831 passing cases, zero critical failures; 27 pre-marked noncritical failures.
