### PR TITLE
Preserve dates through rebuilds and compressed string output

### DIFF
--- a/scm/date.go
+++ b/scm/date.go
@@ -74,7 +74,7 @@ func toTime(v Scmer) (time.Time, bool) {
 		return time.Unix(v.Int(), 0).UTC(), true
 	case tagFloat:
 		return time.Unix(int64(v.Float()), 0).UTC(), true
-	case tagString, tagSymbol:
+	case tagString, tagSymbol, tagCString, tagBString:
 		if ts, ok := ParseDateString(v.String()); ok {
 			return time.Unix(ts, 0).UTC(), true
 		}
@@ -88,7 +88,11 @@ func sqlTemporalOutput(value Scmer, sqlType string, timezone Scmer) Scmer {
 	if value.IsNil() {
 		return NewNil()
 	}
-	if value.GetTag() == tagDate && value.Int() == mysqlZeroDateUnix {
+	t, ok := toTime(value)
+	if !ok {
+		return value
+	}
+	if t.Unix() == mysqlZeroDateUnix {
 		switch strings.ToUpper(sqlType) {
 		case "DATE":
 			return NewString("0000-00-00")
@@ -97,10 +101,6 @@ func sqlTemporalOutput(value Scmer, sqlType string, timezone Scmer) Scmer {
 		default:
 			return value
 		}
-	}
-	t, ok := toTime(value)
-	if !ok {
-		return value
 	}
 	loc, err := ResolveLocation(timezone.String())
 	if err != nil {

--- a/scm/date_output_test.go
+++ b/scm/date_output_test.go
@@ -17,6 +17,7 @@ Copyright (C) 2026  Carl-Philip Hänsch
 package scm
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -52,8 +53,30 @@ func TestSQLTemporalOutputPreservesMySQLZeroDates(t *testing.T) {
 		if !ok {
 			t.Fatalf("ParseDateString(%q) rejected a MySQL zero date", test.input)
 		}
-		if got := sqlTemporalOutput(NewDate(unix), test.sqlType, NewString("UTC")).String(); got != test.want {
-			t.Fatalf("%s output = %q, want %q", test.sqlType, got, test.want)
+		for _, value := range []Scmer{NewDate(unix), NewString(test.input)} {
+			if got := sqlTemporalOutput(value, test.sqlType, NewString("UTC")).String(); got != test.want {
+				t.Fatalf("%s output (tag %d) = %q, want %q", test.sqlType, value.GetTag(), got, test.want)
+			}
 		}
+	}
+}
+
+func TestDateStringConversionsPreserveTemporalValues(t *testing.T) {
+	for _, input := range []string{"1970-01-01 00:00:00", "2024-06-15 10:30:45", "0000-00-00 00:00:00"} {
+		t.Run(input, func(t *testing.T) {
+			unix, ok := ParseDateString(input)
+			if !ok {
+				t.Fatal("invalid test date")
+			}
+			value := NewDate(unix)
+			if got := String(value); got != input {
+				t.Errorf("String(date) = %q, want %q", got, input)
+			}
+			var buffer bytes.Buffer
+			WriteStringValue(bufferTextWriter(&buffer), value)
+			if got := buffer.String(); got != input {
+				t.Errorf("WriteStringValue(date) = %q, want %q", got, input)
+			}
+		})
 	}
 }

--- a/scm/printer.go
+++ b/scm/printer.go
@@ -86,7 +86,7 @@ func String(v Scmer) string {
 	switch v.GetTag() {
 	case tagNil:
 		return "nil"
-	case tagBool, tagInt, tagFloat:
+	case tagBool, tagInt, tagFloat, tagDate:
 		return v.String()
 	case tagString, tagCString, tagBString, tagBSON:
 		return v.String()
@@ -169,7 +169,7 @@ func WriteStringValue(w *schemeTextWriter, v Scmer) {
 		w.WriteString("nil")
 	case tagCString, tagBString:
 		w.writeCompressedText(v)
-	case tagBool, tagString, tagSymbol:
+	case tagBool, tagString, tagSymbol, tagDate:
 		w.WriteString(v.String())
 	case tagSpecialForm:
 		w.WriteString(v.SpecialFormName())

--- a/tests/sql/compatibility/mysql-datetime-defaults.yaml
+++ b/tests/sql/compatibility/mysql-datetime-defaults.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
 # MySQL Compatibility v1 — Date/Time semantics
 
 metadata:
@@ -5,6 +7,7 @@ metadata:
   description: "MySQL v1: CURRENT_TIMESTAMP defaults, NOW(), comparisons"
 
 setup:
+  - sql: "DROP TABLE IF EXISTS tstamp_rebuild"
   - sql: "DROP TABLE IF EXISTS tstamp"
 
 test_cases:
@@ -35,6 +38,20 @@ test_cases:
       rows: 1
       result_contains: "DEFAULT CURRENT_TIMESTAMP"
 
+  - name: "Date string conversion preserves the date"
+    setup:
+      - sql: "CREATE TABLE tstamp_rebuild (id INT PRIMARY KEY, created_at DATETIME, marker INT)"
+      - sql: "INSERT INTO tstamp_rebuild VALUES (1, '2024-06-01 10:30:45', 0)"
+    sql: "SELECT CONCAT(created_at, '') AS value FROM tstamp_rebuild WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - value: "2024-06-01 10:30:45"
+
+  - name: "Rebuild temporal values before restart"
+    scm: "(begin (rebuild) true)"
+    expect: {}
+
   - name: "Persist CURRENT_TIMESTAMP default expression"
     sql: "SHUTDOWN"
 
@@ -50,5 +67,46 @@ test_cases:
       data:
         - ok: true
 
+  - name: "Mix reloaded and newly inserted dates before rebuild"
+    sql: |
+      INSERT INTO tstamp_rebuild VALUES
+      (2, '2024-06-02 10:30:45', 0), (3, '2024-06-03 10:30:45', 0),
+      (4, '2024-06-04 10:30:45', 0), (5, '2024-06-05 10:30:45', 0),
+      (6, '2024-06-06 10:30:45', 0), (7, '2024-06-07 10:30:45', 0),
+      (8, '2024-06-08 10:30:45', 0), (9, '2024-06-09 10:30:45', 0),
+      (10, '2024-06-10 10:30:45', 0)
+    expect:
+      affected_rows: 9
+
+  - name: "Rebuild mixed temporal representations"
+    scm: "(begin (rebuild) true)"
+    expect: {}
+
+  - name: "Rebuild preserves newly inserted dates"
+    sql: "SELECT created_at FROM tstamp_rebuild WHERE id = 2"
+    expect:
+      rows: 1
+      data:
+        - created_at: "2024-06-02 10:30:45"
+
+  - name: "Unrelated update accepts the rebuilt date"
+    sql: "UPDATE tstamp_rebuild SET marker = 1 WHERE id = 2"
+    expect:
+      affected_rows: 1
+
+  - name: "Unrelated update preserves the rebuilt date"
+    sql: "SELECT created_at, marker FROM tstamp_rebuild WHERE id = 2"
+    expect:
+      rows: 1
+      data:
+        - created_at: "2024-06-02 10:30:45"
+          marker: 1
+
+  - name: "Invalid date strings are still rejected"
+    sql: "INSERT INTO tstamp_rebuild VALUES (11, 'not-a-date', 0)"
+    expect:
+      error: true
+
 cleanup:
+  - sql: "DROP TABLE IF EXISTS tstamp_rebuild"
   - sql: "DROP TABLE IF EXISTS tstamp"


### PR DESCRIPTION
Datetime values could become literal `<scmer 16>` strings when a rebuild combined reloaded strings with newly inserted typed dates. Reading or updating the affected rows then returned malformed dates or failed validation. A compressed date copied into the write delta could also be interpreted as a Unix timestamp equal to its leading year (for example, 2024 seconds).

The shared string and streaming-string conversion now format typed dates normally. Temporal parsing also recognizes compressed text, and zero-date handling applies consistently to typed and string representations.

Regression coverage exercises string conversion, persistence/restart, mixed-representation rebuilds, an unrelated-column UPDATE, invalid date rejection, and MySQL zero dates. The SQL suite went from 13/16 to 16/16 passing; focused temporal Go tests pass. No on-disk format changes. Already stored placeholder strings contain no recoverable timestamp; this fix prevents recurrence but cannot reconstruct those values.
