### PR TITLE
Fix feedback cache churn and erased aggregate membership costs

### DIFF
--- a/.github/workflows/jit-performance.yml
+++ b/.github/workflows/jit-performance.yml
@@ -3,24 +3,30 @@
 
 name: JIT Performance A/B
 
-# Kept manual until the JIT correctness workflow is a stable required check.
-# Add the pull_request trigger only after jit-test is enabled and reliable.
+# Production uses JIT; interpreter-only A/B cannot protect that execution path.
 on:
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: jit-performance-ab-${{ github.ref }}
+  group: jit-performance-ab-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
   JIT_GO_REF: jit-foreign-frames-go1.27.0
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   jit-performance-ab:
     name: jit-performance-ab
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -738,14 +738,21 @@ lost; these are disposable planning hints and have no WAL/durability guarantee.
 No learned state changes row visibility, shard binary formats, or query results. Existing integer scan headers remain readable;
 new optional feedback metadata is ordinary serializable Scheme data.
 
-Published feedback cost classes participate in the existing table statistics
-cache guards. Small EMA changes within one geometric class do not invalidate
-plans; changed classes/new keys do. This bounded table-wide invalidation is
-conservative and may recompile unrelated plans on the same table. A future
-per-predicate guard can narrow that dependency without changing scan sampling.
-These are power-of-two selectivity classes, not the exact cost crossover points
-of competing plans. A crossover within a class can therefore remain unnoticed
-until another guard changes; exact plan-specific thresholds remain future work.
+Execution plans guard structural table statistics separately from learned filter
+estimates. Table generation/fingerprint guards with `include_feedback=false`
+must be accompanied by guards for the bound filter metadata actually consumed
+by costing. Learning an unrelated predicate must not invalidate these plans.
+Session bindings must be passed explicitly through reorder and lowering; a
+missing session must not silently substitute another binding's observations.
+
+Filter metadata guards use the central `scan_selectivity_estimate` reader with
+sampling budget zero: validation must never scan, load columns, or build an
+index. An unknown estimate is also a dependency, so newly available feedback
+can cause replanning. Existing cost crossover guards remain active. Where a
+crossover has not been derived, an exact metadata-input guard is conservative;
+it must not be described as a derived operator crossover or removed unchecked.
+EXPLAIN diagnostics and the public default table-statistics API retain the
+table-wide feedback fingerprint so cached diagnostics refresh their estimates.
 
 ## Canonical Naming and Reuse
 

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -754,6 +754,14 @@ it must not be described as a derived operator crossover or removed unchecked.
 EXPLAIN diagnostics and the public default table-statistics API retain the
 table-wide feedback fingerprint so cached diagnostics refresh their estimates.
 
+Performance coverage for these guards must include changing predicates between
+cached executions, not only repetitions of a single already-learned query.
+Expensive suites excluded from ordinary SQL CI with `metadata.ci: false` can
+opt into automatic A/B with `metadata.perf_ci: true`; discovery requires a
+`threshold_ms` case. `metadata.performance_rows` supplies the suite fixture size
+unless a case overrides it. SCM cases with `threshold_ms` must use the same
+warmup, repetitions and A/B timing gate as SQL, with explicit result validation.
+
 ## Canonical Naming and Reuse
 
 Helper identities must be canonical.

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -141,7 +141,7 @@ deduplicate immutable ASTs without serializing the growing expressions. */
 /* Table statistics use a two-level cache guard: immutable generation tokens
 cover the hot path, while a coarse cost-class fingerprint keeps a statistically
 similar REBUILD generation on the cached plan without recompiling the query. */
-(define planner_record_statistics_dependency (lambda (table_expr token fingerprint planning_session)
+(define planner_record_statistics_dependency (lambda (table_expr token fingerprint planning_session include_feedback)
 	(begin
 		(define planning_session (planner_effective_session planning_session))
 		(define dependencies (if (nil? planning_session) nil
@@ -157,7 +157,7 @@ similar REBUILD generation on the cached plan without recompiling the query. */
 						(define count (coalesceNil (dependencies "count") 0))
 						(catalog table_expr true)
 						(dependencies (concat "dependency:" count)
-							(list table_expr token fingerprint))
+							(list table_expr token fingerprint include_feedback))
 						(dependencies "count" (+ count 1)))))))))
 
 (define planner_guarded_choice (lambda (chosen condition planning_session)

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -295,14 +295,14 @@ and barrier ownership come from the pre-normalization query block. */
 					(join_optimizer_column_selectivity_estimate right_ref)
 					(planner_unknown_selectivity_estimate)))))))
 
-(define join_optimizer_expr_prior_estimate (lambda (sources default_alias expr)
+(define join_optimizer_expr_prior_estimate (lambda (sources default_alias expr planning_session)
 	(match expr
 		((symbol equal?) left right) (join_optimizer_equality_selectivity_estimate sources default_alias left right)
-		((quote equal?) left right) (join_optimizer_expr_selectivity_estimate sources default_alias (list (symbol "equal?") left right))
+		((quote equal?) left right) (join_optimizer_expr_selectivity_estimate sources default_alias (list (symbol "equal?") left right) planning_session)
 		((symbol equal??) left right) (join_optimizer_equality_selectivity_estimate sources default_alias left right)
-		((quote equal??) left right) (join_optimizer_expr_selectivity_estimate sources default_alias (list (symbol "equal??") left right))
+		((quote equal??) left right) (join_optimizer_expr_selectivity_estimate sources default_alias (list (symbol "equal??") left right) planning_session)
 		((symbol =) left right) (join_optimizer_equality_selectivity_estimate sources default_alias left right)
-		((quote =) left right) (join_optimizer_expr_selectivity_estimate sources default_alias (list (symbol "=") left right))
+		((quote =) left right) (join_optimizer_expr_selectivity_estimate sources default_alias (list (symbol "=") left right) planning_session)
 		((symbol <) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
 		((quote <) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
 		((symbol <=) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
@@ -327,16 +327,43 @@ and barrier ownership come from the pre-normalization query block. */
 				(planner_unknown_selectivity_estimate)))
 		((quote strlike) value pattern)
 		(join_optimizer_expr_selectivity_estimate sources default_alias
-			(list (symbol "strlike") value pattern))
+			(list (symbol "strlike") value pattern) planning_session)
 		((quote strlike) value pattern collation)
 		(join_optimizer_expr_selectivity_estimate sources default_alias
-			(list (symbol "strlike") value pattern collation))
+			(list (symbol "strlike") value pattern collation) planning_session)
 		_ (planner_unknown_selectivity_estimate))))
 
 /* Feedback keys describe the complete table-local logical predicate, before
 physical residual pruning. Compiling its access metadata here only canonicalizes
 bounded scalar metadata; this lookup never scans, loads columns or builds indexes. */
-(define planner_filter_feedback (lambda (sources default_alias expr)
+(define planner_record_filter_feedback_guard (lambda (src access values planning_session)
+	(begin
+		(define planning_session (planner_effective_session planning_session))
+		(if (or (nil? planning_session)
+			(nil? (planning_session "__memcp_queryplan_guard_conditions"))
+			(empty_list? (car access))
+			(not (list? (car (car access))))) nil
+			(begin
+				/* Guard precisely the metadata input, including an unknown result.
+				A measurement of another bound predicate must not invalidate this
+				plan. The equality is a conservative fallback where no cost crossover
+				inequality has been derived; it is not permission to omit that input.
+				Budget zero is essential: guards never sample or run a filter. */
+				(define read_expr (list (quote scan_selectivity_estimate) nil
+					(list (quote table) (source_schema src) (source_relation src))
+					(list (quote quote) (car access)) (list (quote quote) values)
+					(list (quote quote) '()) (list (quote lambda) '() true) 0))
+				/* Provenance matters too: a prior from other LIKE words may be
+				resampled, whereas a same-predicate measurement need not be. Read
+				the metadata once and retain both decision inputs. */
+				(define value_expr (list (list (quote lambda) (list (quote estimate))
+					(list (quote list)
+						(list (quote qassoc_get) (quote estimate) (list (quote quote) (quote value)) nil)
+						(list (quote qassoc_get) (quote estimate) (list (quote quote) (quote source)) nil))) read_expr))
+				(planner_record_guard_condition
+					(list (quote equal?) value_expr (list (quote quote) (eval value_expr))) planning_session))))))
+
+(define planner_filter_feedback (lambda (sources default_alias expr planning_session)
 	(begin
 		(define aliases (join_hypergraph_expr_aliases default_alias (source_aliases sources) expr))
 		(if (not (single_source? aliases)) nil
@@ -348,20 +375,23 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 							(define cols (extract_columns_for_alias src expr))
 							(define callback (list (quote lambda)
 								(map cols (lambda (col) (symbol (concat (source_alias src) "." col))))
-								(lower_column_expr_for_alias src expr)))
+								(planner_bind_session_values (lower_column_expr_for_alias src expr) planning_session)))
 							(define access (compile_scan_access cols callback true))
+							(define values (map (nth access 1) (lambda (value) (eval value))))
+							(planner_record_session_value_guards expr planning_session)
+							(planner_record_filter_feedback_guard src access values planning_session)
 							(scan_selectivity_estimate nil (table (source_schema src) (source_relation src))
-								(nth access 0) (map (nth access 1) (lambda (value) (eval value)))
+								(nth access 0) values
 								cols (eval callback) 0)))
 						(lambda (_e) nil))))))))
 
-(define join_optimizer_expr_selectivity_estimate (lambda (sources default_alias expr)
-	(coalesceNil (planner_filter_feedback sources default_alias expr)
-		(join_optimizer_expr_prior_estimate sources default_alias expr))))
+(define join_optimizer_expr_selectivity_estimate (lambda (sources default_alias expr planning_session)
+	(coalesceNil (planner_filter_feedback sources default_alias expr planning_session)
+		(join_optimizer_expr_prior_estimate sources default_alias expr planning_session))))
 
-(define join_optimizer_expr_selectivity (lambda (sources default_alias expr)
+(define join_optimizer_expr_selectivity (lambda (sources default_alias expr planning_session)
 	(begin
-		(define estimate (join_optimizer_expr_selectivity_estimate sources default_alias expr))
+		(define estimate (join_optimizer_expr_selectivity_estimate sources default_alias expr planning_session))
 		(planner_estimate_planning_value estimate
 			(if (equal? (qassoc_get estimate (quote source) nil) (quote range_unknown))
 				0.3333333333333333 0.1)))))
@@ -369,7 +399,7 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 (define join_optimizer_product (lambda (values)
 	(reduce (coalesceNil values '()) (lambda (product value) (* product value)) 1)))
 
-(define join_optimizer_source_rows_from_base (lambda (base_rows_value sources default_alias local_predicates src)
+(define join_optimizer_source_rows_from_base (lambda (base_rows_value sources default_alias local_predicates src planning_session)
 	(begin
 		(define base_rows (coalesceNil base_rows_value 1000000))
 		(define local_selectivity (join_optimizer_product
@@ -382,19 +412,19 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 						(equal? (qassoc_get entry (quote origin) nil) (quote where))))))
 				(lambda (entry)
 					(join_optimizer_expr_selectivity sources default_alias
-						(qassoc_get entry (quote predicate) true))))))
+						(qassoc_get entry (quote predicate) true) planning_session)))))
 		(define combined (reduce (filter local_predicates (lambda (entry)
 			(not (and (source_outer? src) (equal? (qassoc_get entry (quote origin) nil) (quote where))))))
 			(lambda (condition entry) (combine_where condition (qassoc_get entry (quote predicate) true))) true))
-		(define feedback (planner_filter_feedback sources default_alias combined))
+		(define feedback (planner_filter_feedback sources default_alias combined planning_session))
 		(max 1 (* base_rows (if (nil? feedback) local_selectivity (qassoc_get feedback (quote value) local_selectivity)))))))
 
-(define join_optimizer_source_rows (lambda (stages sources default_alias graph src)
+(define join_optimizer_source_rows (lambda (stages sources default_alias graph src planning_session)
 	(join_optimizer_source_rows_from_base
 		(planner_estimate_planning_value
 			(planner_source_row_estimate_using_stages stages src) 1000000)
 		sources default_alias
-		(join_optimizer_local_predicates graph (source_alias src)) src)))
+		(join_optimizer_local_predicates graph (source_alias src)) src planning_session)))
 
 (define planner_quoted_value (lambda (value)
 	(list (quote quote) value)))
@@ -428,7 +458,7 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 				(planner_quoted_value local_sources)
 				default_alias
 				(planner_quoted_value local_predicates)
-				(planner_quoted_value src))))))
+				(planner_quoted_value src) (quote session))))))
 
 (define join_optimizer_selectivity_expr (lambda (sources default_alias predicate)
 	(begin
@@ -440,7 +470,7 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 			(list (quote join_optimizer_expr_selectivity)
 				(planner_quoted_value local_sources)
 				default_alias
-				(planner_quoted_value predicate))))))
+				(planner_quoted_value predicate) (quote session))))))
 
 (define join_optimizer_alias_subset? (lambda (required available)
 	(reduce (coalesceNil required '()) (lambda (ok alias)
@@ -506,7 +536,7 @@ cost-reordered around the complete relation unit. */
 						relation_units sources alias))
 					(if (nil? anchor) required (list anchor)))))))))
 
-(define join_optimizer_metadata_nodes (lambda (stages relation_units sources default_alias alias_index graph fixed_cardinality)
+(define join_optimizer_metadata_nodes (lambda (stages relation_units sources default_alias alias_index graph fixed_cardinality planning_session)
 	(map sources (lambda (src)
 		(begin
 			(define stage (join_optimizer_source_stage stages src))
@@ -514,7 +544,7 @@ cost-reordered around the complete relation unit. */
 			(list
 				(source_alias src)
 				(if (or singleton fixed_cardinality) 1
-					(join_optimizer_source_rows stages sources default_alias graph src))
+					(join_optimizer_source_rows stages sources default_alias graph src planning_session))
 				(if (or singleton fixed_cardinality) 1
 					(join_optimizer_source_rows_expr stages sources default_alias graph src))
 				(if (join_optimizer_inner_source? stages src) (quote inner) (quote left-outer))
@@ -522,7 +552,7 @@ cost-reordered around the complete relation unit. */
 				(if (group_stage? stage) (stage_result_max_rows_per_partition stage) nil)
 				singleton))))))
 
-(define join_optimizer_metadata_predicates_from (lambda (sources default_alias entries aliases)
+(define join_optimizer_metadata_predicates_from (lambda (sources default_alias entries aliases planning_session)
 	(map (filter entries (lambda (entry)
 		(join_optimizer_alias_subset? (qassoc_get entry (quote aliases) '()) aliases)))
 		(lambda (entry)
@@ -538,7 +568,7 @@ cost-reordered around the complete relation unit. */
 				(define metadata (list
 					predicate_aliases
 					(join_optimizer_expr_selectivity sources default_alias
-						predicate)
+						predicate planning_session)
 					origin
 					(qassoc_get entry (quote owner) nil)
 					predicate
@@ -546,13 +576,13 @@ cost-reordered around the complete relation unit. */
 					(join_optimizer_selectivity_expr sources default_alias predicate)))
 				metadata)))))
 
-(define join_optimizer_metadata_predicates (lambda (sources default_alias graph aliases)
+(define join_optimizer_metadata_predicates (lambda (sources default_alias graph aliases planning_session)
 	(join_optimizer_metadata_predicates_from
-		sources default_alias (join_optimizer_predicates graph) aliases)))
+		sources default_alias (join_optimizer_predicates graph) aliases planning_session)))
 
-(define join_optimizer_metadata_costed_predicates (lambda (sources default_alias graph aliases)
+(define join_optimizer_metadata_costed_predicates (lambda (sources default_alias graph aliases planning_session)
 	(join_optimizer_metadata_predicates_from
-		sources default_alias (join_optimizer_costed_predicates graph) aliases)))
+		sources default_alias (join_optimizer_costed_predicates graph) aliases planning_session)))
 
 (define join_optimizer_source_by_alias (lambda (sources alias)
 	(reduce sources (lambda (found src)
@@ -1743,16 +1773,19 @@ particular star shape. */
 			(define table_value (table (source_schema src) (source_relation src)))
 			(define table_expr
 				(list (quote table) (source_schema src) (source_relation src)))
+			(define include_feedback (and (not (nil? planning_session))
+				(planning_session "__memcp_queryplan_diagnostic_statistics")))
 			(planner_record_statistics_dependency
 				table_expr
-				(table_planner_statistics_token table_value)
-				(table_planner_statistics_fingerprint table_value)
-				planning_session))) nil)))
+				(table_planner_statistics_token table_value include_feedback)
+				(table_planner_statistics_fingerprint table_value include_feedback)
+				planning_session include_feedback))) nil)))
 
 (define planner_table_statistics_aliases (lambda (sources)
 	(map (filter sources source_is_base_table?) source_alias)))
 
-/* Table dependencies cover rebuild statistics and published feedback classes.
+/* Table dependencies cover rebuild statistics; individual metadata reads guard
+their own bound filter estimates instead of invalidating on unrelated learning.
 Every local filter may now depend on a bound value; record all session-value
 dependencies, not only text-pattern parameters. */
 (define join_order_record_cost_dependencies (lambda (sources nodes predicates planning_session)
@@ -2314,7 +2347,7 @@ source catalog. join_plan remains the single owner of physical join order. */
 		(define aliases (map segment source_alias))
 		(define alias_index (join_hypergraph_alias_index aliases))
 		(define predicates (join_optimizer_metadata_costed_predicates
-			all_sources default_alias graph aliases))
+			all_sources default_alias graph aliases planning_session))
 		(define fixed_functional_pair (and (equal? (count segment) 2)
 			(and (empty_list? required_drivers)
 				(begin
@@ -2331,7 +2364,7 @@ source catalog. join_plan remains the single owner of physical join order. */
 										(list (source_alias driver)))))))))))
 		(define planned (join_order_adaptive segment
 			(join_optimizer_metadata_nodes stages relation_units
-				segment default_alias alias_index graph fixed_functional_pair)
+				segment default_alias alias_index graph fixed_functional_pair planning_session)
 			predicates
 			required_drivers
 			planning_session))
@@ -2410,7 +2443,7 @@ the lowerer can cost it. */
 (define join_optimizer_ordered_source_rows (lambda (stage_catalog sources default_alias graph src planning_session tx)
 	(begin
 		(define fallback (join_optimizer_source_rows
-			stage_catalog sources default_alias graph src))
+			stage_catalog sources default_alias graph src planning_session))
 		(define base_rows (planner_source_row_count src))
 		(define condition (join_optimizer_source_local_condition graph src))
 		(if (or (not (number? base_rows)) (equal? condition true))
@@ -2445,7 +2478,7 @@ the lowerer can cost it. */
 		(define base_row_catalog (map sources (lambda (src)
 			(list (source_alias src)
 				(coalesceNil (planner_source_row_count src)
-					(join_optimizer_source_rows stage_catalog sources default_alias graph src))))))
+					(join_optimizer_source_rows stage_catalog sources default_alias graph src planning_session))))))
 		(define filtered_row_catalog (map sources (lambda (src)
 			(list (source_alias src)
 				(join_optimizer_ordered_source_rows
@@ -2860,11 +2893,14 @@ floor avoids pretending that an unseen word is impossible. */
 						(planner_bind_session_values
 							(lower_column_expr_for_alias src condition) planning_session))))
 					(define access (compile_scan_access filtercols filter_expr))
+					(define values (map (nth access 1) (lambda (value_expr) (eval value_expr))))
+					(planner_record_session_value_guards condition planning_session)
+					(planner_record_filter_feedback_guard src access values planning_session)
 					(define estimate (scan_selectivity_estimate
 						tx
 						(table (source_schema src) (source_relation src))
 						(nth access 0)
-						(map (nth access 1) (lambda (value_expr) (eval value_expr)))
+						values
 						filtercols
 						(eval filter_expr)
 						max_rows))
@@ -2890,11 +2926,11 @@ real estimate instead of an unconditional "unknown": an unbounded scan still
 has a knowable multiplicity (its source's row count), it just isn't capped
 by a LIMIT or a unique point lookup. Falls back to `fallback` only when the
 source itself has no known row count (not a base table). */
-(define planner_row_count_after_selectivity (lambda (src sources default_alias condition fallback)
+(define planner_row_count_after_selectivity (lambda (src sources default_alias condition fallback planning_session)
 	(begin
 		(define source_rows (planner_source_row_count src))
 		(if (number? source_rows)
-			(max 1 (* source_rows (join_optimizer_expr_selectivity sources default_alias condition)))
+			(max 1 (* source_rows (join_optimizer_expr_selectivity sources default_alias condition planning_session)))
 			fallback))))
 
 (define planner_source_row_estimate (lambda (src)
@@ -3104,7 +3140,7 @@ fact table with a small FK domain still selects the reusable partition. */
 					(planner_source_filter_estimate src residual 512 tx planning_session)
 					total_rows
 					(planner_row_count_after_selectivity src (list src)
-						(source_alias src) residual total_rows)))))))
+						(source_alias src) residual total_rows planning_session)))))))
 
 /* Aggregate pushdown runs before physical lowering, but its cached decision
 must observe the same source-local statistic that a later access-path choice
@@ -3177,7 +3213,7 @@ logical IR: it samples once per request and is shared by every guard binding. */
 				(list (quote null_extension_barrier) true)
 				(list (quote reuse) 1))))))
 
-(define query_block_selectivity_estimates (lambda (block)
+(define query_block_selectivity_estimates (lambda (block planning_session)
 	(begin
 		(define sources (qb_sources block))
 		(define default_alias (qassoc_get (qb_facts block) (quote default_alias)
@@ -3190,7 +3226,7 @@ logical IR: it samples once per request and is shared by every guard binding. */
 			(lambda (predicate)
 				(begin
 					(define estimate (join_optimizer_expr_selectivity_estimate
-						sources default_alias predicate))
+						sources default_alias predicate planning_session))
 					(list
 						(list (quote predicate) predicate)
 						(list (quote estimate) estimate)
@@ -3207,7 +3243,7 @@ logical IR: it samples once per request and is shared by every guard binding. */
 	(merge (list
 		(list (list (quote source_estimates) (map (qb_sources block) source_reorder_estimate)))
 		(if (explain_reorder_selectivities? planning_session)
-			(list (list (quote selectivity_estimates) (query_block_selectivity_estimates block)))
+			(list (list (quote selectivity_estimates) (query_block_selectivity_estimates block planning_session)))
 			'())
 		(list (list (quote left_join_requirements) (filter
 			(map (qb_sources block) left_join_requirement)

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1251,7 +1251,7 @@ both names therefore bind to the same parameter. */
 		(define condition (combine_where (qb_where prepared) (source_join_expr src)))
 		(define probe_term (list (quote equal??) key_expr probe))
 		(define probe_work_rows (planner_row_count_after_selectivity
-			src (list src) (source_alias src) probe_term 1))
+			src (list src) (source_alias src) probe_term 1 (planner_context_session (qb_facts prepared))))
 		(define filtercols (merge_unique (list
 			(extract_columns_for_alias src condition)
 			(extract_columns_for_alias src key_expr))))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -3885,15 +3885,15 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 					(quote membership_order_limit_driver) false)
 				facts)
 			(quote membership_downstream_probe_branches)
-			/* ORDER/LIMIT carriers change how many rows reach downstream work even
-			when adaptive batching is structurally unavailable (for example an ordered
-			joined driver). Filter/aggregate carriers feed the same complete residual
-			pipeline, so charging their common work here would estimate the enclosing
-			query a second time. */
-			(if (equal? consumer (quote order_limit))
-				(max (coalesceNil downstream_probe_branches 0)
-					(qassoc_get facts (quote membership_downstream_probe_branches) 0))
-				0)))
+			/* Residual work is common only when its INPUT POPULATION is common.
+			A candidate-first projection feeds matching driver rows to the residual;
+			a driver-first prefilter can evaluate it over the entire local domain.
+			This remains true for COUNT without LIMIT. Zeroing this feature for
+			aggregates hides that difference and disagrees with costgen's features.
+			Keep the measured/calibrated branch cost for every consumer; each carrier
+			cost formula owns the number of rows that actually reach those branches. */
+			(max (coalesceNil downstream_probe_branches 0)
+				(qassoc_get facts (quote membership_downstream_probe_branches) 0))))
 		(define cost_facts (qassoc_set consumer_facts
 			(quote membership_driver_order_partitioned) driver_order_partitioned))
 		(define driver_probe_supported (and allow_driver_probe

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -7938,7 +7938,7 @@ physical decision and preserve its runtime recompile gate. */
 			(join_optimizer_tree_first_alias plan)))
 		(define filter_probe_work_rows (membership_probe_work_rows facts final_condition
 			(planner_row_count_after_selectivity
-				driver_source sources default_alias final_condition nil)))
+				driver_source sources default_alias final_condition nil (planner_context_session facts))))
 		/* A native ordered LIMIT bounds every consumer inside the driver scan,
 		including rejecting scalar probes. Cost that continuation by the rows the
 		window requests, just as join_ordered_streaming_limit_plan does. Plans whose
@@ -8105,7 +8105,7 @@ physical decision and preserve its runtime recompile gate. */
 				source's own row count, scaled by the residual condition's selectivity. */
 				(define unbounded_probe_work_rows (membership_probe_work_rows (qb_facts block) final_condition
 					(planner_row_count_after_selectivity
-						driver_source scan_sources first_alias final_condition nil)))
+						driver_source scan_sources first_alias final_condition nil (planner_context_session (qb_facts block)))))
 				(define projection_probe_work_rows (if (query_limit_active? (qb_offset block) (qb_limit block))
 					(coalesceNil (probe_limit_work_rows (qb_limit block)
 						(planner_context_session (qb_facts block))) 0)
@@ -10469,7 +10469,7 @@ existing scan and expression primitives. No predicate is discarded. */
 				(semijoin_residual_recset src input condition)
 				(list (quote if)
 					(list (quote semijoin_split_filter_wins?) (quoted_runtime_list src)
-						(quoted_runtime_list indexed) (count residual))
+						(quoted_runtime_list indexed) (count residual) (quote session))
 					(semijoin_residual_recset src
 						(candidate_recset_filter_source src input (combine_where_terms indexed true))
 						(combine_where_terms residual true))
@@ -10698,11 +10698,11 @@ without freezing a statistics-dependent decision in the SQL plan cache. */
 			(list (quote not) (list (quote equal?) (coalesceNil (qb_limit block) -1) 0)))
 		(list (quote resultrow) (list (quote list) (car fields) value)) nil)))
 
-(define semijoin_split_filter_wins? (lambda (src indexed residual_width)
+(define semijoin_split_filter_wins? (lambda (src indexed residual_width execution_session)
 	(begin
 		(define input_rows (scan_estimate (table (source_schema src) (source_relation src))))
 		(define selectivity (reduce indexed (lambda (value term)
-			(* value (join_optimizer_expr_selectivity (list src) (source_alias src) term))) 1))
+			(* value (join_optimizer_expr_selectivity (list src) (source_alias src) term execution_session))) 1))
 		(define matching_rows (* input_rows selectivity))
 		(< (+ planner_membership_scan_invocation_ns (* matching_rows planner_membership_recset_build_row_ns))
 			(* (- input_rows matching_rows) residual_width planner_membership_expression_operation_row_ns)))))

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -334,7 +334,7 @@ semantics for multiple independent cache assumptions. */
 				(define dependency_guards (map dependencies (lambda (dependency)
 					(list (quote table_planner_statistics_compatible?)
 						(cadr (car dependency)) (nth (car dependency) 2)
-						(cadr dependency) (nth dependency 2)))))
+						(cadr dependency) (nth dependency 2) (coalesceNil (nth dependency 3) false)))))
 				(sql_queryplan_conjoin_guards dependency_guards))))))
 
 (define sql_queryplan_guard_from_session (lambda (planning_session)
@@ -388,6 +388,12 @@ serialization still see the complete plan. */
 	(begin
 		(tx_check tx)
 		(define planning_session (sql_queryplan_compile_session source_session tx))
+		(define statistics_diagnostic (match (toUpper parse_query)
+			(regex "^\\s*EXPLAIN\\b" _) true
+			_ false))
+		/* EXPLAIN reports metadata, not just a reusable execution decision. Keep
+		its table-wide refresh dependency without executing relational guards. */
+		(planning_session "__memcp_queryplan_diagnostic_statistics" statistics_diagnostic)
 		(define compile_policy (sql_compile_table_policy policy))
 		(define raw_plan (with_session planning_session (lambda ()
 			(sql_invoke_parse_fn parse_fn schema parse_query compile_policy planning_session tx))))
@@ -397,9 +403,6 @@ serialization still see the complete plan. */
 		(define plan (sql_queryplan_compile_formula
 			(sql_queryplan_bind_execution_session raw_plan)))
 		(tx_check tx)
-		(define statistics_diagnostic (match (toUpper parse_query)
-			(regex "^\\s*EXPLAIN\\b" _) true
-			_ false))
 		/* Diagnostics must refresh their captured estimates when table statistics
 		change, but checking their cache must never execute candidate preparations. */
 		(list

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -768,10 +768,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	unknown" discipline as the keytable cost check above. */
 	(define row_count_unknown_src (list "rc" "memcp-tests" "row_count_unknown_source" false nil))
 	(assert (equal? (planner_row_count_after_selectivity
-		row_count_unknown_src (list row_count_unknown_src) "rc" true nil) nil) true
+		row_count_unknown_src (list row_count_unknown_src) "rc" true nil nil) nil) true
 		"row count after selectivity falls back to the caller's sentinel for an unverifiable source")
 	(assert (equal? (planner_row_count_after_selectivity
-		row_count_unknown_src (list row_count_unknown_src) "rc" true 1) 1) true
+		row_count_unknown_src (list row_count_unknown_src) "rc" true 1 nil) 1) true
 		"row count after selectivity preserves whatever fallback the caller passed in")
 	/* query_invariant_presence_stage?/query_invariant_probe_entries_for_stages:
 	a presence probe whose lookup key is a session read (not a reference to

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -1901,6 +1901,15 @@ class SQLTestRunner:
             for i, row in enumerate(expect["data"]):
                 if i >= len(results):
                     return False
+                # /scm returns JSON values, not necessarily SQL row objects.
+                # Keep these cases in the measured A/B path and validate the
+                # value instead of bypassing assertions or calling .items().
+                if not isinstance(row, dict):
+                    if type(row) is not type(results[i]) or row != results[i]:
+                        return False
+                    continue
+                if not isinstance(results[i], dict):
+                    return False
                 for k, v in row.items():
                     if isinstance(v, float) and isinstance(results[i].get(k), (int, float)):
                         if abs(results[i][k] - v) > 0.01:

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -1172,7 +1172,7 @@ class SQLTestRunner:
                 workload_config.get("default_rows", PERF_DEFAULT_ROWS)
                 if isinstance(workload_config, dict) else PERF_DEFAULT_ROWS
             )
-            declared_rows = test_case.get("performance_rows", ci_default_rows)
+            declared_rows = test_case.get("performance_rows", self.suite_metadata.get("performance_rows", ci_default_rows))
             baseline = self.perf_baselines.get(
                 perf_key, self.perf_baselines.get(name, {})
             )
@@ -1360,9 +1360,9 @@ class SQLTestRunner:
             return self._record_fail(
                 name, str(exc), None, None, None, is_noncritical,
             )
-        if scm_code:
-            if is_perf_test:
-                scm_code = scm_code.replace("{rows}", str(perf_rows)).replace("{database}", database)
+        # SCM performance cases must use the same measured repetitions and A/B
+        # gate as SQL. The correctness-only shortcut below has no timing gate.
+        if scm_code and not is_perf_test:
             expect = test_case.get("expect", {})
             expect_error = expect.get("error", False)
             scm_timeout = int(test_case.get(
@@ -1509,7 +1509,7 @@ class SQLTestRunner:
             self._record_success(name, is_noncritical)
             return True
 
-        query = test_case.get("sql") or test_case.get("sparql")
+        query = scm_code or test_case.get("sql") or test_case.get("sparql")
         if query and is_perf_test:
             query = query.replace("{rows}", str(perf_rows)).replace("{database}", database)
         is_sparql = "sparql" in test_case
@@ -1524,6 +1524,21 @@ class SQLTestRunner:
         active_syntax = self._normalize_syntax(test_syntax) if test_syntax is not None else self.suite_syntax
         sql_timeout = int(test_case.get("timeout", 10))
         sql_params = test_case.get("params")
+
+        def execute_sample():
+            if scm_code:
+                try:
+                    return requests.post(f"{self.base_url}/scm", data=query,
+                                         headers=auth_header, timeout=sql_timeout)
+                except requests.RequestException:
+                    return None
+            if is_sparql:
+                return self.execute_sparql(database, query, auth_header, timeout=sql_timeout)
+            return self.execute_sql(
+                database, query, auth_header, active_syntax,
+                session_id=session_id, timeout=sql_timeout, params=sql_params,
+                retry_on_connection_failure=not self._expect_interrupted_ok(test_case.get("expect")),
+            )
 
         # TTL preload if SPARQL
         if is_sparql and "ttl_data" in test_case:
@@ -1583,7 +1598,7 @@ class SQLTestRunner:
             response = resp
         else:
             # Show query plan if PERF_EXPLAIN is enabled
-            if is_perf_test and PERF_EXPLAIN and not is_sparql:
+            if is_perf_test and PERF_EXPLAIN and not is_sparql and not scm_code:
                 explain_resp = self.execute_sql(database, f"DESCRIBE {query}", auth_header, active_syntax)
                 if explain_resp and explain_resp.status_code == 200:
                     print(f"    📋 Query plan for {name}:")
@@ -1685,7 +1700,7 @@ class SQLTestRunner:
                     repeat = resolve_timing_samples(test_case, False)
                 except ValueError as exc:
                     return self._record_fail(name, str(exc), query, None, None, is_noncritical)
-            repeatable_query = query.lstrip().upper().startswith("SELECT")
+            repeatable_query = bool(scm_code) or query.lstrip().upper().startswith("SELECT")
             if ("timing_samples" in test_case or "repetitions" in test_case) and not repeatable_query:
                 return self._record_fail(
                     name, "timing_samples/repetitions is only supported for SELECT queries",
@@ -1694,7 +1709,10 @@ class SQLTestRunner:
             gate = performance_server_gate(exclusive=True) if is_perf_test else PerformanceGate()
             with gate:
                 for _ in range(warmup_runs):
-                    self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(database, query, auth_header, active_syntax, timeout=sql_timeout)
+                    warm_response = execute_sample()
+                    if is_error_response(warm_response):
+                        return self._record_fail(name, "Warmup failed", query, warm_response,
+                                                 test_case.get("expect"), is_noncritical)
 
                 # Scans publish telemetry asynchronously after returning the
                 # query result. Let warmup-triggered writes, group-cache hooks,
@@ -1724,11 +1742,7 @@ class SQLTestRunner:
                 measured_total_ns = 0
                 for _ in range(repeat):
                     start_ns = time.monotonic_ns()
-                    response = self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(
-                        database, query, auth_header, active_syntax,
-                        session_id=session_id, timeout=sql_timeout, params=sql_params,
-                        retry_on_connection_failure=not self._expect_interrupted_ok(test_case.get("expect")),
-                    )
+                    response = execute_sample()
                     sample_ns = time.monotonic_ns() - start_ns
                     samples_ns.append(sample_ns)
                     measured_total_ns += sample_ns
@@ -2439,7 +2453,10 @@ def discover_performance_ci_suites(root: Path = Path("tests/performance")) -> Li
         with path.open('r', encoding='utf-8') as handle:
             spec = yaml.safe_load(handle) or {}
         metadata = spec.get("metadata", {}) or {}
-        if metadata.get("ci", True) is False:
+        # SQL correctness CI and performance CI have independent opt-ins.
+        # Large fixtures may intentionally skip the former without silently
+        # losing their regression measurements in the latter.
+        if metadata.get("ci", True) is False and not metadata.get("perf_ci", False):
             continue
         cases = spec.get("test_cases", [])
         has_measurement = any(

--- a/storage/scan_feedback.go
+++ b/storage/scan_feedback.go
@@ -112,6 +112,17 @@ func compileFilterFeedback(params, columns []scm.Scmer, body scm.Scmer, bindings
 		if name == "optimize" && len(items) == 2 {
 			return visit(items[1])
 		}
+		// Literal parameter binding emits (quote value), whereas scan callback
+		// optimization may already have folded it to value. Both denote the same
+		// scalar predicate. Do not recurse into quoted lists: those are data, not
+		// executable filter expressions, and must never be interpreted as columns.
+		if name == "quote" && len(items) == 2 {
+			value := items[1]
+			if value.IsNil() || value.IsBool() || value.IsInt() || value.IsFloat() || value.IsString() {
+				return visit(value)
+			}
+			return false
+		}
 		// Session parameters are constant over a scan; correlated outer-row values
 		// deliberately do not enter this table-local model.
 		if name == "session" && len(items) == 2 && items[1].IsString() {

--- a/storage/scan_feedback_test.go
+++ b/storage/scan_feedback_test.go
@@ -221,7 +221,7 @@ func TestFilterFeedbackUniquePointRetainsPlanStatistics(t *testing.T) {
 	tbl.mu.Lock()
 	tbl.Unique = []uniqueKey{{Id: "PRIMARY", Cols: cols[:1]}}
 	tbl.mu.Unlock()
-	token, fingerprint := tbl.PlannerStatsToken(), tbl.PlannerStatisticsFingerprint()
+	token, fingerprint := tbl.PlannerStatsToken(true), tbl.PlannerStatisticsFingerprint(true)
 	for _, body := range []string{`(equal? x 1)`, `(equal? x 101)`} {
 		schema, values, filter := feedbackTestCompile(t, body)
 		tbl.scan(nil, schema, values, cols[:1], scm.Eval(filter, &scm.Globalenv), nil,
@@ -231,7 +231,7 @@ func TestFilterFeedbackUniquePointRetainsPlanStatistics(t *testing.T) {
 			t.Fatal("unique point probe trained redundant selectivity")
 		}
 	}
-	if tbl.PlannerStatsToken() != token || tbl.PlannerStatisticsFingerprint() != fingerprint {
+	if tbl.PlannerStatsToken(true) != token || tbl.PlannerStatisticsFingerprint(true) != fingerprint {
 		t.Fatal("unique point probe invalidated cached planning statistics")
 	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -984,11 +984,12 @@ func Init(en scm.Env) {
 			if a[0].IsNil() {
 				return scm.NewNil()
 			}
-			return scm.NewInt(int64(TableFromScmer(a[0]).PlannerStatsToken()))
+			return scm.NewInt(int64(TableFromScmer(a[0]).PlannerStatsToken(len(a) < 2 || scm.ToBool(a[1]))))
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "return the process-unique dependency token of a table's immutable planner-statistics snapshot",
 			Params: []*scm.TypeDescriptor{
 				{Kind: "table", Label: "table"},
+				{Kind: "bool", Label: "include_feedback", Optional: true, Description: "default true; false requires separate guards for every consumed filter estimate"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "int"},
 		},
@@ -1000,11 +1001,12 @@ func Init(en scm.Env) {
 			if a[0].IsNil() {
 				return scm.NewNil()
 			}
-			return scm.NewInt(int64(TableFromScmer(a[0]).PlannerStatisticsFingerprint()))
+			return scm.NewInt(int64(TableFromScmer(a[0]).PlannerStatisticsFingerprint(len(a) < 2 || scm.ToBool(a[1]))))
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "return the coarse cost-class fingerprint of a table's immutable planner-statistics snapshot",
 			Params: []*scm.TypeDescriptor{
 				{Kind: "table", Label: "table"},
+				{Kind: "bool", Label: "include_feedback", Optional: true, Description: "default true; false requires separate guards for every consumed filter estimate"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "int"},
 		},
@@ -1022,11 +1024,12 @@ func Init(en scm.Env) {
 				return scm.NewBool(false)
 			}
 			compileToken := uint64(a[2].Int())
-			if tbl.PlannerStatsToken() == compileToken {
+			includeFeedback := len(a) < 5 || scm.ToBool(a[4])
+			if tbl.PlannerStatsToken(includeFeedback) == compileToken {
 				return scm.NewBool(true)
 			}
 			compileFingerprint := uint64(a[3].Int())
-			return scm.NewBool(tbl.PlannerStatisticsFingerprint() == compileFingerprint)
+			return scm.NewBool(tbl.PlannerStatisticsFingerprint(includeFeedback) == compileFingerprint)
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "check whether cached-plan table statistics remain in the same cost class",
 			Params: []*scm.TypeDescriptor{
@@ -1034,6 +1037,7 @@ func Init(en scm.Env) {
 				{Kind: "string", Label: "table"},
 				{Kind: "int", Label: "compile_token"},
 				{Kind: "int", Label: "compile_fingerprint"},
+				{Kind: "bool", Label: "include_feedback", Optional: true, Description: "must match the scope of the supplied token and fingerprint"},
 			},
 			Return:         &scm.TypeDescriptor{Kind: "bool"},
 			HasSideEffects: true,

--- a/storage/table.go
+++ b/storage/table.go
@@ -626,8 +626,14 @@ func (t *table) publishPlannerStatsToken() {
 	t.plannerStatsToken.Store(nextPlannerStatsToken.Add(1))
 }
 
-func (t *table) PlannerStatsToken() uint64 {
-	return plannerFingerprintMix(t.plannerStatsToken.Load(), t.filterFeedbackFingerprint())
+// PlannerStatsToken can scope dependencies to structural statistics only.
+// Callers excluding feedback must separately guard every consumed filter rate.
+func (t *table) PlannerStatsToken(includeFeedback bool) uint64 {
+	token := t.plannerStatsToken.Load()
+	if includeFeedback {
+		return plannerFingerprintMix(token, t.filterFeedbackFingerprint())
+	}
+	return token
 }
 
 func (t *table) signalTransactionDrain() {
@@ -1726,14 +1732,17 @@ func (t *table) PlannerStatistics() scm.Scmer {
 // PlannerStatisticsFingerprint identifies the coarse cost class of immutable
 // statistics independently of its rebuild generation. It is computed once
 // while publishing the snapshot, so cache revalidation remains O(1).
-func (t *table) PlannerStatisticsFingerprint() uint64 {
+func (t *table) PlannerStatisticsFingerprint(includeFeedback bool) uint64 {
 	if t == nil {
 		return 0
 	}
 	for {
 		snapshot := t.showColumnsSnapshot.Load()
 		if snapshot != nil {
-			return plannerFingerprintMix(snapshot.plannerFingerprint, t.filterFeedbackFingerprint())
+			if includeFeedback {
+				return plannerFingerprintMix(snapshot.plannerFingerprint, t.filterFeedbackFingerprint())
+			}
+			return snapshot.plannerFingerprint
 		}
 		t.publishShowColumnsSnapshot()
 	}

--- a/storage/table_show_test.go
+++ b/storage/table_show_test.go
@@ -187,19 +187,19 @@ func TestPlannerStatisticsUsesHashedImmutableSnapshot(t *testing.T) {
 	})
 	atomic.StoreUint64(&tbl.Columns[1].DistinctEstimate, 17)
 	tbl.publishShowColumnsSnapshot()
-	publishedToken := tbl.PlannerStatsToken()
+	publishedToken := tbl.PlannerStatsToken(true)
 	if publishedToken == 0 {
 		t.Fatal("published planner statistics have no dependency token")
 	}
-	publishedFingerprint := tbl.PlannerStatisticsFingerprint()
+	publishedFingerprint := tbl.PlannerStatisticsFingerprint(true)
 	tbl.publishShowColumnsSnapshot()
-	if tbl.PlannerStatsToken() == publishedToken {
+	if tbl.PlannerStatsToken(true) == publishedToken {
 		t.Fatal("republished planner statistics retained their generation token")
 	}
-	if got := tbl.PlannerStatisticsFingerprint(); got != publishedFingerprint {
+	if got := tbl.PlannerStatisticsFingerprint(true); got != publishedFingerprint {
 		t.Fatalf("unchanged planner statistics changed fingerprint from %d to %d", publishedFingerprint, got)
 	}
-	publishedToken = tbl.PlannerStatsToken()
+	publishedToken = tbl.PlannerStatsToken(true)
 
 	root := tbl.PlannerStatistics().FastDict()
 	rowCount, ok := root.Get(scm.NewString("row_count"))
@@ -231,16 +231,16 @@ func TestPlannerStatisticsUsesHashedImmutableSnapshot(t *testing.T) {
 	if tbl.PlannerStatistics().FastDict() != root {
 		t.Fatal("planner statistics rebuilt an already-published snapshot")
 	}
-	if got := tbl.PlannerStatsToken(); got != publishedToken {
+	if got := tbl.PlannerStatsToken(true); got != publishedToken {
 		t.Fatalf("immutable planner statistics changed token from %d to %d", publishedToken, got)
 	}
 
 	tbl.adjustPlannerRows(9)
-	adjustedToken := tbl.PlannerStatsToken()
+	adjustedToken := tbl.PlannerStatsToken(true)
 	if adjustedToken == publishedToken {
 		t.Fatal("planner row-count update retained a stale dependency token")
 	}
-	if got := tbl.PlannerStatisticsFingerprint(); got != publishedFingerprint {
+	if got := tbl.PlannerStatisticsFingerprint(true); got != publishedFingerprint {
 		t.Fatalf("same-magnitude row-count update changed fingerprint from %d to %d", publishedFingerprint, got)
 	}
 	updatedRoot := tbl.PlannerStatistics().FastDict()

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,3 @@
-<!-- Copyright (C) 2026 Carl-Philip Hänsch; SPDX-License-Identifier: GPL-3.0-or-later -->
 # SQL Test Taxonomy
 
 SQL integration suites use descriptive lower kebab-case filenames without
@@ -15,14 +14,8 @@ sequence numbers. The directory is the stable ownership and selection unit:
 - `performance/`: explicit latency, scaling, and benchmark suites
 
 Every YAML suite is discovered recursively by `git-pre-commit`. A suite may
-opt out with `metadata.ci: false` for manual benchmarks or expensive fixtures.
-An expensive performance suite must additionally set `metadata.perf_ci: true`
-to remain part of automatic performance A/B while skipping ordinary SQL CI.
-Performance discovery requires at least one `threshold_ms` case. Suite-level
-`metadata.performance_rows` supplies the fixture size unless a case overrides it.
-SCM cases with `threshold_ms` use the same warmup, repetition and A/B gate as SQL;
-their assertions must fail explicitly or check the returned JSON result.
-Every suite must provide
+opt out only with `metadata.ci: false`, which is reserved for manual benchmarks
+that do not assert a stable CI budget. Every suite must provide
 `metadata.description`.
 
 Place a regression at the layer that owns its root cause, not at the layer

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright (C) 2026 Carl-Philip Hänsch; SPDX-License-Identifier: GPL-3.0-or-later -->
 # SQL Test Taxonomy
 
 SQL integration suites use descriptive lower kebab-case filenames without
@@ -14,8 +15,14 @@ sequence numbers. The directory is the stable ownership and selection unit:
 - `performance/`: explicit latency, scaling, and benchmark suites
 
 Every YAML suite is discovered recursively by `git-pre-commit`. A suite may
-opt out only with `metadata.ci: false`, which is reserved for manual benchmarks
-that do not assert a stable CI budget. Every suite must provide
+opt out with `metadata.ci: false` for manual benchmarks or expensive fixtures.
+An expensive performance suite must additionally set `metadata.perf_ci: true`
+to remain part of automatic performance A/B while skipping ordinary SQL CI.
+Performance discovery requires at least one `threshold_ms` case. Suite-level
+`metadata.performance_rows` supplies the fixture size unless a case overrides it.
+SCM cases with `threshold_ms` use the same warmup, repetition and A/B gate as SQL;
+their assertions must fail explicitly or check the returned JSON result.
+Every suite must provide
 `metadata.description`.
 
 Place a regression at the layer that owns its root cause, not at the layer

--- a/tests/performance/badge-query-performance.yaml
+++ b/tests/performance/badge-query-performance.yaml
@@ -42,8 +42,8 @@ test_cases:
     expect:
       rows_affected: 0
 
-  - name: "badge count with correlated session subselect"
-    threshold_ms: 500
+  - &badge_count
+    name: "badge count with correlated session subselect"
     session_id: "bp_sess"
     sql: |
       SELECT 1,
@@ -59,8 +59,8 @@ test_cases:
         - "1": 1
           badgeDoc: 2
 
-  - name: "docType list with permission subselects"
-    threshold_ms: 500
+  - &badge_types
+    name: "docType list with permission subselects"
     session_id: "bp_sess"
     sql: |
       SELECT dt.ID, dt.name,
@@ -76,7 +76,6 @@ test_cases:
           doc_count: 2
 
   - name: "badge count warm (second run, must be fast)"
-    threshold_ms: 500
     session_id: "bp_sess"
     sql: |
       SELECT 1,
@@ -91,3 +90,13 @@ test_cases:
       data:
         - "1": 1
           badgeDoc: 2
+
+  # Keep the original correctness/plan-size gates, and ADD measured copies.
+  # Turning the originals into performance cases would exempt those gates.
+  - <<: *badge_count
+    name: "Perf: cached badge count with correlated session subselect"
+    threshold_ms: 500
+
+  - <<: *badge_types
+    name: "Perf: cached type list with permission subselects"
+    threshold_ms: 500

--- a/tests/performance/badge-query-performance.yaml
+++ b/tests/performance/badge-query-performance.yaml
@@ -43,6 +43,7 @@ test_cases:
       rows_affected: 0
 
   - name: "badge count with correlated session subselect"
+    threshold_ms: 500
     session_id: "bp_sess"
     sql: |
       SELECT 1,
@@ -59,6 +60,7 @@ test_cases:
           badgeDoc: 2
 
   - name: "docType list with permission subselects"
+    threshold_ms: 500
     session_id: "bp_sess"
     sql: |
       SELECT dt.ID, dt.name,
@@ -74,6 +76,7 @@ test_cases:
           doc_count: 2
 
   - name: "badge count warm (second run, must be fast)"
+    threshold_ms: 500
     session_id: "bp_sess"
     sql: |
       SELECT 1,

--- a/tests/performance/like-acl-query-shapes.yaml
+++ b/tests/performance/like-acl-query-shapes.yaml
@@ -1,7 +1,7 @@
 # Copyright (C) 2026  Carl-Philip Hänsch
 #
 # Performance regressions for ordered LIKE searches combined with a compound
-# correlated ACL. The performance CI runner executes this suite explicitly;
+# correlated ACL. The performance CI runner discovers the perf_ci opt-in;
 # ordinary SQL CI must not pay for the production-scale fixture.
 
 metadata:
@@ -9,6 +9,8 @@ metadata:
   description: "Ordered direct and projected LIKE searches with compound ACLs"
   isolated: true
   ci: false
+  perf_ci: true
+  performance_rows: 40000
 
 fixture_setup: &like_acl_fixture
   - sql: "DROP TABLE IF EXISTS pla_assignment"

--- a/tests/performance/query-cache-feedback-churn.yaml
+++ b/tests/performance/query-cache-feedback-churn.yaml
@@ -1,0 +1,48 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "Warm ordered queries amid unrelated bound-predicate learning"
+  isolated: true
+setup:
+  - sql: "DROP TABLE IF EXISTS qfc_document"
+  - sql: "CREATE TABLE qfc_document (id INT PRIMARY KEY, category INT) ENGINE=sloppy"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "qfc_document") '("id" "category")
+          (map (produceN 1000) (lambda (i) (list i (mod i 10)))))
+        (rebuild (table "memcp-tests" "qfc_document") true false)
+        (globalvars "qfc_sequence" 1000))
+test_cases:
+  - name: "Ordered cache reuse survives a sequence of unrelated learned filters"
+    performance_rows: 1000
+    threshold_ms: 1000
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT a.id FROM qfc_document a LEFT JOIN qfc_document b ON b.id=a.id LEFT JOIN qfc_document c ON c.id=b.id ORDER BY a.id LIMIT 2")
+        (define rows (newsession))
+        (rows "n" 0)
+        (define emit (lambda (_row) (rows "n" (+ (rows "n") 1))))
+        (define run (lambda ()
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+            emit (lambda (_fields) nil))))
+        (run)
+        (define start (globalvars "qfc_sequence"))
+        (globalvars "qfc_sequence" (+ start 16))
+        (map (produceN 16) (lambda (i) (begin
+          (define callback (list 'lambda (list 'x) (list '< 'x (+ start i))))
+          (define access (compile_scan_access '("category") callback))
+          (scan_recset nil (table "memcp-tests" "qfc_document") (car access)
+            (map (cadr access) (lambda (v) (eval v))) '("category") (eval callback))
+          (run))))
+        (if (equal? (rows "n") 34) true (error "ordered cache churn changed results")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+cleanup:
+  - sql: "DROP TABLE IF EXISTS qfc_document"

--- a/tests/planner/core/query-cache-feedback-isolation.yaml
+++ b/tests/planner/core/query-cache-feedback-isolation.yaml
@@ -1,0 +1,79 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "Unrelated learned predicates must not invalidate cached ordered plans"
+  isolated: true
+setup:
+  - sql: "DROP TABLE IF EXISTS qfi_document"
+  - sql: "CREATE TABLE qfi_document (id INT PRIMARY KEY, label TEXT) ENGINE=sloppy"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "qfi_document") '("id" "label")
+          (map (produceN 1000) (lambda (i) (list i (if (< i 10) "needle" "ordinary")))))
+        (rebuild (table "memcp-tests" "qfi_document") true false))
+test_cases:
+  - name: "Unrelated learned LIKE leaves an ordered self-join cache variant reusable"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT a.id FROM qfi_document a LEFT JOIN qfi_document b ON b.id=a.id ORDER BY a.id LIMIT 2")
+        (define first (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true))
+        (define rows (newsession))
+        (rows "n" 0)
+        (define emit (lambda (_row) (rows "n" (+ (rows "n") 1))))
+        (sql_execute_formula sess nil first emit (lambda (_fields) nil))
+        (define entry (car (cache (car (cache)))))
+        (define variants (count (entry "variants")))
+        (define pred (list 'lambda (list 'x) (list 'strlike 'x "%needle%" "utf8mb4_general_ci")))
+        (define access (compile_scan_access '("label") pred))
+        (scan_recset nil (table "memcp-tests" "qfi_document") (car access)
+          (map (cadr access) (lambda (v) (eval v))) '("label") (eval pred))
+        (sql_execute_formula sess nil
+          (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+          emit (lambda (_fields) nil))
+        (if (and (equal? (rows "n") 4) (equal? (count (entry "variants")) variants))
+          true
+          (error (concat "unrelated feedback recompiled ordered plan: before=" variants
+            " after=" (count (entry "variants")) " rows=" (rows "n")))))
+    expect:
+      data: [true]
+  - name: "Learning the consumed predicate still recompiles and then reuses its plan"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT a.id FROM qfi_document a JOIN qfi_document b ON b.id<=a.id WHERE a.id < 4 ORDER BY a.id LIMIT 2")
+        (define rows (newsession))
+        (rows "n" 0)
+        (define emit (lambda (_row) (rows "n" (+ (rows "n") 1))))
+        (sql_execute_formula sess nil
+          (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+          emit (lambda (_fields) nil))
+        (define entry (car (cache (car (cache)))))
+        (define before (count (entry "variants")))
+        (define pred (list 'lambda (list 'x) (list '< 'x 4)))
+        (define access (compile_scan_access '("id") pred))
+        (scan_recset nil (table "memcp-tests" "qfi_document") (car access)
+          (map (cadr access) (lambda (v) (eval v))) '("id") (eval pred))
+        (sql_execute_formula sess nil
+          (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+          emit (lambda (_fields) nil))
+        (define after (count (entry "variants")))
+        (sql_execute_formula sess nil
+          (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+          emit (lambda (_fields) nil))
+        (if (and (> after before) (equal? after (count (entry "variants")))
+          (equal? (rows "n") 6)) true
+          (error (concat "relevant feedback guard failed: " before " -> " after
+            " -> " (count (entry "variants")) " rows=" (rows "n")
+            " guard=" (serialize (car (car (entry "variants"))))))))
+    expect:
+      data: [true]
+cleanup:
+  - sql: "DROP TABLE IF EXISTS qfi_document"

--- a/tests/planner/joins/adaptive-filter-selectivity.yaml
+++ b/tests/planner/joins/adaptive-filter-selectivity.yaml
@@ -60,7 +60,7 @@ test_cases:
       (begin
         (define src (list "a" "memcp-tests" "afs_check" false nil))
         (define predicate (list '>= (list 'get_column "a" false "id" false) 200))
-        (define reorder (join_optimizer_expr_selectivity_estimate (list src) "a" predicate))
+        (define reorder (join_optimizer_expr_selectivity_estimate (list src) "a" predicate nil))
         (define physical (planner_source_filter_estimate src predicate 512 nil nil))
         (if (and (equal? (qassoc_get reorder 'source nil) 'scan_feedback)
           (equal? (qassoc_get physical 'source nil) 'scan_feedback)
@@ -71,6 +71,31 @@ test_cases:
           (error "reorder and physical costing did not consume the same measured rate")))
     expect:
       data: [true]
+
+  - name: "Bound scalar literals share feedback with their unquoted scan predicate"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "afs_check"))
+        (define callback (list 'lambda (list 'x) (list '>= 'x (list 'quote 200))))
+        (define access (compile_scan_access '("id") callback))
+        (define estimate (scan_selectivity_estimate nil tbl (car access)
+          (map (cadr access) (lambda (v) (eval v))) '()
+          (lambda () (error "quoted binding must reuse metadata without sampling")) 0))
+        (if (and (equal? (qassoc_get estimate 'source nil) 'scan_feedback)
+          (equal? (qassoc_get estimate 'value nil) 0.8)) true
+          (error "quoted binding lost the measured predicate identity")))
+    expect:
+      result_contains: ["true"]
+
+  - name: "Quoted lists must not be interpreted as scalar feedback parameters"
+    scm: |
+      (begin
+        (define callback (list 'lambda (list 'x) (list '>= 'x (list 'quote '(200)))))
+        (define access (compile_scan_access '("id") callback))
+        (if (list? (car (car access)))
+          (error "quoted list incorrectly acquired a scalar feedback identity") true))
+    expect:
+      result_contains: ["true"]
 
   - name: "A different-word length prior must not suppress permitted sampling"
     scm: |
@@ -106,7 +131,7 @@ test_cases:
         (define values (map (nth access 1) (lambda (value) (eval value))))
         (define matches (scan nil tbl (nth access 0) values '("id") (eval callback)
           '() scan_count 0 + false))
-        (define estimate (join_optimizer_expr_selectivity_estimate (list src) "a" expr))
+        (define estimate (join_optimizer_expr_selectivity_estimate (list src) "a" expr nil))
         (and (equal? matches 100)
           (equal? (qassoc_get estimate 'source nil) 'scan_feedback)
           (equal? (qassoc_get estimate 'value nil) 0.1)

--- a/tests/planner/subqueries/membership-consumer-work.yaml
+++ b/tests/planner/subqueries/membership-consumer-work.yaml
@@ -5,7 +5,10 @@ metadata:
   description: "Membership statistics survive lowering and LIMIT does not discount full preparation"
 
 setup: []
-cleanup: []
+cleanup:
+  - sql: "DROP TABLE IF EXISTS mcw_docs"
+  - sql: "DROP TABLE IF EXISTS mcw_files"
+  - sql: "DROP TABLE IF EXISTS mcw_acl"
 test_cases:
   - name: "Late consumer fallback must not shadow measured stage work"
     scm: |
@@ -66,3 +69,51 @@ test_cases:
         (define expected (qassoc_get (planner_membership_downstream_probe_cost 50000) 'total_ns 0))
         (if (< (sql_abs (- extra expected)) 1) true
           (error "unbounded candidate consumer incorrectly received LIMIT braking")))
+
+  - name: "COUNT lowering does not erase population-dependent residual costs"
+    setup:
+      - sql: "DROP TABLE IF EXISTS mcw_docs"
+      - sql: "DROP TABLE IF EXISTS mcw_files"
+      - sql: "DROP TABLE IF EXISTS mcw_acl"
+      - sql: "CREATE TABLE mcw_docs (id INT PRIMARY KEY, file_id INT, site_id INT) ENGINE=sloppy"
+      - sql: "CREATE TABLE mcw_files (id INT PRIMARY KEY, name TEXT, content TEXT) ENGINE=sloppy"
+      - sql: "CREATE TABLE mcw_acl (id INT PRIMARY KEY, allowed INT) ENGINE=sloppy"
+      - scm: |
+          (begin
+            (insert (table "memcp-tests" "mcw_docs") '("id" "file_id" "site_id")
+              (map (produceN 2000) (lambda (i) (list i (mod i 100) (mod i 8)))))
+            (insert (table "memcp-tests" "mcw_files") '("id" "name" "content")
+              (map (produceN 100) (lambda (i) (list i (if (< i 5) "needle" "ordinary") "ordinary"))))
+            (insert (table "memcp-tests" "mcw_acl") '("id" "allowed")
+              (map (produceN 8) (lambda (i) (list i 1))))
+            (rebuild))
+    scm: |
+      (begin
+        (define planning (newsession))
+        (define sink (newsession))
+        (planning "__memcp_explain_physical" sink)
+        (parse_sql "memcp-tests"
+          "SELECT COUNT(*) FROM mcw_docs d WHERE d.file_id IN (SELECT f.id FROM mcw_files f WHERE f.name LIKE '%needle%' UNION SELECT f.id FROM mcw_files f WHERE f.content LIKE '%needle%') AND COALESCE((SELECT a.allowed FROM mcw_acl a WHERE a.id=d.site_id LIMIT 1), FALSE)"
+          nil planning nil)
+        (define decisions (filter (planner_physical_explain_decisions sink)
+          (lambda (d) (equal? (qassoc_get d "decision" nil) "membership_carrier"))))
+        (define alternatives (merge (map decisions (lambda (d) (qassoc_get d "alternatives" '())))))
+        (define carriers (filter alternatives (lambda (a)
+          (contains? '("candidate_keyset" "prefiltered_candidate_keyset") (qassoc_get a "plan" nil)))))
+        (if (and (>= (count carriers) 2)
+          (reduce carriers (lambda (ok a)
+            (and ok (> (qassoc_get (qassoc_get a "cost" '()) 'probe_ns 0) 0))) true))
+          true (error "COUNT erased residual probe work from carrier alternatives")))
+    expect:
+      result_contains: ["true"]
+
+  - name: "COUNT with projected membership and scalar ACL retains exact results"
+    sql: |
+      SELECT COUNT(*) AS n FROM mcw_docs d
+      WHERE d.file_id IN (
+        SELECT f.id FROM mcw_files f WHERE f.name LIKE '%needle%'
+        UNION SELECT f.id FROM mcw_files f WHERE f.content LIKE '%needle%'
+      ) AND COALESCE((SELECT a.allowed FROM mcw_acl a WHERE a.id=d.site_id LIMIT 1), FALSE)
+    expect:
+      rows: 1
+      data: [{n: 100}]

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -101,6 +101,21 @@ class PerformanceScaleContractTest(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(post.call_count, 2)
 
+    def test_scm_scalar_data_expectations_are_validated(self) -> None:
+        runner = SQLTestRunner("http://localhost:1")
+        for expected, actual, wanted in [
+            ("ok", "ok", True), ("ok", "wrong", False),
+            (True, True, True), (True, 1, False),
+            (20, 20, True), (20, 19, False),
+            (None, None, True), ([1, 2], [1, 2], True),
+            ({"n": 1}, "not a row", False),
+        ]:
+            with self.subTest(expected=expected, actual=actual):
+                response = SimpleNamespace(status_code=200, text="value", headers={})
+                self.assertEqual(runner.validate_expectation(
+                    {"scm": "value", "expect": {"data": [expected]}},
+                    response, [actual]), wanted)
+
     def test_ci_workload_seed_initializes_safe_rows(self) -> None:
         seed = Path(__file__).resolve().parents[1] / "tests/performance/ci-workloads.json"
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 import os
+import itertools
 import signal
 import sys
 import tempfile
@@ -42,6 +43,7 @@ from run_sql_tests import (  # noqa: E402
     SQLTestRunner,
     _load_runner_config,
     adaptive_measurement_complete,
+    discover_performance_ci_suites,
     is_error_response,
     initialize_performance_recording,
     load_performance_scale,
@@ -70,6 +72,35 @@ from tools.check_test_table_names import mutable_table_collisions  # noqa: E402
 
 
 class PerformanceScaleContractTest(unittest.TestCase):
+    def test_performance_discovery_honors_independent_ci_opt_in(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "enabled.yaml").write_text(
+                "metadata: {ci: false, perf_ci: true}\n"
+                "test_cases: [{name: measured, sql: SELECT 1, threshold_ms: 10}]\n"
+            )
+            (root / "manual.yaml").write_text(
+                "metadata: {ci: false}\n"
+                "test_cases: [{name: manual, sql: SELECT 1, threshold_ms: 10}]\n"
+            )
+            self.assertEqual(discover_performance_ci_suites(root), [str(root / "enabled.yaml")])
+
+    def test_scm_performance_cannot_bypass_timing_gate(self) -> None:
+        runner = SQLTestRunner("http://localhost:1")
+        response = SimpleNamespace(status_code=200, text="true", headers={})
+        clock = itertools.count(0, 1_000_000)
+        with mock.patch("run_sql_tests.PERF_TEST_ENABLED", True), \
+                mock.patch("run_sql_tests.PERF_AB_MODE", ""), \
+                mock.patch("run_sql_tests.find_memcp_pid", return_value=None), \
+                mock.patch("run_sql_tests.time.monotonic_ns", side_effect=lambda: next(clock)), \
+                mock.patch("run_sql_tests.requests.post", return_value=response) as post:
+            result = runner.run_test_case({
+                "name": "SCM must be measured", "scm": "true", "threshold_ms": 0.01,
+                "repetitions": 2, "warmup": 0, "expect": {"rows": 1},
+            }, "memcp-tests")
+        self.assertFalse(result)
+        self.assertEqual(post.call_count, 2)
+
     def test_ci_workload_seed_initializes_safe_rows(self) -> None:
         seed = Path(__file__).resolve().parents[1] / "tests/performance/ci-workloads.json"
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Problem and evidence

Learning a new filter on a table changed the table-wide planner token and
fingerprint. Consequently an otherwise unchanged ordered query on the same
table lost its cached variant, even when it did not consume that filter's
statistics. This can repeatedly put parsing, planning and compilation back on
the request path; it is not a universally disabled query cache.

The permanent regression was written first and failed on master 75ba87f77:
`unrelated feedback recompiled ordered plan: before=1 after=2 rows=4`.
It now passes, as does the inverse assertion: learning a consumed predicate
must still invalidate its old estimate and then reuse the new variant.

## Change

- Separate structural table-statistics guards from bound filter dependencies.
  Rebuild/data-growth guards and existing cost crossover conditions remain.
- Guard metadata inputs through the central `scan_selectivity_estimate` API
  with budget zero. No guard sampling, index construction or row scans.
  Unknown estimates and provenance are dependencies too. Exact input guards
  are a conservative fallback, **not** a claim that every crossover formula
  has now been derived.
- Thread the planning session explicitly through reorder/physical metadata
  consumers and execution context through generated runtime cost calls.
  Bound scalar `(quote value)` and folded literals use the same feedback key;
  quoted lists are not interpreted as filter expressions.
- Preserve table-wide refresh for EXPLAIN diagnostics and the public default
  statistics API.

### Second root cause: erased residual costs for COUNT

The lowerer forcibly set `membership_downstream_probe_branches=0` for all
filter/aggregate consumers, claiming their residual work was common. It is
not common: candidate-first and driver-prefilter-first plans feed different
row populations to the same ACL. The existing model and `tools/costgen`
already charge these populations differently; the lowerer hid that input.
Remove that consumer-specific zeroing, retaining the existing calibrated
coefficients, formulas and crossover guards. A new YAML compilation test
checks nonzero residual costs for both alternatives (not a forced winner):
master fails, patch passes. It also checks the exact COUNT result.

No calibrated coefficients, dominance rules, scan operators, persistence
formats or data visibility semantics are changed. The corrected cost input
now permits candidate-first COUNT plans to win normally.

## Why existing performance CI missed this

The large LIKE/ACL suite had `ci: false` and was excluded from automatic A/B
discovery. SCM cases also returned through a correctness shortcut before the
timing/A/B gate. JIT A/B was manual only. This PR adds an independent `perf_ci`
opt-in, enables the existing LIKE/ACL shapes, adds timing to the small badge
cases and routes SCM measurements through the same sampling/gate as SQL.
JIT A/B now runs for relevant master-targeting PRs, respecting the new shared
documentation-only relevance gate. No safety threshold is relaxed.

## Manual A/B (before PR creation)

Same machine, patched Go/JIT toolchain, identical fixture and candidate test
runner; baseline binary AND Scheme library from master 75ba87f77. The later
787d2ae20 base update changes CI only. Each side used 1,000 rows, 2 warmups and
5 measured samples. Each sample primes an ordered three-way LEFT JOIN, then
alternates 16 new unrelated filter observations and the same ordered query.
Both sides assert exactly 34 emitted rows.

| Workload | Master median | Patch median | Change |
|---|---:|---:|---:|
| Feedback churn + 16 cached ordered queries | 30.342527 ms | 4.290399 ms | -26.052128 ms / -85.9% (7.07x) |

This is a cache-churn reproduction, **not** a claim that cold full-text search
or every production request is now 7x faster. The re-enabled 40,000-row ACL
fixture exposed pre-existing projected COUNT latencies of about 3.6–4.3 s on
master, leading to the second root cause above. An initial sequential broader
A/B also reported slowdowns; paired alternating runs were used to investigate
those, rather than relaxing thresholds or dismissing failures.

### COUNT A/B after restoring residual costs

Same JIT compiler, 40,000 documents / 20,000 files, identical fixtures, two
warmups followed by five samples. Master and patch requests alternate, with
the order reversed each round. Every sample returned the same exact counts.

| Workload | Master median | Patch median | Change |
|---|---:|---:|---:|
| Broad projected search + ACL COUNT (8,066 matches) | 2,617.938 ms | 641.652 ms | -75.5% / 4.08x |
| Selective projected search + ACL COUNT (700 matches) | 2,254.626 ms | 38.176 ms | -98.3% / 59.06x |

EXPLAIN PHYSICAL changes from `prefiltered_candidate_keyset` to
`candidate_keyset` by cost, not a forced-plan hook. A manually composed SCM
plan that builds the 64-key ACL domain, projects file and ACL RecSets to
documents and intersects/counts them measured 5.04/5.98 ms for the selective/
broad fixtures. This demonstrates **remaining** batching potential; the
compiler patch does not yet reach that manually composed topology.

The independently paired selective list check was essentially unchanged
(6.251 ms master / 6.313 ms patch, three post-warmup samples).

## Validation

- New cache-isolation regression: 2/2, with master RED verified first.
- Adaptive feedback and quoted-binding cases: 15/15.
- Range coverage: 114/114; cache growth: 1/1.
- Residual membership cost/results: 6/6, with the new cost test RED on master.
- Compound boolean ACL: 35/35; prepared statements: 57/57.
- Test runner contract tests: 55/55, including a deliberately over-budget SCM
  case that must fail the timing gate and independent performance discovery.
- JIT build/startup and normal Go build succeed; changed Scheme files pass lint.
- Full suites are delegated to CI, not run locally. All checks are green on
  c26fe8661: SQL (13m04s), JIT SQL (20m43s), Go, JIT Go, PHP, alternative
  storage, packaging, policy guards, normal A/B (16m33s) and JIT A/B (19m52s).

### CI follow-up: validate scalar SCM results, do not bypass them

The newly measured handwritten WordPress SCM case exposed a runner exception:
`expect.data: ["ok"]` reached a validator assuming every result was a SQL row
dictionary. A new runner regression reproduced that exception first. The
validator now checks scalar JSON values with strict type/value equality;
SQL row-subset validation is unchanged. The real WordPress suite passes 9/9
locally, and the formerly crashing case completes in both A/B jobs. No test
assertion, timing gate or threshold was removed.

The subsequent normal A/B reported duplicate INSERT at 159.740 -> 246.733 ms;
JIT A/B reported fresh INSERT at 572.024 -> 767.754 ms. These existing mutation
cases each time a single execution. A targeted follow-up used three independent
30,000-row fixtures per side, alternating base 787d2ae20 and c26fe8661, normal
Go builds, and the unchanged YAML (zero warmups for mutating inserts, two for
the duplicate-only case). It does not reproduce the reported slowdown:

| Mutation | Base median | Patch median | Change |
|---|---:|---:|---:|
| Fresh unique INSERT | 441.260 ms | 448.919 ms | +1.7% |
| Unique INSERT after rebuild | 449.790 ms | 480.812 ms | +6.9% |
| INSERT IGNORE duplicates | 183.295 ms | 185.610 ms | +1.3% |

Serialized generated SCM for both INSERT shapes is identical across base and
patch. The two failed A/B jobs were rerun without changing the commit or any
limits; this local comparison is evidence for investigation, not a replacement
for a green CI result.

Both unchanged A/B reruns subsequently passed in full. Normal A/B measured
fresh INSERT 732.507 -> 605.047 ms, rebuilt INSERT 677.659 -> 699.474 ms and
duplicate INSERT 206.610 -> 210.369 ms. JIT A/B measured 663.020 -> 688.525 ms,
826.941 -> 732.695 ms and 154.355 -> 152.115 ms respectively. Together with
the fixed-fixture local trials, this supports single-trial variability rather
than the initially reported systematic INSERT regression. The existing
single-trial mutation benchmarks still have that statistical limitation;
this PR does not loosen them or claim to have eliminated their noise.

The live instance has not been restarted or modified for this patch. In
particular this PR does not yet establish restoration of historical cold
search latency; that requires execution-plan/primitives A/B beyond this
confirmed cache regression.
