### PR TITLE
Fix compressed string correctness and add Base64/timestamp formats

### DIFF
--- a/scm/alu.go
+++ b/scm/alu.go
@@ -33804,7 +33804,7 @@ func init_alu() {
 				}
 				return NewBool(as == bs)
 			}
-			return EqualSQL(a[0], a[1])
+			return equalCollatedValues(a[0], a[1], coll)
 		},
 		Type: &TypeDescriptor{Kind: "func", Description: "performs SQL equality with a specified collation (e.g. *_ci case-insensitive, *_bin case-sensitive); returns nil if either arg is nil",
 			Params: []*TypeDescriptor{
@@ -35449,9 +35449,36 @@ func init_alu() {
 					d208.ID = 0
 					d207 = JITPrepareScmerGoArg(ctx, d207)
 					d208 = JITPrepareScmerGoArg(ctx, d208)
+					ctx.EnsureDesc(&d22)
+					if d22.Loc == LocImm {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d22.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+						ctx.TrackImm(d22.Imm)
+						ptrWord, _ := d22.Imm.RawWords()
+						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
+						ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d22.Imm.String())))
+						d22 = tmpPair
+					} else if d22.Loc == LocReg {
+						tmpPair := JITValueDesc{Loc: LocRegPair, Type: d22.Type, Reg: ctx.AllocRegExcept(d22.Reg), Reg2: ctx.AllocRegExcept(d22.Reg)}
+						switch d22.Type {
+						case tagBool:
+							ctx.EmitMakeBool(tmpPair, d22)
+						case tagInt:
+							ctx.EmitMakeInt(tmpPair, d22)
+						case tagFloat:
+							ctx.EmitMakeFloat(tmpPair, d22)
+						default:
+							panic("jit: generic call arg scalar type unknown for 2-word value")
+						}
+						ctx.FreeDesc(&d22)
+						d22 = tmpPair
+					}
+					if d22.Loc != LocRegPair && d22.Loc != LocStackPair && d22.Loc != LocInputPair {
+						panic("jit: generic call arg expects 2-word value (equalCollatedValues arg2)")
+					}
 					ctx.SyncDesc(&d207)
 					ctx.SyncDesc(&d208)
-					d209 = ctx.EmitGoCallScalar(GoFuncAddr(EqualSQL), []JITValueDesc{d207, d208}, 2)
+					ctx.SyncDesc(&d22)
+					d209 = ctx.EmitGoCallScalar(GoFuncAddr(equalCollatedValues), []JITValueDesc{d207, d208, d22}, 2)
 					d209.NoHeapPointer = false
 					ctx.BindReg(d209.Reg, &d209)
 					ctx.BindReg(d209.Reg2, &d209)

--- a/scm/compare.go
+++ b/scm/compare.go
@@ -110,6 +110,22 @@ func cstringEqual(a, b Scmer) bool {
 		return equalStringValues(a, b, false) // decode only until a difference
 	}
 	if aFmt >= 11 {
+		av, aok := makeStringView(a)
+		bv, bok := makeStringView(b)
+		if aok && bok && av.offset == bv.offset {
+			start, n := 0, aCharLen
+			if av.offset == 1 && n > 0 {
+				if av.data[0]&15 != bv.data[0]&15 {
+					return false
+				}
+				start, n = 1, n-1
+			}
+			full := n / 2
+			if av.data[start:start+full] != bv.data[start:start+full] {
+				return false
+			}
+			return n&1 == 0 || av.data[start+full]>>4 == bv.data[start+full]>>4
+		}
 		return equalStringValues(a, b, false)
 	}
 	aNibOff := int((aVal >> CStringOffsetShift) & 1)
@@ -185,12 +201,11 @@ func Equal(a, b Scmer) bool {
 		case tagCString:
 			return cstringEqual(a, b)
 		case tagBString:
-			aLen := int(auxVal(a.aux) & ((1 << 47) - 1))
-			bLen := int(auxVal(b.aux) & ((1 << 47) - 1))
-			if aLen != bLen {
-				return false
+			if auxVal(a.aux)>>46 == auxVal(b.aux)>>46 {
+				an, bn := int(auxVal(a.aux)&bstringLengthMask), int(auxVal(b.aux)&bstringLengthMask)
+				return an == bn && unsafe.String(a.ptr, an) == unsafe.String(b.ptr, bn)
 			}
-			return unsafe.String(a.ptr, aLen) == unsafe.String(b.ptr, bLen)
+			return equalStringValues(a, b, false)
 		case tagBSON:
 			return bsonRawEqual(bsonRawValue(a), bsonRawValue(b))
 		case tagSlice:
@@ -282,14 +297,6 @@ func Equal(a, b Scmer) bool {
 	case tagCString:
 		return equalStringValues(a, b, false)
 	case tagBString:
-		if tb == tagBString {
-			aLen := int(auxVal(a.aux) & ((1 << 47) - 1))
-			bLen := int(auxVal(b.aux) & ((1 << 47) - 1))
-			if aLen != bLen {
-				return false
-			}
-			return unsafe.String(a.ptr, aLen) == unsafe.String(b.ptr, bLen)
-		}
 		return equalStringValues(a, b, false)
 	case tagBSON:
 		if tb == tagBSON {
@@ -414,12 +421,10 @@ func EqualSQL(a, b Scmer) Scmer {
 		case tagCString:
 			return NewBool(equalStringValues(a, b, true))
 		case tagBString:
-			aLen := int(auxVal(a.aux) & ((1 << 47) - 1))
-			bLen := int(auxVal(b.aux) & ((1 << 47) - 1))
-			if aLen != bLen {
-				return NewBool(false)
+			if a.aux == b.aux && unsafe.String(a.ptr, int(auxVal(a.aux)&bstringLengthMask)) == unsafe.String(b.ptr, int(auxVal(b.aux)&bstringLengthMask)) {
+				return NewBool(true)
 			}
-			return NewBool(unsafe.String(a.ptr, aLen) == unsafe.String(b.ptr, bLen))
+			return NewBool(equalStringValues(a, b, true))
 		case tagBSON:
 			return NewBool(bsonRawEqual(bsonRawValue(a), bsonRawValue(b)))
 		case tagSlice:
@@ -501,14 +506,6 @@ func EqualSQL(a, b Scmer) Scmer {
 		if tb == tagBool {
 			return NewBool(a.Bool() == b.Bool())
 		}
-		if tb == tagBString {
-			aLen := int(auxVal(a.aux) & ((1 << 47) - 1))
-			bLen := int(auxVal(b.aux) & ((1 << 47) - 1))
-			if aLen != bLen {
-				return NewBool(false)
-			}
-			return NewBool(unsafe.String(a.ptr, aLen) == unsafe.String(b.ptr, bLen))
-		}
 		return NewBool(equalStringValues(a, b, true))
 	case tagBSON:
 		if tb == tagBSON {
@@ -540,6 +537,17 @@ func EqualSQL(a, b Scmer) Scmer {
 	}
 
 	return NewBool(equalStringValues(a, b, true))
+}
+
+// Keep representation dispatch out of generated collation emitters; their
+// existing plain-string arm stays small and eligible for JIT inlining.
+//
+//jitgen:noinline
+func equalCollatedValues(a, b Scmer, collation string) Scmer {
+	if (a.IsString() || a.IsSymbol()) && (b.IsString() || b.IsSymbol()) {
+		return NewBool(equalStringValues(a, b, strings.Contains(collation, "_ci")))
+	}
+	return EqualSQL(a, b)
 }
 
 func LessScm(a ...Scmer) Scmer    { return NewBool(Less(a[0], a[1])) }
@@ -583,6 +591,11 @@ func Less(a, b Scmer) bool {
 func lessNonNumeric(a, b Scmer, ta, tb uint8) bool {
 	if ta == tagCString || tb == tagCString {
 		if c, ok := compareCString(a, b, false); ok {
+			return c < 0
+		}
+	}
+	if ta == tagBString || tb == tagBString {
+		if c, ok := compareBase64Text(a, b, false); ok {
 			return c < 0
 		}
 	}

--- a/scm/compressed_strings.go
+++ b/scm/compressed_strings.go
@@ -18,6 +18,7 @@ package scm
 
 import "io"
 import "hash"
+import "bytes"
 import "unsafe"
 import "strings"
 import "crypto/md5"
@@ -25,12 +26,13 @@ import "crypto/sha1"
 import "encoding/hex"
 import "crypto/sha256"
 import "encoding/base64"
+import "encoding/binary"
 
 func isCompressedText(s Scmer) bool { tag := s.GetTag(); return tag == tagCString || tag == tagBString }
 
 func compressedTextLen(s Scmer) int {
 	if s.IsBString() {
-		return base64.StdEncoding.EncodedLen(int(auxVal(s.aux) & ((1 << 47) - 1)))
+		return bstringEncoding(s).EncodedLen(int(auxVal(s.aux) & bstringLengthMask))
 	}
 	return int(auxVal(s.aux) & CStringLengthMask)
 }
@@ -47,8 +49,8 @@ func makeOperatorView(s Scmer) (operatorStringView, bool) {
 	if val>>47 != 0 {
 		alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 	}
-	data := unsafe.String(s.ptr, int(val&((1<<47)-1)))
-	return operatorStringView{stringView: stringView{data: data, n: base64.StdEncoding.EncodedLen(len(data))}, base64: alphabet}, true
+	data := unsafe.String(s.ptr, int(val&bstringLengthMask))
+	return operatorStringView{stringView: stringView{data: data, n: bstringEncoding(s).EncodedLen(len(data))}, base64: alphabet}, true
 }
 
 // Writers consume bounded decoded chunks; no complete intermediate text is
@@ -65,10 +67,7 @@ func writeOperatorText(w io.Writer, s Scmer) {
 	}
 	var buf [768]byte
 	if s.IsBString() {
-		enc := base64.StdEncoding
-		if auxVal(s.aux)>>47 != 0 {
-			enc = base64.URLEncoding
-		}
+		enc := bstringEncoding(s)
 		for pos := 0; pos < len(v.data); {
 			n := min(576, len(v.data)-pos)
 			enc.Encode(buf[:], unsafe.Slice(unsafe.StringData(v.data[pos:]), n))
@@ -249,7 +248,7 @@ func (v operatorStringView) decodeBase64Into(dst []byte, start int, fold bool) {
 // actually needs encoded text. The Scmer pointer keeps that immutable string alive.
 func encodeTextBase64(s Scmer) Scmer {
 	text := String(s)
-	return NewBString(unsafe.StringData(text), len(text), false)
+	return NewBString(unsafe.StringData(text), len(text), false, false)
 }
 
 func encodeTextHex(s Scmer) Scmer {
@@ -273,9 +272,9 @@ func encodeTextHex(s Scmer) Scmer {
 func likeAlphabetPossible(v operatorStringView, pattern string, fold bool) bool {
 	index := int(v.format)
 	if v.base64 != "" {
-		index = 17
+		index = 21
 		if v.base64[62] == '-' {
-			index = 18
+			index = 22
 		}
 	}
 	if index == 0 || index >= len(textAlphabetMasks) {
@@ -285,6 +284,11 @@ func likeAlphabetPossible(v operatorStringView, pattern string, fold bool) bool 
 	if fold {
 		allowed = textFoldedAlphabetMasks[index]
 	}
+	// Unpadded values and complete groups never contain '='.
+	if v.base64 != "" && (len(v.data)%3 == 0 || v.n%4 != 0) {
+		allowed['='>>6] &^= uint64(1) << ('=' & 63)
+	}
+
 	for i := 0; i < len(pattern); i++ {
 		c := pattern[i]
 		if c >= 128 {
@@ -351,8 +355,8 @@ func (w *schemeTextWriter) writeCompressedText(s Scmer) {
 }
 
 // The final two table entries are operator-only Base64 alphabets, not format IDs.
-var textAlphabetMasks, textFoldedAlphabetMasks = func() ([19][2]uint64, [19][2]uint64) {
-	var plain, folded [19][2]uint64
+var textAlphabetMasks, textFoldedAlphabetMasks = func() ([23][2]uint64, [23][2]uint64) {
+	var plain, folded [23][2]uint64
 	for i := 1; i < len(plain); i++ {
 		a := CStringAlphabet(uint8(i))
 		switch i {
@@ -360,9 +364,9 @@ var textAlphabetMasks, textFoldedAlphabetMasks = func() ([19][2]uint64, [19][2]u
 			a = "0123456789abcdef-"
 		case 7:
 			a = "0123456789ABCDEF-"
-		case 17:
+		case 21:
 			a = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
-		case 18:
+		case 22:
 			a = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_="
 		}
 		for j := range a {
@@ -462,5 +466,291 @@ func (v operatorStringView) matchRange(start int, pattern string, fold bool) (bo
 }
 
 func bstringRawText(s Scmer) Scmer {
-	return NewString(unsafe.String(s.ptr, int(auxVal(s.aux)&((1<<47)-1))))
+	return NewString(unsafe.String(s.ptr, int(auxVal(s.aux)&bstringLengthMask)))
+}
+
+// These bits describe transient values, never an on-disk layout.
+const bstringLengthMask = (1 << 46) - 1
+
+func bstringEncoding(s Scmer) *base64.Encoding {
+	val := auxVal(s.aux)
+	if val&(1<<46) != 0 {
+		if val&(1<<47) != 0 {
+			return base64.RawURLEncoding
+		}
+		return base64.RawStdEncoding
+	}
+	if val&(1<<47) != 0 {
+		return base64.URLEncoding
+	}
+	return base64.StdEncoding
+}
+
+var strictBStringEncodings = [...]*base64.Encoding{
+	base64.StdEncoding.Strict(), base64.RawStdEncoding.Strict(),
+	base64.URLEncoding.Strict(), base64.RawURLEncoding.Strict(),
+}
+
+// Binary equality can decode the other operand directly into packed bytes.
+// Strict tail validation preserves textual equality for noncanonical Base64.
+func equalBase64Bytes(a, b Scmer) (bool, bool) {
+	if !a.IsBString() {
+		a, b = b, a
+	}
+	if b.IsBString() {
+		// Different alphabets/padding can represent different strings even
+		// when their decoded bytes agree. The text comparator handles those.
+		return false, false
+	}
+	if b.GetTag() == tagString || b.GetTag() == tagSymbol {
+		text := unsafe.String(b.ptr, int(auxVal(b.aux)))
+		if len(text) <= 64 {
+			cmp, ok := compareBase64Plain(a, text, false)
+			return cmp == 0, ok
+		}
+	}
+	view, ok := makeStringView(b)
+	if !ok {
+		return false, false
+	}
+	raw := unsafe.Slice(a.ptr, int(auxVal(a.aux)&bstringLengthMask))
+	enc := strictBStringEncodings[auxVal(a.aux)>>46]
+	if enc.EncodedLen(len(raw)) != view.n {
+		return false, true
+	}
+	if view.n != 0 {
+		alphabet := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+		if auxVal(a.aux)&(1<<47) != 0 {
+			alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+		}
+		if view.at(0) != alphabet[raw[0]>>2] {
+			return false, true
+		}
+	}
+	var text [256]byte
+	var decoded [192]byte
+	for pos, offset := 0, 0; pos < view.n; {
+		count := min(len(text), view.n-pos)
+		var source []byte
+		if view.format == 0 {
+			source = unsafe.Slice(unsafe.StringData(view.data[pos:pos+count]), count)
+		} else {
+			view.decodeInto(text[:count], pos, false)
+			source = text[:count]
+		}
+		n, err := enc.Decode(decoded[:], source)
+		want := min(len(decoded), len(raw)-offset)
+		if err != nil || n != want || !bytes.Equal(decoded[:n], raw[offset:offset+want]) {
+			return false, true
+		}
+		pos += count
+		offset += n
+	}
+	return true, true
+}
+
+// Base64's alphabet is not in ASCII order. Compare the represented text,
+// including padding and alphabet, and stop at the first decisive chunk.
+// Keep this larger operator view out of CString's packed comparison paths.
+func compareBase64Text(a, b Scmer, fold bool) (int, bool) {
+	if a.IsBString() && (b.GetTag() == tagString || b.GetTag() == tagSymbol) {
+		return compareBase64Plain(a, unsafe.String(b.ptr, int(auxVal(b.aux))), fold)
+	}
+	if b.IsBString() && (a.GetTag() == tagString || a.GetTag() == tagSymbol) {
+		c, ok := compareBase64Plain(b, unsafe.String(a.ptr, int(auxVal(a.aux))), fold)
+		return -c, ok
+	}
+
+	av, aok := makeOperatorView(a)
+	bv, bok := makeOperatorView(b)
+	if !aok || !bok {
+		return 0, false
+	}
+	if av.base64 != "" && av.base64 == bv.base64 && av.n == bv.n && len(av.data) == len(bv.data) {
+		if av.data == bv.data {
+			return 0, true
+		}
+		if !fold {
+			// A differing raw byte affects exactly two adjacent sextets.
+			// Skip equal packed blocks, then map only that byte's sextets.
+			pos := 0
+			for pos+32 <= len(av.data) && av.data[pos:pos+32] == bv.data[pos:pos+32] {
+				pos += 32
+			}
+			for av.data[pos] == bv.data[pos] {
+				pos++
+			}
+			char := pos * 8 / 6
+			if x, y := av.at(char), bv.at(char); x != y {
+				return int(x) - int(y), true
+			}
+			return int(av.at(char+1)) - int(bv.at(char+1)), true
+		}
+	}
+	n := min(av.n, bv.n)
+	// Reject early differences without encoding even one full chunk.
+	head := min(n, 1)
+	for i := 0; i < head; i++ {
+		x, y := av.at(i), bv.at(i)
+		if fold {
+			if x >= 128 || y >= 128 {
+				return 0, false
+			}
+			x, y = asciiFoldByte(x), asciiFoldByte(y)
+		}
+		if x != y {
+			return int(x) - int(y), true
+		}
+	}
+	var ab, bb [256]byte
+	for pos := 0; pos < n; {
+		count := min(len(ab), n-pos)
+		av.decodeInto(ab[:count], pos, false)
+		bv.decodeInto(bb[:count], pos, false)
+		if fold {
+			if bytes.Equal(ab[:count], bb[:count]) {
+				pos += count
+				continue
+			}
+			for i := 0; i < count; i++ {
+				x, y := ab[i], bb[i]
+				if x >= 128 || y >= 128 {
+					return 0, false
+				}
+				x, y = asciiFoldByte(x), asciiFoldByte(y)
+				if x != y {
+					return int(x) - int(y), true
+				}
+			}
+		} else if cmp := bytes.Compare(ab[:count], bb[:count]); cmp != 0 {
+			return cmp, true
+		}
+		pos += count
+	}
+	// Unicode case folding can change UTF-8 length (e.g. Kelvin sign).
+	if fold && av.n != bv.n {
+		longer := av
+		if bv.n > av.n {
+			longer = bv
+		}
+		if longer.at(n) >= 128 {
+			return 0, false
+		}
+	}
+	return compareLength(av.n, bv.n), true
+}
+
+// Fuse Base64 generation and comparison in complete groups. The plain
+// operand needs neither a view nor per-character decoding.
+func compareBase64Plain(a Scmer, text string, fold bool) (int, bool) {
+	raw := unsafe.Slice(a.ptr, int(auxVal(a.aux)&bstringLengthMask))
+	enc := bstringEncoding(a)
+	length, plainLength := enc.EncodedLen(len(raw)), len(text)
+	if min(length, plainLength) == 0 {
+		return compareLength(length, plainLength), true
+	}
+	alphabet := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	if auxVal(a.aux)&(1<<47) != 0 {
+		alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	}
+	x, y := alphabet[raw[0]>>2], text[0]
+	if fold {
+		if y >= 128 {
+			return 0, false
+		}
+		x, y = asciiFoldByte(x), asciiFoldByte(y)
+	}
+	if x != y {
+		return int(x) - int(y), true
+	}
+	if min(length, plainLength) > 64 {
+		return compareBase64Chunks(raw, text, enc, fold)
+	}
+
+	// Two-byte load plus one byte yields four sextets. Compare all four ASCII
+	// characters at once, in big-endian text order. No per-character shifts.
+	for len(raw) >= 3 && len(text) >= 4 {
+		pair, third := binary.BigEndian.Uint16(raw), raw[2]
+		word := uint32(alphabet[pair>>10])<<24 |
+			uint32(alphabet[(pair>>4)&63])<<16 |
+			uint32(alphabet[(pair&15)<<2|uint16(third>>6)])<<8 |
+			uint32(alphabet[third&63])
+		other := binary.BigEndian.Uint32([]byte(text))
+		if word != other {
+			if fold {
+				if other&0x80808080 != 0 {
+					return 0, false
+				}
+				word, other = foldASCIIWord(word), foldASCIIWord(other)
+			}
+			if word < other {
+				return -1, true
+			}
+			if word > other {
+				return 1, true
+			}
+		}
+		raw, text = raw[3:], text[4:]
+	}
+	// Handle the final partial input/output group and padding only once.
+	var tail [4]byte
+	count := min(3, len(raw))
+	enc.Encode(tail[:], raw[:count])
+	count = min(enc.EncodedLen(count), len(text))
+	if fold {
+		for i, c := range tail[:count] {
+			p := text[i]
+			if p >= 128 {
+				return 0, false
+			}
+			x, y := asciiFoldByte(c), asciiFoldByte(p)
+			if x != y {
+				return int(x) - int(y), true
+			}
+		}
+	} else if c := bytes.Compare(tail[:count], []byte(text[:count])); c != 0 {
+		return c, true
+	}
+	return compareLength(length, plainLength), true
+}
+
+func foldASCIIWord(word uint32) uint32 {
+	return uint32(asciiFoldByte(byte(word>>24)))<<24 |
+		uint32(asciiFoldByte(byte(word>>16)))<<16 |
+		uint32(asciiFoldByte(byte(word>>8)))<<8 |
+		uint32(asciiFoldByte(byte(word)))
+}
+
+// Longer common prefixes favor the encoder's unrolled 3-byte/4-character
+// loop followed by a bulk comparison. Keep its stack buffer off short paths.
+func compareBase64Chunks(raw []byte, text string, enc *base64.Encoding, fold bool) (int, bool) {
+	length, plainLength := enc.EncodedLen(len(raw)), len(text)
+	n := min(length, plainLength)
+	var chunk [256]byte
+	pos := 0
+	for source := 0; pos < n; {
+		count := min(192, len(raw)-source)
+		enc.Encode(chunk[:], raw[source:source+count])
+		encoded := min(enc.EncodedLen(count), n-pos)
+		other := text[pos : pos+encoded]
+		if fold {
+			if string(chunk[:encoded]) != other {
+				for i, c := range chunk[:encoded] {
+					p := other[i]
+					if p >= 128 {
+						return 0, false
+					}
+					x, y := asciiFoldByte(c), asciiFoldByte(p)
+					if x != y {
+						return int(x) - int(y), true
+					}
+				}
+			}
+		} else if c := bytes.Compare(chunk[:encoded], []byte(other)); c != 0 {
+			return c, true
+		}
+		source += count
+		pos += encoded
+	}
+	return compareLength(length, plainLength), true
 }

--- a/scm/cstring.go
+++ b/scm/cstring.go
@@ -26,43 +26,39 @@ const CStringFormatShift = 43
 const CStringOffsetShift = 42
 const CStringLengthMask = (1 << CStringOffsetShift) - 1
 
-// CStringAlphabet is the shared immutable format registry for storage and
+// cstringAlphabets is the shared immutable format registry for storage and
 // execution. IDs 1..10 are permanent legacy assignments; 11..16 are sorted,
-// high-nibble-first encodings. UUIDs have fixed separators, not a nibble table.
+// high-nibble-first encodings, as are timestamp IDs 19/20. UUIDs have fixed
+// separators, not a nibble table. IDs 17/18 belong to BString storage.
+var cstringAlphabets = [...]string{
+	1:  "0123456789 +-/()",
+	2:  "0123456789abcdef",
+	3:  "0123456789ABCDEF",
+	8:  "0123456789+-.,eE",
+	9:  "0123456789-:. T",
+	10: "0123456789+-()#*",
+	11: "0123456789abcdef",
+	12: "0123456789ABCDEF",
+	13: " ()+-/0123456789",
+	14: "#()*+-0123456789",
+	15: "+,-.0123456789Ee",
+	16: " -.0123456789:T",
+	19: " -.0123456789:TZ",
+	20: "+-.0123456789:TZ",
+}
+
+// CStringAlphabet returns an immutable nibble alphabet, or empty for other formats.
 func CStringAlphabet(format uint8) string {
-	switch format {
-	case 1:
-		return "0123456789 +-/()"
-	case 2:
-		return "0123456789abcdef"
-	case 3:
-		return "0123456789ABCDEF"
-	case 8:
-		return "0123456789+-.,eE"
-	case 9:
-		return "0123456789-:. T"
-	case 10:
-		return "0123456789+-()#*"
-	case 11:
-		return "0123456789abcdef"
-	case 12:
-		return "0123456789ABCDEF"
-	case 13:
-		return " ()+-/0123456789"
-	case 14:
-		return "#()*+-0123456789"
-	case 15:
-		return "+,-.0123456789Ee"
-	case 16:
-		return " -.0123456789:T"
+	if int(format) < len(cstringAlphabets) {
+		return cstringAlphabets[format]
 	}
 	return ""
 }
 
 // Two decoded ASCII characters per packed byte, in text order. The folded
 // table keeps case conversion out of compressed/plain comparison loops.
-var cstringPairs, cstringFoldedPairs = func() ([17][256]uint16, [17][256]uint16) {
-	var plain, folded [17][256]uint16
+var cstringPairs, cstringFoldedPairs = func() ([21][256]uint16, [21][256]uint16) {
+	var plain, folded [21][256]uint16
 	for f := 0; f < len(plain); f++ {
 		alphabet := CStringAlphabet(uint8(f))
 		if alphabet == "" {
@@ -152,6 +148,15 @@ func (s stringView) at(i int) byte {
 }
 
 func (v stringView) decodeInto(dst []byte, start int, fold bool) {
+	if v.format == 0 {
+		copy(dst, v.data[start:start+len(dst)])
+		if fold {
+			for i, c := range dst {
+				dst[i] = asciiFoldByte(c)
+			}
+		}
+		return
+	}
 	if v.alphabet != "" {
 		pairs := &cstringPairs[v.format]
 		if fold {
@@ -463,6 +468,20 @@ func equalStringValues(a, b Scmer, fold bool) bool {
 			if c, ok := compareStringViews(av, bv, fold); ok {
 				return c == 0
 			}
+		}
+	}
+	if a.IsBString() || b.IsBString() {
+		if !fold && a.IsBString() && b.IsBString() && auxVal(a.aux)>>46 == auxVal(b.aux)>>46 {
+			an, bn := int(auxVal(a.aux)&bstringLengthMask), int(auxVal(b.aux)&bstringLengthMask)
+			return unsafe.String(a.ptr, an) == unsafe.String(b.ptr, bn)
+		}
+		if !fold {
+			if equal, ok := equalBase64Bytes(a, b); ok {
+				return equal
+			}
+		}
+		if c, ok := compareBase64Text(a, b, fold); ok {
+			return c == 0
 		}
 	}
 	if fold {

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -1483,14 +1483,14 @@ func TestJITCompressedTextOperators(t *testing.T) {
 	}
 	compiled := compileJITExpressionTestProc(t, `(lambda (s) (list (string? s) (strlen s) (substr s 1 3) (toUpper s) (strtrim s) (concat s "!") (strlike_cs s "%m9%") (base64_decode s) (md5 s) (sha1 s) (sha256 s)))`)
 	text := "foo"
-	compressed := NewBString(unsafe.StringData(text), len(text), false)
+	compressed := NewBString(unsafe.StringData(text), len(text), false, false)
 	got := Apply(compiled, compressed)
 	want := Apply(compiled, NewString(compressed.String()))
 	if String(got) != String(want) {
 		t.Fatalf("compressed %s, plain %s", String(got), String(want))
 	}
 	large := strings.Repeat("foo", 1024)
-	largeValue := NewBString(unsafe.StringData(large), len(large), false)
+	largeValue := NewBString(unsafe.StringData(large), len(large), false, false)
 	if got, want := Apply(compiled, largeValue), Apply(compiled, NewString(largeValue.String())); String(got) != String(want) {
 		t.Fatal("large compressed operator chain differs from plain text")
 	}
@@ -1500,6 +1500,24 @@ func TestJITCompressedTextOperators(t *testing.T) {
 		result := Apply(proc)
 		if result != literal {
 			t.Fatal("compressed literal changed during compilation")
+		}
+	}
+}
+
+func TestJITBase64Representations(t *testing.T) {
+	op := compileJITExpressionTestProc(t, `(lambda (s other) (list (equal? s other) (equal?? s other) (equal_collate s other "utf8_bin") (equal_collate s other "utf8_general_ci") (< s other) (strlen s) (substr s 0 (min (strlen s) 2)) (toLower s) (strlike_cs s "%A%") (sha256 s)))`)
+	for _, raw := range []string{"", "x", "xy", "xyz", "\xfb\xff", strings.Repeat("x", 2048)} {
+		for _, url := range []bool{false, true} {
+			for _, unpadded := range []bool{false, true} {
+				v := NewBString(unsafe.StringData(raw), len(raw), url, unpadded)
+				for _, other := range []Scmer{v, NewString(v.String()), NewString(strings.ToLower(v.String())), NewString("!")} {
+					got := Apply(op, v, other)
+					want := Apply(op, NewString(v.String()), NewString(other.String()))
+					if String(got) != String(want) {
+						t.Fatalf("%q: got %s want %s", v.String(), String(got), String(want))
+					}
+				}
+			}
 		}
 	}
 }

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -76,7 +76,7 @@ const (
 	tagAny
 	tagRegex       // *regexp.Regexp
 	tagCString     // compressed string; ptr=bytes in StorageString dict, aux=format+nibbleOff+charLen
-	tagBString     // binary blob; ptr=raw bytes in StorageString dict, aux=urlSafe(bit47)+byteLen(bits46-0)
+	tagBString     // binary blob; ptr=raw bytes in StorageString dict, aux=urlSafe(bit47)+unpadded(bit46)+byteLen(bits45-0)
 	tagClosure     // lightweight id-carrying closure; ptr=*func(uint32,...Scmer)Scmer, aux=(id<<8)|tagClosure
 	tagPromise     // tagPromise Scmer; ptr points to cells[0] of a [2]Scmer backing (auxVal==0 heap, auxVal==1 list-backed)
 	tagBSON        // raw BSON value; ptr=payload bytes, aux packs BSON type and payload length
@@ -129,11 +129,14 @@ func NewCString(ptr *byte, format uint8, nibbleOff uint8, charLen int) Scmer {
 
 // NewBString creates a binary-blob Scmer whose string representation is Base64.
 // ptr points to raw bytes in the StorageString dictionary (must stay alive as long as the Scmer).
-// byteLen is the number of raw bytes. urlSafe selects URL-safe vs standard Base64 on .String().
-func NewBString(ptr *byte, byteLen int, urlSafe bool) Scmer {
+// byteLen is the number of raw bytes. urlSafe selects the alphabet; unpadded omits trailing equals signs.
+func NewBString(ptr *byte, byteLen int, urlSafe, unpadded bool) Scmer {
 	var flag uint64
 	if urlSafe {
 		flag = 1 << 47
+	}
+	if unpadded {
+		flag |= 1 << 46
 	}
 	return Scmer{ptr, makeAux(tagBString, flag|uint64(byteLen))}
 }
@@ -833,13 +836,7 @@ func (s Scmer) AppendString(dst []byte) (string, []byte) {
 		}
 		return "<compressed string>", dst
 	case tagBString:
-		val := auxVal(s.aux)
-		byteLen := int(val & ((1 << 47) - 1))
-		b := unsafe.Slice(s.ptr, byteLen)
-		if val>>47 != 0 {
-			return base64.URLEncoding.EncodeToString(b), dst
-		}
-		return base64.StdEncoding.EncodeToString(b), dst
+		return bstringEncoding(s).EncodeToString(unsafe.Slice(s.ptr, int(auxVal(s.aux)&bstringLengthMask))), dst
 	case tagBSON:
 		start := len(dst)
 		var err error

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -31283,22 +31283,28 @@ func init_strings() {
 				if d6.Loc == LocRegPair || d6.Loc == LocStackPair || d6.Loc == LocRegTriple || d6.Loc == LocStackTriple {
 					panic("jit: generic call arg expects 1-word value")
 				}
+				d7 := JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)}
+				if d7.Loc == LocRegPair || d7.Loc == LocStackPair || d7.Loc == LocRegTriple || d7.Loc == LocStackTriple {
+					panic("jit: generic call arg expects 1-word value")
+				}
 				ctx.SyncDesc(&d4)
 				ctx.SyncDesc(&d5)
 				ctx.SyncDesc(&d6)
-				d7 := ctx.EmitGoCallScalar(GoFuncAddr(NewBString), []JITValueDesc{d4, d5, d6}, 2)
-				d7.NoHeapPointer = false
-				ctx.BindReg(d7.Reg, &d7)
-				ctx.BindReg(d7.Reg2, &d7)
+				ctx.SyncDesc(&d7)
+				d8 := ctx.EmitGoCallScalar(GoFuncAddr(NewBString), []JITValueDesc{d4, d5, d6, d7}, 2)
+				d8.NoHeapPointer = false
+				ctx.BindReg(d8.Reg, &d8)
+				ctx.BindReg(d8.Reg2, &d8)
 				ctx.FreeDesc(&d6)
+				ctx.FreeDesc(&d7)
 				ctx.FreeDesc(&d4)
 				ctx.FreeDesc(&d5)
 				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d7)
+				ctx.EnsureDesc(&d8)
 				ctx.FreeDesc(&d0)
-				if d7.Loc == LocImm {
+				if d8.Loc == LocImm {
 					if result.Loc == LocAny {
-						return d7
+						return d8
 					}
 				}
 				if result.Loc == LocAny {
@@ -31306,20 +31312,20 @@ func init_strings() {
 					ctx.BindReg(result.Reg, &result)
 					ctx.BindReg(result.Reg2, &result)
 				}
-				ctx.SyncDesc(&d7)
-				if d7.Loc == LocRegPair || d7.Loc == LocStackPair || d7.Loc == LocInputPair {
-					ctx.EmitMovPairToResult(&d7, &result)
-					result.Type = d7.Type
+				ctx.SyncDesc(&d8)
+				if d8.Loc == LocRegPair || d8.Loc == LocStackPair || d8.Loc == LocInputPair {
+					ctx.EmitMovPairToResult(&d8, &result)
+					result.Type = d8.Type
 				} else {
-					switch d7.Type {
+					switch d8.Type {
 					case tagBool:
-						ctx.EmitMakeBool(result, d7)
+						ctx.EmitMakeBool(result, d8)
 						result.Type = tagBool
 					case tagInt:
-						ctx.EmitMakeInt(result, d7)
+						ctx.EmitMakeInt(result, d8)
 						result.Type = tagInt
 					case tagFloat:
-						ctx.EmitMakeFloat(result, d7)
+						ctx.EmitMakeFloat(result, d8)
 						result.Type = tagFloat
 					case tagNil:
 						ctx.EmitMakeNil(result)
@@ -31339,7 +31345,7 @@ func init_strings() {
 		Name: "base64_decode",
 
 		Fn: func(a ...Scmer) Scmer {
-			if a[0].IsBString() && auxVal(a[0].aux)>>47 == 0 {
+			if a[0].IsBString() && auxVal(a[0].aux)>>46 == 0 {
 				return bstringRawText(a[0])
 			}
 			decoded, err := base64.StdEncoding.DecodeString(String(a[0]))
@@ -31996,9 +32002,9 @@ func init_strings() {
 					ctx.EnsureDesc(&d61)
 					var d62 JITValueDesc
 					if d61.Loc == LocImm {
-						d62 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d61.Imm.Int()) >> 47))}
+						d62 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d61.Imm.Int()) >> 46))}
 					} else {
-						ctx.EmitShrRegImm8(d61.Reg, 47)
+						ctx.EmitShrRegImm8(d61.Reg, 46)
 						d62 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d61.Reg}
 						ctx.BindReg(d61.Reg, &d62)
 					}

--- a/storage/base64-string-formats.md
+++ b/storage/base64-string-formats.md
@@ -1,0 +1,247 @@
+# Exact compressed strings and additional formats
+
+Copyright (C) 2026 Carl-Philip Hänsch. Licensed under GPL-3.0-or-later.
+
+Base64 already uses BString: its payload is decoded binary data, while the
+value still represents the original Base64 text. No additional runtime tag is
+needed. Prefix compression remains the responsibility of StoragePrefix.
+
+## Correctness and compatibility
+
+- Format detection now requires canonical Base64, including padding shape and
+  unused tail bits. `Zh==`, `Zm9=`, and `AA=A` remain exact strings instead of
+  being normalized or causing a rebuild panic. Unpadded input receives the same
+  strict checks.
+- Empty strings disqualify fixed-width UUID encoding, fixing rebuilds containing
+  UUIDs and empty strings (including all-empty columns).
+- Binary equality preserves alphabet and padding distinctions. SQL equality
+  keeps the existing text case-folding semantics; explicit binary collations
+  no longer accidentally use SQL case-insensitive equality for compressed values.
+- Existing format IDs and readers remain unchanged. StorageString version 3
+  introduces permanent IDs 17–20. Readers for legacy and versions 0, 1, and 2
+  remain available. Existing files require no migration; a future rebuild can
+  choose the new formats. Older executables cannot read version 3 columns.
+
+| ID | Representation | Payload |
+| --- | --- | --- |
+| 17 | Unpadded standard Base64 | Decoded bytes |
+| 18 | Unpadded URL Base64 | Decoded bytes |
+| 19 | Timestamp alphabet ` -.0123456789:TZ` | Ordered high-first nibbles |
+| 20 | Timestamp alphabet `+-.0123456789:TZ` | Ordered high-first nibbles |
+
+Timestamp formats are lossless alphabet encodings, not date parsers. They
+preserve spelling and fractional precision. Mixed alphabets fall back to another
+eligible format or raw strings. Both dictionary and non-dictionary storage,
+nullable columns, bulk readers, serialization, and reload support the new IDs.
+
+## Operators
+
+BString carries URL and unpadded flags in transient metadata. Shared bounded
+string views extend comparisons, LIKE, substrings, length, trimming, case
+conversion, concatenation, hashes, output, and Base64/hex operations to the new
+formats. Base64 decoding retains the public decoder's rejection of unsupported
+padding/alphabet variants.
+
+Binary BString equality with identical encoding flags compares stored bytes.
+Long mixed binary equality strictly decodes the other operand in 256-character
+blocks into a 192-byte stack buffer, compares raw bytes, and stops on a decisive
+mismatch. Short mixed comparisons retain the faster fused loop. Aligned CString
+equality compares complete packed bytes and masks only boundary nibbles.
+
+Base64 sorting must compare encoded text: raw byte order differs from Base64
+alphabet order. Same-format BString sorting skips equal raw blocks and decodes
+only the sextets affected by the first differing byte. Mixed sorting and SQL
+case-insensitive equality stop at the first decisive block. Short values use a
+16-bit plus 8-bit load, four constant sextet extractions, and a 32-bit text
+comparison; final partial groups stay outside the loop. Longer values use the
+chunk encoder. All these comparison paths avoid full-string allocations.
+
+## Manual measurements
+
+Measurements compare development baseline `2c3f45274` (master including PR #846)
+with this branch. The detached benchmark baseline uses `1d7cd1bfd`, whose source
+matches that master commit except README. Both use identical benchmark fixtures.
+Host: AMD Ryzen 9 7900X3D, linux/amd64. Other workloads were active, so small
+changes should be treated as noise rather than guaranteed improvements.
+
+Results below are manual development measurements, independent of CI.
+
+### Loop experiment
+
+Fixed CPU 2, GOMAXPROCS=1, 500 ms per case, ABBA order, two samples per variant:
+short (16 raw bytes) late-difference SQL equality improved from 48.01 to 32.355 ns
+(-32.6%) with fused sextet processing. At 2048 raw bytes, late-difference sorting
+regressed from 1939 to 2178 ns (+12.3%), and SQL equality from 1487 to 1735 ns
+(+16.7%). Therefore only values up to 64 text bytes use the fused loop.
+
+The additional strict-decoding equality experiment (same setup) measured long
+late-difference binary equality at 1722.5 versus 1551 ns (-10.0%) compared with
+the all-fused prototype. Short values regressed, so they retain fused comparison.
+These intermediate experiments are separate from the final master comparison.
+
+### Practical limits
+
+Bulk column readers still materialize text into a shared arena before many SQL
+operators. Therefore direct compressed-operator microbenchmarks do not predict
+the same speedup for a full SQL projection. Repeated SQL ORDER BY measurements
+can reuse an already-built index; the separate 4096-value sorting benchmark
+measures actual comparison work. General language-collation sorting still has
+materialization fallbacks. Dictionary payload sizes exclude column metadata,
+row indexes, and outer compression.
+
+
+### Plan inspection
+
+EXPLAIN, EXPLAIN IR, EXPLAIN PHYSICAL, and EXPLAIN REORDER were inspected for
+all three new SQL performance cases. Both projections lower to a single `scan`
+with their scalar operators in the result-row callback; ORDER BY LIMIT lowers
+to `scan_order` with a 100-row limit. No planner changes are required here.
+
+### Validation
+
+169 targeted SQL cases pass: string compression (70), scalar functions (51),
+string functions (29), and LIKE (19). The compression suite includes rebuild and
+restart. Targeted Go tests include old on-disk CString fixtures, all Base64
+representation pairs and bit positions, new dictionary/non-dictionary formats,
+nullable/bulk reads, operator parity, and UUID/empty-string regressions.
+
+
+### Final operator and build A/B
+
+Stock Go 1.24.0, CPU 2, GOMAXPROCS=1; ABBA, two samples/version,
+200 ms/case with Go's iteration calibration. Tables show arithmetic means.
+No additional explicit warmup is used for these Go benchmarks. `B` denotes
+BString, `C` CString, `S` plain string. Differences are text-byte positions.
+All candidate Base64 comparisons below use zero bytes and zero allocations.
+
+The shared host was heavily loaded in this sweep. Even repeated instances of
+the same unchanged same-value comparison varied substantially. These are
+observations, not confidence intervals; the focused CString control below
+resolves the apparent large CString regressions in this noisy sweep.
+
+| Benchmark | Baseline ns/op | Candidate ns/op | Change |
+| --- | ---: | ---: | ---: |
+| `CStringCompare/difference-0/equal-CS` | 41.45 | 40.67 | -1.9% |
+| `CStringCompare/difference-0/equalSQL-CS` | 36.47 | 53.82 | +47.6% |
+| `CStringCompare/difference-0/less-CS` | 35.41 | 49.52 | +39.8% |
+| `CStringCompare/difference-0/less-CC` | 35.36 | 55.38 | +56.6% |
+| `CStringCompare/difference-31/equal-CS` | 53.73 | 69.60 | +29.5% |
+| `CStringCompare/difference-31/equalSQL-CS` | 70.16 | 83.66 | +19.2% |
+| `CStringCompare/difference-31/less-CS` | 39.50 | 63.02 | +59.5% |
+| `CStringCompare/difference-31/less-CC` | 34.51 | 37.67 | +9.2% |
+| `CStringCompare/difference-63/equal-CS` | 61.11 | 90.62 | +48.3% |
+| `CStringCompare/difference-63/equalSQL-CS` | 95.75 | 128.20 | +33.9% |
+| `CStringCompare/difference-63/less-CS` | 82.81 | 89.53 | +8.1% |
+| `CStringCompare/difference-63/less-CC` | 34.02 | 30.79 | -9.5% |
+| `CStringCompare/difference-64/equal-CS` | 84.00 | 79.55 | -5.3% |
+| `CStringCompare/difference-64/equalSQL-CS` | 101.84 | 106.99 | +5.1% |
+| `CStringCompare/difference-64/less-CS` | 85.44 | 98.87 | +15.7% |
+| `CStringCompare/difference-64/less-CC` | 37.56 | 31.77 | -15.4% |
+| `CStringCompare/uuid-less-CC` | 38.12 | 35.20 | -7.7% |
+| `CStringIndexSort` | 2371475.50 | 2268547.00 | -4.3% |
+| `Base64Compare/16/difference-0/equal-BS` | 100.70 | 19.61 | -80.5% |
+| `Base64Compare/16/difference-0/less-BS` | 104.29 | 11.13 | -89.3% |
+| `Base64Compare/16/difference-0/less-BB` | 229.50 | 41.18 | -82.1% |
+| `Base64Compare/16/difference-0/equal-BB` | 12.62 | 10.28 | -18.6% |
+| `Base64Compare/16/difference-0/equal-same-BB` | 9.72 | 9.19 | -5.5% |
+| `Base64Compare/16/difference-0/equalSQL-BS` | 83.22 | 17.94 | -78.4% |
+| `Base64Compare/16/difference-0/equalSQL-same-BB` | 8.70 | 9.90 | +13.7% |
+| `Base64Compare/16/difference-20/equal-BS` | 95.64 | 46.09 | -51.8% |
+| `Base64Compare/16/difference-20/less-BS` | 91.37 | 54.42 | -40.4% |
+| `Base64Compare/16/difference-20/less-BB` | 120.25 | 66.07 | -45.1% |
+| `Base64Compare/16/difference-20/equal-BB` | 9.90 | 14.09 | +42.4% |
+| `Base64Compare/16/difference-20/equal-same-BB` | 6.99 | 11.35 | +62.3% |
+| `Base64Compare/16/difference-20/equalSQL-BS` | 99.37 | 57.87 | -41.8% |
+| `Base64Compare/16/difference-20/equalSQL-same-BB` | 7.60 | 11.65 | +53.2% |
+| `Base64Compare/2048/difference-0/equal-BS` | 3010.00 | 34.05 | -98.9% |
+| `Base64Compare/2048/difference-0/less-BS` | 3097.00 | 15.06 | -99.5% |
+| `Base64Compare/2048/difference-0/less-BB` | 5953.00 | 42.88 | -99.3% |
+| `Base64Compare/2048/difference-0/equal-BB` | 9.76 | 10.68 | +9.4% |
+| `Base64Compare/2048/difference-0/equal-same-BB` | 7.10 | 11.41 | +60.7% |
+| `Base64Compare/2048/difference-0/equalSQL-BS` | 2734.00 | 15.07 | -99.4% |
+| `Base64Compare/2048/difference-0/equalSQL-same-BB` | 7.83 | 9.36 | +19.5% |
+| `Base64Compare/2048/difference-2728/equal-BS` | 2862.50 | 2414.00 | -15.7% |
+| `Base64Compare/2048/difference-2728/less-BS` | 3718.50 | 3007.50 | -19.1% |
+| `Base64Compare/2048/difference-2728/less-BB` | 4951.00 | 496.45 | -90.0% |
+| `Base64Compare/2048/difference-2728/equal-BB` | 30.54 | 33.84 | +10.8% |
+| `Base64Compare/2048/difference-2728/equal-same-BB` | 9.08 | 7.81 | -13.9% |
+| `Base64Compare/2048/difference-2728/equalSQL-BS` | 3996.50 | 2277.50 | -43.0% |
+| `Base64Compare/2048/difference-2728/equalSQL-same-BB` | 9.12 | 10.65 | +16.7% |
+| `Base64IndexSort` | 12487670.00 | 3602135.50 | -71.2% |
+
+Focused CString control: CPU 9, GOMAXPROCS=1, 1 second/case, ABBA,
+two samples/version, same fixtures and Go iteration calibration:
+
+| Benchmark | Baseline ns/op | Candidate ns/op | Change |
+| --- | ---: | ---: | ---: |
+| `CStringCompare/difference-0/equal-CS` | 25.020 | 23.285 | -6.9% |
+| `CStringCompare/difference-0/equalSQL-CS` | 22.890 | 24.035 | +5.0% |
+| `CStringCompare/difference-0/less-CS` | 21.695 | 21.720 | +0.1% |
+| `CStringCompare/difference-63/equal-CS` | 56.855 | 49.865 | -12.3% |
+| `CStringCompare/difference-63/equalSQL-CS` | 88.335 | 68.415 | -22.6% |
+| `CStringCompare/difference-63/less-CS` | 59.910 | 48.190 | -19.6% |
+
+Build fixture: 128 rows with 8 distinct values; size is raw input bytes for
+Base64, text length for hex. Timestamp values contain fractional seconds and
+`+02:00`. This measures format selection plus column construction. Extra format
+validation and actual decoding of newly compressible inputs can increase build
+cost and allocations; the read and space benefits do not make rebuilding free.
+
+| Format/size | Baseline µs | Candidate µs | Change | Dictionary bytes before → after |
+| --- | ---: | ---: | ---: | ---: |
+| hex/16 | 72.89 | 83.15 | +14.1% | 64 → 64 |
+| hex/2048 | 27621.39 | 31526.70 | +14.1% | 8192 → 8192 |
+| base64/16 | 104.14 | 126.49 | +21.5% | 128 → 128 |
+| base64/2048 | 45672.67 | 44164.78 | -3.3% | 16384 → 16384 |
+| raw-base64/16 | 94.20 | 124.36 | +32.0% | 176 → 128 |
+| raw-base64/2048 | 43432.87 | 44922.30 | +3.4% | 21848 → 16384 |
+| timestamp/16 | 103.54 | 119.99 | +15.9% | 232 → 116 |
+
+The Base64 sorting benchmark sorts 4096 shuffled compressed values each
+iteration. Allocation drops from roughly 13 MB / 204741 allocations per sort
+to 88 bytes / 3 allocations (sort closure bookkeeping). CString sort is an
+independent control with 4096 values.
+
+Targeted race tests and JIT compressed-operator/representation tests also pass.
+
+
+### SQL A/B
+
+JIT-enabled Go toolchain at `84fe25ee`, GOMAXPROCS=4, CPUs 0–3; the same
+4096-row fixtures from `tests/storage/formats/string-compression.yaml` on both
+versions. The initial suite-level ABBA used 5 warmups and 31 samples/query,
+with two runs/version. Its means of runner-reported timings appear below.
+These runs suffered substantial host-load drift, including apparent regressions
+in unchanged cached-index and materialized-string paths.
+
+The follow-up kept two isolated, warmed servers alive and immediately alternated
+requests A/B/B/A for 16 cycles: 32 samples/version/query after 5 warmups each.
+Its values are median client wall time (including HTTP), not the runner's metric.
+Do not compare absolute timings across these two methodologies. The interleaved
+comparison removes the long delay between baseline and candidate samples.
+
+| Query | Suite baseline ms | Suite candidate ms | Suite change | Interleaved baseline ms | Interleaved candidate ms | Interleaved change |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| CString mixed SQL equality projection | 14.650 | 18.750 | +28.0% | 4.810 | 4.893 | +1.7% |
+| CString LIKE projection | 18.350 | 20.950 | +14.2% | 5.352 | 5.406 | +1.0% |
+| CString ordered range | 2.600 | 3.000 | +15.4% | 0.986 | 0.986 | +0.0% |
+| Compressed text composed projection | 23.400 | 22.750 | -2.8% | 7.187 | 7.266 | +1.1% |
+| Compressed text Base64 roundtrip projection | 19.050 | 19.350 | +1.6% | 5.156 | 5.114 | -0.8% |
+| Base64 mixed early comparison projection | 21.300 | 20.900 | -1.9% | 8.388 | 8.342 | -0.5% |
+| Base64 index sort | 1.400 | 1.950 | +39.3% | 0.495 | 0.479 | -3.3% |
+| Timestamp compressed operator projection | 27.200 | 27.150 | -0.2% | 8.737 | 8.953 | +2.5% |
+
+Reproduce the operator sweep by building the same benchmark file on baseline
+and candidate, then running each test binary from its `storage` directory:
+
+```sh
+GOMAXPROCS=1 taskset -c 2 ./storage.test -test.run='^$' \
+  -test.bench='Benchmark(CStringCompare|CStringIndexSort|Base64Compare|Base64IndexSort|StringFormatBuild)$' \
+  -test.benchtime=200ms -test.count=1
+```
+
+For SQL, create the two performance fixtures from the YAML on separate fresh
+instances, rebuild, then execute its eight performance queries using the
+warmup/sample configurations above. Exclude setup, rebuild, startup and reload
+from query timings. The SQL fixtures explicitly insert 4096 rows; the runner's
+calibrated `rows` metadata does not change these hardcoded fixture sizes.

--- a/storage/compressed_string_ops_test.go
+++ b/storage/compressed_string_ops_test.go
@@ -25,7 +25,7 @@ import "github.com/launix-de/memcp/scm"
 
 func compressedOpValues() []scm.Scmer {
 	var values []scm.Scmer
-	for _, f := range []StringFormat{1, 2, 3, 8, 9, 10, 11, 12, 13, 14, 15, 16} {
+	for _, f := range []StringFormat{1, 2, 3, 8, 9, 10, 11, 12, 13, 14, 15, 16, 19, 20} {
 		alphabet := scm.CStringAlphabet(uint8(f))
 		for _, text := range []string{"", "0", "00", alphabet, strings.Repeat(alphabet, 100)} {
 			for offset := 0; offset < 2; offset++ {
@@ -42,7 +42,9 @@ func compressedOpValues() []scm.Scmer {
 	}
 	for _, s := range []string{"", "x", "xy", "xyz", "xyzw", "xyzwa", "\xfb\xff\xff", strings.Repeat("abcdef?\xff", 200)} {
 		for _, url := range []bool{false, true} {
-			values = append(values, scm.NewBString(unsafe.StringData(s), len(s), url))
+			for _, raw := range []bool{false, true} {
+				values = append(values, scm.NewBString(unsafe.StringData(s), len(s), url, raw))
+			}
 		}
 	}
 	return values
@@ -126,7 +128,7 @@ func BenchmarkCompressedStringOperators(b *testing.B) {
 				v = comparisonCString(text, 11, 1)
 			}
 			if representation == "bstring" {
-				v = scm.NewBString(unsafe.StringData(text), len(text), false)
+				v = scm.NewBString(unsafe.StringData(text), len(text), false, false)
 			}
 			for _, op := range []struct {
 				name string
@@ -150,7 +152,7 @@ func BenchmarkCompressedStringOperators(b *testing.B) {
 }
 
 func TestCompressedStringGenericCompatibility(t *testing.T) {
-	for _, v := range []scm.Scmer{scm.NewAny("text"), scm.NewString("text"), scm.NewBString(nil, 0, false)} {
+	for _, v := range []scm.Scmer{scm.NewAny("text"), scm.NewString("text"), scm.NewBString(nil, 0, false, false)} {
 		if !scm.Globalenv.Vars["string?"].Func()(v).Bool() {
 			t.Fatal("string type rejected")
 		}

--- a/storage/cstring_comparison_bench_test.go
+++ b/storage/cstring_comparison_bench_test.go
@@ -20,6 +20,7 @@ import "fmt"
 import "sort"
 import "strings"
 import "testing"
+import "encoding/base64"
 import "github.com/launix-de/memcp/scm"
 
 var cstringBenchSink bool
@@ -131,5 +132,95 @@ func BenchmarkCStringLegacy(b *testing.B) {
 				cstringBenchSink = scm.Equal(a, plain)
 			}
 		})
+	}
+}
+
+// Identical fixtures on the development baseline and candidate; constructors
+// are intentionally reached through storage to measure the selected format.
+func BenchmarkBase64Compare(b *testing.B) {
+	for _, size := range []int{16, 2048} {
+		text := base64.StdEncoding.EncodeToString([]byte(strings.Repeat("x", size)))
+		for _, at := range []int{0, len(text) - 4} {
+			other := text[:at] + "A" + text[at+1:]
+			col := buildStringColumn([]string{text, other})
+			a, c := col.GetValue(0), col.GetValue(1)
+			p := scm.NewString(other)
+			for _, op := range []struct {
+				name string
+				fn   func() bool
+			}{
+				{"equal-BS", func() bool { return scm.Equal(a, p) }},
+				{"less-BS", func() bool { return scm.Less(a, p) }},
+				{"less-BB", func() bool { return scm.Less(a, c) }},
+				{"equal-BB", func() bool { return scm.Equal(a, c) }},
+				{"equal-same-BB", func() bool { return scm.Equal(a, a) }},
+				{"equalSQL-BS", func() bool { return scm.EqualSQL(a, p).Bool() }},
+				{"equalSQL-same-BB", func() bool { return scm.EqualSQL(a, a).Bool() }},
+			} {
+				b.Run(fmt.Sprintf("%d/difference-%d/%s", size, at, op.name), func(b *testing.B) {
+					b.ReportAllocs()
+					for i := 0; i < b.N; i++ {
+						cstringBenchSink = op.fn()
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkBase64IndexSort(b *testing.B) {
+	values := make([]string, 4096)
+	for i := range values {
+		values[i] = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("prefix-%032d", (i*2654435761)%4096)))
+	}
+	col := buildStringColumn(values)
+	original := make([]scm.Scmer, len(values))
+	work := make([]scm.Scmer, len(values))
+	for i := range original {
+		original[i] = col.GetValue(uint32(i))
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		copy(work, original)
+		sort.Slice(work, func(i, j int) bool { return scm.Less(work[i], work[j]) })
+	}
+}
+
+func BenchmarkStringFormatBuild(b *testing.B) {
+	for _, format := range []string{"hex", "base64", "raw-base64", "timestamp"} {
+		for _, size := range []int{16, 2048} {
+			if format == "timestamp" && size != 16 {
+				continue
+			}
+			values := make([]string, 128)
+			for i := range values {
+				switch format {
+				case "hex":
+					values[i] = fmt.Sprintf("%0*x", size, i%8)
+				case "base64", "raw-base64":
+					raw := []byte(strings.Repeat("x", size))
+					raw[len(raw)-1] = byte(i % 8)
+					enc := base64.StdEncoding
+					if format == "raw-base64" {
+						enc = base64.RawStdEncoding
+					}
+					values[i] = enc.EncodeToString(raw)
+				case "timestamp":
+					values[i] = fmt.Sprintf("2026-09-09T12:34:56.%03d+02:00", i%8)
+				}
+			}
+			b.Run(fmt.Sprintf("%s/%d", format, size), func(b *testing.B) {
+				col := buildStringColumn(values)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					col = buildStringColumn(values)
+				}
+				b.StopTimer()
+				b.ReportMetric(float64(len(col.ensureDict())), "dict-B")
+				cstringValueSink = col.GetValue(0)
+			})
+		}
 	}
 }

--- a/storage/storage-string.go
+++ b/storage/storage-string.go
@@ -57,6 +57,11 @@ const (
 	FormatOrderedPhoneDTMF StringFormat = 14
 	FormatOrderedDecimal   StringFormat = 15
 	FormatOrderedDateTime  StringFormat = 16
+	// Permanent IDs: unpadded Base64 and sorted timestamp alphabets.
+	FormatRawBase64Std   StringFormat = 17
+	FormatRawBase64URL   StringFormat = 18
+	FormatDateTimeZulu   StringFormat = 19
+	FormatDateTimeOffset StringFormat = 20
 )
 
 // nibbleCharset holds the encode (index→char) and decode (char→index) tables
@@ -95,8 +100,8 @@ var (
 )
 
 // orderedCharsets uses the same immutable alphabet definitions as CString comparisons.
-var orderedCharsets = func() [6]nibbleCharset {
-	var result [6]nibbleCharset
+var orderedCharsets = func() [10]nibbleCharset {
+	var result [10]nibbleCharset
 	for i := range result {
 		result[i] = makeNibbleCharset([]byte(scm.CStringAlphabet(uint8(i + 11))))
 		result[i].highFirst = true
@@ -104,16 +109,17 @@ var orderedCharsets = func() [6]nibbleCharset {
 	return result
 }()
 
-// allFormatsValid tracks eligibility using legacy alphabet IDs only.
+// allFormatsValid tracks legacy alphabet IDs and the new IDs 17..20.
 // chooseBestFormat maps eligible nibble alphabets to their ordered writer IDs.
-const allFormatsValid uint16 = (1 << 11) - 1 // bits 0..10
+const allFormatsValid uint32 = (1 << 11) - 1 | 1<<17 | 1<<18 | 1<<19 | 1<<20
 
 // checkFormatBits returns which StringFormat bits remain compatible with s.
 // bit i is set iff StringFormat(i) is still a valid encoding for s.
 // FormatRaw (bit 0) is always set.
-func checkFormatBits(s string) uint16 {
+func checkFormatBits(s string) uint32 {
 	if len(s) == 0 {
-		return allFormatsValid // empty string is compatible with everything
+		// Fixed-width UUID readers always emit 36 characters, so cannot represent empty text.
+		return allFormatsValid &^ (1<<FormatUUIDLower | 1<<FormatUUIDUpper)
 	}
 	valid := allFormatsValid
 
@@ -146,14 +152,23 @@ func checkFormatBits(s string) uint16 {
 		isAlpha := (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
 		isDigit := c >= '0' && c <= '9'
 		if !isAlpha && !isDigit && c != '+' && c != '/' && c != '=' {
-			valid &^= 1 << FormatBase64Upper
+			valid &^= 1<<FormatBase64Upper | 1<<FormatRawBase64Std
 		}
 		if !isAlpha && !isDigit && c != '-' && c != '_' && c != '=' {
-			valid &^= 1 << FormatBase64Lower
+			valid &^= 1<<FormatBase64Lower | 1<<FormatRawBase64URL
 		}
 		// '=' is only valid at the last two positions in a base64 string
 		if c == '=' && i < len(s)-2 {
 			valid &^= (1 << FormatBase64Upper) | (1 << FormatBase64Lower)
+		}
+		if orderedCharsets[FormatDateTimeZulu-11].dec[c] < 0 {
+			valid &^= 1 << FormatDateTimeZulu
+		}
+		if orderedCharsets[FormatDateTimeOffset-11].dec[c] < 0 {
+			valid &^= 1 << FormatDateTimeOffset
+		}
+		if c == '=' {
+			valid &^= 1<<FormatRawBase64Std | 1<<FormatRawBase64URL
 		}
 		// early exit once only FormatRaw remains
 		if valid == 1 {
@@ -161,6 +176,20 @@ func checkFormatBits(s string) uint16 {
 		}
 	}
 
+	// Character checks above prove all complete interior quartets valid.
+	// Strictly validate the tail: padding shape and unused bits must round-trip.
+	tail := len(s) % 4
+	if tail == 0 {
+		tail = 4
+	}
+	var decoded [3]byte
+	for _, candidate := range base64Formats {
+		if valid&(1<<candidate.format) != 0 {
+			if _, err := candidate.encoding.Decode(decoded[:], []byte(s[len(s)-tail:])); err != nil {
+				valid &^= 1 << candidate.format
+			}
+		}
+	}
 	isUUIDLow, isUUIDUp := checkUUID(s)
 	if !isUUIDLow {
 		valid &^= 1 << FormatUUIDLower
@@ -203,7 +232,7 @@ func checkUUID(s string) (lower, upper bool) {
 }
 
 // chooseBestFormat picks the most space-efficient format from validFormats.
-func chooseBestFormat(valid uint16) StringFormat {
+func chooseBestFormat(valid uint32) StringFormat {
 	// UUID: 16 bytes vs 36 chars → ~56% savings (best for fixed-length UUID columns)
 	if valid&(1<<FormatUUIDLower) != 0 {
 		return FormatUUIDLower
@@ -230,12 +259,23 @@ func chooseBestFormat(valid uint16) StringFormat {
 	if valid&(1<<FormatDateTime) != 0 {
 		return FormatOrderedDateTime
 	}
+	for _, f := range []StringFormat{FormatDateTimeZulu, FormatDateTimeOffset} {
+		if valid&(1<<f) != 0 {
+			return f
+		}
+	}
 	// Base64: ~25% savings
 	if valid&(1<<FormatBase64Upper) != 0 {
 		return FormatBase64Upper
 	}
 	if valid&(1<<FormatBase64Lower) != 0 {
 		return FormatBase64Lower
+	}
+	if valid&(1<<FormatRawBase64Std) != 0 {
+		return FormatRawBase64Std
+	}
+	if valid&(1<<FormatRawBase64URL) != 0 {
+		return FormatRawBase64URL
 	}
 	return FormatRaw
 }
@@ -261,7 +301,7 @@ func appendNibbles(dst []byte, s string, cs *nibbleCharset, compNibble int) ([]b
 
 // isNibbleFormat reports whether format uses 4-bit nibble packing.
 func isNibbleFormat(f StringFormat) bool {
-	if f >= FormatOrderedHexLower && f <= FormatOrderedDateTime {
+	if (f >= FormatOrderedHexLower && f <= FormatOrderedDateTime) || f == FormatDateTimeZulu || f == FormatDateTimeOffset {
 		return true
 	}
 	switch f {
@@ -273,7 +313,7 @@ func isNibbleFormat(f StringFormat) bool {
 
 // nibbleCharsetFor returns the nibble charset for a nibble format, or nil.
 func nibbleCharsetFor(f StringFormat) *nibbleCharset {
-	if f >= FormatOrderedHexLower && f <= FormatOrderedDateTime {
+	if (f >= FormatOrderedHexLower && f <= FormatOrderedDateTime) || f == FormatDateTimeZulu || f == FormatDateTimeOffset {
 		return &orderedCharsets[f-FormatOrderedHexLower]
 	}
 	switch f {
@@ -296,16 +336,10 @@ func nibbleCharsetFor(f StringFormat) *nibbleCharset {
 // compressNonNibble encodes s for UUID, Base64, or Raw formats and appends to dst.
 func compressNonNibble(dst []byte, s string, format StringFormat) []byte {
 	switch format {
-	case FormatBase64Upper:
-		b, err := base64.StdEncoding.DecodeString(s)
+	case FormatBase64Upper, FormatBase64Lower, FormatRawBase64Std, FormatRawBase64URL:
+		b, err := base64Encoding(format).DecodeString(s)
 		if err != nil {
-			panic(fmt.Sprintf("compressNonNibble: invalid standard base64 %q: %v", s, err))
-		}
-		return append(dst, b...)
-	case FormatBase64Lower:
-		b, err := base64.URLEncoding.DecodeString(s)
-		if err != nil {
-			panic(fmt.Sprintf("compressNonNibble: invalid URL-safe base64 %q: %v", s, err))
+			panic(fmt.Sprintf("compressNonNibble: invalid base64: %v", err))
 		}
 		return append(dst, b...)
 	case FormatUUIDLower, FormatUUIDUpper:
@@ -322,11 +356,11 @@ func compressNonNibble(dst []byte, s string, format StringFormat) []byte {
 // bitsize.  Must be called BEFORE lens.init().
 func adjustLensForFormat(lens *StorageInt, format StringFormat) {
 	switch format {
-	case FormatBase64Upper, FormatBase64Lower:
+	case FormatBase64Upper, FormatBase64Lower, FormatRawBase64Std, FormatRawBase64URL:
 		// build() stores decoded byte count; use 0 as safe lower bound to avoid
 		// negative relative values from padding variability
 		lens.offset = 0
-		lens.max = int64(base64.StdEncoding.DecodedLen(int(lens.max)))
+		lens.max = int64(base64Encoding(format).DecodedLen(int(lens.max)))
 		// All nibble formats (Hex, Phone, PhoneDTMF, Decimal, DateTime): char count == raw len → no adjustment
 		// UUID: lens is never read → no adjustment
 		// Raw: byte count == char count → no adjustment
@@ -476,7 +510,7 @@ type StorageString struct {
 	reverseMap   map[string][3]uint
 	count        uint
 	allsize      int
-	validFormats uint16
+	validFormats uint32
 	// prefix statistics
 	prefixstat map[string]int
 	laststr    string
@@ -602,14 +636,15 @@ func (s *StorageString) ensureDict() string {
 // format).  Old "smallerstrings" data had 0 there (pad was zero-filled), so it
 // reads correctly as version 0.
 //
-// Version 2 introduces ordered nibble IDs 11..16. The body layout remains V1.
+// Version 2 introduces ordered nibble IDs 11..16; version 3 adds IDs 17..20.
+// Both retain the V1 body layout.
 // The historical raw sentinel is exactly ASCII '1' (49), never a format range.
-const storageStringVersion = 2
+const storageStringVersion = 3
 
 // StorageString binary layout (magic byte 20 consumed by shard loader):
 //
 //	[nodict uint8]         ← 0=dict mode, 1=buffer mode
-//	[format uint8]         ← StringFormat (0..16); ASCII 49: legacy raw sentinel
+//	[format uint8]         ← StringFormat (0..20); ASCII 49: legacy raw sentinel
 //
 //	Legacy (format byte == 49, i.e. '1'=49 from old ASCII dummy "123456"):
 //	  [legacyPad 5 bytes]  ← consume remaining dummy bytes; format = FormatRaw
@@ -622,8 +657,8 @@ const storageStringVersion = 2
 //	  [count uint64] [values StorageInt] [starts StorageInt] [lens StorageInt]
 //	  [dictlen uint64] [dict bytes]
 //
-//	Version 1/2:
-//	  [version uint8]      ← 1 or 2
+//	Version 1/2/3:
+//	  [version uint8]      ← 1, 2 or 3
 //	  [pad 4 bytes]        ← alignment padding
 //	  [compressed uint8]   ← 0=uncompressed dict, 1=lz4-compressed dict
 //	  [count uint64] [values StorageInt] [starts StorageInt] [lens StorageInt]
@@ -634,7 +669,8 @@ const storageStringVersion = 2
 //
 //	0: smallerstrings format; format byte 0..10; version in pad[0].
 //	1: adds lz4-compressed dictionary support.
-//	2 (current): ordered nibble IDs 11..16; V1 body layout.
+//	2: ordered nibble IDs 11..16; V1 body layout.
+//	3 (current): unpadded Base64 and timestamp IDs 17..20; V1 body layout.
 func (s *StorageString) Serialize(f io.Writer) {
 	binary.Write(f, binary.LittleEndian, uint8(20)) // 20 = StorageString
 	var nodict uint8 = 0
@@ -692,7 +728,7 @@ func (s *StorageString) Deserialize(f io.Reader) uint {
 		s.format = FormatRaw
 		return s.deserializeStringBody(f)
 	}
-	if formatByte > uint8(FormatOrderedDateTime) {
+	if formatByte > uint8(FormatDateTimeOffset) {
 		panic(fmt.Sprintf("StorageString: unknown format %d", formatByte))
 	}
 	s.format = StringFormat(formatByte)
@@ -703,6 +739,9 @@ func (s *StorageString) Deserialize(f io.Reader) uint {
 	if formatByte >= 11 && version < 2 {
 		panic("StorageString: ordered format requires version 2")
 	}
+	if formatByte >= 17 && version < 3 {
+		panic("StorageString: new format requires version 3")
+	}
 	switch version {
 	case 0:
 		return s.deserializeStringBody(f)
@@ -710,6 +749,8 @@ func (s *StorageString) Deserialize(f io.Reader) uint {
 		return s.deserializeStringV1(f)
 	case 2:
 		return s.deserializeStringV2(f)
+	case 3:
+		return s.deserializeStringV3(f)
 	default:
 		panic(fmt.Sprintf("StorageString: unknown version %d", version))
 	}
@@ -761,6 +802,8 @@ func (s *StorageString) deserializeStringV2(f io.Reader) uint {
 	return s.deserializeStringV1(f)
 }
 
+func (s *StorageString) deserializeStringV3(f io.Reader) uint { return s.deserializeStringV1(f) }
+
 func (s *StorageString) GetCachedReader() ColumnReader { return s.storageJITFunctions.reader(s) }
 
 func (s *StorageString) GetValue(i uint32) scm.Scmer {
@@ -810,7 +853,7 @@ func (s *StorageString) decodeAt(i uint32, dict string, dictBase unsafe.Pointer)
 		return scm.NewString(dict[byteStart : byteStart+lensVal])
 	case FormatHexLower, FormatHexUpper,
 		FormatPhone, FormatPhoneDTMF, FormatDecimal, FormatDateTime,
-		FormatOrderedHexLower, FormatOrderedHexUpper, FormatOrderedPhone, FormatOrderedPhoneDTMF, FormatOrderedDecimal, FormatOrderedDateTime:
+		FormatOrderedHexLower, FormatOrderedHexUpper, FormatOrderedPhone, FormatOrderedPhoneDTMF, FormatOrderedDecimal, FormatOrderedDateTime, FormatDateTimeZulu, FormatDateTimeOffset:
 		nibblePos := startVal
 		nibbleOff := uint8(nibblePos & 1)
 		byteOff := nibblePos >> 1
@@ -824,14 +867,14 @@ func (s *StorageString) decodeAt(i uint32, dict string, dictBase unsafe.Pointer)
 		byteOff := startVal
 		ptr := (*byte)(unsafe.Pointer(uintptr(dictBase) + uintptr(byteOff)))
 		return scm.NewCString(ptr, uint8(s.format), 0, 36)
-	case FormatBase64Upper, FormatBase64Lower:
+	case FormatBase64Upper, FormatBase64Lower, FormatRawBase64Std, FormatRawBase64URL:
 		byteOff := startVal
 		decodedLen := int(lensVal)
 		if decodedLen == 0 {
 			return scm.NewString("")
 		}
 		ptr := (*byte)(unsafe.Pointer(uintptr(dictBase) + uintptr(byteOff)))
-		return scm.NewBString(ptr, decodedLen, s.format == FormatBase64Lower)
+		return scm.NewBString(ptr, decodedLen, s.format == FormatBase64Lower || s.format == FormatRawBase64URL, s.format == FormatRawBase64Std || s.format == FormatRawBase64URL)
 	default:
 		return scm.NewNil()
 	}
@@ -955,17 +998,12 @@ func (s *StorageString) bulkDecoder() (outLen func(lensVal uint64) int, decode b
 				ptr := (*byte)(unsafe.Pointer(uintptr(dictBase) + uintptr(startVal)))
 				writeUUIDInto(dst, ptr, upper)
 			}, false
-	case FormatBase64Upper:
-		return func(lensVal uint64) int { return base64.StdEncoding.EncodedLen(int(lensVal)) },
+	case FormatBase64Upper, FormatBase64Lower, FormatRawBase64Std, FormatRawBase64URL:
+		enc := base64Encoding(s.format)
+		return func(lensVal uint64) int { return enc.EncodedLen(int(lensVal)) },
 			func(dst []byte, dictBase unsafe.Pointer, dict string, startVal, lensVal uint64) {
-				ptr := (*byte)(unsafe.Pointer(uintptr(dictBase) + uintptr(startVal)))
-				base64.StdEncoding.Encode(dst, unsafe.Slice(ptr, int(lensVal)))
-			}, false
-	case FormatBase64Lower:
-		return func(lensVal uint64) int { return base64.URLEncoding.EncodedLen(int(lensVal)) },
-			func(dst []byte, dictBase unsafe.Pointer, dict string, startVal, lensVal uint64) {
-				ptr := (*byte)(unsafe.Pointer(uintptr(dictBase) + uintptr(startVal)))
-				base64.URLEncoding.Encode(dst, unsafe.Slice(ptr, int(lensVal)))
+				ptr := (*byte)(unsafe.Add(dictBase, startVal))
+				enc.Encode(dst, unsafe.Slice(ptr, int(lensVal)))
 			}, false
 	default:
 		return nil, nil, true
@@ -1161,7 +1199,7 @@ func (s *StorageString) init(i uint32) {
 				switch s.format {
 				case FormatUUIDLower, FormatUUIDUpper:
 					// lens unused for UUID (always 16 bytes)
-				case FormatBase64Upper, FormatBase64Lower:
+				case FormatBase64Upper, FormatBase64Lower, FormatRawBase64Std, FormatRawBase64URL:
 					s.lens.build(e.idx, scm.NewInt(int64(compLen)))
 				}
 			}
@@ -1196,7 +1234,7 @@ func (s *StorageString) build(i uint32, value scm.Scmer) {
 			switch s.format {
 			case FormatUUIDLower, FormatUUIDUpper:
 				// lens unused for UUID (always 16 bytes)
-			case FormatBase64Upper, FormatBase64Lower:
+			case FormatBase64Upper, FormatBase64Lower, FormatRawBase64Std, FormatRawBase64URL:
 				s.lens.build(i, scm.NewInt(int64(compLen)))
 			default: // FormatRaw
 				s.lens.build(i, scm.NewInt(int64(len(v))))
@@ -1346,4 +1384,28 @@ func (s *StorageString) JITEmit(ctx *scm.JITContext, idx scm.JITValueDesc, resul
 	result.Type = d6.Type
 	return result
 	return result
+}
+
+var base64Formats = [...]struct {
+	format   StringFormat
+	encoding *base64.Encoding
+}{
+	{FormatBase64Upper, base64.StdEncoding.Strict()},
+	{FormatBase64Lower, base64.URLEncoding.Strict()},
+	{FormatRawBase64Std, base64.RawStdEncoding.Strict()},
+	{FormatRawBase64URL, base64.RawURLEncoding.Strict()},
+}
+
+func base64Encoding(format StringFormat) *base64.Encoding {
+	switch format {
+	case FormatBase64Upper:
+		return base64.StdEncoding
+	case FormatBase64Lower:
+		return base64.URLEncoding
+	case FormatRawBase64Std:
+		return base64.RawStdEncoding
+	case FormatRawBase64URL:
+		return base64.RawURLEncoding
+	}
+	panic("not a Base64 format")
 }

--- a/storage/storage-string_test.go
+++ b/storage/storage-string_test.go
@@ -19,7 +19,10 @@ package storage
 import "fmt"
 import "sync"
 import "bytes"
+import "unsafe"
+import "strings"
 import "testing"
+import "encoding/base64"
 import "encoding/binary"
 import "github.com/launix-de/memcp/scm"
 
@@ -715,4 +718,158 @@ func TestConcurrentReadAfterCompress(t *testing.T) {
 	for e := range errs {
 		t.Error(e)
 	}
+}
+
+// Arbitrary text resembling Base64 must never be normalized or panic at rebuild.
+func TestBase64ExactText(t *testing.T) {
+	for _, value := range []string{"", "Zh==", "Zm9=", "AA=A", "A===", "====", "Zg=", "Z", "Zg===", "Zg==\n", "Zh", "Zm9", "-_9=", "-_9", "Zg==", "Zm8=", "Zg", "Zm8"} {
+		t.Run(value, func(t *testing.T) {
+			c := buildStringColumn([]string{value})
+			if got := c.GetValue(0).String(); got != value {
+				t.Fatalf("got %q want %q", got, value)
+			}
+			var buf bytes.Buffer
+			c.Serialize(&buf)
+			var restored StorageString
+			restored.Deserialize(bytes.NewReader(buf.Bytes()[1:]))
+			if got := restored.GetValue(0).String(); got != value {
+				t.Fatalf("restored %q want %q", got, value)
+			}
+		})
+	}
+}
+
+func TestNewStringFormats(t *testing.T) {
+	for _, fixture := range []struct {
+		format StringFormat
+		values []string
+	}{
+		{FormatRawBase64Std, []string{"+w", "//8", "Zm9v", ""}},
+		{FormatRawBase64URL, []string{"-w", "__8", "Zm9v", ""}},
+		{FormatDateTimeZulu, []string{"2026-09-09 12:34:56.789Z", "2026-09-09T00:00:00Z", ""}},
+		{FormatDateTimeOffset, []string{"2026-09-09T12:34:56+02:00", "2026-09-09T00:00:00Z", ""}},
+	} {
+		for _, nodict := range []bool{false, true} {
+			values := fixture.values
+			if nodict {
+				values = make([]string, 128)
+				for i := range values {
+					switch fixture.format {
+					case FormatRawBase64Std:
+						values[i] = base64.RawStdEncoding.EncodeToString([]byte{251, byte(i)})
+					case FormatRawBase64URL:
+						values[i] = base64.RawURLEncoding.EncodeToString([]byte{251, byte(i)})
+					case FormatDateTimeZulu:
+						values[i] = fmt.Sprintf("2026-09-09 12:34:56.%03dZ", i)
+					case FormatDateTimeOffset:
+						values[i] = fmt.Sprintf("2026-09-09T12:34:56.%03d+02:00", i)
+					}
+				}
+			}
+			c := buildStringColumn(values)
+			if c.format != fixture.format || c.nodict != nodict {
+				t.Fatalf("format=%d nodict=%v want %d %v", c.format, c.nodict, fixture.format, nodict)
+			}
+			check := func(c *StorageString) {
+				for i, v := range values {
+					if got := c.GetValue(uint32(i)).String(); got != v {
+						t.Fatalf("got %q want %q", got, v)
+					}
+				}
+				verifyStringBulkAgainstGetValue(t, "new format", c, len(values))
+			}
+			check(c)
+			nullable := make([]scm.Scmer, len(values)+1)
+			for i, v := range values {
+				nullable[i] = scm.NewString(v)
+			}
+			nullable[len(values)] = scm.NewNil()
+			withNull := buildStorageString(nullable)
+			if withNull.format != fixture.format {
+				t.Fatal("NULL changed the selected format")
+			}
+			verifyStringBulkAgainstGetValue(t, "new format with NULL", withNull, len(nullable))
+			var buf bytes.Buffer
+			c.Serialize(&buf)
+			var restored StorageString
+			restored.Deserialize(bytes.NewReader(buf.Bytes()[1:]))
+			check(&restored)
+		}
+	}
+}
+
+func TestBase64ComparisonRepresentations(t *testing.T) {
+	texts := []string{strings.Repeat("a", 300), "Zh==", "Zm9=", "AA=A", "Zh", "", "AAAA", "aaaa", "++//", "--__", "Zg==", "Zg", "Zm8=", "Zm8", "KAAA", "kAAA", "SAAA", "sAAA", "AAAAZg==", "aaaaZg=="}
+	for _, tail := range []string{"Zg==", "Zh==", "Zm8=", "Zm9=", "Zg", "Zh"} {
+		texts = append(texts, strings.Repeat("AAAA", 70)+tail)
+	}
+	for _, at := range []int{0, 3, 4, 127, 128, 129, 2047} {
+		raw := strings.Repeat("x", 2048)
+		texts = append(texts, base64.StdEncoding.EncodeToString([]byte(raw[:at]+"y"+raw[at+1:])))
+	}
+	variants := func(s string) []scm.Scmer {
+		out := []scm.Scmer{scm.NewString(s)}
+		for _, f := range base64Formats {
+			if raw, err := f.encoding.DecodeString(s); err == nil && base64Encoding(f.format).EncodeToString(raw) == s {
+				out = append(out, scm.NewBString(unsafe.SliceData(raw), len(raw), f.format == FormatBase64Lower || f.format == FormatRawBase64URL, f.format == FormatRawBase64Std || f.format == FormatRawBase64URL))
+			}
+		}
+		return out
+	}
+	// Include mixed CString and Unicode strings, whose case folding can change byte length.
+	values := []scm.Scmer{comparisonCString(strings.Repeat("a", 300), FormatOrderedHexLower, 1), comparisonCString("aaaa", FormatOrderedHexLower, 1), scm.NewString("KAAA"), scm.NewString("ſAAA")}
+	for _, text := range texts {
+		values = append(values, variants(text)...)
+	}
+	for _, a := range values {
+		for _, b := range values {
+			ap, bp := scm.NewString(a.String()), scm.NewString(b.String())
+			for _, coll := range []string{"utf8_bin", "utf8_general_ci"} {
+				for _, name := range []string{"equal_collate", "notequal_collate"} {
+					fn := scm.Globalenv.Vars[scm.Symbol(name)].Func()
+					if fn(a, b, scm.NewString(coll)).Bool() != fn(ap, bp, scm.NewString(coll)).Bool() {
+						t.Fatalf("%s %s differs across representations: %q vs %q", name, coll, ap.String(), bp.String())
+					}
+				}
+			}
+			if scm.Equal(a, b) != scm.Equal(ap, bp) || scm.EqualSQL(a, b).Bool() != scm.EqualSQL(ap, bp).Bool() || scm.Less(a, b) != scm.Less(ap, bp) {
+				t.Fatalf("comparison mismatch %q/%d and %q/%d", ap.String(), a.GetTag(), bp.String(), b.GetTag())
+			}
+		}
+	}
+}
+
+func TestBase64PackedOrderBits(t *testing.T) {
+	for size := 1; size <= 9; size++ {
+		left := make([]byte, size)
+		for i := range left {
+			left[i] = byte(i*37 + 251)
+		}
+		for pos := range left {
+			for bit := 0; bit < 8; bit++ {
+				right := append([]byte(nil), left...)
+				right[pos] ^= 1 << bit
+				for _, url := range []bool{false, true} {
+					for _, raw := range []bool{false, true} {
+						a := scm.NewBString(unsafe.SliceData(left), len(left), url, raw)
+						b := scm.NewBString(unsafe.SliceData(right), len(right), url, raw)
+						if scm.Less(a, b) != (a.String() < b.String()) || scm.Less(b, a) != (b.String() < a.String()) {
+							t.Fatalf("size=%d pos=%d bit=%d url=%v raw=%v", size, pos, bit, url, raw)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestStringUUIDWithEmpty(t *testing.T) {
+	values := []string{"550e8400-e29b-41d4-a716-446655440000", ""}
+	c := buildStringColumn(values)
+	for i, want := range values {
+		if got := c.GetValue(uint32(i)).String(); got != want {
+			t.Fatalf("got %q want %q", got, want)
+		}
+	}
+	verifyStringBulkAgainstGetValue(t, "UUID with empty", c, len(values))
 }

--- a/tests/storage/formats/string-compression.yaml
+++ b/tests/storage/formats/string-compression.yaml
@@ -388,8 +388,104 @@ test_cases:
     threshold_ms: 200
     expect: {rows: 4096}
 
+  - name: "Exact Base64 text survives rebuild"
+    setup:
+      - sql: "DROP TABLE IF EXISTS sc_b64exact"
+      - sql: "CREATE TABLE sc_b64exact (id INT, val TEXT)"
+      - sql: "INSERT INTO sc_b64exact VALUES (1, 'Zh=='), (2, 'Zm9='), (3, 'AA=A')"
+      - scm: "(rebuild)"
+    sql: "SELECT id, val FROM sc_b64exact ORDER BY id"
+    expect: {data: [{id: 1, val: 'Zh=='}, {id: 2, val: 'Zm9='}, {id: 3, val: 'AA=A'}]}
+
+  - name: "SQL equality is independent of Base64 representation"
+    setup:
+      - sql: "DROP TABLE IF EXISTS sc_b64case"
+      - sql: "CREATE TABLE sc_b64case (id INT, val TEXT)"
+      - sql: "INSERT INTO sc_b64case VALUES (1, 'AAAA'), (2, 'aaaa')"
+      - scm: "(rebuild)"
+    sql: "SELECT a.val = b.val AS matched FROM sc_b64case a CROSS JOIN sc_b64case b"
+    expect: {data: [{matched: true}, {matched: true}, {matched: true}, {matched: true}]}
+
+  - name: "Binary collation respects Base64 case"
+    sql: "SELECT id, val COLLATE utf8mb4_bin = 'aaaa' AS matched FROM sc_b64case ORDER BY id"
+    expect: {data: [{id: 1, matched: false}, {id: 2, matched: true}]}
+
+  - name: "Binary collation respects CString case"
+    sql: "SELECT lo COLLATE utf8mb4_bin = up AS matched FROM sc_compare_cases WHERE id = 3"
+    expect: {data: [{matched: false}]}
+
+  - name: "UUIDs mixed with empty text rebuild losslessly"
+    setup:
+      - sql: "INSERT INTO sc_uuid VALUES (4, '')"
+      - scm: "(rebuild)"
+    sql: "SELECT id, val FROM sc_uuid WHERE id IN (1, 4) ORDER BY id"
+    expect: {data: [{id: 1, val: '550e8400-e29b-41d4-a716-446655440000'}, {id: 4, val: ''}]}
+
+  - name: "Unpadded Base64 roundtrip and operators"
+    setup:
+      - sql: "DROP TABLE IF EXISTS sc_b64raw"
+      - sql: "CREATE TABLE sc_b64raw (id INT, val TEXT)"
+      - sql: "INSERT INTO sc_b64raw VALUES (1, '-w'), (2, '__8'), (3, 'Zm8'), (4, '')"
+      - scm: "(rebuild)"
+    sql: "SELECT id, val, LENGTH(val) AS n, SUBSTRING(val, 1, 2) AS part FROM sc_b64raw ORDER BY id"
+    expect: {data: [{id: 1, val: '-w', n: 2, part: '-w'}, {id: 2, val: '__8', n: 3, part: '__'}, {id: 3, val: 'Zm8', n: 3, part: Zm}, {id: 4, val: '', n: 0, part: ''}]}
+
+  - name: "Standard Base64 decoder still rejects missing padding"
+    sql: "SELECT FROM_BASE64(val) FROM sc_b64raw WHERE id = 3"
+    expect: {error: true}
+
+  - name: "Standard Base64 decoder still rejects malformed padding"
+    sql: "SELECT FROM_BASE64(val) FROM sc_b64exact WHERE id = 3"
+    expect: {error: true}
+
+  - name: "New formats reload"
+    sql: "SHUTDOWN"
+    expect: {rows: 0}
+
+  - name: "Unpadded Base64 reload keeps spelling"
+    sql: "SELECT id, val FROM sc_b64raw ORDER BY id"
+    expect: {data: [{id: 1, val: '-w'}, {id: 2, val: '__8'}, {id: 3, val: Zm8}, {id: 4, val: ''}]}
+
+  - name: "Base64 comparison performance fixture"
+    setup:
+      - sql: "DROP TABLE IF EXISTS sc_b64perf"
+      - sql: "CREATE TABLE sc_b64perf (id INT, val TEXT, stamp TEXT)"
+      - scm: |
+          (insert (table "memcp-tests" "sc_b64perf") '("id" "val" "stamp")
+            (map (produceN 4096) (lambda (i)
+              (list i (base64_encode (concat (string_repeat "x" 1024) (string i)))
+                (concat "2026-09-09T12:34:56." (string i) "+02:00")))))
+      - scm: "(rebuild)"
+    sql: "SELECT COUNT(*) AS n FROM sc_b64perf"
+    expect: {data: [{n: 4096}]}
+
+  - name: "Base64 mixed early comparison projection"
+    sql: "SELECT id, val < '!AAA' AS matched FROM sc_b64perf"
+    warmup: 3
+    repetitions: 7
+    threshold_ms: 200
+    expect: {rows: 4096}
+
+  - name: "Base64 index sort"
+    sql: "SELECT id FROM sc_b64perf ORDER BY val LIMIT 100"
+    warmup: 3
+    repetitions: 7
+    threshold_ms: 200
+    expect: {rows: 100}
+
+  - name: "Timestamp compressed operator projection"
+    sql: "SELECT id, LENGTH(stamp) AS n, SUBSTRING(stamp, 1, 10) AS day, stamp LIKE '%+02:00' AS matched FROM sc_b64perf"
+    warmup: 3
+    repetitions: 7
+    threshold_ms: 200
+    expect: {rows: 4096}
+
   - name: "Cleanup"
     cleanup:
+      - sql: "DROP TABLE IF EXISTS sc_b64exact"
+      - sql: "DROP TABLE IF EXISTS sc_b64case"
+      - sql: "DROP TABLE IF EXISTS sc_b64raw"
+      - sql: "DROP TABLE IF EXISTS sc_b64perf"
       - sql: "DROP TABLE IF EXISTS sc_compare_cases"
       - sql: "DROP TABLE IF EXISTS sc_compare"
       - sql: "DROP TABLE IF EXISTS `sc_uuid`"


### PR DESCRIPTION
Base64 format detection could silently change stored text (`Zh==` → `Zg==`), accept malformed padding, or panic rebuilding UUID columns containing empty strings. This fixes exact round-tripping and compressed equality/collation semantics, adds lossless encodings for common payloads, and keeps comparisons on compressed data.

- Add permanent format IDs 17/18 for unpadded standard/URL Base64 and 19/20 for ordered timestamp alphabets (`Z`, fractional seconds, UTC offsets). StorageString version 3 retains every legacy/versioned reader and existing format assignment. Existing files stay readable; future rebuilds can select the new IDs.
- Extend BString metadata, dictionary/non-dictionary and bulk storage readers, serialization/reload, and shared string operators to these formats. Preserve Base64 alphabet/padding spelling and the public decoder's error behavior.
- Compare raw bytes for same-encoding BString binary equality and complete packed bytes for aligned CString equality, masking boundary nibbles. Long mixed binary equality strictly decodes only the counterpart's current block. Binary ordering and case-insensitive equality retain text semantics and stop at decisive prefixes.
- Use fused 16-bit + 8-bit loads / four fixed sextet operations for short mixed Base64 comparisons; keep tails outside the loop and use the faster chunk path for longer values. Fix explicit binary collations and SQL case folding across compressed representations.

Manual A/B against master `2c3f45274` (benchmark baseline `1d7cd1bfd`, identical source except README), Ryzen 9 7900X3D, same fixtures:

| Measurement | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| 4096 BString binary sort | 12.488 ms | 3.602 ms | −71.2% |
| 2048-byte early binary equality BString/String | 3010 ns | 34.05 ns | −98.9% |
| 2048-byte late binary equality BString/String | 2862.5 ns | 2414 ns | −15.7% |
| 2048-byte late binary ordering BString/BString | 4951 ns | 496.45 ns | −90.0% |
| Focused late CString/String binary equality | 56.855 ns | 49.865 ns | −12.3% |

Operator sweep: stock Go 1.24, CPU 2, GOMAXPROCS=1, ABBA, two 200 ms samples/version with Go iteration calibration. Focused CString control: CPU 9, otherwise identical, 1 second/sample. Candidate Base64 comparisons allocate zero bytes; sort allocations fall from ~13 MB / 204741 to 88 B / 3 per iteration. The shared host was busy; the full report includes noisy regressions and their focused follow-ups rather than treating small changes as conclusive.

Manual SQL A/B: JIT toolchain `84fe25ee`, CPUs 0–3, GOMAXPROCS=4, identical 4096-row rebuilt fixtures, two isolated servers, 5 warmups/query/version, 32 samples/version interleaved A/B/B/A. Median client wall times:

| Query | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| CString equality projection | 4.810 ms | 4.893 ms | +1.7% |
| Base64 early comparison projection | 8.388 ms | 8.342 ms | −0.5% |
| Cached Base64 ORDER BY LIMIT | 0.495 ms | 0.479 ms | −3.3% |
| Timestamp operators | 8.737 ms | 8.953 ms | +2.5% |

All eight SQL controls range from −3.3% to +2.5%. Bulk readers still materialize many SQL operands, and repeated ORDER BY reuses an index, so direct operator gains do not imply equivalent end-to-end query gains. EXPLAIN, IR, PHYSICAL and REORDER confirm the projection/ordered-scan paths.

Dictionary payload (8 distinct entries): raw Base64 176 → 128 B and 21848 → 16384 B; timestamp 232 → 116 B. Build costs can increase: the short raw-Base64 fixture measured +32% while gaining compression. This excludes column metadata and outer compression.

Loop experiments and all manual tables, including the initial noisy suite-level ABBA, are in [storage/base64-string-formats.md](storage/base64-string-formats.md). The short SQL equality fused-loop experiment improved 48.01 → 32.355 ns (−32.6%); its long-value regression motivated the hybrid cutoff. Strict-decoding equality improved the long all-fused prototype from 1722.5 → 1551 ns (−10.0%); short mixed values retain their faster loop.

Validation: 169 targeted SQL cases pass, including rebuild/restart, invalid Base64 and public-decoder must-fail cases. Targeted Go storage/comparison/operator tests, old CString disk fixtures, race checks, and JIT compressed-text/representation tests pass. Full suite and performance gates run in CI per repository workflow.
