### PR TITLE
Mount PHP apps from Scheme and route authenticated local PDO connections

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -15,6 +15,9 @@ on:
       relevant:
         description: "'true' unless the change set is documentation-only"
         value: ${{ jobs.detect.outputs.relevant }}
+      php:
+        description: "'true' for PHP integration or shared frontend/build changes"
+        value: ${{ jobs.detect.outputs.php }}
 
 permissions:
   contents: read
@@ -25,6 +28,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
+      php: ${{ steps.filter.outputs.php }}
     steps:
       - name: Classify changed files
         id: filter
@@ -35,7 +39,7 @@ jobs:
           set -euo pipefail
 
           # Any uncertainty about the diff errs on the side of running CI.
-          emit() { echo "relevant=$1" >> "$GITHUB_OUTPUT"; exit 0; }
+          emit() { echo "relevant=$1" >> "$GITHUB_OUTPUT"; echo "php=${2:-$1}" >> "$GITHUB_OUTPUT"; exit 0; }
 
           case "${GITHUB_EVENT_NAME}" in
             pull_request|pull_request_target)
@@ -60,7 +64,7 @@ jobs:
             echo "Compare API unavailable; running the full CI." >&2; emit true
           fi
 
-          mapfile -t files < <(jq -r '.files[]?.filename' <<<"${compare}")
+          mapfile -t files < <(jq -r '.files[]? | .filename, (.previous_filename // empty)' <<<"${compare}")
           nfiles="${#files[@]}"
 
           # The compare response lists at most 300 files. Anything at or above
@@ -75,14 +79,19 @@ jobs:
           printf 'changed: %s\n' "${files[@]}" >&2
 
           relevant=false
+          php=false
           for f in "${files[@]}"; do
             case "${f}" in
-              tests/*|scm/*|storage/*|lib/*|tools/*|apps/*|corelib/*|packaging/*|debian/*|.github/*) relevant=true ;;
+              phpbridge/*|tests/*|scm/*|storage/*|lib/*|tools/*|apps/*|corelib/*|packaging/*|debian/*|.github/*) relevant=true ;;
               *.go|go.mod|go.sum|Makefile|Dockerfile|memcp.spec|memcp.service|git-pre-commit) relevant=true ;;
               run_sql_tests.py|run_tests_unbuffered.py|CHANGELOG.md) relevant=true ;;
             esac
-            [ "${relevant}" = true ] && break
+            case "${f}" in
+              phpbridge/*|tests/php/*|php*.go|main.go|go.mod|go.sum|Makefile) php=true ;;
+              scm/network.go|scm/mysql.go|scm/session*.go|lib/main.scm|lib/sql.scm) php=true ;;
+              .github/workflows/php.yml|.github/workflows/test.yml|.github/workflows/detect-changes.yml) php=true ;;
+            esac
           done
 
           echo "Relevant paths changed: ${relevant}" | tee -a "$GITHUB_STEP_SUMMARY" >&2
-          emit "${relevant}"
+          emit "${relevant}" "${php}"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 name: PHP integration
 on:
-  pull_request:
-    branches: [master]
-  push:
-    branches: [master]
+  workflow_call:
 jobs:
   php:
     runs-on: ubuntu-latest
@@ -29,7 +26,7 @@ jobs:
           ./configure --prefix="$RUNNER_TEMP/php-zts" \
             --disable-all --enable-cli --enable-embed=shared --enable-zts \
             --disable-zend-signals --enable-zend-max-execution-timers \
-            --enable-pdo --with-pdo-sqlite --enable-session
+            --enable-pdo --with-pdo-sqlite --with-pdo-mysql=mysqlnd --enable-mysqlnd --enable-session
           make -j2
           make install
       - name: Test embedded PHP and PDO coexistence

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,11 @@ jobs:
           --mariadb-port=3306
           --mysqldump=mariadb-dump
 
+  php:
+    needs: [changes, test]
+    if: ${{ needs.changes.outputs.php == 'true' }}
+    uses: ./.github/workflows/php.yml
+
   packaging:
     needs: [changes, test]
     if: ${{ needs.changes.outputs.relevant == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ php:
 test-php: php
 	CGO_ENABLED=1 CGO_CFLAGS="$$($(PHP_CONFIG) --includes)" \
 		CGO_LDFLAGS="-L$$($(PHP_CONFIG) --prefix)/lib -Wl,-rpath,$$($(PHP_CONFIG) --prefix)/lib $$($(PHP_CONFIG) --ldflags) $$($(PHP_CONFIG) --libs)" \
-		go test -tags=php,nowatcher,nobrotli,nomercure -run TestPHP -count=1 -v .
+		go test -tags=php,nowatcher,nobrotli,nomercure -run 'TestPHP|TestResultBuffer' -count=1 -v . ./phpbridge
 
 # Keep the experimental compiler outside the tracked source tree. Clean
 # checkouts fast-forward on every invocation, while a checkout with local

--- a/README-PHP.md
+++ b/README-PHP.md
@@ -4,7 +4,7 @@
 
 MemCP can optionally host PHP applications in its own process using the
 versioned FrankenPHP Go library. The host is application-independent: choose
-an application's document root, listen address, thread count, and optional
+an application's document root, URL mount, thread count, and optional
 front controller. WordPress is one example; other PHP applications can use the
 same host and their usual PHP extensions.
 
@@ -34,21 +34,50 @@ PHP build requirements. The shared Go module graph now requires Go 1.26 due
 to FrankenPHP. The PHP build disables optional Watcher, Brotli and Mercure
 features; no Caddy dependency is added.
 
-## Serve an application
+## Mount applications from Scheme
+
+`servePHP` returns a `(req res)` handler, just like `serveStatic`. It creates no
+listener. Mount any number of applications in the existing Scheme HTTP router;
+all mounts share the process-wide FrankenPHP thread pool.
+
+For example, place this in a Scheme module loaded after `lib/main.scm`:
+
+```scheme
+(define blog (servePHP "/srv/blog/public" "/blog" "index.php"))
+(define wiki (servePHP "/srv/wiki" "/wiki" "index.php"))
+(define http_handler (begin
+    (define previous http_handler)
+    (lambda (req res)
+        (match (req "path")
+            (regex "^/blog(/|$)" _ _) (blog req res)
+            (regex "^/wiki(/|$)" _ _) (wiki req res)
+            _ (previous req res)))))
+```
 
 ```sh
 ./memcp-php --no-repl -data /path/to/persistent/memcp-data \
-  --php-root=/path/to/application/public \
-  --php-listen=127.0.0.1:8080 --php-threads=4 \
-  --php-front-controller=index.php lib/main.scm
+  --api-port=8080 --php-threads=4 lib/main.scm /path/to/apps.scm
 ```
 
-Use the application's actual public directory. Without `--php-front-controller`,
-missing files return 404. Existing directories use `index.php` or `index.html`; PHP `PATH_INFO` is supported. Static files
-are served from the document root. Dotfiles, PHP source backups, and symlinks
-outside the root are rejected. The PHP listener is separate from the SQL API;
-it binds to loopback by default. Configure an HTTPS reverse proxy when exposing
-it remotely. SIGTERM/SIGINT drains PHP before shutting down storage.
+The arguments are document root, optional URL prefix, and optional fallback PHP
+filename. Relative roots resolve against the importing Scheme file. An empty
+prefix mounts at `/`; without a fallback, missing files return 404. For an
+independent listener, explicitly call `(serve port app_handler)` from Scheme,
+using the same HTTP machinery as every other handler. Its optional third
+argument binds an address, e.g. `(serve 8080 app_handler "127.0.0.1")`.
+The former
+`--php-root`, `--php-listen` and `--php-front-controller` options are removed.
+
+PHP receives the original request URI, query, body, cookies and headers;
+`SCRIPT_NAME` and `PHP_SELF` include the mount prefix, while script lookup stays
+inside the configured document root. Existing directories use `index.php` or
+`index.html`, and PHP `PATH_INFO` is supported. Static assets remain within the
+root; dotfiles, PHP source backups and escaping symlinks are rejected. Routing
+and HTTP authentication can run in Scheme before invoking the PHP handler.
+
+The shared PHP runtime starts lazily after Scheme bootstrap, on its first
+request. `--php-threads` configures its fixed thread count. SIGTERM/SIGINT drains
+the Scheme HTTP servers before shutting down PHP and storage.
 
 The host uses classic PHP request lifecycles. Request globals and ordinary
 objects are released after each request; OPcache stays warm. Long-lived PHP
@@ -80,12 +109,39 @@ hex literals. They do not yet provide native parameter binding or persistent
 connections; unsupported modes fail explicitly. Values retain MemCP's runtime
 numeric types (an integral SQL literal may be a PHP float).
 
-Results are buffered with a 64 MiB limit per result and copied into C-owned
-memory in one batch. Strings retain arbitrary bytes. Use SQL pagination for
-larger results. SQL execution has a 30-second timeout. Connections have separate
-sessions, appear in the process list, and roll back unfinished transactions on
-close. PDO teardown also runs after PHP exceptions. This is an initial driver,
-not a claim of compatibility with every framework-specific PDO attribute.
+### Result callbacks and sessions
+
+Every `new PDO('memcp:...', user, password)` authenticates against `mysql_auth`
+before a connection handle is created. An HTTP login or PHP session does not
+bypass this check. Database existence is checked separately, and every query
+uses the existing SQL permission checks for that authenticated username.
+
+Each PDO connection owns a separate Scheme session initialized with `username`
+and `schema`, plus a registered `SessionState`. Neither is borrowed from the
+HTTP request's `__session` or from PHP's `$_SESSION`. Transactions, connection
+variables and insert IDs therefore belong to the PDO connection. Persistent
+PDO connections are not supported.
+
+The Go bridge creates stable row/metadata callback closures when the connection
+is opened and wraps them with `scm.NewFunc`. On each query it calls the existing
+Scheme `mysql_handler` with `(schema, sql, resultrow_sql, resultfields_sql,
+connection_session, session_state, query_sequence)`. SQL result execution calls
+these supplied closures; no global result handler is replaced.
+
+A connection mutex serializes query/close. The result collector has a separate
+mutex because storage workers may invoke the row callback concurrently. The
+synchronous SQL call completes its workers before the collector is copied and
+reset. Reusable cell/byte buffers are each bounded to 64 KiB of retained capacity;
+larger buffers are released after the query. Metadata keys are cleared between
+queries. Rows are written directly into the collector's flat cell array.
+
+Results are limited to 64 MiB and copied into independent C-owned memory in one
+batch. Existing PDO statements retain their own data when another query reuses
+the collector; fetching rows never calls back into Go. Strings preserve arbitrary
+bytes. Use SQL pagination for larger results. The 30-second query timeout,
+process-list tracking, cancellation and transaction handling remain active.
+Closing a connection rolls back unfinished transactions, releases its locks and
+unregisters its session, including during request teardown after PHP exceptions.
 
 Applications or ORMs that recognize only specific PDO driver names may need a
 MemCP/MySQL-dialect adapter. Applications using `mysqli`, including unmodified
@@ -95,20 +151,23 @@ A native PDO driver alone cannot transparently replace `mysqli`.
 
 ## Verification
 
-Install `pdo_sqlite` alongside PDO in the ZTS build, then run:
+Install `pdo_sqlite` and `pdo_mysql` alongside PDO in the ZTS build, then run:
 
 ```sh
 make test-php PHP_CONFIG=/path/to/php-zts/bin/php-config
-make test
 ```
 
 `test-php` creates a disposable server and database. It checks ZTS/OPcache,
-coexistence with SQLite, authentication failures, binary parameters, request
-teardown rollback, independent parallel requests, and HTTP file boundaries.
+coexistence with MySQL wire and SQLite, authentication failures, binary
+parameters, request teardown rollback, independent parallel requests, and HTTP
+file boundaries. It also checks multiple Scheme mounts, POST/cookies/headers,
+independent statement buffers and concurrent result callbacks. Full SQL tests
+run in CI; the PHP job depends on the successful SQL job and a PHP-related path
+guard.
 It contains only our own PHP test fixtures and does not download applications.
 
 For a WordPress demonstration, download WordPress and WP-CLI into a directory
 outside the checkout. Configure a dedicated persistent MemCP database and
-Unix socket in `wp-config.php`, set the PHP document root to the WordPress
-directory, and run the normal WordPress installer. Keep credentials, uploaded
-files, and the MemCP data directory outside the source tree.
+Unix socket in `wp-config.php`, mount the WordPress directory with `servePHP`
+in a Scheme module, and run the normal WordPress installer. Keep credentials,
+uploaded files, and the MemCP data directory outside the source tree.

--- a/README-PHP.md
+++ b/README-PHP.md
@@ -36,6 +36,19 @@ features; no Caddy dependency is added.
 
 ## Mount applications from Scheme
 
+For a single application, the standard Scheme bootstrap accepts a document root
+relative to the current working directory (or an absolute path):
+
+```sh
+./memcp-php --serve /srv/my-app/public --api-port=8080 --mysql-port=3307
+```
+
+`--serve=PATH` is equivalent. `lib/main.scm` installs the PHP folder at `/`
+with `index.php` as front controller, below the existing SQL/dashboard/RDF
+handlers. `/dashboard`, its API/WebSocket routes, and the SQL API remain
+available with their normal authentication. No application-specific Scheme
+module is needed for this mode.
+
 `servePHP` returns a `(req res)` handler, just like `serveStatic`. It creates no
 listener. Mount any number of applications in the existing Scheme HTTP router;
 all mounts share the process-wide FrankenPHP thread pool.
@@ -86,14 +99,30 @@ crashes affect the entire process, including MemCP.
 
 ## PDO connections
 
-The addon registers **only `memcp:`**. It neither replaces `PDO` nor intercepts
-other DSNs. Existing driver extensions continue to resolve their own schemes:
+The addon registers **only `memcp:`** and leaves other driver registrations
+intact. It also routes a narrow set of local MySQL DSNs at base `PDO` connection
+construction, before the original constructor selects a driver:
 
 ```php
 $local = new PDO('memcp:dbname=shop', $user, $password);
 $mysql = new PDO('mysql:host=db.example;dbname=shop', $user, $password);
 $sqlite = new PDO('sqlite:/path/to/cache.sqlite');
 ```
+
+A base `new PDO(...)` or `PDO::connect(...)` using
+`mysql:host=127.0.0.1;port=3307;dbname=shop` automatically selects the RAM path
+if 3307 is this process's successfully started, Scheme-registered MySQL port.
+The exact hostname `localhost` also matches. Host, port and database must all
+be explicit; optional `charset=utf8mb4` or `charset=utf8` is accepted.
+The resulting PDO driver name is `memcp`, and the same username/password
+authentication applies. The caller's DSN string is preserved.
+
+Other hosts/ports, Unix sockets, omitted/ambiguous DSN fields, other charsets,
+driver-specific options, timeouts, native-prepare requests and persistent connections
+retain native PDO behavior. PDO subclasses (including `Pdo\Mysql`) retain
+their original behavior too. The constructor dispatch is installed once during
+PHP module initialization, before request threads start; no handler pointers
+change while requests execute. No external source is patched.
 
 Create the MemCP database and account using the existing SQL administration
 interface before connecting. Authentication uses MemCP's user catalog, and
@@ -147,7 +176,10 @@ Applications or ORMs that recognize only specific PDO driver names may need a
 MemCP/MySQL-dialect adapter. Applications using `mysqli`, including unmodified
 WordPress, can instead use MemCP's existing MySQL TCP/Unix socket frontend.
 That path uses the MySQL protocol even though PHP runs in the same process.
-A native PDO driver alone cannot transparently replace `mysqli`.
+The normal MySQL host/port/username/password installer fields work with this
+wire frontend; neither application needs a MemCP-specific DSN. PDO constructor
+routing does **not** accelerate `mysqli`: that additionally requires integration
+with mysqlnd.
 
 ## Verification
 

--- a/lib/main.scm
+++ b/lib/main.scm
@@ -22,13 +22,24 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 (set static_files (serveStatic "../assets"))
 
+/* Install the application below the SQL/dashboard/RDF wrappers. CLI paths
+resolve against the process working directory, not this module's lib/ folder. */
+(define cli_php_root (arg "serve" nil))
+(define cli_php_handler (if (nil? cli_php_root) nil (begin
+	(if (or (not (string? cli_php_root)) (equal? cli_php_root ""))
+		(error "--serve requires a directory path"))
+	(servePHP (if (equal? (substr cli_php_root 0 1) "/")
+		cli_php_root (concat __CWD__ "/" cli_php_root)) "" "index.php")
+)))
+
 /* this can be overhooked */
 (define http_handler (lambda (req res) (begin
 	(print "request " req)
-	(if (equal? (req "path") "/") (begin
-		((res "header") "Location" "/dashboard")
-		((res "status") 301)
-	) (static_files req res))
+	(if (not (nil? cli_php_handler)) (cli_php_handler req res)
+		(if (equal? (req "path") "/") (begin
+			((res "header") "Location" "/dashboard")
+			((res "status") 301)
+		) (static_files req res)))
 	/*
 	((res "header") "Content-Type" "text/plain")
 	((res "status") 404)

--- a/main.go
+++ b/main.go
@@ -590,6 +590,7 @@ func getImport(path string) func(a ...scm.Scmer) scm.Scmer {
 				"watch":       scm.NewFunc(getWatch(wd)),
 				"readfile":    scm.NewFunc(getReadfile(wd)),
 				"serveStatic": scm.NewFunc(scm.HTTPStaticGetter(wd)),
+				"servePHP":    scm.NewFunc(getServePHP(wd)),
 			},
 			VarsNumbered: nil,
 			Outer:        &IOEnv,
@@ -874,6 +875,7 @@ func setupIO(wd string) {
 			Params: []*scm.TypeDescriptor{
 				{Kind: "number", Label: "port", Description: "port number for HTTP server"},
 				{Kind: "func", Label: "handler", Description: "handler that processes each HTTP request", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "req", Description: "HTTP request object"}, {Kind: "any", Label: "res", Description: "HTTP response object"}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "handler result"}},
+				{Kind: "string", Label: "host", Description: "optional bind address; defaults to all interfaces", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
@@ -900,6 +902,25 @@ func setupIO(wd string) {
 				{Kind: "string", Label: "directory", Description: "folder with the files to serve"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "func", Label: "handler", Description: "HTTP handler that serves files from the configured directory",
+				Params: []*scm.TypeDescriptor{
+					{Kind: "any", Label: "req", Description: "HTTP request object"},
+					{Kind: "any", Label: "res", Description: "HTTP response object"},
+				},
+				Return: &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "handler result"},
+			},
+		},
+	})
+	scm.Declare(&IOEnv, &scm.Declaration{
+		Name: "servePHP",
+
+		Fn: getServePHP(wd),
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a PHP HTTP handler for use with serve", HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", Label: "directory", Description: "application document root, relative to this Scheme file"},
+				{Kind: "string", Label: "prefix", Description: "URL mount prefix", Optional: true},
+				{Kind: "string", Label: "front_controller", Description: "optional fallback PHP script", Optional: true},
+			},
+			Return: &scm.TypeDescriptor{Kind: "func", Label: "handler", Description: "HTTP handler that serves PHP and static files from the configured directory",
 				Params: []*scm.TypeDescriptor{
 					{Kind: "any", Label: "req", Description: "HTTP request object"},
 					{Kind: "any", Label: "res", Description: "HTTP response object"},
@@ -1215,11 +1236,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  --mysql-socket=PATH    Unix socket path (default /tmp/memcp.sock, empty to disable)\n")
 		fmt.Fprintf(os.Stderr, "  --root-password-file=PATH  Read the initial root password from a file\n")
 		fmt.Fprintf(os.Stderr, "  --disable-mysql        Disable MySQL protocol server\n")
-		fmt.Fprintf(os.Stderr, "\nOptional PHP host (make php):\n")
-		fmt.Fprintf(os.Stderr, "  --php-root=PATH        Application document root\n")
-		fmt.Fprintf(os.Stderr, "  --php-listen=ADDRESS   HTTP listen address (default 127.0.0.1:8080)\n")
 		fmt.Fprintf(os.Stderr, "  --php-threads=N        PHP threads (default 4)\n")
-		fmt.Fprintf(os.Stderr, "  --php-front-controller=FILE  Optional fallback PHP script\n")
 		fmt.Fprintf(os.Stderr, "... and much more (please refer to your module's documentation)\n\n")
 	}
 
@@ -1445,9 +1462,9 @@ func cronroutine() {
 
 func exitroutine() {
 	exitOnce.Do(func() {
-		stopPHP()
 		drainSecs := storage.Settings.ShutdownDrainSeconds
 		scm.ShutdownServers(drainSecs)
+		stopPHP()
 		exitsignal <- true
 		exitable.Wait()
 		fmt.Println("Exit procedure...")

--- a/main.go
+++ b/main.go
@@ -725,9 +725,13 @@ func (i *arrayFlags) Set(value string) error {
 }
 
 func setupIO(wd string) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
 	// define some IO functions (scm will not provide them since it is sandboxable)
 	IOEnv = scm.Env{
-		Vars:         scm.Vars{},
+		Vars:         scm.Vars{"__CWD__": scm.NewString(cwd)},
 		VarsNumbered: nil,
 		Outer:        &scm.Globalenv,
 		Nodefine:     true, // other defines go into Globalenv
@@ -1236,6 +1240,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  --mysql-socket=PATH    Unix socket path (default /tmp/memcp.sock, empty to disable)\n")
 		fmt.Fprintf(os.Stderr, "  --root-password-file=PATH  Read the initial root password from a file\n")
 		fmt.Fprintf(os.Stderr, "  --disable-mysql        Disable MySQL protocol server\n")
+		fmt.Fprintf(os.Stderr, "  --serve PATH           Mount a PHP application at /; keep /dashboard (make php)\n")
 		fmt.Fprintf(os.Stderr, "  --php-threads=N        PHP threads (default 4)\n")
 		fmt.Fprintf(os.Stderr, "... and much more (please refer to your module's documentation)\n\n")
 	}
@@ -1267,6 +1272,12 @@ func main() {
 		} else if len(arg) > 2 && arg[:2] == "--" {
 			// This is a long flag for Scheme - don't treat as import file
 			schemeArgs = append(schemeArgs, arg)
+			// Preserve the separate PATH token for Scheme, not as an import.
+			// lib/main.scm owns validation and mounting.
+			if arg == "--serve" && i+2 < len(os.Args) && !strings.HasPrefix(os.Args[i+2], "-") {
+				schemeArgs = append(schemeArgs, os.Args[i+2])
+				skipNext = true
+			}
 		} else if len(arg) > 1 && arg[0] == '-' {
 			// This looks like a short flag but we don't recognize it - also for Scheme
 			schemeArgs = append(schemeArgs, arg)

--- a/php.go
+++ b/php.go
@@ -7,121 +7,150 @@ package main
 
 import "os"
 import "fmt"
-import "net"
 import "sync"
-import "time"
-import "context"
+import "path"
 import "strconv"
 import "strings"
 import "net/http"
 import "path/filepath"
 import "github.com/dunglas/frankenphp"
+import "github.com/launix-de/memcp/scm"
 import "github.com/launix-de/memcp/phpbridge"
 
-var phpServer *http.Server
 var phpLifecycle sync.Mutex
+var phpReady = make(chan struct{})
+var phpThreads = 4
+var phpStarted, phpStopping bool
+var phpInitErr error
 
+// HTTP listeners belong to Scheme's serve. This only publishes PHP settings
+// after Scheme initialization; the first PHP request starts the shared runtime.
 func startPHP(args []string) error {
-	phpLifecycle.Lock()
-	defer phpLifecycle.Unlock()
-	root, listen, front := "", "127.0.0.1:8080", ""
-	threads := 4
 	for _, arg := range args {
 		if !strings.HasPrefix(arg, "--php-") {
 			continue
 		}
 		key, value, ok := strings.Cut(arg, "=")
-		if !ok {
-			return fmt.Errorf("use %s=value", key)
+		if !ok || key != "--php-threads" {
+			return fmt.Errorf("%s is not supported; mount (servePHP directory prefix front_controller) in a Scheme HTTP handler", key)
 		}
-		switch key {
-		case "--php-root":
-			root = value
-		case "--php-listen":
-			listen = value
-		case "--php-front-controller":
-			front = value
-		case "--php-threads":
-			n, err := strconv.Atoi(value)
-			if err != nil || n < 1 {
-				return fmt.Errorf("php-threads must be positive")
-			}
-			threads = n
-		default:
-			return fmt.Errorf("unknown PHP option %s", key)
+		n, err := strconv.Atoi(value)
+		if err != nil || n < 1 {
+			return fmt.Errorf("php-threads must be positive")
 		}
+		phpThreads = n
 	}
-	if root == "" {
-		for _, arg := range args {
-			if strings.HasPrefix(arg, "--php-") {
-				return fmt.Errorf("--php-root is required")
-			}
-		}
-		return nil
+	close(phpReady)
+	return nil
+}
+
+func ensurePHP() error {
+	phpLifecycle.Lock()
+	defer phpLifecycle.Unlock()
+	if phpStopping {
+		return fmt.Errorf("PHP is shutting down")
 	}
-	abs, err := filepath.Abs(root)
-	if err != nil {
-		return err
-	}
-	abs, err = filepath.EvalSymlinks(abs)
-	if err != nil {
-		return err
-	}
-	info, err := os.Stat(abs)
-	if err != nil {
-		return err
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("PHP root is not a directory")
-	}
-	if front != "" && (filepath.Base(front) != front || !strings.HasSuffix(front, ".php")) {
-		return fmt.Errorf("PHP front controller must be a PHP filename inside the document root")
-	}
-	listener, err := net.Listen("tcp", listen)
-	if err != nil {
-		return err
+	if phpStarted || phpInitErr != nil {
+		return phpInitErr
 	}
 	if err := phpbridge.Register(&IOEnv); err != nil {
-		listener.Close()
+		phpInitErr = err
 		return err
 	}
-	if err = frankenphp.Init(frankenphp.WithNumThreads(threads), frankenphp.WithMaxThreads(threads), frankenphp.WithPhpIni(map[string]string{
+	if err := frankenphp.Init(frankenphp.WithNumThreads(phpThreads), frankenphp.WithMaxThreads(phpThreads), frankenphp.WithPhpIni(map[string]string{
 		"expose_php": "0", "display_errors": "0", "log_errors": "1", "opcache.enable": "1",
 	})); err != nil {
-		listener.Close()
+		phpInitErr = err
 		return err
 	}
-	phpServer = &http.Server{Handler: phpHandler(abs, front), ReadHeaderTimeout: 10 * time.Second}
-	server := phpServer
-	go func() {
-		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			fmt.Fprintln(os.Stderr, "PHP server:", err)
-		}
-	}()
-	fmt.Printf("PHP serving %s at http://%s (%d threads)\n", abs, listener.Addr(), threads)
+	phpStarted = true
 	return nil
 }
 
 func stopPHP() {
 	phpLifecycle.Lock()
 	defer phpLifecycle.Unlock()
-	if phpServer == nil {
-		return
+	phpStopping = true
+	if phpStarted {
+		frankenphp.Shutdown()
+		phpStarted = false
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if err := phpServer.Shutdown(ctx); err != nil {
-		phpServer.Close()
+}
+
+// Like serveStatic, relative document roots resolve against the importing SCM
+// file. Each returned handler has its own root/mount; PHP threads are shared.
+func getServePHP(wd string) func(...scm.Scmer) scm.Scmer {
+	return func(a ...scm.Scmer) scm.Scmer {
+		root := a[0].String()
+		if !filepath.IsAbs(root) {
+			root = filepath.Join(wd, root)
+		}
+		root, err := filepath.Abs(root)
+		if err != nil {
+			panic(err)
+		}
+		root, err = filepath.EvalSymlinks(root)
+		if err != nil {
+			panic(err)
+		}
+		info, err := os.Stat(root)
+		if err != nil || !info.IsDir() {
+			panic("PHP root must be a directory")
+		}
+		mount, front := "", ""
+		if len(a) > 1 {
+			mount = strings.TrimSuffix(a[1].String(), "/")
+		}
+		if len(a) > 2 {
+			front = a[2].String()
+		}
+		if mount != "" && (!strings.HasPrefix(mount, "/") || path.Clean(mount) != mount || strings.ContainsAny(mount, "?\\#")) {
+			panic("PHP mount must be an absolute URL path prefix")
+		}
+		if front != "" && (filepath.Base(front) != front || !strings.HasSuffix(front, ".php")) {
+			panic("PHP front controller must be a PHP filename inside the document root")
+		}
+		handler := phpHandler(root, front, mount)
+		return scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
+			req := scm.Apply(a[0], scm.NewString("req")).Any().(*http.Request)
+			res := scm.Apply(a[1], scm.NewString("res")).Any().(http.ResponseWriter)
+			select {
+			case <-phpReady:
+			case <-req.Context().Done():
+				return scm.NewNil()
+			}
+			if err := ensurePHP(); err != nil {
+				panic(err)
+			}
+			res.Header().Del("Content-Type")
+			handler.ServeHTTP(res, req)
+			return scm.NewNil()
+		})
 	}
-	frankenphp.Shutdown()
-	phpServer = nil
 }
 
 // PHP gets only existing script paths. Static files stay inside the resolved
 // document root; dotfiles and PHP configuration/source backups are not served.
-func phpHandler(root, front string) http.Handler {
+func phpHandler(root, front, mount string) http.Handler {
 	files := http.FileServer(http.Dir(root))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		original := r
+		if mount != "" {
+			if r.URL.Path == mount {
+				u := *r.URL
+				u.Path += "/"
+				http.Redirect(w, r, u.String(), http.StatusMovedPermanently)
+				return
+			}
+			if !strings.HasPrefix(r.URL.Path, mount+"/") {
+				http.NotFound(w, r)
+				return
+			}
+			r = r.Clone(r.Context())
+			r.URL.Path = strings.TrimPrefix(r.URL.Path, mount)
+			r.URL.RawPath = ""
+		}
+
 		for _, part := range strings.Split(r.URL.Path, "/") {
 			if strings.HasPrefix(part, ".") || strings.Contains(part, "\\") {
 				http.NotFound(w, r)
@@ -142,7 +171,7 @@ func phpHandler(root, front string) http.Handler {
 		if err == nil && info.IsDir() {
 			if !strings.HasSuffix(requestPath, "/") {
 				u := *r.URL
-				u.Path += "/"
+				u.Path = mount + u.Path + "/"
 				http.Redirect(w, r, u.String(), http.StatusMovedPermanently)
 				return
 			}
@@ -179,16 +208,22 @@ func phpHandler(root, front string) http.Handler {
 			files.ServeHTTP(w, r)
 			return
 		}
-		original := r
 		r = r.Clone(r.Context())
 		r.URL.Path = requestPath
+		r.URL.RawPath = ""
 		// CGI maps '-' to '_'; drop ambiguous header spellings before the SAPI.
 		for name := range r.Header {
 			if strings.Contains(name, "_") {
 				r.Header.Del(name)
 			}
 		}
-		request, err := frankenphp.NewRequestWithContext(r, frankenphp.WithRequestDocumentRoot(root, false), frankenphp.WithOriginalRequest(original))
+		scriptName := requestPath
+		if split := strings.Index(strings.ToLower(scriptName), ".php/"); split >= 0 {
+			scriptName = scriptName[:split+4]
+		}
+		request, err := frankenphp.NewRequestWithContext(r, frankenphp.WithRequestDocumentRoot(root, false), frankenphp.WithOriginalRequest(original), frankenphp.WithRequestEnv(map[string]string{
+			"SCRIPT_NAME": mount + scriptName, "PHP_SELF": mount + requestPath,
+		}))
 		if err != nil {
 			http.Error(w, "PHP request initialization failed", 500)
 			return

--- a/php_disabled.go
+++ b/php_disabled.go
@@ -7,6 +7,7 @@ package main
 
 import "fmt"
 import "strings"
+import "github.com/launix-de/memcp/scm"
 
 func startPHP(args []string) error {
 	for _, arg := range args {
@@ -18,3 +19,7 @@ func startPHP(args []string) error {
 }
 
 func stopPHP() {}
+
+func getServePHP(wd string) func(...scm.Scmer) scm.Scmer {
+	return func(a ...scm.Scmer) scm.Scmer { panic("PHP support is not built in; use make php") }
+}

--- a/php_test.go
+++ b/php_test.go
@@ -13,6 +13,7 @@ import "sync"
 import "time"
 import "os/exec"
 import "strings"
+import "strconv"
 import "testing"
 import "net/http"
 import "encoding/json"
@@ -70,10 +71,41 @@ func testPHPIntegration(t *testing.T, front string) {
 		t.Fatal(err)
 	}
 	defer log.Close()
-	cmd := exec.Command(binary, "--no-repl", "--disable-api", "--disable-mysql", "--mysql-socket=", "-data", filepath.Join(dir, "data"), "-c", `(createdatabase "memcp-tests" true)`, "--php-root="+root, "--php-listen="+address, "--php-threads=4", "lib/main.scm")
-	if front != "" {
-		cmd.Args = append(cmd.Args, "--php-front-controller="+front)
+	socketPath := filepath.Join(dir, "mysql.sock")
+	// Apps are attached by Scheme on the ordinary HTTP listener. Resolve root
+	// relative to this imported script, and keep a second mount independent.
+	other := filepath.Join(dir, "other")
+	if err := os.Mkdir(other, 0700); err != nil {
+		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(other, "second.txt"), []byte("second app"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	config, _ := json.Marshal(map[string]string{"socket": socketPath})
+	if err := os.WriteFile(filepath.Join(root, "wire.json"), config, 0600); err != nil {
+		t.Fatal(err)
+	}
+	mount := fmt.Sprintf(`(define app (servePHP "public" "/app" %s))
+(define second (servePHP "other" "/other"))
+(define http_handler (begin (define previous http_handler) (lambda (req res)
+ (match (req "path")
+  (regex "^/app(/|$)" _ _) (app req res)
+  (regex "^/other(/|$)" _ _) (second req res)
+  "/outside" ((res "print") "Scheme handler")
+  _ (previous req res)))))`, strconv.Quote(front))
+	mountFile := filepath.Join(dir, "mount.scm")
+	if err := os.WriteFile(mountFile, []byte(mount), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, port, _ := net.SplitHostPort(address)
+	apiFlag := "--api-port=" + port
+	if front != "" {
+		apiFlag = "--disable-api"
+		if err := os.WriteFile(mountFile, []byte(mount+"\n(serve "+port+" (lambda (req res) (http_handler req res)) \"127.0.0.1\")"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command(binary, "--no-repl", apiFlag, "--disable-mysql", "--mysql-socket="+socketPath, "-data", filepath.Join(dir, "data"), "-c", `(createdatabase "memcp-tests" true)`, "--php-threads=4", "lib/main.scm", mountFile)
 	cmd.Stdout = log
 	cmd.Stderr = log
 	if err := cmd.Start(); err != nil {
@@ -106,7 +138,7 @@ func testPHPIntegration(t *testing.T, front string) {
 	}
 	ready := false
 	for deadline := time.Now().Add(120 * time.Second); time.Now().Before(deadline); {
-		status, body, err := get("/probe.php")
+		status, body, err := get("/app/probe.php")
 		if err == nil && status == 200 {
 			var probe struct {
 				Zts     bool
@@ -136,8 +168,8 @@ func testPHPIntegration(t *testing.T, front string) {
 	if !ready {
 		t.Fatal("PHP did not become ready")
 	}
-	for _, action := range []string{"setup", "pdo", "abandon", "verify"} {
-		status, body, err := get("/probe.php?action=" + action)
+	for _, action := range []string{"setup", "pdo", "wire", "buffers", "latency", "abandon", "verify"} {
+		status, body, err := get("/app/probe.php?action=" + action)
 		want := 200
 		if action == "abandon" {
 			want = 500
@@ -151,25 +183,52 @@ func testPHPIntegration(t *testing.T, front string) {
 		missingStatus = 200
 	}
 	for path, want := range map[string]int{"/hello.txt": 200, "/.env": 404, "/source.php.bak": 404, "/link.txt": 404, "/absent.php": missingStatus, "/": 200} {
-		status, body, err := get(path)
+		status, body, err := get("/app" + path)
 		if err != nil || status != want {
 			t.Fatalf("%s: %d %s %v", path, status, body, err)
 		}
 	}
-	status, body, err := get("/probe.php/extra?action=routing")
+	status, body, err := get("/app/probe.php/extra?action=routing")
 	var routing struct {
 		Script   string
 		PathInfo string `json:"path_info"`
 		URI      string `json:"uri"`
 	}
-	if err != nil || status != 200 || json.Unmarshal([]byte(body), &routing) != nil || routing.Script != "/probe.php" || routing.PathInfo != "/extra" || routing.URI != "/probe.php/extra?action=routing" {
+	if err != nil || status != 200 || json.Unmarshal([]byte(body), &routing) != nil || routing.Script != "/app/probe.php" || routing.PathInfo != "/extra" || routing.URI != "/app/probe.php/extra?action=routing" {
 		t.Fatalf("PATH_INFO: %d %s %v", status, body, err)
 	}
+	req, err := http.NewRequest("POST", "http://"+address+"/app/probe.php?action=routing", strings.NewReader("value=hello%26world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Cookie", "probe=cookie-value")
+	req.Header.Set("X-Probe", "header-value")
+	response, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var posted map[string]string
+	err = json.NewDecoder(response.Body).Decode(&posted)
+	response.Body.Close()
+	if err != nil || response.StatusCode != 200 || posted["method"] != "POST" || posted["post"] != "hello&world" || posted["cookie"] != "cookie-value" || posted["header"] != "header-value" {
+		t.Fatalf("POST/cookie/header routing: %v %v", posted, err)
+	}
 	if front != "" {
-		status, body, err := get("/example/route?action=routing")
-		if err != nil || status != 200 || json.Unmarshal([]byte(body), &routing) != nil || routing.Script != "/index.php" || routing.URI != "/example/route?action=routing" {
+		status, body, err := get("/app/example/route?action=routing")
+		if err != nil || status != 200 || json.Unmarshal([]byte(body), &routing) != nil || routing.Script != "/app/index.php" || routing.URI != "/app/example/route?action=routing" {
 			t.Fatalf("front controller: %d %s %v", status, body, err)
 		}
+	}
+	for path, want := range map[string]string{"/outside": "Scheme handler", "/other/second.txt": "second app"} {
+		status, body, err := get(path)
+		if err != nil || status != 200 || body != want {
+			t.Fatalf("mount %s: %d %s %v", path, status, body, err)
+		}
+	}
+	status, _, err = get("/application/probe.php")
+	if err != nil || status != 404 {
+		t.Fatalf("mount boundary: %d %v", status, err)
 	}
 	var wg sync.WaitGroup
 	var intervals [4]struct{ Start, End float64 }
@@ -177,7 +236,7 @@ func testPHPIntegration(t *testing.T, front string) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			status, body, err := get(fmt.Sprintf("/probe.php?action=parallel&value=%d", i))
+			status, body, err := get(fmt.Sprintf("/app/probe.php?action=parallel&value=%d", i))
 			if err != nil || status != 200 {
 				t.Errorf("parallel: %d %s %v", status, body, err)
 			}

--- a/php_test.go
+++ b/php_test.go
@@ -15,6 +15,7 @@ import "os/exec"
 import "strings"
 import "strconv"
 import "testing"
+import "context"
 import "net/http"
 import "encoding/json"
 import "path/filepath"
@@ -25,17 +26,39 @@ func TestPHPIntegration(t *testing.T) {
 		if front != "" {
 			name = "front-controller"
 		}
-		t.Run(name, func(t *testing.T) { testPHPIntegration(t, front) })
+		t.Run(name, func(t *testing.T) { testPHPIntegration(t, front, "") })
 	}
 }
 
-func testPHPIntegration(t *testing.T, front string) {
+func TestPHPServeCLI(t *testing.T) {
+	for _, mode := range []string{"split", "equals"} {
+		t.Run(mode, func(t *testing.T) { testPHPIntegration(t, "index.php", mode) })
+	}
+}
+
+func TestPHPServeCLIRequiresPath(t *testing.T) {
+	for _, option := range []string{"--serve", "--serve="} {
+		t.Run(option, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			output, err := exec.CommandContext(ctx, "./memcp-php", "--no-repl", "--disable-api", "--disable-mysql", "--mysql-socket=", "-data", t.TempDir(), option).CombinedOutput()
+			if err == nil || !strings.Contains(string(output), "--serve requires a directory path") {
+				t.Fatalf("expected missing PATH error: %v %s", err, output)
+			}
+		})
+	}
+}
+
+func testPHPIntegration(t *testing.T, front, cli string) {
 	binary, err := filepath.Abs("memcp-php")
 	if err != nil {
 		t.Fatal(err)
 	}
 	dir := t.TempDir()
 	root := filepath.Join(dir, "public")
+	if cli != "" {
+		root += ".scm"
+	}
 	if err := os.Mkdir(root, 0700); err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +104,17 @@ func testPHPIntegration(t *testing.T, front string) {
 	if err := os.WriteFile(filepath.Join(other, "second.txt"), []byte("second app"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	config, _ := json.Marshal(map[string]string{"socket": socketPath})
+	freePort := func() string {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, port, _ := net.SplitHostPort(listener.Addr().String())
+		listener.Close()
+		return port
+	}
+	mysqlPort, otherPort := freePort(), freePort()
+	config, _ := json.Marshal(map[string]string{"socket": socketPath, "port": mysqlPort, "other_port": otherPort})
 	if err := os.WriteFile(filepath.Join(root, "wire.json"), config, 0600); err != nil {
 		t.Fatal(err)
 	}
@@ -93,19 +126,38 @@ func testPHPIntegration(t *testing.T, front string) {
   (regex "^/other(/|$)" _ _) (second req res)
   "/outside" ((res "print") "Scheme handler")
   _ (previous req res)))))`, strconv.Quote(front))
+	if cli != "" {
+		mount = strings.ReplaceAll(mount, `"public"`, `"public.scm"`)
+	}
+	mount += "\n(mysql " + otherPort + " mysql_auth mysql_schema mysql_handler)"
 	mountFile := filepath.Join(dir, "mount.scm")
 	if err := os.WriteFile(mountFile, []byte(mount), 0600); err != nil {
 		t.Fatal(err)
 	}
 	_, port, _ := net.SplitHostPort(address)
 	apiFlag := "--api-port=" + port
-	if front != "" {
+	if front != "" && cli == "" {
 		apiFlag = "--disable-api"
 		if err := os.WriteFile(mountFile, []byte(mount+"\n(serve "+port+" (lambda (req res) (http_handler req res)) \"127.0.0.1\")"), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
-	cmd := exec.Command(binary, "--no-repl", apiFlag, "--disable-mysql", "--mysql-socket="+socketPath, "-data", filepath.Join(dir, "data"), "-c", `(createdatabase "memcp-tests" true)`, "--php-threads=4", "lib/main.scm", mountFile)
+	cmd := exec.Command(binary, "--no-repl", apiFlag, "--mysql-port="+mysqlPort, "--mysql-socket="+socketPath, "-data", filepath.Join(dir, "data"), "-c", `(createdatabase "memcp-tests" true)`, "--php-threads=4", "lib/main.scm", mountFile)
+	if cli != "" {
+		workingDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		relative, err := filepath.Rel(workingDir, root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cli == "split" {
+			cmd.Args = append(cmd.Args, "--serve", relative)
+		} else {
+			cmd.Args = append(cmd.Args, "--serve="+relative)
+		}
+	}
 	cmd.Stdout = log
 	cmd.Stderr = log
 	if err := cmd.Start(); err != nil {
@@ -168,7 +220,36 @@ func testPHPIntegration(t *testing.T, front string) {
 	if !ready {
 		t.Fatal("PHP did not become ready")
 	}
-	for _, action := range []string{"setup", "pdo", "wire", "buffers", "latency", "abandon", "verify"} {
+	if cli != "" {
+		for _, path := range []string{"/", "/a/pretty/permalink"} {
+			status, body, err := get(path + "?action=routing")
+			var result map[string]string
+			if err != nil || status != 200 || json.Unmarshal([]byte(body), &result) != nil || result["script"] != "/index.php" || result["uri"] != path+"?action=routing" {
+				t.Fatalf("CLI root %s: %d %s %v", path, status, body, err)
+			}
+		}
+		status, _, err := get("/dashboard")
+		if err != nil || status != 401 {
+			t.Fatalf("dashboard authentication: %d %v", status, err)
+		}
+		for _, path := range []string{"/dashboard", "/dashboard/api/whoami", "/sql/memcp-tests"} {
+			req, err := http.NewRequest("GET", "http://"+address+path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.SetBasicAuth("root", "admin")
+			response, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := io.ReadAll(response.Body)
+			response.Body.Close()
+			if err != nil || response.StatusCode != 200 || strings.Contains(string(body), `"script":"/index.php"`) {
+				t.Fatalf("MemCP route %s: %d %s %v", path, response.StatusCode, body, err)
+			}
+		}
+	}
+	for _, action := range []string{"setup", "pdo", "wire", "route-dsn", "buffers", "latency", "abandon", "verify"} {
 		status, body, err := get("/app/probe.php?action=" + action)
 		want := 200
 		if action == "abandon" {
@@ -227,7 +308,7 @@ func testPHPIntegration(t *testing.T, front string) {
 		}
 	}
 	status, _, err = get("/application/probe.php")
-	if err != nil || status != 404 {
+	if err != nil || (cli == "" && status != 404) || (cli != "" && status != 200) {
 		t.Fatalf("mount boundary: %d %v", status, err)
 	}
 	var wg sync.WaitGroup

--- a/phpbridge/bridge.go
+++ b/phpbridge/bridge.go
@@ -40,10 +40,128 @@ func Register(env *scm.Env) error {
 }
 
 type connection struct {
-	mu      sync.Mutex // one SQL execution or close per connection
-	session scm.Scmer
-	state   *scm.SessionState
-	schema  string
+	mu           sync.Mutex // one SQL execution or close per connection
+	session      scm.Scmer
+	state        *scm.SessionState
+	schema       scm.Scmer
+	stateValue   scm.Scmer
+	buffer       resultBuffer
+	fields, rows scm.Scmer
+}
+
+// Only the connection owner resets/releases buffers, after the synchronous
+// SQL call has joined its workers. Result callbacks can run on different shard
+// goroutines and serialize access with mu. No Go pointer is retained by C.
+type resultBuffer struct {
+	mu          sync.Mutex
+	columns     map[string]int
+	columnCount int
+	metadata    bool
+	cells       []C.memcp_cell
+	data        []byte
+	rowCount    C.size_t
+}
+
+const resultLimit = 64 << 20
+const retainedResultBytes = 64 << 10
+
+func (b *resultBuffer) release() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.columnCount > 256 {
+		b.columns = nil
+	} else {
+		clear(b.columns)
+	}
+	if cap(b.cells)*int(unsafe.Sizeof(C.memcp_cell{})) > retainedResultBytes {
+		b.cells = nil
+	} else {
+		b.cells = b.cells[:0]
+	}
+	if cap(b.data) > retainedResultBytes {
+		b.data = nil
+	} else {
+		b.data = b.data[:0]
+	}
+	b.metadata, b.columnCount, b.rowCount = false, 0, 0
+}
+
+func (b *resultBuffer) appendValue(value scm.Scmer) C.memcp_cell {
+	v := C.memcp_cell{}
+	switch {
+	case value.IsNil():
+	case value.IsBool():
+		v.kind = 4
+		if value.Bool() {
+			v.integer = 1
+		}
+	case value.IsInt():
+		v.kind, v.integer = 1, C.int64_t(value.Int())
+	case value.IsFloat():
+		v.kind, v.number = 2, C.double(value.Float())
+	default:
+		s := value.String()
+		if len(s) > resultLimit-len(b.data)-len(b.cells)*int(unsafe.Sizeof(v)) {
+			panic("PDO result exceeds 64 MiB; use SQL LIMIT or pagination")
+		}
+		v.kind, v.offset, v.length = 3, C.size_t(len(b.data)), C.size_t(len(s))
+		b.data = append(b.data, s...)
+	}
+	return v
+}
+
+// Callers hold mu. Metadata and rows share the flat C-cell layout, avoiding
+// a second temporary allocation/copy for every returned row.
+func (b *resultBuffer) growCells(count int) int {
+	if count > (resultLimit-len(b.data))/int(unsafe.Sizeof(C.memcp_cell{}))-len(b.cells) {
+		panic("PDO result exceeds 64 MiB; use SQL LIMIT or pagination")
+	}
+	start := len(b.cells)
+	b.cells = append(b.cells, make([]C.memcp_cell, count)...)
+	return start
+}
+
+func (b *resultBuffer) setColumns(titles []scm.Scmer) {
+	b.metadata, b.columnCount = true, len(titles)
+	if b.columns == nil {
+		b.columns = make(map[string]int, len(titles))
+	}
+	b.growCells(len(titles))
+	for i, title := range titles {
+		b.columns[title.String()] = i
+		b.cells[i] = b.appendValue(title)
+	}
+}
+
+func (b *resultBuffer) captureFields(a ...scm.Scmer) scm.Scmer {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.metadata {
+		panic("duplicate result metadata")
+	}
+	b.setColumns(a[0].Slice())
+	return scm.NewBool(true)
+}
+
+func (b *resultBuffer) captureRow(a ...scm.Scmer) scm.Scmer {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	row := a[0].Slice()
+	if !b.metadata {
+		titles := make([]scm.Scmer, 0, len(row)/2)
+		for i := 0; i+1 < len(row); i += 2 {
+			titles = append(titles, row[i])
+		}
+		b.setColumns(titles)
+	}
+	start := b.growCells(b.columnCount)
+	for i := 0; i+1 < len(row); i += 2 {
+		if j, ok := b.columns[row[i].String()]; ok {
+			b.cells[start+j] = b.appendValue(row[i+1])
+		}
+	}
+	b.rowCount++
+	return scm.NewBool(true)
 }
 
 func result() *C.memcp_result {
@@ -83,7 +201,10 @@ func memcp_open(db, username, password *C.char) (r *C.memcp_result) {
 	s := scm.NewSession()
 	s.Func()(scm.NewString("username"), u)
 	s.Func()(scm.NewString("schema"), d)
-	c := &connection{session: scm.NewFunc(s.Func()), state: scm.RegisterSession(u.String(), "PHP in-process", d.String()), schema: d.String()}
+	c := &connection{session: scm.NewFunc(s.Func()), state: scm.RegisterSession(u.String(), "PHP in-process", d.String()), schema: d}
+	c.stateValue = scm.NewAny(c.state)
+	c.fields = scm.NewFunc(c.buffer.captureFields)
+	c.rows = scm.NewFunc(c.buffer.captureRow)
 	r.handle = C.uintptr_t(cgo.NewHandle(c))
 	return r
 }
@@ -119,79 +240,14 @@ func memcp_query(handle C.uintptr_t, sql *C.char, length C.size_t) (r *C.memcp_r
 	c.state.SetCancel(seq, cancel)
 	c.state.SetQueryContext(seq, ctx)
 	defer c.state.EndQuery(seq, "Sleep", "")
-	var mu sync.Mutex
-	var names []string
-	var cells []C.memcp_cell
-	var data []byte
-	var columns map[string]int
-	const maxBytes = 64 << 20
-	appendValue := func(value scm.Scmer) C.memcp_cell {
-		v := C.memcp_cell{}
-		switch {
-		case value.IsNil():
-		case value.IsBool():
-			v.kind = 4
-			if value.Bool() {
-				v.integer = 1
-			}
-		case value.IsInt():
-			v.kind = 1
-			v.integer = C.int64_t(value.Int())
-		case value.IsFloat():
-			v.kind = 2
-			v.number = C.double(value.Float())
-		default:
-			s := value.String()
-			v.kind = 3
-			v.offset = C.size_t(len(data))
-			v.length = C.size_t(len(s))
-			data = append(data, s...)
-		}
-		return v
-	}
-	setColumns := func(titles []scm.Scmer) {
-		columns = make(map[string]int, len(titles))
-		for i, title := range titles {
-			names = append(names, title.String())
-			columns[title.String()] = i
-			cells = append(cells, appendValue(title))
-		}
-	}
-	fields := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
-		mu.Lock()
-		defer mu.Unlock()
-		if columns != nil {
-			panic("duplicate result metadata")
-		}
-		setColumns(a[0].Slice())
-		return scm.NewBool(true)
-	})
-	rows := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
-		mu.Lock()
-		defer mu.Unlock()
-		row := a[0].Slice()
-		if columns == nil {
-			titles := make([]scm.Scmer, 0, len(row)/2)
-			for i := 0; i < len(row); i += 2 {
-				titles = append(titles, row[i])
-			}
-			setColumns(titles)
-		}
-		values := make([]C.memcp_cell, len(names))
-		for i := 0; i+1 < len(row); i += 2 {
-			if j, ok := columns[row[i].String()]; ok {
-				values[j] = appendValue(row[i+1])
-			}
-		}
-		cells = append(cells, values...)
-		if len(data)+len(cells)*int(unsafe.Sizeof(C.memcp_cell{})) > maxBytes {
-			panic("PDO result exceeds 64 MiB; use SQL LIMIT or pagination")
-		}
-		r.rows++
-		return scm.NewBool(true)
-	})
-	ret := scm.Apply(query, scm.NewString(c.schema), scm.NewString(statement), rows, fields, c.session, scm.NewAny(c.state), scm.NewInt(int64(seq)))
-	if columns == nil && !ret.IsNil() {
+	b := &c.buffer
+	defer b.release()
+	ret := scm.Apply(query, c.schema, scm.NewString(statement), c.rows, c.fields, c.session, c.stateValue, scm.NewInt(int64(seq)))
+	// The SQL frontend has completed all result callbacks before returning.
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	r.rows = b.rowCount
+	if !b.metadata && !ret.IsNil() {
 		r.affected = C.int64_t(ret.Int())
 	} else {
 		r.affected = C.int64_t(r.rows)
@@ -201,13 +257,13 @@ func memcp_query(handle C.uintptr_t, sql *C.char, length C.size_t) (r *C.memcp_r
 	if !f(scm.NewString("transaction")).IsNil() {
 		r.transaction = 1
 	}
-	r.columns = C.size_t(len(names))
-	if len(cells) > 0 {
-		r.cells = (*C.memcp_cell)(C.calloc(C.size_t(len(cells)), C.size_t(unsafe.Sizeof(C.memcp_cell{}))))
-		copy(unsafe.Slice(r.cells, len(cells)), cells)
+	r.columns = C.size_t(b.columnCount)
+	if len(b.cells) > 0 {
+		r.cells = (*C.memcp_cell)(C.calloc(C.size_t(len(b.cells)), C.size_t(unsafe.Sizeof(C.memcp_cell{}))))
+		copy(unsafe.Slice(r.cells, len(b.cells)), b.cells)
 	}
-	if len(data) > 0 {
-		r.bytes = (*C.char)(C.CBytes(data))
+	if len(b.data) > 0 {
+		r.bytes = (*C.char)(C.CBytes(b.data))
 	}
 	return r
 }

--- a/phpbridge/bridge.go
+++ b/phpbridge/bridge.go
@@ -15,6 +15,7 @@ import "sync"
 import "time"
 import "unsafe"
 import "context"
+import "strconv"
 import "runtime/cgo"
 import "github.com/dunglas/frankenphp"
 import "github.com/launix-de/memcp/scm"
@@ -34,6 +35,18 @@ func Register(env *scm.Env) error {
 	auth, schemaCheck, query, rollback = lookup("mysql_auth"), lookup("mysql_schema"), lookup("mysql_handler"), lookup("tx_rollback")
 	if auth.IsNil() || schemaCheck.IsNil() || query.IsNil() || rollback.IsNil() {
 		return fmt.Errorf("PHP PDO requires the SQL frontend (lib/main.scm)")
+	}
+	// Snapshot the actually started Scheme listener before PHP workers start.
+	C.memcp_set_mysql_port(0)
+	if registry := lookup("service_registry"); !registry.IsNil() {
+		if service := scm.Apply(registry, scm.NewString("MySQL Protocol")); !service.IsNil() {
+			items := service.Slice()
+			if len(items) > 0 {
+				if port, err := strconv.ParseUint(items[0].String(), 10, 16); err == nil && port != 0 {
+					C.memcp_set_mysql_port(C.uint(port))
+				}
+			}
+		}
 	}
 	frankenphp.RegisterExtension(C.memcp_module())
 	return nil

--- a/phpbridge/bridge.h
+++ b/phpbridge/bridge.h
@@ -25,4 +25,6 @@ typedef struct {
 } memcp_result;
 void memcp_result_free(memcp_result *result);
 void *memcp_module(void);
+/* Set before PHP MINIT; zero disables automatic PDO DSN routing. */
+void memcp_set_mysql_port(unsigned int port);
 #endif

--- a/phpbridge/bridge_test.go
+++ b/phpbridge/bridge_test.go
@@ -1,0 +1,68 @@
+//go:build php
+
+// Copyright (C) 2026 Carl-Philip Hänsch
+// SPDX-License-Identifier: GPL-3.0-or-later
+package phpbridge
+
+import "sync"
+import "strings"
+import "testing"
+import "github.com/launix-de/memcp/scm"
+
+func TestResultBufferConcurrentRows(t *testing.T) {
+	var b resultBuffer
+	b.captureFields(scm.NewSlice([]scm.Scmer{scm.NewString("id"), scm.NewString("optional")}))
+	var wg sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				b.captureRow(scm.NewSlice([]scm.Scmer{scm.NewString("id"), scm.NewInt(int64(worker*1000 + i))}))
+			}
+		}(worker)
+	}
+	wg.Wait()
+	b.mu.Lock()
+	if b.rowCount != 8000 {
+		t.Errorf("rows: %d", b.rowCount)
+	}
+	seen := make(map[int64]bool)
+	for i := 2; i < len(b.cells); i += 2 {
+		id := int64(b.cells[i].integer)
+		if seen[id] {
+			t.Errorf("duplicate %d", id)
+		}
+		seen[id] = true
+		if b.cells[i+1].kind != 0 {
+			t.Error("missing column must be NULL")
+		}
+	}
+	b.mu.Unlock()
+	b.release()
+	if len(b.cells) != 0 || b.cells != nil || b.metadata || len(b.columns) != 0 {
+		t.Fatal("large result retained or metadata leaked")
+	}
+	b.captureFields(scm.NewSlice([]scm.Scmer{scm.NewString("next")}))
+	b.captureRow(scm.NewSlice([]scm.Scmer{scm.NewString("next"), scm.NewString("clean")}))
+	if string(b.data) != "nextclean" || b.rowCount != 1 || b.columnCount != 1 {
+		t.Fatal("result state leaked across reuse")
+	}
+}
+
+func TestResultBufferBoundedReuse(t *testing.T) {
+	var b resultBuffer
+	b.captureRow(scm.NewSlice([]scm.Scmer{scm.NewString("value"), scm.NewString(strings.Repeat("x", retainedResultBytes+1))}))
+	b.release()
+	if b.data != nil {
+		t.Fatal("oversized byte buffer retained")
+	}
+	b.captureRow(scm.NewSlice([]scm.Scmer{scm.NewString("value"), scm.NewNil()}))
+	if b.cells[1].kind != 0 {
+		t.Fatal("stale data in NULL cell")
+	}
+	b.release()
+	if cap(b.cells) == 0 {
+		t.Fatal("small cell buffer not reused")
+	}
+}

--- a/phpbridge/pdo.c
+++ b/phpbridge/pdo.c
@@ -221,8 +221,125 @@ static int connect_db(pdo_dbh_t *dbh, zval *options) {
 }
 
 static const pdo_driver_t driver = { PDO_DRIVER_HEADER(memcp), connect_db };
-PHP_MINIT_FUNCTION(pdo_memcp) { return php_pdo_register_driver(&driver); }
-PHP_MSHUTDOWN_FUNCTION(pdo_memcp) { php_pdo_unregister_driver(&driver); return SUCCESS; }
+
+/* Constructor dispatch is installed at MINIT, before request threads start.
+ * The native MySQL driver's registry entry and methods are never modified. */
+static unsigned int local_mysql_port;
+static zif_handler original_construct, original_connect;
+void memcp_set_mysql_port(unsigned int port) { local_mysql_port = port; }
+
+static zend_string *local_dsn(zend_execute_data *execute_data) {
+	if (!local_mysql_port || ZEND_CALL_NUM_ARGS(execute_data) < 1 ||
+		zend_get_called_scope(execute_data) != php_pdo_get_dbh_ce()) return NULL;
+	zval *arg = ZEND_CALL_ARG(execute_data, 1);
+	if (Z_TYPE_P(arg) != IS_STRING || Z_STRLEN_P(arg) < 6 ||
+		memcmp(Z_STRVAL_P(arg), "mysql:", 6) || strlen(Z_STRVAL_P(arg)) != Z_STRLEN_P(arg)) return NULL;
+	/* Keep options whose semantics require native MySQL on the wire path. */
+	if (ZEND_CALL_NUM_ARGS(execute_data) >= 4) {
+		zval *options = ZEND_CALL_ARG(execute_data, 4);
+		if (Z_TYPE_P(options) != IS_NULL && Z_TYPE_P(options) != IS_ARRAY) return NULL;
+		if (Z_TYPE_P(options) == IS_ARRAY) {
+			zend_ulong key; zend_string *name; zval *value;
+			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(options), key, name, value) {
+				if (name) return NULL;
+				switch (key) {
+				case PDO_ATTR_ERRMODE: case PDO_ATTR_CASE: case PDO_ATTR_ORACLE_NULLS:
+				case PDO_ATTR_DEFAULT_FETCH_MODE: case PDO_ATTR_STRINGIFY_FETCHES:
+					break; /* handled by PDO itself */
+				case PDO_ATTR_EMULATE_PREPARES:
+					if (!zend_is_true(value)) return NULL;
+					break;
+				default: return NULL;
+				}
+			} ZEND_HASH_FOREACH_END();
+		}
+	}
+	/* An exact, unambiguous subset only; native PDO parses every other DSN.
+	 * Require explicit host/port/database; never capture Unix socket DSNs. */
+	const char *host = NULL, *database = NULL;
+	size_t host_len = 0, database_len = 0;
+	unsigned int port = 0, seen = 0;
+	const char *p = Z_STRVAL_P(arg)+6, *end = Z_STRVAL_P(arg)+Z_STRLEN_P(arg);
+	while (p < end) {
+		const char *stop = memchr(p, ';', (size_t)(end-p));
+		if (!stop) stop = end;
+		const char *equal = memchr(p, '=', (size_t)(stop-p));
+		if (!equal || equal+1 == stop) return NULL;
+		const char *value = equal+1;
+		size_t length = (size_t)(stop-value), key_len = (size_t)(equal-p);
+		unsigned int bit;
+		if (key_len == 4 && !memcmp(p, "host", 4)) {
+			bit = 1; host = value; host_len = length;
+		} else if (key_len == 4 && !memcmp(p, "port", 4)) {
+			bit = 2;
+			if (length > 5) return NULL;
+			for (const char *digit = value; digit < stop; digit++) {
+				if (*digit < '0' || *digit > '9') return NULL;
+				port = port*10+(unsigned int)(*digit-'0');
+			}
+		} else if (key_len == 6 && !memcmp(p, "dbname", 6)) {
+			bit = 4; database = value; database_len = length;
+		} else if (key_len == 7 && !memcmp(p, "charset", 7)) {
+			bit = 8;
+			if (!((length == 7 && !memcmp(value, "utf8mb4", 7)) ||
+				(length == 4 && !memcmp(value, "utf8", 4)))) return NULL;
+		} else return NULL;
+		if (seen & bit) return NULL;
+		seen |= bit;
+		p = stop == end ? end : stop+1;
+	}
+	if ((seen & 7) != 7 || port != local_mysql_port ||
+		!((host_len == 9 && !memcmp(host, "localhost", 9)) ||
+		  (host_len == 9 && !memcmp(host, "127.0.0.1", 9)))) return NULL;
+	zend_string *dsn = zend_string_alloc(sizeof("memcp:dbname=")-1+database_len, 0);
+	memcpy(ZSTR_VAL(dsn), "memcp:dbname=", sizeof("memcp:dbname=")-1);
+	memcpy(ZSTR_VAL(dsn)+sizeof("memcp:dbname=")-1, database, database_len);
+	ZSTR_VAL(dsn)[ZSTR_LEN(dsn)] = '\0';
+	return dsn;
+}
+
+static void routed_construct(zif_handler original, INTERNAL_FUNCTION_PARAMETERS) {
+	zend_string *dsn = local_dsn(execute_data);
+	if (!dsn) { original(INTERNAL_FUNCTION_PARAM_PASSTHRU); return; }
+	zval *arg = ZEND_CALL_ARG(execute_data, 1), saved;
+	ZVAL_COPY_VALUE(&saved, arg);
+	ZVAL_STR(arg, dsn);
+	/* Preserve the original argument and PDO's own exceptions/SQLSTATE. */
+	zend_try {
+		original(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+	} zend_catch {
+		zval_ptr_dtor(arg); ZVAL_COPY_VALUE(arg, &saved);
+		zend_bailout();
+	} zend_end_try();
+	zval_ptr_dtor(arg); ZVAL_COPY_VALUE(arg, &saved);
+}
+static void routed_pdo_construct(INTERNAL_FUNCTION_PARAMETERS) {
+	routed_construct(original_construct, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+static void routed_pdo_connect(INTERNAL_FUNCTION_PARAMETERS) {
+	routed_construct(original_connect, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+PHP_MINIT_FUNCTION(pdo_memcp) {
+	if (php_pdo_register_driver(&driver) != SUCCESS) return FAILURE;
+	zend_class_entry *ce = php_pdo_get_dbh_ce();
+	original_construct = ce->constructor->internal_function.handler;
+	ce->constructor->internal_function.handler = routed_pdo_construct;
+	zend_function *connect = zend_hash_str_find_ptr(&ce->function_table, "connect", sizeof("connect")-1);
+	if (connect) {
+		original_connect = connect->internal_function.handler;
+		connect->internal_function.handler = routed_pdo_connect;
+	}
+	return SUCCESS;
+}
+PHP_MSHUTDOWN_FUNCTION(pdo_memcp) {
+	zend_class_entry *ce = php_pdo_get_dbh_ce();
+	if (ce->constructor->internal_function.handler == routed_pdo_construct)
+		ce->constructor->internal_function.handler = original_construct;
+	zend_function *connect = zend_hash_str_find_ptr(&ce->function_table, "connect", sizeof("connect")-1);
+	if (connect && connect->internal_function.handler == routed_pdo_connect)
+		connect->internal_function.handler = original_connect;
+	php_pdo_unregister_driver(&driver); return SUCCESS;
+}
 static const zend_module_dep dependencies[] = { ZEND_MOD_REQUIRED("pdo") ZEND_MOD_END };
 static zend_module_entry module = {
 	STANDARD_MODULE_HEADER_EX, NULL, dependencies, "pdo_memcp", NULL,

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -145,11 +145,11 @@ type MySQLWrapper struct {
 }
 
 func mysqlScmSession(session *driver.Session) Scmer {
-	if scmSessionAny, ok := mysqlsessions.Load(session.ID()); ok {
+	if scmSessionAny, ok := mysqlsessions.Load(session); ok {
 		return NewFunc(scmSessionAny.(func(...Scmer) Scmer))
 	}
 	newSession := NewSession().Func()
-	mysqlsessions.Store(session.ID(), newSession)
+	mysqlsessions.Store(session, newSession)
 	return NewFunc(newSession)
 }
 
@@ -157,14 +157,16 @@ func withMySQLScmSession(session *driver.Session, fn func()) {
 	fn()
 }
 
-/* session storage -> map from session id to SCM session object */
+// Protocol connection IDs are only unique within one listener. Key both maps
+// by the connection object so TCP/Unix listeners cannot overwrite or delete
+// each other's sessions. Entries are removed by SessionClosed.
 var mysqlsessions sync.Map
 
-// mysqlStates maps driver session ID -> *SessionState for SHOW PROCESSLIST
+// mysqlStates maps *driver.Session -> *SessionState for SHOW PROCESSLIST
 var mysqlStates sync.Map
 
 func refreshMySQLSessionProcesslistMeta(session *driver.Session) {
-	if v, ok := mysqlStates.Load(session.ID()); ok {
+	if v, ok := mysqlStates.Load(session); ok {
 		ss := v.(*SessionState)
 		if user := session.User(); user != "" {
 			ss.User = user
@@ -183,9 +185,9 @@ func (m *MySQLWrapper) SetServerVersion() {
 }
 func (m *MySQLWrapper) NewSession(session *driver.Session) {
 	m.log.Info("%s", "New Session from "+session.Addr())
-	mysqlsessions.Store(session.ID(), NewSession().Func())
+	mysqlsessions.Store(session, NewSession().Func())
 	ss := RegisterSession(session.User(), session.Addr(), session.Schema())
-	mysqlStates.Store(session.ID(), ss)
+	mysqlStates.Store(session, ss)
 	refreshMySQLSessionProcesslistMeta(session)
 }
 func (m *MySQLWrapper) SessionInc(session *driver.Session) {
@@ -196,8 +198,8 @@ func (m *MySQLWrapper) SessionDec(session *driver.Session) {
 }
 func (m *MySQLWrapper) SessionClosed(session *driver.Session) {
 	m.log.Info("%s", "Closed Session "+session.User()+" from "+session.Addr())
-	mysqlsessions.Delete(session.ID())
-	if v, ok := mysqlStates.LoadAndDelete(session.ID()); ok {
+	mysqlsessions.Delete(session)
+	if v, ok := mysqlStates.LoadAndDelete(session); ok {
 		st := v.(*SessionState)
 		st.ReleaseAllLocks()
 		UnregisterSession(st.ID)
@@ -390,7 +392,7 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 	var querySeq uint64
 	queryCtx, queryCancel := context.WithCancel(context.Background())
 	defer queryCancel()
-	if v, ok := mysqlStates.Load(session.ID()); ok {
+	if v, ok := mysqlStates.Load(session); ok {
 		ss = v.(*SessionState)
 		refreshMySQLSessionProcesslistMeta(session)
 		ss.Touch()
@@ -475,7 +477,7 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 		bufferedRowCount = 0
 	}
 	// load scm session object
-	scmSessionAny, _ := mysqlsessions.Load(session.ID())
+	scmSessionAny, _ := mysqlsessions.Load(session)
 	// result from scheme
 	sessionFunc := scmSessionAny.(func(...Scmer) Scmer)
 	scmSessionScmer := NewFunc(sessionFunc)

--- a/scm/network.go
+++ b/scm/network.go
@@ -77,11 +77,15 @@ func HTTPRequest(a ...Scmer) Scmer {
 
 // build this function into your SCM environment to offer http server capabilities
 func HTTPServe(a ...Scmer) Scmer {
-	// HTTP endpoint; params: (port, handler)
+	// HTTP endpoint; params: (port, handler, optional bind host)
 	port := a[0].String()
+	host := ""
+	if len(a) > 2 {
+		host = a[2].String()
+	}
 	handler := &HttpServer{a[1]}
 	server := &http.Server{
-		Addr:           fmt.Sprintf(":%v", port),
+		Addr:           net.JoinHostPort(host, port),
 		Handler:        handler,
 		ReadTimeout:    300 * time.Second,
 		WriteTimeout:   300 * time.Second,

--- a/tests/php/integration.php
+++ b/tests/php/integration.php
@@ -93,6 +93,37 @@ try {
             check($wire->query('SELECT 1')->fetchColumn() == 1, 'PDO wire query');
             check($db->query('SELECT 2')->fetchColumn() == 2, 'PDO direct query alongside wire');
         }
+    } elseif ($action === 'route-dsn') {
+        $config = json_decode(file_get_contents(__DIR__ . '/wire.json'), true);
+        foreach (['localhost', '127.0.0.1'] as $host) {
+            $dsn = 'mysql:host=' . $host . ';port=' . $config['port'] . ';dbname=memcp-tests;charset=utf8mb4';
+            $before = $dsn;
+            foreach ([
+                fn() => new PDO($dsn, 'root', 'admin'),
+                fn() => PDO::connect(dsn: $dsn, username: 'root', password: 'admin')
+            ] as $open) {
+                $local = $open();
+                check($local->getAttribute(PDO::ATTR_DRIVER_NAME) === 'memcp', 'Local PDO DSN routes in-process');
+                check($local->query('SELECT 1')->fetchColumn() == 1, 'Routed PDO result');
+                check($dsn === $before, 'Caller DSN must remain unchanged');
+            }
+            fails(fn() => new PDO($dsn, 'root', 'wrong'), '28000');
+            fails(fn() => PDO::connect($dsn), '28000');
+            $reader = new PDO($dsn, 'php_reader', 'reader-password');
+            check($reader->getAttribute(PDO::ATTR_DRIVER_NAME) === 'memcp', 'Non-root route');
+        }
+        $dsn = 'mysql:host=127.0.0.1;port=' . $config['other_port'] . ';dbname=memcp-tests';
+        $wire = new PDO($dsn, 'root', 'admin');
+        check($wire->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql', 'Other TCP port remains wire');
+        check($wire->query('SELECT 2')->fetchColumn() == 2, 'Other port wire query');
+        $dsn = 'mysql:host=127.0.0.1;port=' . $config['port'] . ';dbname=memcp-tests';
+        $wire = new PDO($dsn, 'root', 'admin', [PDO::ATTR_EMULATE_PREPARES => false]);
+        check($wire->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql', 'Native prepare option keeps wire');
+        check(!$wire->getAttribute(PDO::ATTR_EMULATE_PREPARES), 'Native prepare option preserved');
+        $wire->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+        check($wire->query('SELECT 3')->fetchColumn() == 3, 'Wire query after enabling emulation');
+        $wire = Pdo\Mysql::connect($dsn, 'root', 'admin');
+        check($wire->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql', 'Driver-specific PDO class keeps wire');
     } elseif ($action === 'buffers') {
         $first = $db->query("SELECT 'first' AS value, NULL AS optional UNION ALL SELECT 'second', 'present'");
         $second = $db->query("SELECT 'different' AS other");
@@ -127,6 +158,9 @@ try {
     } elseif ($action === 'verify') {
         check($db->query("SELECT COUNT(*) FROM php_test WHERE value = 'abandoned'")->fetchColumn() == 0, 'Request teardown rollback');
     } elseif ($action === 'parallel') {
+        $config = json_decode(file_get_contents(__DIR__ . '/wire.json'), true);
+        $db = new PDO('mysql:host=127.0.0.1;port=' . $config['port'] . ';dbname=memcp-tests', 'root', 'admin');
+        check($db->getAttribute(PDO::ATTR_DRIVER_NAME) === 'memcp', 'Parallel routed PDO');
         $stmt = $db->prepare('SELECT ? AS value');
         $value = $_GET['value'];
         $stmt->execute([$value]);
@@ -140,5 +174,5 @@ try {
     echo json_encode(['ok' => true]);
 } catch (Throwable $e) {
     http_response_code(500);
-    echo json_encode(['error' => $e->getMessage()]);
+    echo json_encode(['error' => $e->getMessage(), 'line' => $e->getLine()]);
 }

--- a/tests/php/integration.php
+++ b/tests/php/integration.php
@@ -16,7 +16,7 @@ header('Content-Type: application/json');
 try {
     $action = $_GET['action'] ?? 'probe';
     if ($action === 'routing') {
-        echo json_encode(['script' => $_SERVER['SCRIPT_NAME'], 'path_info' => $_SERVER['PATH_INFO'] ?? '', 'uri' => $_SERVER['REQUEST_URI']]);
+        echo json_encode(['script' => $_SERVER['SCRIPT_NAME'], 'path_info' => $_SERVER['PATH_INFO'] ?? '', 'uri' => $_SERVER['REQUEST_URI'], 'method' => $_SERVER['REQUEST_METHOD'], 'post' => $_POST['value'] ?? '', 'cookie' => $_COOKIE['probe'] ?? '', 'header' => $_SERVER['HTTP_X_PROBE'] ?? '']);
         return;
     }
     if ($action === 'probe') {
@@ -33,6 +33,7 @@ try {
     } elseif ($action === 'pdo') {
         $reader = new PDO('memcp:dbname=memcp-tests', 'php_reader', 'reader-password');
         fails(fn() => $reader->query('SELECT COUNT(*) FROM php_test'));
+        fails(fn() => $reader->exec("INSERT INTO php_test(value) VALUES ('forbidden')"));
         $db->exec('GRANT SELECT ON `memcp-tests`.* TO php_reader');
         check($reader->query('SELECT COUNT(*) FROM php_test')->fetchColumn() == 0, 'Read permission');
         $sqlite = new PDO('sqlite::memory:');
@@ -61,6 +62,13 @@ try {
         fails(fn() => $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false));
         fails(fn() => $db->query('SELECT absent FROM php_missing_table'));
         fails(fn() => new PDO('memcp:dbname=memcp-tests', 'root', 'wrong'), '28000');
+        fails(fn() => new PDO('memcp:dbname=memcp-tests', 'root', ''), '28000');
+        fails(fn() => new PDO('memcp:dbname=memcp-tests'), '28000');
+        fails(fn() => new PDO('memcp:dbname=memcp-tests', 'php_unknown', 'admin'), '28000');
+        // An authenticated reader must not inherit root's transaction session.
+        $db->beginTransaction();
+        check($db->inTransaction() && !$reader->inTransaction(), 'PDO sessions are independent');
+        $db->rollBack();
         fails(fn() => new PDO('memcp:dbname=does-not-exist', 'root', 'admin'), '3D000');
         fails(fn() => new PDO('memcp:host=elsewhere', 'root', 'admin'));
         fails(fn() => new PDO('memcp:dbname=memcp-tests', 'root', 'admin', [PDO::ATTR_PERSISTENT => true]));
@@ -77,6 +85,40 @@ try {
         check((int)$db->lastInsertId() > 0, 'Insert ID');
         $db->commit();
         check($db->query('SELECT COUNT(*) FROM php_test')->fetchColumn() == 1, 'Commit persists');
+    } elseif ($action === 'wire') {
+        $config = json_decode(file_get_contents(__DIR__ . '/wire.json'), true);
+        $wire = new PDO('mysql:unix_socket=' . $config['socket'] . ';dbname=memcp-tests', 'root', 'admin', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        check($wire->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql', 'PDO mysql dispatch');
+        for ($i = 0; $i < 30; $i++) {
+            check($wire->query('SELECT 1')->fetchColumn() == 1, 'PDO wire query');
+            check($db->query('SELECT 2')->fetchColumn() == 2, 'PDO direct query alongside wire');
+        }
+    } elseif ($action === 'buffers') {
+        $first = $db->query("SELECT 'first' AS value, NULL AS optional UNION ALL SELECT 'second', 'present'");
+        $second = $db->query("SELECT 'different' AS other");
+        check($first->fetch(PDO::FETCH_ASSOC) === ['value'=>'first', 'optional'=>null], 'Buffered statement survives another query');
+        check($second->fetch(PDO::FETCH_ASSOC) === ['other'=>'different'], 'Different metadata');
+        check($first->fetch(PDO::FETCH_ASSOC) === ['value'=>'second', 'optional'=>'present'], 'Buffered next row');
+        $large = $db->query("SELECT REPEAT('x', 131072) AS payload");
+        fails(fn() => $db->query('SELECT missing FROM php_missing_table'));
+        check($db->query('SELECT 1')->fetchColumn() == 1, 'Reuse after query error');
+        check(strlen($large->fetchColumn()) === 131072, 'Large result survives reuse and error');
+        check($db->query('SELECT value FROM php_test WHERE id = -1')->fetchAll() === [], 'Empty result after large result');
+        $stmt = $db->prepare('SELECT ? AS bytes');
+        foreach (["a\0b", '', 'last'] as $value) {
+            $stmt->execute([$value]); check($stmt->fetchColumn() === $value, 'Reused binary result'); $stmt->closeCursor();
+        }
+    } elseif ($action === 'latency') {
+        // Perf-capable fixture: fixed query, warm connection, timer inside PHP.
+        $warmup = min(1000, max(1, (int)($_GET['warmup'] ?? 100)));
+        $samples = min(100000, max(1, (int)($_GET['samples'] ?? 200)));
+        $times = [];
+        for ($i = 0; $i < $warmup + $samples; $i++) {
+            $start = hrtime(true); $stmt = $db->query('SELECT 1'); $value = $stmt->fetchColumn(); $stmt->closeCursor();
+            $elapsed = hrtime(true) - $start; check($value == 1, 'Latency result');
+            if ($i >= $warmup) $times[] = $elapsed;
+        }
+        echo json_encode(['ok'=>true, 'ns'=>$times]); return;
     } elseif ($action === 'abandon') {
         $db->beginTransaction();
         $db->exec("INSERT INTO php_test (value) VALUES ('abandoned')");


### PR DESCRIPTION
The standard bootstrap now accepts --serve PATH (or --serve=PATH), mounting PHP at / with index.php fallback while preserving the authenticated dashboard, SQL API and other frontend routes. Relative CLI paths resolve against the process working directory.

PHP applications now mount through Scheme's `servePHP(directory, prefix, front_controller)` handler, using the existing HTTP router/server and one shared external FrankenPHP pool. Remove the separate PHP listener and its CLI flags; add an optional bind host to Scheme `serve` so local deployments can keep their loopback binding.

The PDO RAM path creates result callbacks once per authenticated connection, appends rows directly into its flat collector, and reuses bounded buffers (at most 64 KiB each for cells/bytes). Separate collector locking permits concurrent shard callbacks; each PDO statement keeps an independent C-owned result. Authentication is still required before a handle/session exists, and queries retain existing permission/transaction checks. Base PDO constructors and PDO::connect also route explicit localhost/127.0.0.1 MySQL DSNs matching the started MemCP TCP port to the authenticated RAM driver. Unsupported DSNs/options, other destinations, Unix sockets and PDO subclasses retain native wire behavior. Constructor dispatch is installed during PHP MINIT, before threads start; the native MySQL driver registration is unchanged. mysqli remains on the ordinary MySQL wire frontend.

The multi-listener coexistence fixture reproduced a pre-existing session collision: listener-local numeric connection IDs were used as global map keys, so closing one connection could delete another listener’s session. Key both Scheme-session and process-list maps by the actual driver connection object instead. The fixture now passes while keeping connections to both ports alive.

PHP CI is reusable and runs only after successful `Test/test`, with a PHP/frontend/build path guard (including renames and conservative fallback).

Validation: targeted PHP integration tests passed with both normal Go and the experimental JIT toolchain; collector concurrency tests passed under the race detector; targeted HTTP tests and the non-PHP package build passed. Coverage includes wrong/missing credentials, denied database access, simultaneous memcp/MySQL-wire/SQLite PDO, retained statement results, error recovery, parallel requests, multiple Scheme mounts, PATH_INFO/front controllers, POST/cookies/headers, --serve split/equal forms and missing-PATH failures, authenticated dashboard alongside a root PHP app, local DSN routing and unchanged native wire destinations/options. Seven local path-guard/dependency cases passed. Full SQL and performance suites are left to CI as requested.

Manual A/B before opening this PR: same checkout/frontend, PHP 8.5.10 ZTS + OPcache, Go 1.27 experimental JIT, same `SELECT 1` fixture, 12 alternating AB/BA rounds, 500 warmups then 5,000 timed query/fetch/close operations per round (60,000 samples per variant). Baseline substitutes only the previous `phpbridge/bridge.go` through an external Go overlay; candidate uses this change.

- Median: 9.849 → 9.438 µs (−0.411 µs, −4.17%).
- p95: 16.371 → 14.798 µs. Candidate faster in 10/12 paired round medians; host timing noise remains.

No third-party source is copied or patched; only MemCP's own addon/fixtures are tracked. Prepared statements remain emulated and persistent PDO connections remain unsupported.


Follow-up validation after CI's cold aggregate outlier: rebased onto 55621603e (including #851 and #854). Ran only tests/performance/typed-filter-buffer.yaml through the unchanged performance-runner measurement path, with the CI settings (warmup=0, timing_samples=1, PERF_REPEAT=1000, minimum measure=1000 ms, jitter=50 ms), fresh fixtures/processes per run, alternating base/candidate/candidate/base/base/candidate. Uncached aggregate: base 16.255/18.347/17.048 ms; candidate 16.026/20.183/35.420 ms. The 83.902 ms CI failure was not consistently reproduced; the slowest local candidate run also slowed the adjacent wide aggregate from ~32 to 64 ms. No performance thresholds or fixture semantics changed. CI must confirm the rebased candidate.

The policy prerequisite #854 has been merged with the authorized administrative exception. Required checks and admin enforcement were verified restored immediately afterwards. A live authenticated PDO probe on the hosted instance confirms that both explicit loopback MySQL DSNs on port 3307 select driver memcp and return SELECT 1.
