### PR TITLE
Bound numeric IN-list scans in Scheme physical lowering

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2443,6 +2443,55 @@ retain the scalar's complete value, including SQL NULL. */
 							(or (equal? head (quote optimize))
 								(equal? head (symbol "optimize")))))))))))
 
+/* A numeric IN list supplies a candidate interval, never an exact filter.
+Keep IN as the residual for gaps and duplicates. Bounds depend on this request's
+values and are evaluated by the scan access program before the scan. Restrict
+this to numeric base columns and numeric literal/session lists: SQL string
+coercion and collations do not have the same ordering proof. */
+(define physical_in_binding? (lambda (expr)
+	(match expr
+		((symbol session) key) (string? key)
+		((quote session) key) (string? key)
+		_ (or (number? expr) (or (string? expr) (nil? expr))))))
+
+(define physical_numeric_in_interval (lambda (src terms term planning_session)
+	(match term
+		((symbol sql_in) (cons constructor values) probe) (begin
+			(define col (direct_column_name_for_alias src probe))
+			(define info (if (or (nil? col) (not (source_is_base_table? src))) nil
+				(find (get_schema (source_schema src) (source_relation src))
+					(lambda (candidate) (equal?? (candidate "Field") col)) nil)))
+			(define eligible (and (or (equal? constructor list) (equal? constructor (quote list)))
+				(not (nil? info)) (not (empty_list? values))
+				(contains? '("int" "integer" "bigint" "smallint" "tinyint" "mediumint" "float" "double" "decimal")
+					(toLower (coalesceNil (info "RawType") "")))
+				(reduce values (lambda (ok value) (and ok (physical_in_binding? value))) true)
+				(not (reduce terms (lambda (conflict other)
+					(or conflict (and (not (equal? other term))
+						(contains? (extract_columns_for_alias src other) col)))) false))))
+			(if (not eligible) term (begin
+				(define numeric (lambda (value) (and (number? value) (<= value value))))
+				(define supported (reduce values (lambda (ok value)
+					(and ok (numeric (planner_literal_value value planning_session)))) true))
+				(define guard (cons (quote and) (map values (lambda (value)
+					(list (quote and) (list (quote number?) value) (list (quote <=) value value))))))
+				(planner_record_guard_condition (if supported guard (list (quote not) guard)) planning_session)
+				(if (not supported) term (begin
+					(define bound (lambda (op)
+						(list (quote reduce) (cons (quote list) values)
+							(list (quote lambda) (list (quote lo) (quote value))
+								(list (quote if) (list op (quote value) (quote lo)) (quote value) (quote lo)))
+							(car values))))
+					(list (quote and) (list (quote >=) probe (bound (quote <)))
+						(list (quote <=) probe (bound (quote >))) term))))))
+		_ term)))
+
+(define physical_numeric_in_intervals (lambda (src condition planning_session)
+	(begin
+		(define terms (split_and_terms condition))
+		(combine_where_terms (map terms (lambda (term)
+			(physical_numeric_in_interval src terms term planning_session))) true))))
+
 (define lower_column_expr_for_join_truth_context (lambda (sources default_alias expr probe_work_rows)
 	(match expr
 		((symbol scalar_first_probe) stage requested_col)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4267,10 +4267,11 @@ plan construction or timing during compilation. */
 					(if membership_driver
 						(strip_driver_membership_for_source src condition direct_membership)
 						(replace_driver_membership_markers src condition bound_memberships))))
-				(define filter_condition (if use_membership_keysets
-					(replace_driver_membership_keyset_markers
-						candidate_filter_condition membership_keysets)
-					candidate_filter_condition))
+				(define filter_condition (physical_numeric_in_intervals src
+					(if use_membership_keysets
+						(replace_driver_membership_keyset_markers
+							candidate_filter_condition membership_keysets)
+						candidate_filter_condition) (planner_context_session (qb_facts block))))
 				(define filtercols (merge_unique (list
 					(if (or membership_filter scalar_membership_filter)
 						(list "$recset_contains") '())
@@ -5402,7 +5403,7 @@ until the caller has selected this physical alternative. */
 		base table ordered and replaces a supported direct-column marker with the
 		query-scoped key index; unsupported computed keys retain the established probe
 		fallback and its separately calibrated cost. */
-		(define filter_condition effective_condition)
+		(define filter_condition (physical_numeric_in_intervals src effective_condition planning_session))
 		/* Stage-output column references require a relational source and cannot be
 		read directly from the driver callback. Scalar/EXISTS probe markers are not
 		deferred: lowering them at batch cardinality is the purpose of this path. */
@@ -7108,8 +7109,9 @@ carrier remains on the measured direct path and is never built eagerly. */
 					(equal? (car access_path_plan)
 						(qassoc_get access_path_candidate (quote plan) nil))))
 				(define residual_condition
-					(strip_scan_access_path_predicate effective_condition
-						(if access_path_selected access_path_candidate nil)))
+					(physical_numeric_in_intervals src
+						(strip_scan_access_path_predicate effective_condition
+							(if access_path_selected access_path_candidate nil)) planning_session))
 				(define membership_var (symbol "__membership_recset"))
 				(define membership_filter_expr (if membership_filter
 					(recset_contains_call_expr membership_var)

--- a/tests/execution/operators/in-list-like-prefix.yaml
+++ b/tests/execution/operators/in-list-like-prefix.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
 # Tests for IN-list and LIKE prefix boundary extraction for index usage.
 # IN (1,2,3) → range [min,max]; LIKE 'foo%' → range [prefix, prefix+1)
 
@@ -109,3 +111,68 @@ test_cases:
     expect:
       data:
         - cnt: 10
+
+  - name: "Numeric IN bounds preserve gaps and duplicate values"
+    sql: "SELECT id FROM inlike WHERE id IN (13,10,13) ORDER BY id"
+    expect: {rows: 2, data: [{id: 10}, {id: 13}]}
+
+  - name: "Numeric IN bounds change with cached bindings"
+    sql: "SELECT id FROM inlike WHERE id IN (73,70,73) ORDER BY id"
+    expect: {rows: 2, data: [{id: 70}, {id: 73}]}
+
+  - name: "Numeric IN bounds preserve existing tighter comparison"
+    sql: "SELECT id FROM inlike WHERE id IN (13,10,13) AND id > 11 ORDER BY id"
+    expect: {rows: 1, data: [{id: 13}]}
+
+  - name: "Numeric IN bounds preserve NULL list semantics"
+    sql: "SELECT id FROM inlike WHERE id IN (NULL,10,13) ORDER BY id"
+    expect: {rows: 2, data: [{id: 10}, {id: 13}]}
+
+  - name: "Numeric IN bounds never narrow NOT IN"
+    sql: "SELECT id FROM inlike WHERE id NOT IN (10,NULL) ORDER BY id"
+    expect: {rows: 0}
+
+  - name: "Numeric IN bounds never narrow disjunction"
+    sql: "SELECT id FROM inlike WHERE id IN (10,13) OR id = 199 ORDER BY id"
+    expect: {rows: 3, data: [{id: 10}, {id: 13}, {id: 199}]}
+
+  - name: "Numeric IN projection keeps SQL UNKNOWN"
+    sql: "SELECT id, id IN (10,NULL) AS member FROM inlike WHERE id IN (10,13) ORDER BY id"
+    expect: {rows: 2, data: [{id: 10, member: true}, {id: 13, member: null}]}
+
+  - name: "Numeric IN malformed list is rejected"
+    sql: "SELECT id FROM inlike WHERE id IN (10,,13)"
+    expect: {error: true}
+
+  - name: "Numeric IN access plan has bounds and retains membership"
+    sql: "EXPLAIN SELECT id FROM inlike WHERE id IN (10,13)"
+    expect:
+      rows: 1
+      result_contains:
+        - '(scan_boundary \"range\" \"id\" 0 1 true true \"\" false)'
+        - 'sql_in'
+
+  - name: "IN cached shape accepts string values after numeric values"
+    sql: "SELECT id FROM inlike WHERE id IN ('13','10','13') ORDER BY id"
+    expect: {rows: 2, data: [{id: 10}, {id: 13}]}
+
+  - name: "IN cached shape returns to numeric values"
+    sql: "SELECT id FROM inlike WHERE id IN (23,20,23) ORDER BY id"
+    expect: {rows: 2, data: [{id: 20}, {id: 23}]}
+
+  - name: "Numeric IN bounds reject NULL column values"
+    setup:
+      - sql: "INSERT INTO inlike (id,name,val) VALUES (NULL,'null-id',9999)"
+    sql: "SELECT id FROM inlike WHERE id IN (23,20,23) ORDER BY id"
+    expect: {rows: 2, data: [{id: 20}, {id: 23}]}
+
+  - name: "Numeric IN access bounds stay out of logical IR"
+    sql: "EXPLAIN IR SELECT id FROM inlike WHERE id IN (10,13)"
+    expect:
+      rows: 1
+      result_contains: ['sql_in']
+      result_not_contains: ['scan_boundary', 'reduce']
+
+  - name: "Numeric IN with an ordered join preserves results"
+    sql: "SELECT a.id, b.val FROM inlike a JOIN inlike b ON b.id = a.id WHERE a.id IN (13,10,13) ORDER BY a.id LIMIT 2"
+    expect: {rows: 2, data: [{id: 10, val: 50}, {id: 13, val: 65}]}

--- a/tests/execution/operators/in-list-like-prefix.yaml
+++ b/tests/execution/operators/in-list-like-prefix.yaml
@@ -176,3 +176,9 @@ test_cases:
   - name: "Numeric IN with an ordered join preserves results"
     sql: "SELECT a.id, b.val FROM inlike a JOIN inlike b ON b.id = a.id WHERE a.id IN (13,10,13) ORDER BY a.id LIMIT 2"
     expect: {rows: 2, data: [{id: 10, val: 50}, {id: 13, val: 65}]}
+
+  - name: "Numeric IN bounds retain adjacent large BIGINT values"
+    setup:
+      - sql: "INSERT INTO inlike (id,name,val) VALUES (9007199254740992,'large-low',1),(9007199254740993,'large-high',2)"
+    sql: "SELECT name FROM inlike WHERE id IN (9007199254740993,9007199254740992) ORDER BY val"
+    expect: {rows: 2, data: [{name: "large-low"}, {name: "large-high"}]}

--- a/tests/performance/wordpress-postmeta-order-limit.yaml
+++ b/tests/performance/wordpress-postmeta-order-limit.yaml
@@ -46,6 +46,34 @@ test_cases:
     sql: "SELECT post_title FROM wordpress_perf_posts WHERE ID = 4242"
     expect: {rows: 1}
 
+  - name: "WordPress batch post lookup"
+    warmup: 10
+    timing_samples: 30
+    performance_rows: 8214
+    threshold_ms: 2
+    sql: "SELECT * FROM wordpress_perf_posts WHERE ID IN (4249,4248,4247,4246,4245,4244,4243,4242,4241,4240) ORDER BY ID"
+    expect:
+      rows: 10
+      data:
+        - {ID: 4240, post_title: "Benchmark Post 4240", post_status: "draft", post_type: "post"}
+        - {ID: 4241, post_title: "Benchmark Post 4241", post_status: "publish", post_type: "post"}
+        - {ID: 4242, post_title: "Benchmark Post 4242", post_status: "publish", post_type: "post"}
+        - {ID: 4243, post_title: "Benchmark Post 4243", post_status: "publish", post_type: "post"}
+        - {ID: 4244, post_title: "Benchmark Post 4244", post_status: "publish", post_type: "post"}
+        - {ID: 4245, post_title: "Benchmark Post 4245", post_status: "publish", post_type: "post"}
+        - {ID: 4246, post_title: "Benchmark Post 4246", post_status: "publish", post_type: "post"}
+        - {ID: 4247, post_title: "Benchmark Post 4247", post_status: "publish", post_type: "post"}
+        - {ID: 4248, post_title: "Benchmark Post 4248", post_status: "publish", post_type: "post"}
+        - {ID: 4249, post_title: "Benchmark Post 4249", post_status: "publish", post_type: "post"}
+
+  - name: "WordPress batch metadata lookup"
+    warmup: 10
+    timing_samples: 30
+    performance_rows: 75000
+    threshold_ms: 3
+    sql: "SELECT post_id, meta_key, meta_value FROM wordpress_perf_postmeta WHERE post_id IN (4249,4248,4247,4246,4245,4244,4243,4242,4241,4240) ORDER BY meta_id"
+    expect: {rows: 90}
+
   - name: "WordPress post ordered limit"
     warmup: 10
     timing_samples: 50


### PR DESCRIPTION
WordPress loads each page's posts and metadata with numeric `IN (...)` lists. After autoindexing has completed, these queries still visit the full indexed population: the access program contains no bounds for the membership values. A ten-post lookup in the fixture visits all 8,214 posts.

During Scheme physical lowering, derive an inclusive min/max candidate interval for numeric base-column membership in a positive conjunction. Bind the interval from the executing query's values before scanning and retain `sql_in` as the residual for gaps and duplicates. Cache guards validate the numeric parameter domain; strings, NULL-containing lists, NOT/OR/value contexts and competing predicates retain their existing paths. Parser/logical IR and Go scan execution are unchanged.

Manual warm A/B against master 55621603e, performed before opening this PR:

- Identical existing fixture: 8,214 posts and 75,000 metadata rows, rebuilt and restarted before each run.
- Same normal-Go binary; baseline/candidate Scheme sources. Order B/C/C/B, 10 warmups and 30 measured HTTP samples per case per run; medians below pool the 60 measured samples per variant.
- Ten-post batch: **7.403 → 0.463 ms**, −6.939 ms / **−93.74%**.
- Ninety-row metadata batch: **61.827 → 0.636 ms**, −61.191 ms / **−98.97%**.
- Sparse IN control: 3.185 → 3.204 ms (+0.60%); point-select control: 0.374 → 0.430 ms (+0.056 ms / +15.11%).
- Complete ordered results matched within each run and across both revisions. Captured EXPLAIN, IR, PHYSICAL and REORDER for both target queries.

Validation: 27 targeted IN/LIKE correctness cases passed with normal Go and JIT, including bound-plan and logical-IR assertions, changing cached values/types, NULLs, duplicates, gaps, competing ranges, ordered joins, adjacent BIGINT values above 2^53 and malformed SQL. The existing WordPress performance topic (11 cases including the two new batch cases) passed with both runtimes. Full suites and broad performance comparisons are delegated to CI as requested.

This is a database-query improvement. Full WordPress page measurements and an identically populated MariaDB comparison are separate measurements; these figures do not claim a complete-page speedup or a MariaDB win.
