### PR TITLE
Reuse runtime-bound plans without dropping lookup predicates

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -6699,17 +6699,21 @@ remain ordinary residual predicates. */
 			ir
 			(make_ir (ir_kind ir) outer_block all_stages (ir_context_of ir) (ir_return ir))))))
 
-/* Partitioning on a complete non-null unique key cannot reduce the number of
+/* Partitioning at most one input row, or a complete non-null unique key,
+cannot reduce the number of
 stage probes: each surviving row still owns one group. The partition alternative
 adds strictly positive startup/build cost to the same probes, independently of
 selectivity. Prove that dominance before sampling, and do not install a runtime
 sampling guard for a choice that no cardinality change can reverse. */
 (define aggregate_pushdown_identity_partition? (lambda (driver columns)
-	(reduce (source_unique_key_sets driver) (lambda (found key)
+	(begin
+		(define rows (planner_source_row_count driver))
+		(or (and (number? rows) (<= rows 1))
+		(reduce (source_unique_key_sets driver) (lambda (found key)
 		(or found (and (not (empty_list? key))
 			(reduce key (lambda (complete col)
 				(and complete (and (contains? columns col)
-					(source_column_guaranteed_nonnull? driver col)))) true)))) false)))
+					(source_column_guaranteed_nonnull? driver col)))) true)))) false)))))
 
 (define aggregate_pushdown_logical (lambda (ir planning_session tx)
 	(begin

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -336,12 +336,16 @@ and barrier ownership come from the pre-normalization query block. */
 /* Feedback keys describe the complete table-local logical predicate, before
 physical residual pruning. Compiling its access metadata here only canonicalizes
 bounded scalar metadata; this lookup never scans, loads columns or builds indexes. */
-(define planner_record_filter_feedback_guard (lambda (src access values planning_session)
+(define planner_record_filter_feedback_guard (lambda (src columns callback planning_session)
 	(begin
 		(define planning_session (planner_effective_session planning_session))
 		(if (or (nil? planning_session)
-			(nil? (planning_session "__memcp_queryplan_guard_conditions"))
-			(empty_list? (car access))
+			(nil? (planning_session "__memcp_queryplan_guard_conditions"))) nil
+		(begin
+		/* Keep the predicate unbound while generating metadata. Its slots must
+		read the executing session, not a literal/memo key from compilation. */
+		(define access (compile_scan_access columns callback true false))
+		(if (or (empty_list? (car access))
 			(not (list? (car (car access))))) nil
 			(begin
 				/* Guard precisely the metadata input, including an unknown result.
@@ -351,7 +355,7 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 				Budget zero is essential: guards never sample or run a filter. */
 				(define read_expr (list (quote scan_selectivity_estimate) nil
 					(list (quote table) (source_schema src) (source_relation src))
-					(list (quote quote) (car access)) (list (quote quote) values)
+					(list (quote quote) (car access)) (cons (quote list) (cadr access))
 					(list (quote quote) '()) (list (quote lambda) '() true) 0))
 				/* Provenance matters too: a prior from other LIKE words may be
 				resampled, whereas a same-predicate measurement need not be. Read
@@ -361,7 +365,8 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 						(list (quote qassoc_get) (quote estimate) (list (quote quote) (quote value)) nil)
 						(list (quote qassoc_get) (quote estimate) (list (quote quote) (quote source)) nil))) read_expr))
 				(planner_record_guard_condition
-					(list (quote equal?) value_expr (list (quote quote) (eval value_expr))) planning_session))))))
+					(list (quote equal?) value_expr (list (quote quote)
+						(eval (planner_bind_session_values value_expr planning_session)))) planning_session))))))))
 
 (define planner_filter_feedback (lambda (sources default_alias expr planning_session)
 	(begin
@@ -375,11 +380,11 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 							(define cols (extract_columns_for_alias src expr))
 							(define callback (list (quote lambda)
 								(map cols (lambda (col) (symbol (concat (source_alias src) "." col))))
-								(planner_bind_session_values (lower_column_expr_for_alias src expr) planning_session)))
-							(define access (compile_scan_access cols callback true))
+								(lower_column_expr_for_alias src expr)))
+							(define access (compile_scan_access cols
+								(planner_bind_session_values callback planning_session) true))
 							(define values (map (nth access 1) (lambda (value) (eval value))))
-							(planner_record_session_value_guards expr planning_session)
-							(planner_record_filter_feedback_guard src access values planning_session)
+							(planner_record_filter_feedback_guard src cols callback planning_session)
 							(scan_selectivity_estimate nil (table (source_schema src) (source_relation src))
 								(nth access 0) values
 								cols (eval callback) 0)))
@@ -429,7 +434,7 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 (define planner_quoted_value (lambda (value)
 	(list (quote quote) value)))
 
-(define join_optimizer_source_rows_expr (lambda (stages sources default_alias graph src)
+(define join_optimizer_source_rows_expr (lambda (stages sources default_alias graph src planning_session)
 	(begin
 		(define local_predicates
 			(join_optimizer_local_predicates graph (source_alias src)))
@@ -458,19 +463,37 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 				(planner_quoted_value local_sources)
 				default_alias
 				(planner_quoted_value local_predicates)
-				(planner_quoted_value src) (quote session))))))
+				(planner_quoted_value src) (quote session)) planning_session))))
 
-(define join_optimizer_selectivity_expr (lambda (sources default_alias predicate)
+(define join_optimizer_selectivity_expr (lambda (sources default_alias predicate planning_session)
 	(begin
 		(define aliases (join_hypergraph_expr_aliases
 			default_alias (source_aliases sources) predicate))
 		(define local_sources (filter sources (lambda (src)
 			(contains? aliases (source_alias src)))))
-		(planner_guard_runtime_binding
-			(list (quote join_optimizer_expr_selectivity)
-				(planner_quoted_value local_sources)
-				default_alias
-				(planner_quoted_value predicate) (quote session))))))
+		(define src (if (single_source? local_sources) (car local_sources) nil))
+		(define prior (join_optimizer_expr_prior_estimate sources default_alias predicate planning_session))
+		(define fallback (planner_estimate_planning_value prior
+			(if (equal? (qassoc_get prior (quote source) nil) (quote range_unknown))
+				0.3333333333333333 0.1)))
+		/* Emit the metadata read once, not the optimizer/access compiler itself.
+		The predicate shape and column statistics are compile-time inputs; only
+		its scalar value slots are rebound on a cache lookup. */
+		(if (not (source_is_base_table? src)) fallback
+			(begin
+				(define cols (extract_columns_for_alias src predicate))
+				(define callback (list (quote lambda)
+					(map cols (lambda (col) (symbol (concat (source_alias src) "." col))))
+					(lower_column_expr_for_alias src predicate)))
+				(define access (compile_scan_access cols callback true false))
+				(if (empty_list? (car access)) fallback
+					(planner_guard_runtime_binding
+						(list (quote qassoc_get)
+							(list (quote scan_selectivity_estimate) nil
+								(list (quote table) (source_schema src) (source_relation src))
+								(planner_quoted_value (car access)) (cons (quote list) (cadr access))
+								(planner_quoted_value '()) (list (quote lambda) '() true) 0)
+							(planner_quoted_value (quote value)) fallback) planning_session))))))))
 
 (define join_optimizer_alias_subset? (lambda (required available)
 	(reduce (coalesceNil required '()) (lambda (ok alias)
@@ -546,7 +569,7 @@ cost-reordered around the complete relation unit. */
 				(if (or singleton fixed_cardinality) 1
 					(join_optimizer_source_rows stages sources default_alias graph src planning_session))
 				(if (or singleton fixed_cardinality) 1
-					(join_optimizer_source_rows_expr stages sources default_alias graph src))
+					(join_optimizer_source_rows_expr stages sources default_alias graph src planning_session))
 				(if (join_optimizer_inner_source? stages src) (quote inner) (quote left-outer))
 				(join_optimizer_outer_requirements stages relation_units sources default_alias alias_index src)
 				(if (group_stage? stage) (stage_result_max_rows_per_partition stage) nil)
@@ -573,7 +596,7 @@ cost-reordered around the complete relation unit. */
 					(qassoc_get entry (quote owner) nil)
 					predicate
 					barrier_owner
-					(join_optimizer_selectivity_expr sources default_alias predicate)))
+					(join_optimizer_selectivity_expr sources default_alias predicate planning_session)))
 				metadata)))))
 
 (define join_optimizer_metadata_predicates (lambda (sources default_alias graph aliases planning_session)
@@ -1786,8 +1809,8 @@ particular star shape. */
 
 /* Table dependencies cover rebuild statistics; individual metadata reads guard
 their own bound filter estimates instead of invalidating on unrelated learning.
-Every local filter may now depend on a bound value; record all session-value
-dependencies, not only text-pattern parameters. */
+Guard cost inputs, not the SQL values used only to obtain those inputs. Exact
+value guards remain necessary for sampled or executable specialization. */
 (define join_order_record_cost_dependencies (lambda (sources nodes predicates planning_session)
 	(begin
 		(planner_record_table_statistics_guards sources planning_session)
@@ -1803,8 +1826,13 @@ dependencies, not only text-pattern parameters. */
 						(cadr node)) planning_session))) nil)
 		(reduce predicates (lambda (_ predicate)
 			(begin
-				(define expr (join_order_pred_expr predicate))
-				(planner_record_session_value_guards expr planning_session))) nil))))
+				/* A changed SQL value is not itself a changed cost input. Keep the
+				chosen input regime using the compiled metadata expression. This is
+				still conservative where no crossover inequality is available, but
+				does not force recompilation for every clock tick/range threshold. */
+				(planner_record_guard_condition
+					(list (quote equal?) (join_order_pred_selectivity_expr predicate)
+						(join_order_pred_selectivity predicate)) planning_session))) nil))))
 
 /* Every subset containing one vertex and any selection of its regular-edge
 neighbors is connected. A degree d therefore proves at least 2^d connected
@@ -2446,11 +2474,15 @@ the lowerer can cost it. */
 			stage_catalog sources default_alias graph src planning_session))
 		(define base_rows (planner_source_row_count src))
 		(define condition (join_optimizer_source_local_condition graph src))
+		/* max(1, matches) is constant when the entire population is <= 1.
+		This is dominance, not a selective-filter heuristic: do not sample or
+		bind a changing parameter for a choice it cannot influence. */
+		(if (and (number? base_rows) (<= base_rows 1)) 1
 		(if (or (not (number? base_rows)) (equal? condition true))
 			fallback
 			(begin
 				(define estimate (planner_source_filter_estimate src condition 512 tx planning_session))
-				(max 1 (planner_estimated_matching_rows estimate base_rows fallback)))))))
+				(max 1 (planner_estimated_matching_rows estimate base_rows fallback))))))))
 
 (define join_optimizer_ordered_driver_work (lambda (sources base_row_catalog filtered_row_catalog planned target)
 	(begin
@@ -2895,7 +2927,10 @@ floor avoids pretending that an unseen word is impossible. */
 					(define access (compile_scan_access filtercols filter_expr))
 					(define values (map (nth access 1) (lambda (value_expr) (eval value_expr))))
 					(planner_record_session_value_guards condition planning_session)
-					(planner_record_filter_feedback_guard src access values planning_session)
+					(planner_record_filter_feedback_guard src filtercols
+						(list (quote lambda)
+							(map filtercols (lambda (col) (symbol (concat alias "." col))))
+							(lower_column_expr_for_alias src condition)) planning_session)
 					(define estimate (scan_selectivity_estimate
 						tx
 						(table (source_schema src) (source_relation src))
@@ -2903,7 +2938,7 @@ floor avoids pretending that an unseen word is impossible. */
 						values
 						filtercols
 						(eval filter_expr)
-						max_rows))
+							max_rows))
 					(define text_prior (expr_text_selectivity_prior condition))
 					(define enriched (if (number? text_prior)
 						(qassoc_set estimate (quote fallback_selectivity) text_prior)

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -479,7 +479,12 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 		/* Emit the metadata read once, not the optimizer/access compiler itself.
 		The predicate shape and column statistics are compile-time inputs; only
 		its scalar value slots are rebound on a cache lookup. */
-		(if (not (source_is_base_table? src)) fallback
+		/* A catalog-backed virtual source can have a named relation without a
+		storage table. It has no scan feedback: retain the prior, never emit a
+		storage metadata call for a nonexistent handle (or materialize its rows
+		inside a guard). Semantic source validation still belongs to lowering. */
+		(if (or (not (source_is_base_table? src))
+			(nil? (planner_table_statistics (source_schema src) (source_relation src)))) fallback
 			(begin
 				(define cols (extract_columns_for_alias src predicate))
 				(define callback (list (quote lambda)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -5177,12 +5177,17 @@ until the caller has selected this physical alternative. */
 						(combine_where_terms (nth local_terms index) true))
 					(if (equal? local_condition true)
 						base_rows
+						/* The clamped estimate is identically one for a population
+						of at most one row. Sampling cannot affect this cost, so do
+						not introduce a dependency on an irrelevant session value.
+						Table-statistics guards still protect against data growth. */
+						(if (<= base_rows 1) 1
 						(begin
 							(define estimate
 								(planner_source_filter_estimate src local_condition 512
 									planning_tx planning_session))
 							(max 1 (planner_estimated_matching_rows estimate
-								base_rows base_rows))))))) nil))
+								base_rows base_rows)))))))) nil))
 		/* A local driver predicate is only the first acceptance stage. Every
 		later input may reject the driver row as well, so price ordered braking
 		from the product of the independently estimated inner selectivities.

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -307,7 +307,11 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 			(sql_queryplan_guard_references_symbol? head target)
 			(reduce tail (lambda (found item)
 				(or found (sql_queryplan_guard_references_symbol? item target))) false))
-		_ (equal? expr target))))
+		/* equal? admits truth-value coercion: true compares equal to a symbol.
+		Liveness is syntactic, not SQL/SCM value equality. Without this type
+		check a literal true keeps every discarded cost binding alive, executing
+		unused estimator calls on each cached query. */
+		_ (and (symbol? expr) (equal? expr target)))))
 
 /* Avoid degenerate generated `and` forms while retaining normal short-circuit
 semantics for multiple independent cache assumptions. */

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -167,9 +167,9 @@ type scanAccessSegment struct {
 type scanAccessRuntime struct {
 	// computedMapCols is populated only for compiled computed-index probes.
 	computedMapCols []string
-	// inserted contains runtime-only ordered constraints. insertAt places them
-	// between the compiled sorted prefix and advisory matchers without copying
-	// either segment.
+	// inserted contains runtime-only sorted constraints. insertAt places order
+	// columns after the compiled sorted prefix, or mandatory batch equality
+	// keys before local filters, without copying either segment.
 	insertAt int
 	inserted scanAccessSegment
 	suffix   scanAccessSegment

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -1618,7 +1618,13 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 	}
 	if requiredAccess.len() > 0 || source != nil {
 		runtime := access.ensureRuntime()
-		runtime.suffix = scanAccessAsSegment(requiredAccess)
+		// Batch join keys are equality seeks, not advisory trailing hooks.
+		// Put them before the local access constraints: otherwise a local range
+		// can hide the key from the sorted prefix, or a broad local equality
+		// index can be scanned afresh for every batch item. Keep every local
+		// boundary after the keys; uniqueness never makes its predicate optional.
+		runtime.insertAt = 0
+		runtime.inserted = scanAccessAsSegment(requiredAccess)
 		if source != nil {
 			runtime.extra = scanAccessSegmentFromAnalyzed(appendRecSetBoundary(nil, source))
 		}

--- a/storage/scan_join_order.go
+++ b/storage/scan_join_order.go
@@ -943,16 +943,12 @@ func probeScanJoinOrderInput(currentTx *TxContext, spec *scanJoinOrderSpec, tupl
 	combine := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
 		return scm.NewSlice(append(values[0].Slice(), values[1].Slice()...))
 	})
-	accessSchema := input.accessSchema
-	accessValues := input.accessValues
-	if input.table.hasUniqueColumns(input.targetKeyCols) {
-		// A complete dynamic unique-key probe dominates every local access
-		// boundary. Keep the local predicates in the residual callback so this
-		// path reads at most one candidate instead of building a wider index.
-		accessSchema = emptyScanAccessSchema
-		accessValues = nil
-	}
-	rows := input.table.scanWithBatchFrom(currentTx, nil, accessSchema, accessValues, runtimeScanAccess(required), conditionCols, condition,
+	// A unique probe dominates the choice of seek, not the other predicates.
+	// Access compilation may already have removed exact bounds from condition,
+	// including when some unrelated residual remains. Keep those bounds while
+	// merging the mandatory batch keys; dropping them silently admits rows that
+	// SQL rejects. Never infer predicate redundancy from key uniqueness alone.
+	rows := input.table.scanWithBatchFrom(currentTx, nil, input.accessSchema, input.accessValues, runtimeScanAccess(required), conditionCols, condition,
 		callbackCols, mapReduce, scm.NewSlice(nil), combine, false,
 		stride, batchdata).Slice()
 	hits := make([][]*scanJoinOrderRecord, len(tuples))

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1069,21 +1069,28 @@ func Init(en scm.Env) {
 				{Kind: "list", Label: "filterColumns", Description: "physical columns corresponding to the filter lambda parameters"},
 				{Kind: "list", Label: "filterExpression", Description: "unevaluated filter lambda AST"},
 				{Kind: "bool", Label: "feedback_only", Description: "compile only safe statistical identity metadata, without access boundaries", Optional: true},
+				{Kind: "bool", Label: "bind_values", Description: "evaluate value expressions now (default true); false returns their ASTs for compile-time guard generation", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "list", Description: "pair of static schema and bound runtime values"},
 		},
 	}, func(code []scm.Scmer, caller *scm.Env) scm.Scmer {
-		if len(code) < 2 || len(code) > 3 {
-			panic("compile_scan_access expects filter columns, a filter expression and optional feedback_only")
+		if len(code) < 2 || len(code) > 4 {
+			panic("compile_scan_access expects filter columns, a filter expression, optional feedback_only and bind_values")
 		}
 		columns := scm.Eval(code[0], caller)
 		filter := scm.Eval(code[1], caller)
 		var schema scm.Scmer
 		var valueExprs []scm.Scmer
-		if len(code) == 3 && scm.ToBool(scm.Eval(code[2], caller)) {
+		if len(code) >= 3 && scm.ToBool(scm.Eval(code[2], caller)) {
 			schema, valueExprs = compileFilterFeedbackAccess(columns, filter)
 		} else {
 			schema, valueExprs, _ = compileScanAccess(columns, filter)
+		}
+		// A cached guard must bind the executing request, not the values seen
+		// while compiling it. Return the same schema and its binding recipe;
+		// never run access compilation or a scan from the runtime guard.
+		if len(code) == 4 && !scm.ToBool(scm.Eval(code[3], caller)) {
+			return scm.NewSlice([]scm.Scmer{schema, scm.NewSlice(valueExprs)})
 		}
 		values := make([]scm.Scmer, len(valueExprs))
 		for i, expression := range valueExprs {

--- a/tests/performance/query-cache-feedback-churn.yaml
+++ b/tests/performance/query-cache-feedback-churn.yaml
@@ -41,6 +41,29 @@ test_cases:
     expect:
       rows: 1
       result_contains: ["true"]
+  - name: "Changing runtime cutoffs retain an ACL count plan"
+    performance_rows: 1000
+    threshold_ms: 1000
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT COUNT(*) AS n FROM qfc_clock a WHERE a.id > @cutoff AND COALESCE((SELECT CASE WHEN b.category=9 THEN TRUE ELSE EXISTS(SELECT 1 FROM qfc_document c WHERE c.id=b.id AND c.category=9) END FROM qfc_document b WHERE b.id=a.id LIMIT 1),FALSE)")
+        (define rows (newsession))
+        (rows "n" 0)
+        (reduce (produceN 16) (lambda (_ i)
+          (begin
+            (sess "cutoff" (+ 998 i))
+            (sql_execute_formula sess nil
+              (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+              (lambda (row) (rows "n" (+ (rows "n") (cadr row))))
+              (lambda (_fields) nil)))) nil)
+        (if (equal? (rows "n") 1) true (error "runtime cutoff changed ACL count results")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
   - name: "Ordered cache reuse survives a sequence of unrelated learned filters"
     performance_rows: 1000
     threshold_ms: 1000

--- a/tests/performance/query-cache-feedback-churn.yaml
+++ b/tests/performance/query-cache-feedback-churn.yaml
@@ -5,6 +5,10 @@ metadata:
   description: "Warm ordered queries amid unrelated bound-predicate learning"
   isolated: true
 setup:
+  - sql: "DROP TABLE IF EXISTS qfc_clock"
+  - sql: "CREATE TABLE qfc_clock (id INT PRIMARY KEY) ENGINE=sloppy"
+  - sql: "INSERT INTO qfc_clock VALUES (999)"
+  - scm: '(rebuild (table "memcp-tests" "qfc_clock") true false)'
   - sql: "DROP TABLE IF EXISTS qfc_document"
   - sql: "CREATE TABLE qfc_document (id INT PRIMARY KEY, category INT) ENGINE=sloppy"
   - scm: |
@@ -14,6 +18,29 @@ setup:
         (rebuild (table "memcp-tests" "qfc_document") true false)
         (globalvars "qfc_sequence" 1000))
 test_cases:
+  - name: "Changing runtime cutoffs retain a singleton ordered plan"
+    performance_rows: 1000
+    threshold_ms: 1000
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT a.id,b.category,c.category,d.category FROM qfc_clock a LEFT JOIN qfc_document b ON b.id=a.id LEFT JOIN qfc_document c ON c.id=a.id LEFT JOIN qfc_document d ON d.id=a.id WHERE a.id > @cutoff ORDER BY a.id LIMIT 72")
+        (define rows (newsession))
+        (rows "n" 0)
+        (reduce (produceN 16) (lambda (_ i)
+          (begin
+            (sess "cutoff" (+ 998 i))
+            (sql_execute_formula sess nil
+              (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+              (lambda (_row) (rows "n" (+ (rows "n") 1)))
+              (lambda (_fields) nil)))) nil)
+        (if (equal? (rows "n") 1) true (error "runtime cutoff changed query results")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
   - name: "Ordered cache reuse survives a sequence of unrelated learned filters"
     performance_rows: 1000
     threshold_ms: 1000
@@ -45,4 +72,5 @@ test_cases:
       rows: 1
       result_contains: ["true"]
 cleanup:
+  - sql: "DROP TABLE IF EXISTS qfc_clock"
   - sql: "DROP TABLE IF EXISTS qfc_document"

--- a/tests/performance/query-cache-feedback-churn.yaml
+++ b/tests/performance/query-cache-feedback-churn.yaml
@@ -7,7 +7,7 @@ metadata:
 setup:
   - sql: "DROP TABLE IF EXISTS qfc_clock"
   - sql: "CREATE TABLE qfc_clock (id INT PRIMARY KEY) ENGINE=sloppy"
-  - sql: "INSERT INTO qfc_clock VALUES (999)"
+  - sql: "INSERT INTO qfc_clock (id) VALUES (999)"
   - scm: '(rebuild (table "memcp-tests" "qfc_clock") true false)'
   - sql: "DROP TABLE IF EXISTS qfc_document"
   - sql: "CREATE TABLE qfc_document (id INT PRIMARY KEY, category INT) ENGINE=sloppy"
@@ -43,7 +43,9 @@ test_cases:
       result_contains: ["true"]
   - name: "Changing runtime cutoffs retain an ACL count plan"
     performance_rows: 1000
-    threshold_ms: 1000
+    # Sixteen complete requests; measured baseline is about 2-4 seconds.
+    # The A/B ratio remains enforced independently of this absolute ceiling.
+    threshold_ms: 5000
     scm: |
       (begin
         (define cache (newcachemap))

--- a/tests/performance/wordpress-postmeta-order-limit.yaml
+++ b/tests/performance/wordpress-postmeta-order-limit.yaml
@@ -179,8 +179,11 @@ test_cases:
             (list
               (list 370535686995968 (scan_boundary "equal" "meta_key" 0 0 true true "" false))
               (list 370535955431424
-                (scan_boundary "equal" "post_status" 0 0 true true "" false)
-                (scan_boundary "equal" "post_type" 1 1 true true "" false)))
+                /* Slots address the single shared accessValues array below,
+                not an array per input. Dropping unique-probe boundaries
+                used to hide incorrect slots here (status=custom_color). */
+                (scan_boundary "equal" "post_status" 1 1 true true "" false)
+                (scan_boundary "equal" "post_type" 2 2 true true "" false)))
             (list "custom_color" "publish" "post")
             (list (list) (list))
             (list (lambda () true) (lambda () true))

--- a/tests/planner/core/query-cache-feedback-isolation.yaml
+++ b/tests/planner/core/query-cache-feedback-isolation.yaml
@@ -5,6 +5,10 @@ metadata:
   description: "Unrelated learned predicates must not invalidate cached ordered plans"
   isolated: true
 setup:
+  - sql: "DROP TABLE IF EXISTS qfi_single"
+  - sql: "CREATE TABLE qfi_single (id INT PRIMARY KEY) ENGINE=sloppy"
+  - sql: "INSERT INTO qfi_single VALUES (999)"
+  - scm: '(rebuild (table "memcp-tests" "qfi_single") true false)'
   - sql: "DROP TABLE IF EXISTS qfi_document"
   - sql: "CREATE TABLE qfi_document (id INT PRIMARY KEY, label TEXT) ENGINE=sloppy"
   - scm: |
@@ -13,6 +17,70 @@ setup:
           (map (produceN 1000) (lambda (i) (list i (if (< i 10) "needle" "ordinary")))))
         (rebuild (table "memcp-tests" "qfi_document") true false))
 test_cases:
+  - name: "Access templates retain runtime binding expressions without evaluating them"
+    scm: |
+      (begin
+        (define access (compile_scan_access '("id")
+          (list 'lambda (list 'id) (list '> 'id (list 'session "unbound_guard_value"))) true false))
+        (if (and (not (empty_list? (car access)))
+          (equal? (cadr access) (list (list 'session "unbound_guard_value"))))
+          true (error "access template froze or lost its binding expression")))
+    expect:
+      data: [true]
+  - name: "Runtime range bindings reuse a provably constant singleton cost regime"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT a.id,b.label FROM qfi_single a LEFT JOIN qfi_document b ON b.id=a.id WHERE a.id > @cutoff ORDER BY a.id LIMIT 2")
+        (define rows (newsession))
+        (define run (lambda (cutoff)
+          (begin
+            (sess "cutoff" cutoff)
+            (rows "n" 0)
+            (sql_execute_formula sess nil
+              (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+              (lambda (_row) (rows "n" (+ (rows "n") 1)))
+              (lambda (_fields) nil))
+            (rows "n"))))
+        (define first (run 998))
+        (define entry (car (cache (car (cache)))))
+        (define before (count (entry "variants")))
+        (define second (run 999))
+        (define third (run 1000))
+        (define null_result (run nil))
+        (if (and (equal? first 1) (equal? second 0) (equal? third 0)
+          (equal? null_result 0)
+          (equal? before (count (entry "variants")))) true
+          (error (concat "runtime binding must change results without recompiling an unchanged choice: "
+            first "/" second "/" third " variants=" before " -> "
+            (count (entry "variants")) " guard="
+            (serialize (car (car (entry "variants"))))))))
+    expect:
+      data: [true]
+  - name: "A binding shared by a filter and LIMIT still controls execution"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT a.id,b.label FROM qfi_single a LEFT JOIN qfi_document b ON b.id=a.id WHERE a.id > @bound ORDER BY a.id LIMIT @bound")
+        (define rows (newsession))
+        (define run (lambda (bound)
+          (begin
+            (sess "bound" bound)
+            (rows "n" 0)
+            (sql_execute_formula sess nil
+              (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+              (lambda (_row) (rows "n" (+ (rows "n") 1))) (lambda (_fields) nil))
+            (rows "n"))))
+        (if (equal? (list (run 998) (run 0) (run 999)) (list 1 0 0))
+          true (error "cost-only guard hid a binding needed by LIMIT")))
+    expect:
+      data: [true]
   - name: "Unrelated learned LIKE leaves an ordered self-join cache variant reusable"
     scm: |
       (begin
@@ -75,5 +143,35 @@ test_cases:
             " guard=" (serialize (car (car (entry "variants"))))))))
     expect:
       data: [true]
+  - name: "Growth invalidates the singleton dominance proof"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (sess "cutoff" -1)
+        (define q "SELECT a.id,b.label FROM qfi_single a LEFT JOIN qfi_document b ON b.id=a.id WHERE a.id > @cutoff ORDER BY a.id LIMIT 2")
+        (define rows (newsession))
+        (define run (lambda ()
+          (begin
+            (rows "n" 0)
+            (sql_execute_formula sess nil
+              (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+              (lambda (_row) (rows "n" (+ (rows "n") 1))) (lambda (_fields) nil))
+            (rows "n"))))
+        (define first (run))
+        (define entry (car (cache (car (cache)))))
+        (define before (count (entry "variants")))
+        (insert (table "memcp-tests" "qfi_single") '("id")
+          (map (produceN 256) (lambda (i) (list i))))
+        (rebuild (table "memcp-tests" "qfi_single") true false)
+        (define second (run))
+        (if (and (equal? first 1) (equal? second 2)
+          (> (count (entry "variants")) before)) true
+          (error "singleton plan survived growth without rechecking its assumptions")))
+    expect:
+      data: [true]
 cleanup:
+  - sql: "DROP TABLE IF EXISTS qfi_single"
   - sql: "DROP TABLE IF EXISTS qfi_document"

--- a/tests/planner/core/query-cache-feedback-isolation.yaml
+++ b/tests/planner/core/query-cache-feedback-isolation.yaml
@@ -17,6 +17,19 @@ setup:
           (map (produceN 1000) (lambda (i) (list i (if (< i 10) "needle" "ordinary")))))
         (rebuild (table "memcp-tests" "qfi_document") true false))
 test_cases:
+  - name: "Truthy guard literals are not references to statistic bindings"
+    scm: |
+      (begin
+        (define target (symbol "__unused_statistic_binding"))
+        (if (and
+          (not (sql_queryplan_guard_references_symbol? true target))
+          (not (sql_queryplan_guard_references_symbol?
+            (list (quote equal?) (list (quote lambda) (list) true) 1) target))
+          (sql_queryplan_guard_references_symbol?
+            (list (quote equal?) target 1) target)) true
+          (error "guard liveness treated a boolean literal as a symbol reference")))
+    expect:
+      data: [true]
   - name: "Access templates retain runtime binding expressions without evaluating them"
     scm: |
       (begin

--- a/tests/planner/core/query-cache-feedback-isolation.yaml
+++ b/tests/planner/core/query-cache-feedback-isolation.yaml
@@ -143,6 +143,28 @@ test_cases:
             " guard=" (serialize (car (car (entry "variants"))))))))
     expect:
       data: [true]
+  - name: "An ACL count does not reconsider a dominated singleton partition for every cutoff"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT COUNT(*) AS n FROM qfi_single a WHERE a.id > @cutoff AND COALESCE((SELECT CASE WHEN b.label='ordinary' THEN TRUE ELSE EXISTS(SELECT 1 FROM qfi_document c WHERE c.id=b.id AND c.label='needle') END FROM qfi_document b WHERE b.id=a.id LIMIT 1),FALSE)")
+        (define rows (newsession))
+        (rows "n" 0)
+        (reduce (list 998 999 1000) (lambda (_ cutoff)
+          (begin
+            (sess "cutoff" cutoff)
+            (sql_execute_formula sess nil
+              (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+              (lambda (row) (rows "n" (+ (rows "n") (cadr row))))
+              (lambda (_fields) nil)))) nil)
+        (define entry (car (cache (car (cache)))))
+        (if (and (equal? (rows "n") 1) (equal? (count (entry "variants")) 1))
+          true (error "singleton ACL count recompiled or changed its result")))
+    expect:
+      data: [true]
   - name: "Growth invalidates the singleton dominance proof"
     scm: |
       (begin

--- a/tests/planner/joins/ordered-lookup-boundaries.yaml
+++ b/tests/planner/joins/ordered-lookup-boundaries.yaml
@@ -28,6 +28,14 @@ test_cases:
     sql: "SELECT a.id FROM olb_lookup a JOIN olb_driver b ON b.id=a.id WHERE a.id < 999 AND a.enabled + 1 = 2 AND b.label IS NOT NULL ORDER BY a.id LIMIT 2"
     expect:
       rows: 0
+  - name: "A non-key equality still rejects the unique batch lookup"
+    sql: "SELECT a.id FROM olb_lookup a JOIN olb_driver b ON b.id=a.id WHERE a.enabled=0 AND b.label IS NOT NULL ORDER BY a.id LIMIT 2"
+    expect:
+      rows: 0
+  - name: "A matching non-key equality preserves the unique batch lookup"
+    sql: "SELECT a.id FROM olb_lookup a JOIN olb_driver b ON b.id=a.id WHERE a.enabled=1 AND b.label IS NOT NULL ORDER BY a.id LIMIT 2"
+    expect:
+      data: [{id: 999}]
 cleanup:
   - sql: "DROP TABLE IF EXISTS olb_lookup"
   - sql: "DROP TABLE IF EXISTS olb_driver"

--- a/tests/planner/joins/ordered-lookup-boundaries.yaml
+++ b/tests/planner/joins/ordered-lookup-boundaries.yaml
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "Ordered unique-key probes retain predicates consumed by access boundaries"
+setup:
+  - sql: "DROP TABLE IF EXISTS olb_driver"
+  - sql: "DROP TABLE IF EXISTS olb_lookup"
+  - sql: "CREATE TABLE olb_driver (id INT PRIMARY KEY, label TEXT)"
+  - sql: "CREATE TABLE olb_lookup (id INT PRIMARY KEY, enabled INT)"
+  - sql: "INSERT INTO olb_lookup VALUES (999, 1)"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "olb_driver") '("id" "label")
+          (map (produceN 1000) (lambda (i) (list i "ordinary"))))
+        (rebuild (table "memcp-tests" "olb_driver") true false)
+        (rebuild (table "memcp-tests" "olb_lookup") true false))
+test_cases:
+  - name: "Exclusive lower bound rejects an otherwise matching unique lookup"
+    sql: "SELECT a.id FROM olb_lookup a JOIN olb_driver b ON b.id=a.id WHERE a.id > 999 AND b.label IS NOT NULL ORDER BY a.id LIMIT 2"
+    expect:
+      rows: 0
+  - name: "Inclusive lower bound preserves the matching unique lookup"
+    sql: "SELECT a.id FROM olb_lookup a JOIN olb_driver b ON b.id=a.id WHERE a.id >= 999 AND b.label IS NOT NULL ORDER BY a.id LIMIT 2"
+    expect:
+      data: [{id: 999}]
+  - name: "A remaining residual does not replace a consumed upper bound"
+    sql: "SELECT a.id FROM olb_lookup a JOIN olb_driver b ON b.id=a.id WHERE a.id < 999 AND a.enabled + 1 = 2 AND b.label IS NOT NULL ORDER BY a.id LIMIT 2"
+    expect:
+      rows: 0
+cleanup:
+  - sql: "DROP TABLE IF EXISTS olb_lookup"
+  - sql: "DROP TABLE IF EXISTS olb_driver"


### PR DESCRIPTION
## Summary

Stop treating every new runtime range value as a new query-planning regime.
Keep the statistical predicate template unbound, bind its scalar slots from the
executing session, and check the consumed metadata through
`scan_selectivity_estimate` with a zero sampling budget. The new access-template
option returns binding ASTs at compile time; the guard does not call the access
compiler for these reads.

Restore explicit compile-session threading for shared reorder guard expressions
and emit table-local selectivity reads directly. Reorder input guards compare
cost inputs rather than their originating SQL values. Exact parameter guards
remain for sampled physical estimates; existing crossover guards are retained.
This is NOT a claim that all historical DP crossover inequalities have been
restored. Where no inequality exists, equality of consumed cost metadata is
still the conservative fallback, not equality of every filter parameter.

Two dominance proofs avoid measurements that cannot influence a choice:

- `max(1, matching_rows)` is constant for a table population of at most one;
- partitioning at most one input row cannot reduce the number of downstream
  probes, but adds partition startup/build work.

These proofs are protected by table-statistics guards: growth still invalidates
the plan. No table names, session-variable names, thresholds, calibration
weights or operator preferences were special-cased. Existing calibrated cost
comparisons and the logical/physical boundary remain in place; no costgen
coefficient change is required.

## Correctness found while testing

The ordered unique-probe operator discarded all local access boundaries on the
assumption that the full condition remained in its callback. Access compilation
can already have pruned those predicates, including with a nonempty residual.
A matching unique key therefore admitted a row rejected by an exclusive range.
Keep the local boundaries when merging mandatory batch keys. This correction
is a separate commit with a test that fails on the baseline (two wrong-result
cases) and passes after the fix. Uniqueness dominates seek selection, not SQL
predicate semantics.

## Regression coverage

- Runtime range changes alter results, including NULL, while retaining one plan
  in a proven unchanged singleton cost regime. Baseline creates three variants.
- A parameter shared by a filter and LIMIT still changes execution correctly.
- ACL COUNT retains one plan across changing cutoffs.
- Growing the singleton table to 257 rows forces a new variant.
- Existing consumed-feedback, unrelated-feedback, and growth tests remain intact.
- Compiled access templates retain unevaluated session-value slots.
- Exclusive/inclusive lookup ranges, including a remaining residual, preserve
  correct row visibility.
- New A/B-capable SCM workloads run 16 distinct cutoff bindings per sample for
  both an ordered list and a compound CASE/EXISTS/scalar ACL count.

The initial exploratory 1000-row test changed measured candidates from 3 to 1
to 0; identical plan variants are not generally guaranteed for changed cost
inputs. The permanent reuse assertions instead exercise the provable singleton
regime and separately require invalidation after growth/changed feedback.

## Manual A/B measurements

Baseline: f6020ceb0 (same executable/planner source as branch base 55621603e;
the intervening commit changes CI YAML discovery only). Candidate: this branch.
Both use the same JIT toolchain/build configuration. Same local machine,
separate dev processes, identical rebuilt fixtures: 1000 lookup rows and one
driving row. Two warmups, seven measured samples, alternating A/B request order.
Each sample includes a fresh plan cache, initial compilation and sixteen runtime
bindings, not sixteen repetitions of an identical cutoff. Results validated on
both sides. HTTP wall-clock medians, milliseconds:

| Workload | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Ordered list with changing cutoff | 183.815 | 23.596 | -87.2%, 7.8x faster |
| Compound ACL COUNT with changing cutoff | 3201.002 | 2301.208 | -28.1% |
| Existing unrelated-feedback control | 6.779 | 7.980 | +17.7% |

The host was noisy during the final run (other compiler/simulator processes).
Earlier interleaved list measurements were 62.803 -> 5.326 ms and the existing
control 2.590 -> 2.731 ms. These are reported as separate runs, not mixed into
the final median. CI A/B must independently check the broader regression pool;
no barrier or existing test was relaxed. The new COUNT's absolute ceiling is
5 seconds for the complete sixteen-request workload, calibrated from the
measured 2-4 second baseline; the normal relative A/B gate still applies.

This is a dev-fixture A/B, not a production end-to-end claim. A read-only
production baseline independently showed changing the time binding costing
101-112 ms versus 2.8-3.3 ms for the identical binding. The live instance has
not been modified or restarted for this patch. Static partial-aggregate cache
alternatives remain a separate measured optimization, not an assumed winner.

## Validation

Targeted YAML suites: query-cache-feedback-isolation, query-cache-growth,
session-group-reminders, session-group-empty-keytable, adaptive-filter-selectivity,
session-group-cache, ordered-lookup-boundaries, scan-batch-optimizer.
JIT startup: 1276/1276 Scheme tests passed. Scheme lint and diff checks pass.
Full SQL/JIT suites and full performance A/B belong to CI and will be watched.

### CI follow-up

The first full SQL and JIT runs caught virtual INFORMATION_SCHEMA joins: a
named virtual source is not a storage table, so its guard must not emit a
storage-feedback read. Commit 438c48d79 retains the prior when storage metadata
is unavailable. The unchanged information-schema suite now passes 38/38 locally,
alongside 7/7 new/retained cache-regression cases. No test was disabled or weakened.

The following run passed full SQL, JIT SQL, Go/JIT Go, alternative storage and
packaging, but both A/B runs caught an ordered WordPress join regression. Local
EXPLAIN was identical: retaining local access bounds exposed incorrect boundary
ordering in the operator. Mandatory batch equality keys must precede local
filters, rather than following a broad equality/range access prefix. Commit
8773a0ce6 uses the existing segmented access view to do this without copying
the compiled schema or discarding predicates.

Local interleaved A/B/C for the unchanged SQL workload, same rebuilt fixture
(8,214 posts, 75,000 metadata rows), three warmups and fifteen measured requests:
baseline **1.735 ms**, regressed candidate **12.719 ms**, corrected candidate
**1.574 ms** (9.3% below baseline). Five ordered-lookup correctness cases,
seven cache-guard cases and thirteen scan-batch cases pass locally.

The explicitly revision-specific handwritten benchmark also contained invalid
binding slots: all input schemas address one shared values array, but its second
input read slots 0/1 (custom_color/publish) instead of 1/2 (publish/post). The old
operator's dropped boundaries masked that error. Commit f622ee557 corrects these
two slots, not the expected result, samples, timing ceiling or A/B barrier.
An initial direct-operator comparison still contained delta rows (unlike CI's
restart-after-setup fixture). CPU profiling attributed most work to delta-tree
iteration. Explicitly completing rebuild on both sides, then interleaving ten
warmups and one hundred samples, gives **0.709 -> 0.741 ms (+4.6%)** for the
handwritten path. This is reported separately from the SQL measurements above;
neither it nor the SQL improvement substitutes for the full A/B gate.

### Interpreter-only guard regression

The next run passed JIT A/B and full SQL/JIT suites, but ordinary A/B exposed
extra interpreter work on the empty grouped metadata lookup. Guard serialization
showed unused row-estimator arguments. The existing liveness walker used
coercing `equal?` on arbitrary literals: `true` compares equal to a truthy symbol,
therefore a literal true kept every registered binding alive. Require a symbol
before comparing symbol identity. This removes only unreferenced computations,
not guard conditions, crossover checks or metadata dependencies. A new
self-asserting YAML case fails before the fix and passes after it; cache/growth
tests remain green.

Manual no-JIT isolation A/B/C: identical rebuilt WordPress fixture, same binary
for both Scheme revisions (isolating guard generation), ten warmups and one
hundred samples per query, interleaved baseline/regressed/fixed order:

| Workload | Baseline Scheme | Before liveness fix | After liveness fix |
| --- | ---: | ---: | ---: |
| Filtered ordered join | 1.374 ms | 2.406 ms | 1.295 ms |
| Empty grouped metadata lookup | 0.820 ms | 1.972 ms | 0.843 ms |

The final column is -5.8% / +2.9% against the baseline, respectively. Full CI
is rerun for this correction; no timing limit or A/B policy was changed.

## Final CI A/B results (b3f32d90d)

Both full performance A/B workflows passed, with all gates unchanged:
[ordinary A/B](https://github.com/launix-de/memcp/actions/runs/34363829884),
[JIT A/B](https://github.com/launix-de/memcp/actions/runs/34363829897).
These independently complement the manual measurements above.

| Workload | Ordinary base -> candidate | JIT base -> candidate |
| --- | ---: | ---: |
| Changing cutoffs, ordered list (16 bindings) | 284.158 -> 19.721 ms (-93.1%) | 88.598 -> 5.655 ms (-93.6%) |
| Changing cutoffs, ACL count (16 bindings) | 4916.593 -> 1664.213 ms (-66.2%) | 1504.333 -> 894.406 ms (-40.5%) |
| WordPress filtered ordered join | 1.435 -> 1.537 ms (+7.1%) | 1.092 -> 1.148 ms (+5.1%) |
| Empty grouped metadata lookup | 1.293 -> 1.360 ms (+5.1%) | 1.011 -> 1.001 ms (-1.0%) |
| Handwritten batched ordered join | 1.271 -> 1.349 ms (+6.2%) | 1.023 -> 1.034 ms (+1.1%) |

All checks for **b3f32d90d** completed successfully: full SQL (13m09s),
JIT SQL (20m54s), Go/JIT Go, ordinary/JIT A/B, alternative storage, packaging,
PHP integration, and regression policies. GitHub reports `CLEAN` / `MERGEABLE`.
No local full suite was run; only targeted suites and the documented manual
measurements. The live instance remains unchanged. Ready for review/merge;
not auto-merged.
