### PR TITLE
perf: cost-order scalar scan filters

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -7536,3 +7536,43 @@ threshold outside Costgen's model. */
 				planner_membership_scan_invocation_ns)
 				0 0 0 0 0 0 0 target 0.65)
 			target 0.65))))
+
+/* Reorder only a closed, side-effect-free scalar subset. Probe markers,
+user functions, CASE and other evaluation boundaries retain their order. */
+(define physical_reorderable_filter? (lambda (expr)
+	(match expr
+		((symbol get_column) _alias _ci _column _column_ci) true
+		((symbol session) key) (string? key)
+		(cons head tail) (and
+			(contains? '("and" "or" "equal??" "equal?" "<" ">" "<=" ">=" "strlike" "strlike_cs" "nil?") (string head))
+			(reduce tail (lambda (valid item) (and valid (physical_reorderable_filter? item))) true))
+		_ (or (nil? expr) (or (number? expr) (or (string? expr) (or (equal? expr true) (equal? expr false))))))))
+
+/* For short-circuit AND, sorting by cost / rejection probability minimizes
+expected work under the same independent-selectivity assumption as join
+costing. Unknown selectivity uses the same neutral prior for every term.
+Costs reuse costgen's scalar-operation and decoded-text-byte coefficients.
+Only callback evaluation order changes; access candidates and logical IR
+remain the inputs already chosen by the planner. */
+(define physical_filter_order_score (lambda (src term planning_session)
+	(begin
+		(define work (physical_expression_work_profile src term planning_session))
+		(define cost (+
+			(* (qassoc_get work (quote operations) 0) planner_membership_expression_operation_row_ns)
+			(* (qassoc_get work (quote broad_text_matches) 0) planner_membership_broad_text_match_row_ns)
+			(* (qassoc_get work (quote broad_text_average_bytes) 0) planner_membership_broad_text_match_byte_ns)))
+		(define selectivity (planner_estimate_planning_value
+			(join_optimizer_expr_prior_estimate (list src) (source_alias src) term planning_session) 0.5))
+		(/ cost (max 0.000001 (- 1 selectivity))))))
+
+(define physical_order_filter_terms (lambda (src condition planning_session)
+	(begin
+		(define terms (split_and_terms condition))
+		(if (or (< (count terms) 2) (not (physical_reorderable_filter? condition)))
+			condition
+			(begin
+				(define scored (map (produceN (count terms)) (lambda (i)
+					(list (nth terms i) (physical_filter_order_score src (nth terms i) planning_session) i))))
+				(combine_where_terms (map
+					(sort scored (lambda (a b) (if (equal? (cadr a) (cadr b))
+						(< (nth a 2) (nth b 2)) (< (cadr a) (cadr b))))) car) true))))))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4268,10 +4268,13 @@ plan construction or timing during compilation. */
 						(strip_driver_membership_for_source src condition direct_membership)
 						(replace_driver_membership_markers src condition bound_memberships))))
 				(define filter_condition (physical_numeric_in_intervals src
-					(if use_membership_keysets
-						(replace_driver_membership_keyset_markers
-							candidate_filter_condition membership_keysets)
-						candidate_filter_condition) (planner_context_session (qb_facts block))))
+					(physical_order_filter_terms src
+						(if use_membership_keysets
+							(replace_driver_membership_keyset_markers
+								candidate_filter_condition membership_keysets)
+							candidate_filter_condition)
+						(planner_context_session (qb_facts block)))
+					(planner_context_session (qb_facts block))))
 				(define filtercols (merge_unique (list
 					(if (or membership_filter scalar_membership_filter)
 						(list "$recset_contains") '())

--- a/tests/execution/operators/in-list-like-prefix.yaml
+++ b/tests/execution/operators/in-list-like-prefix.yaml
@@ -1,5 +1,6 @@
 # Copyright (C) 2026 Carl-Philip Hänsch
 # SPDX-License-Identifier: GPL-3.0-or-later
+
 # Tests for IN-list and LIKE prefix boundary extraction for index usage.
 # IN (1,2,3) → range [min,max]; LIKE 'foo%' → range [prefix, prefix+1)
 
@@ -182,3 +183,18 @@ test_cases:
       - sql: "INSERT INTO inlike (id,name,val) VALUES (9007199254740992,'large-low',1),(9007199254740993,'large-high',2)"
     sql: "SELECT name FROM inlike WHERE id IN (9007199254740993,9007199254740992) ORDER BY val"
     expect: {rows: 2, data: [{name: "large-low"}, {name: "large-high"}]}
+  - name: "LIKE disjunction and cheap equality disjunction preserve rows"
+    sql: "SELECT id FROM inlike WHERE (name LIKE '%19%' OR name LIKE '%18%') AND (val = 900 OR val = 950) ORDER BY id"
+    expect: {rows: 2, data: [{id: 180}, {id: 190}]}
+
+  - name: "Nullable text disjunction preserves WHERE truth semantics"
+    sql: "SELECT id FROM inlike WHERE (name LIKE '%19%' OR NULL) AND (val = 900 OR val = 950) ORDER BY id"
+    expect: {rows: 1, data: [{id: 190}]}
+
+  - name: "CASE remains an evaluation boundary in a text filter"
+    sql: "SELECT id FROM inlike WHERE (CASE WHEN val = 950 THEN name LIKE '%19%' ELSE FALSE END) AND id > 0 ORDER BY id"
+    expect: {rows: 1, data: [{id: 190}]}
+
+  - name: "Malformed text filter is rejected"
+    sql: "SELECT id FROM inlike WHERE name LIKE AND val = 950"
+    expect: {error: true}

--- a/tests/performance/wordpress-search.yaml
+++ b/tests/performance/wordpress-search.yaml
@@ -1,0 +1,147 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Ten historical revisions per article reproduce a content-heavy search table.
+metadata:
+  version: '1.0'
+  description: WordPress search excludes revision history before scanning article
+    text
+  isolated: true
+  ci: true
+  restart_after_setup: true
+setup:
+- sql: DROP TABLE IF EXISTS wordpress_search_posts
+- sql: CREATE TABLE wordpress_search_posts (ID BIGINT PRIMARY KEY, post_title TEXT,
+    post_excerpt TEXT, post_content TEXT, post_status VARCHAR(20), post_type VARCHAR(20),
+    post_password VARCHAR(20), post_date BIGINT) ENGINE=sloppy
+- scm: |-
+    (insert (table "memcp-tests" "wordpress_search_posts")
+      '("ID" "post_title" "post_excerpt" "post_content" "post_status" "post_type" "post_password" "post_date")
+      (map (produceN 22000) (lambda (i)
+        (begin
+          (define k (mod i 2000))
+          (define rare (equal? (mod k 197) 0))
+          (list (+ i 1)
+            (concat "Article " k (if (and rare (equal? (mod k 3) 0)) " nightjar" ""))
+            (concat "Summary " k (if (and rare (equal? (mod k 3) 1)) " nightjar" ""))
+            (concat (reduce (produceN (+ 3 (mod k 7))) (lambda (text n)
+              (concat text " This article discusses everyday publishing and readers in chapter " n ".")) "")
+              (if (and rare (equal? (mod k 3) 2)) " nightjar" "")
+              (if (equal? (mod k 3) 0) " performance" ""))
+            (if (>= i 2000) "inherit" (if (equal? (mod k 20) 0) "draft" "publish"))
+            (if (>= i 2000) "revision" (if (equal? (mod k 17) 0) "page" (if (equal? (mod k 11) 0) "attachment" "post")))
+            (if (equal? (mod k 29) 0) "protected" "") k)))))
+- scm: (rebuild)
+test_cases:
+- name: WordPress rare search with revision history
+  warmup: 10
+  timing_samples: 30
+  threshold_ms: 200
+  sql: |-
+    SELECT SQL_CALC_FOUND_ROWS ID FROM wordpress_search_posts
+    WHERE ((post_title LIKE '%nightjar%') OR (post_excerpt LIKE '%nightjar%') OR (post_content LIKE '%nightjar%'))
+      AND post_password = ''
+      AND ((post_type = 'attachment' AND post_status = 'publish')
+        OR (post_type = 'page' AND post_status = 'publish')
+        OR (post_type = 'post' AND post_status = 'publish'))
+    ORDER BY post_title LIKE '%nightjar%' DESC, post_date DESC LIMIT 10
+  expect:
+    rows: 10
+    data:
+    - ID: 1774
+    - ID: 1183
+    - ID: 592
+    - ID: 1971
+    - ID: 1577
+    - ID: 1380
+    - ID: 986
+    - ID: 789
+    - ID: 395
+    - ID: 198
+- name: WordPress common search with revision history
+  warmup: 10
+  timing_samples: 30
+  threshold_ms: 200
+  sql: |-
+    SELECT SQL_CALC_FOUND_ROWS ID FROM wordpress_search_posts
+    WHERE ((post_title LIKE '%performance%') OR (post_excerpt LIKE '%performance%') OR (post_content LIKE '%performance%'))
+      AND post_password = ''
+      AND ((post_type = 'attachment' AND post_status = 'publish')
+        OR (post_type = 'page' AND post_status = 'publish')
+        OR (post_type = 'post' AND post_status = 'publish'))
+    ORDER BY post_title LIKE '%performance%' DESC, post_date DESC LIMIT 10
+  expect:
+    rows: 10
+    data:
+    - ID: 1999
+    - ID: 1996
+    - ID: 1993
+    - ID: 1990
+    - ID: 1987
+    - ID: 1984
+    - ID: 1978
+    - ID: 1975
+    - ID: 1972
+    - ID: 1969
+- name: WordPress absent search with revision history
+  warmup: 10
+  timing_samples: 30
+  threshold_ms: 200
+  sql: |-
+    SELECT SQL_CALC_FOUND_ROWS ID FROM wordpress_search_posts
+    WHERE ((post_title LIKE '%quasarless%') OR (post_excerpt LIKE '%quasarless%') OR (post_content LIKE '%quasarless%'))
+      AND post_password = ''
+      AND ((post_type = 'attachment' AND post_status = 'publish')
+        OR (post_type = 'page' AND post_status = 'publish')
+        OR (post_type = 'post' AND post_status = 'publish'))
+    ORDER BY post_title LIKE '%quasarless%' DESC, post_date DESC LIMIT 10
+  expect:
+    rows: 0
+    data: []
+- name: WordPress rare search with revision history total before LIMIT
+  scm: |-
+    (begin
+      (define cache (newcachemap))
+      (define sess (newsession))
+      (sess "username" "root")
+      (sess "schema" "memcp-tests")
+      (define formula (cached_parse cache (list parse_sql) "memcp-tests"
+        "SELECT SQL_CALC_FOUND_ROWS ID FROM wordpress_search_posts\nWHERE ((post_title LIKE '%nightjar%') OR (post_excerpt LIKE '%nightjar%') OR (post_content LIKE '%nightjar%'))\n  AND post_password = ''\n  AND ((post_type = 'attachment' AND post_status = 'publish')\n    OR (post_type = 'page' AND post_status = 'publish')\n    OR (post_type = 'post' AND post_status = 'publish'))\nORDER BY post_title LIKE '%nightjar%' DESC, post_date DESC LIMIT 10" nil "root" sess true nil))
+      (sql_execute_formula sess nil formula (lambda (_row) true) (lambda (_fields) nil))
+      (if (equal? (sess "found_rows") 10) "ok"
+        (error (concat "unexpected FOUND_ROWS: " (sess "found_rows")))))
+  expect:
+    data:
+    - ok
+- name: WordPress common search with revision history total before LIMIT
+  scm: |-
+    (begin
+      (define cache (newcachemap))
+      (define sess (newsession))
+      (sess "username" "root")
+      (sess "schema" "memcp-tests")
+      (define formula (cached_parse cache (list parse_sql) "memcp-tests"
+        "SELECT SQL_CALC_FOUND_ROWS ID FROM wordpress_search_posts\nWHERE ((post_title LIKE '%performance%') OR (post_excerpt LIKE '%performance%') OR (post_content LIKE '%performance%'))\n  AND post_password = ''\n  AND ((post_type = 'attachment' AND post_status = 'publish')\n    OR (post_type = 'page' AND post_status = 'publish')\n    OR (post_type = 'post' AND post_status = 'publish'))\nORDER BY post_title LIKE '%performance%' DESC, post_date DESC LIMIT 10" nil "root" sess true nil))
+      (sql_execute_formula sess nil formula (lambda (_row) true) (lambda (_fields) nil))
+      (if (equal? (sess "found_rows") 612) "ok"
+        (error (concat "unexpected FOUND_ROWS: " (sess "found_rows")))))
+  expect:
+    data:
+    - ok
+- name: WordPress absent search with revision history total before LIMIT
+  scm: |-
+    (begin
+      (define cache (newcachemap))
+      (define sess (newsession))
+      (sess "username" "root")
+      (sess "schema" "memcp-tests")
+      (define formula (cached_parse cache (list parse_sql) "memcp-tests"
+        "SELECT SQL_CALC_FOUND_ROWS ID FROM wordpress_search_posts\nWHERE ((post_title LIKE '%quasarless%') OR (post_excerpt LIKE '%quasarless%') OR (post_content LIKE '%quasarless%'))\n  AND post_password = ''\n  AND ((post_type = 'attachment' AND post_status = 'publish')\n    OR (post_type = 'page' AND post_status = 'publish')\n    OR (post_type = 'post' AND post_status = 'publish'))\nORDER BY post_title LIKE '%quasarless%' DESC, post_date DESC LIMIT 10" nil "root" sess true nil))
+      (sql_execute_formula sess nil formula (lambda (_row) true) (lambda (_fields) nil))
+      (if (equal? (sess "found_rows") 0) "ok"
+        (error (concat "unexpected FOUND_ROWS: " (sess "found_rows")))))
+  expect:
+    data:
+    - ok
+cleanup:
+- sql: DROP TABLE wordpress_search_posts


### PR DESCRIPTION
WordPress search evaluates large article/revision text before its cheap type/status filters. Order safe scalar AND terms by estimated evaluation cost per rejected row when lowering a single-source row scan. This reduces text matching on excluded revisions while preserving every predicate and result ordering.

The Scheme lowerer uses existing scalar-operation/text-byte costgen coefficients and selectivity priors, before scan compilation/JIT. Ties preserve input order. Probe markers, CASE, user functions and expressions outside the supported pure scalar subset retain their evaluation order. Logical IR, access-path enumeration, count planning and Go scan loops are unchanged. The change is rebased on #855 and retains its numeric IN bounds.

Manual A/B, performed before opening this PR: baseline `d9ca46c6c` versus `a28f7bd2d`, identical normal Go 1.26 binary, loopback HTTP latency. Each variant gets the same 22,000-row fixture (2,000 articles plus 20,000 revisions), REBUILD and restart, 10 warmups and 30 measured calls per query. Run order B/C/C/B gives 60 measured samples per variant; table reports pooled medians. All complete ordered result sets match across all runs.

| Query | Baseline | Change | Delta |
|---|---:|---:|---:|
| WordPress rare search with revision history | 51.125 ms | 38.717 ms | -24.3% |
| WordPress common search with revision history | 2.518 ms | 2.010 ms | -20.2% |
| WordPress absent search with revision history | 80.848 ms | 67.251 ms | -16.8% |
| Point lookup control | 0.389 ms | 0.345 ms | -11.1% |

The small point-lookup difference is a control, not an attributed optimization. EXPLAIN, IR, PHYSICAL and REORDER were captured for rare/common searches; the emitted callback checks type/status before text while retaining the original password access boundary.

Targeted validation: 31 IN/LIKE/filter correctness cases pass normally and with JIT, including NULL, CASE, malformed SQL and #855's cached-binding/BIGINT checks. Search fixtures verify exact rare/common/absent results and FOUND_ROWS totals of 10/612/0 before LIMIT. The six-case search suite passed with JIT, and the three count checks passed again normally and with JIT after rebasing. Scheme files formatted and diff checked. Full tests and broad A/B regressions are delegated to CI.

Additional manual INSERT IGNORE duplicate control (same B/C/C/B, 10 warmups and 30 samples per run): 129.054 → 130.964 ms (+1.5%). The source SELECT code, IR, PHYSICAL and REORDER output are identical between baseline and candidate.
