### PR TITLE
fix: avoid computed-index deadlock during shard rebuild

### DIFF
--- a/storage/compute.go
+++ b/storage/compute.go
@@ -34,15 +34,16 @@ func requireStatelessComputedCallback(label string, callback scm.Scmer) {
 }
 
 // newCachedColumnReaderTx returns a per-goroutine ColumnReader for the given
-// storage and tx context.
+// storage and tx context. alreadyLocked records an existing read or write lock
+// on the owning shard; recursive computed inputs must not acquire it again.
 //
 // For StorageEnum this gives O(1) sequential decode; for others it's a no-op.
 // Do not strip runtime overlays here: generic scan/read paths must still see
 // user-visible values (for example OverlayBlob must dereference its hash marker
 // back to the persisted blob payload after restart).
-func newCachedColumnReaderTx(col ColumnStorage, tx *TxContext) ColumnReader {
+func newCachedColumnReaderTx(col ColumnStorage, tx *TxContext, alreadyLocked bool) ColumnReader {
 	if provider, ok := col.(TxColumnReaderProvider); ok {
-		return provider.GetCachedReaderTx(tx)
+		return provider.GetCachedReaderTx(tx, alreadyLocked)
 	}
 	return col.GetCachedReader()
 }

--- a/storage/compute_concurrency_test.go
+++ b/storage/compute_concurrency_test.go
@@ -390,7 +390,7 @@ func TestUnfilteredComputeColumnReusesCompletePreparationUntilMutation(t *testin
 		t.Fatalf("post-insert repair invoked computor %d times, want 4 total", got)
 	}
 
-	reader := tbl.ActiveShards()[0].ColumnReaderTx(nil, "cached")
+	reader := tbl.ActiveShards()[0].ColumnReaderTx(nil, "cached", false)
 	if got := reader(3).Int(); got != 80 {
 		t.Fatalf("repaired appended computed value = %d, want 80", got)
 	}

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -267,20 +267,19 @@ func (r *computeProxyReader) GetValueMulti(recids []uint32, target []scm.Scmer, 
 	}
 }
 
-func (p *StorageComputeProxy) GetCachedReaderTx(tx *TxContext) ColumnReader {
+func (p *StorageComputeProxy) GetCachedReaderTx(tx *TxContext, alreadyLocked bool) ColumnReader {
 	if p.isOrdered {
 		return &orderedComputeProxyReader{proxy: p, tx: tx}
 	}
-	// Bind input readers before the physical scan acquires the shard read lock.
-	// A cache miss may compute a value, but it must stay within the already
-	// acquired shard capability instead of re-entering GetRead/ColumnReaderTx.
-	// This also keeps the reader executable on a future remote shard owner.
+	// Ordinary scans bind before locking; index/rebuild setup already holds
+	// the shard lock. Propagate that ownership through every computed input
+	// instead of recursively acquiring the same write-preferring RWMutex.
 	readers := make([]ColumnReader, len(p.inputCols))
 	for i, col := range p.inputCols {
 		// tx is a physical lock-capability token here, not callback state.
 		// Passing it through prevents a mutation scan which already owns the
 		// shard write lock from recursively acquiring the same RWMutex.
-		readers[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col))
+		readers[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col, alreadyLocked))
 	}
 	return &computeProxyReader{
 		proxy:   p,
@@ -312,11 +311,11 @@ func (p *StorageComputeProxy) needsUnfilteredPreparation() bool {
 func (p *StorageComputeProxy) prewarmDeltaRows(_ *TxContext, filterCols []string, filter scm.Scmer, onlyMissing bool) {
 	filterReaders := make([]ColumnReader, len(filterCols))
 	for i, col := range filterCols {
-		filterReaders[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(nil, col))
+		filterReaders[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(nil, col, false))
 	}
 	inputReaders := make([]ColumnReader, len(p.inputCols))
 	for i, col := range p.inputCols {
-		inputReaders[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(nil, col))
+		inputReaders[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(nil, col, false))
 	}
 
 	recids := p.visibleDeltaRecids()
@@ -442,7 +441,7 @@ func (p *StorageComputeProxy) getValueTx(tx *TxContext, idx uint32) scm.Scmer {
 	for i, col := range p.inputCols {
 		// Delta rows must be read via the shard-level ColumnReader; direct
 		// ColumnStorage access only understands main-row indexes.
-		colvalues[i] = p.shard.ColumnReaderTx(tx, col)(idx)
+		colvalues[i] = p.shard.ColumnReaderTx(tx, col, false)(idx)
 	}
 	val := scm.Apply(p.computor, colvalues...)
 
@@ -497,7 +496,7 @@ func (p *StorageComputeProxy) getValueRLocked(_ *TxContext, idx uint32) scm.Scme
 			continue
 		}
 		if idx < p.shard.main_count {
-			values[i] = newCachedColumnReaderTx(cs, nil).GetValue(idx)
+			values[i] = newCachedColumnReaderTx(cs, nil, true).GetValue(idx)
 			continue
 		}
 		deltaIndex := int(idx - p.shard.main_count)
@@ -580,7 +579,7 @@ func (p *StorageComputeProxy) GetValueMulti(recids []uint32, target []scm.Scmer,
 }
 
 func (p *StorageComputeProxy) GetCachedReader() ColumnReader {
-	return p.GetCachedReaderTx(nil)
+	return p.GetCachedReaderTx(nil, false)
 }
 
 // Compress materializes all values into a compressed main storage.
@@ -591,7 +590,7 @@ func (p *StorageComputeProxy) Compress(_ *TxContext) {
 	compressedNow := false
 	readers := make([]ColumnReader, len(p.inputCols))
 	for i, col := range p.inputCols {
-		readers[i] = newCachedColumnReaderTx(p.shard.getColumnStorageOrPanic(col, false, nil), nil)
+		readers[i] = newCachedColumnReaderTx(p.shard.getColumnStorageOrPanic(col, false, nil), nil, false)
 	}
 	func() {
 		p.mu.Lock()
@@ -670,11 +669,11 @@ func (p *StorageComputeProxy) Compress(_ *TxContext) {
 func (p *StorageComputeProxy) CompressFiltered(_ *TxContext, filterCols []string, filter scm.Scmer) {
 	filterReaders := make([]ColumnReader, len(filterCols))
 	for i, col := range filterCols {
-		filterReaders[i] = newCachedColumnReaderTx(p.shard.getColumnStorageOrPanic(col, false, nil), nil)
+		filterReaders[i] = newCachedColumnReaderTx(p.shard.getColumnStorageOrPanic(col, false, nil), nil, false)
 	}
 	readers := make([]ColumnReader, len(p.inputCols))
 	for i, col := range p.inputCols {
-		readers[i] = newCachedColumnReaderTx(p.shard.getColumnStorageOrPanic(col, false, nil), nil)
+		readers[i] = newCachedColumnReaderTx(p.shard.getColumnStorageOrPanic(col, false, nil), nil, false)
 	}
 
 	func() {

--- a/storage/index.go
+++ b/storage/index.go
@@ -290,8 +290,9 @@ func (s *StorageIndex) usesNaturalAscendingOrder(col int) bool {
 }
 
 // buildGetters returns per-column value getters for this index, reading from the
-// shard under a currently-held RLock. Must be called with s.t.mu.RLock held.
-func (s *StorageIndex) buildGetters(_ *TxContext, storage []colGetter) []colGetter {
+// shard under its currently-held read or write lock. Recursive computed
+// readers must use that same lock instead of entering it again.
+func (s *StorageIndex) buildGetters(tx *TxContext, storage []colGetter) []colGetter {
 	var getters []colGetter
 	if cap(storage) >= len(s.Cols) {
 		getters = storage[:len(s.Cols)]
@@ -312,14 +313,14 @@ func (s *StorageIndex) buildGetters(_ *TxContext, storage []colGetter) []colGett
 					continue
 				}
 				cs := s.t.getColumnStorageRLocked(mc)
-				mapColReaders[j] = newCachedColumnReaderTx(cs, nil)
+				mapColReaders[j] = newCachedColumnReaderTx(cs, tx, true)
 			}
 			mapFn := s.ColMapFn[i]
 			fn := scm.PrepareSerialProc(mapFn)
 			getters[i] = colGetter{mapCols: mapColReaders, mapFn: &fn, mapArgs: make([]scm.Scmer, len(mapColReaders))}
 		} else {
 			cs := s.t.getColumnStorageRLocked(col)
-			getters[i] = colGetter{raw: newCachedColumnReaderTx(cs, nil)}
+			getters[i] = colGetter{raw: newCachedColumnReaderTx(cs, tx, true)}
 		}
 	}
 	return getters
@@ -506,7 +507,7 @@ func (s *StorageIndex) getDeltaColValueTx(tx *TxContext, recid uint32, data []sc
 				if !proxy.isOrdered {
 					vals[i] = proxy.getValueRLocked(tx, recid)
 				} else {
-					vals[i] = s.t.ColumnReaderTx(tx, mc)(recid)
+					vals[i] = s.t.ColumnReaderTx(tx, mc, true)(recid)
 				}
 			} else {
 				vals[i] = s.getDeltaValue(data, mc)
@@ -519,7 +520,7 @@ func (s *StorageIndex) getDeltaColValueTx(tx *TxContext, recid uint32, data []sc
 		if !proxy.isOrdered {
 			return proxy.getValueRLocked(tx, recid)
 		}
-		return s.t.ColumnReaderTx(tx, s.Cols[colIdx])(recid)
+		return s.t.ColumnReaderTx(tx, s.Cols[colIdx], true)(recid)
 	}
 	return s.getDeltaValue(data, s.Cols[colIdx])
 }
@@ -1523,7 +1524,7 @@ func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, indexBo
 			if alignedWithIndex && colIdx < len(cols) {
 				reader = cols[colIdx].raw
 			} else if _, mapFn := bounds.boundaryMap(colIdx); !isScanPseudoColName(column) && mapFn.IsNil() {
-				reader = newCachedColumnReaderTx(s.t.getColumnStorageRLocked(column), tx)
+				reader = newCachedColumnReaderTx(s.t.getColumnStorageRLocked(column), tx, true)
 			}
 			hook = analyzer.Deploy(IndexDeployContext{
 				MainCount: s.t.main_count,

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -878,7 +878,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 						oldShard.mu.RUnlock()
 						if !isProxy {
 							// Old shard has plain storage for this column — read values directly
-							reader := oldShard.ColumnReaderTx(nil, col.Name)
+							reader := oldShard.ColumnReaderTx(nil, col.Name, false)
 							for _, item := range items {
 								val := reader(uint32(item))
 								newProxy.delta[newIdx] = val
@@ -899,7 +899,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 					// Normal column: read values and compress
 					var i uint32
 					for s2id, items := range datasetids[si] {
-						reader := oldshards[s2id].ColumnReaderTx(nil, col.Name)
+						reader := oldshards[s2id].ColumnReaderTx(nil, col.Name, false)
 						for _, item := range items {
 							values[i] = reader(uint32(item))
 							i++

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -560,7 +560,7 @@ func (t *storageShard) collectRecSet(access scanAccess, conditionCols []string, 
 				continue
 			}
 			ccols[i] = t.getColumnStorageOrPanic(k, skipShardReadLock, currentTx)
-			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx, false)
 			if _, ok := ccols[i].(*StorageComputeProxy); ok {
 				cNeedsCachedReader[i] = true
 			}
@@ -1233,7 +1233,7 @@ func (t *storageShard) recSetPartExists(part *recSetShard, conditionCols []strin
 			continue
 		}
 		ccols[i] = t.getColumnStorageOrPanic(k, skipShardReadLock, currentTx)
-		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx, false)
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
@@ -1320,7 +1320,7 @@ func (t *storageShard) scanRecSetPart(part *recSetShard, conditionCols []string,
 			continue
 		}
 		ccols[i] = t.getColumnStorageOrPanic(k, skipShardReadLock, currentTx)
-		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx, false)
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
 	var mapperStorage ShardMapReducer
@@ -1495,7 +1495,7 @@ func (t *storageShard) filterRecSetPart(part *recSetShard, conditionCols []strin
 				continue
 			}
 			ccols[i] = t.getColumnStorageOrPanic(k, skipShardReadLock, currentTx)
-			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx, false)
 		}
 		cdataset = make([]scm.Scmer, len(conditionCols))
 	}

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -2055,7 +2055,7 @@ func (t *storageShard) scanFirstRecord(access scanAccess, conditionCols []string
 				continue
 			}
 			ccols[i] = t.getColumnStorageOrPanic(k, skipShardReadLock, currentTx)
-			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx, false)
 			if _, ok := ccols[i].(*StorageComputeProxy); ok {
 				cNeedsCachedReader[i] = true
 			}
@@ -2318,7 +2318,7 @@ func (t *storageShard) scan(access scanAccess, conditionCols []string, condition
 				continue
 			}
 			ccols[i] = t.getColumnStorageOrPanic(k, skipShardReadLock, currentTx)
-			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx, false)
 		}
 		cdataset = make([]scm.Scmer, len(conditionCols))
 	}
@@ -2616,7 +2616,7 @@ func (t *storageShard) scanBatch(access scanAccess, conditionCols []string, cond
 				continue
 			}
 			ccols[i] = t.getColumnStorageOrPanic(k, skipShardReadLock, currentTx)
-			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx, false)
 			if _, ok := ccols[i].(*StorageComputeProxy); ok {
 				cNeedsCachedReader[i] = true
 			}

--- a/storage/scan_column_cost_bench_test.go
+++ b/storage/scan_column_cost_bench_test.go
@@ -525,7 +525,7 @@ func BenchmarkFilterBufferLocalScan(b *testing.B) {
 			values[row] = scm.NewInt(int64(row + i))
 		}
 		storage := buildStorageInt(values)
-		readers[i] = newCachedColumnReaderTx(storage, nil)
+		readers[i] = newCachedColumnReaderTx(storage, nil, false)
 		emitters[i] = storage.JITEmit
 		valueTypes[i] = storage.JITValueType()
 	}
@@ -714,7 +714,7 @@ func TestTypedFilterMixedMainDelta(t *testing.T) {
 	shard.inserts = [][]scm.Scmer{{scm.NewFloat(3.5)}, {scm.NewNil()}}
 	shard.mu.Unlock()
 	column := shard.getColumnStorageOrPanic("amount", false, nil)
-	readers := []ColumnReader{newCachedColumnReaderTx(column, nil)}
+	readers := []ColumnReader{newCachedColumnReaderTx(column, nil, false)}
 	predicate := benchmarkMapReduceFusionProc(t, "(lambda (a) (> a 2))")
 	kernel := scm.CompileJITFilterBuffer(predicate.Proc(), []uint8{column.JITValueType()})
 	if kernel == nil {

--- a/storage/scan_lookup.go
+++ b/storage/scan_lookup.go
@@ -335,7 +335,7 @@ func (t *storageShard) scanLookupMapOne(access scanAccess, mapCols []string, cur
 	t.ensureMainCount(false)
 	lookupCol := access.boundaryColumn(0)
 	lookupValue := access.boundValue(0, false)
-	lookupReader := newCachedColumnReaderTx(t.getColumnStorageOrPanic(lookupCol, false, currentTx), currentTx)
+	lookupReader := newCachedColumnReaderTx(t.getColumnStorageOrPanic(lookupCol, false, currentTx), currentTx, false)
 	lookupGetValue := compiledColumnGetValue(lookupReader)
 	var fixedMapReaders [8]scanLookupMapReader
 	mapReaders := fixedMapReaders[:]
@@ -391,7 +391,7 @@ func (t *storageShard) scanLookupMapOne(access scanAccess, mapCols []string, cur
 func (t *storageShard) prepareScanLookupMapReaders(mapCols []string, readers []scanLookupMapReader, currentTx *TxContext) {
 	for i, col := range mapCols {
 		storage := t.getColumnStorageOrPanic(col, false, currentTx)
-		readers[i].reader = newCachedColumnReaderTx(storage, currentTx)
+		readers[i].reader = newCachedColumnReaderTx(storage, currentTx, false)
 		readers[i].compiled = compiledColumnGetValue(readers[i].reader)
 		_, readers[i].computed = storage.(*StorageComputeProxy)
 	}
@@ -480,14 +480,14 @@ func (t *storageShard) scanLookupOne(access scanAccess, resultCol string, return
 	lookupCol := access.boundaryColumn(0)
 	lookupValue := access.boundValue(0, false)
 	lookupStorage := t.getColumnStorageOrPanic(lookupCol, false, currentTx)
-	lookupReader := newCachedColumnReaderTx(lookupStorage, currentTx)
+	lookupReader := newCachedColumnReaderTx(lookupStorage, currentTx, false)
 	lookupGetValue := compiledColumnGetValue(lookupReader)
 	var resultReader ColumnReader
 	var resultGetValue scm.JITStorageGetValueFunc
 	resultComputed := false
 	if returnValue {
 		resultStorage := t.getColumnStorageOrPanic(resultCol, false, currentTx)
-		resultReader = newCachedColumnReaderTx(resultStorage, currentTx)
+		resultReader = newCachedColumnReaderTx(resultStorage, currentTx, false)
 		resultGetValue = compiledColumnGetValue(resultReader)
 		_, resultComputed = resultStorage.(*StorageComputeProxy)
 	}
@@ -635,13 +635,13 @@ func (t *storageShard) scanLookupMany(access scanAccess, resultCol string, retur
 		lookupReaders = make([]scanLookupValueReader, access.len())
 	}
 	for i := range lookupReaders {
-		lookupReaders[i] = newScanLookupValueReader(newCachedColumnReaderTx(t.getColumnStorageOrPanic(access.boundaryColumn(i), false, currentTx), currentTx))
+		lookupReaders[i] = newScanLookupValueReader(newCachedColumnReaderTx(t.getColumnStorageOrPanic(access.boundaryColumn(i), false, currentTx), currentTx, false))
 	}
 	var resultReader scanLookupValueReader
 	resultComputed := false
 	if returnValue {
 		resultStorage := t.getColumnStorageOrPanic(resultCol, false, currentTx)
-		resultReader = newScanLookupValueReader(newCachedColumnReaderTx(resultStorage, currentTx))
+		resultReader = newScanLookupValueReader(newCachedColumnReaderTx(resultStorage, currentTx, false))
 		_, resultComputed = resultStorage.(*StorageComputeProxy)
 	}
 
@@ -769,7 +769,7 @@ func (t *storageShard) scanLookupMapMany(access scanAccess, mapCols []string, cu
 		lookupReaders = make([]scanLookupValueReader, access.len())
 	}
 	for i := range lookupReaders {
-		lookupReaders[i] = newScanLookupValueReader(newCachedColumnReaderTx(t.getColumnStorageOrPanic(access.boundaryColumn(i), false, currentTx), currentTx))
+		lookupReaders[i] = newScanLookupValueReader(newCachedColumnReaderTx(t.getColumnStorageOrPanic(access.boundaryColumn(i), false, currentTx), currentTx, false))
 	}
 	var fixedMapReaders [8]scanLookupMapReader
 	mapReaders := fixedMapReaders[:]

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -1847,7 +1847,7 @@ func (t *storageShard) scan_order(access scanAccess, conditionCols []string, con
 	for i, scol := range sortcols {
 		if scol.IsString() {
 			colname := scol.String()
-			result.scols[i] = t.ColumnReaderTx(currentTx, colname)
+			result.scols[i] = t.ColumnReaderTx(currentTx, colname, false)
 			continue
 		}
 		if scol.IsProc() {
@@ -1872,7 +1872,7 @@ func (t *storageShard) scan_order(access scanAccess, conditionCols []string, con
 					txValue := scm.NewAny(currentTx)
 					largs[j] = func(uint32) scm.Scmer { return txValue }
 				} else {
-					largs[j] = t.ColumnReaderTx(currentTx, name)
+					largs[j] = t.ColumnReaderTx(currentTx, name, false)
 				}
 			}
 			procFn := scm.PrepareSerialProc(scol)
@@ -1919,7 +1919,7 @@ func (t *storageShard) scan_order(access scanAccess, conditionCols []string, con
 				continue
 			}
 			ccols[i] = t.getColumnStorageOrPanic(k, skipShardReadLock, currentTx)
-			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx, false)
 			if _, ok := ccols[i].(*StorageComputeProxy); ok {
 				cNeedsCachedReader[i] = true
 			}
@@ -1936,7 +1936,7 @@ func (t *storageShard) scan_order(access scanAccess, conditionCols []string, con
 	aMultiFuncs := make([]scm.JITStorageGetValueMultiFunc, len(acceptCols))
 	for i, column := range acceptCols {
 		acols[i] = t.getColumnStorageOrPanic(column, skipShardReadLock, currentTx)
-		aReaders[i] = newCachedColumnReaderTx(acols[i], currentTx)
+		aReaders[i] = newCachedColumnReaderTx(acols[i], currentTx, false)
 		if _, ok := acols[i].(*StorageComputeProxy); ok {
 			aNeedsCachedReader[i] = true
 		}

--- a/storage/scan_order_batch_accept_test.go
+++ b/storage/scan_order_batch_accept_test.go
@@ -197,7 +197,7 @@ func TestCollectOrderedCandidateBatchPrunesRangePartitions(t *testing.T) {
 		ids := make([]int64, len(records))
 		for i, record := range records {
 			release := record.shard.GetRead()
-			ids[i] = int64(scm.ToInt(record.shard.ColumnReaderTx(nil, "id")(record.recid)))
+			ids[i] = int64(scm.ToInt(record.shard.ColumnReaderTx(nil, "id", false)(record.recid)))
 			release()
 		}
 		return ids

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1516,13 +1516,20 @@ func (t *storageShard) propagateDeleteToNext(next *storageShard, oldRecid uint32
 	next.UpdateFunction(targetRecid, false, false, currentTx)()
 }
 
-func (t *storageShard) ColumnReaderTx(tx *TxContext, col string) func(uint32) scm.Scmer {
+func (t *storageShard) ColumnReaderTx(tx *TxContext, col string, alreadyLocked bool) func(uint32) scm.Scmer {
 	// Computed readers recursively bind their input columns. A mutation scan
 	// initializes them while holding this shard's write lock, recorded explicitly
 	// on the transaction, so re-entering the RWMutex here would self-deadlock.
-	alreadyLocked := tx != nil && tx.HasShardWrite(t)
-	cstorage := t.getColumnStorageOrPanic(col, alreadyLocked, tx)
-	reader := newCachedColumnReaderTx(cstorage, tx)
+	writeLocked := tx != nil && tx.HasShardWrite(t)
+	var cstorage ColumnStorage
+	if alreadyLocked && !writeLocked {
+		// Index setup may own only a read lock. Its columns must already be
+		// loaded; this path must neither acquire a lock nor attach runtime data.
+		cstorage = t.getColumnStorageRLocked(col)
+	} else {
+		cstorage = t.getColumnStorageOrPanic(col, writeLocked, tx)
+	}
+	reader := newCachedColumnReaderTx(cstorage, tx, alreadyLocked || writeLocked)
 	_, computed := cstorage.(*StorageComputeProxy)
 	return func(idx uint32) scm.Scmer {
 		if idx < t.main_count {
@@ -1702,7 +1709,7 @@ func (t *storageShard) initReadMapReducer(mr *ShardMapReducer, cols []string, ma
 
 	for i, colName := range cols {
 		mainCol := t.getColumnStorageOrPanic(colName, alreadyLocked, currentTx)
-		mainReader := newCachedColumnReaderTx(mainCol, currentTx)
+		mainReader := newCachedColumnReaderTx(mainCol, currentTx, false)
 		mr.mainCols[i] = mainCol
 		mr.mainBulkReaders[i] = mainReader
 		mr.mainValueFuncs[i] = compiledColumnGetValue(mainReader)
@@ -2024,7 +2031,7 @@ func (t *storageShard) initMapReducer(mr *ShardMapReducer, cols []string, mapRed
 			continue
 		}
 		mainCol := mr.mainCols[i]
-		mainReader := newCachedColumnReaderTx(mainCol, mr.currentTx)
+		mainReader := newCachedColumnReaderTx(mainCol, mr.currentTx, false)
 		mr.mainBulkReaders[i] = mainReader
 		mr.mainMultiFuncs[i] = compiledColumnGetValueMulti(mainReader)
 		colName := mr.colNames[i]

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -731,7 +731,7 @@ func TestShardRebuildUpdatePropagationUsesStableTranslation(t *testing.T) {
 	rebuilt.mu.RLock()
 	rowOneDeleted := rebuilt.deletions.Get(1)
 	rebuilt.mu.RUnlock()
-	got := rebuilt.ColumnReaderTx(nil, "payload")(2)
+	got := rebuilt.ColumnReaderTx(nil, "payload", false)(2)
 	if !rowOneDeleted || got.String() != "two-updated" {
 		t.Fatalf("rebuilt update state = (deleted=%v, payload=%v), want (true, two-updated)", rowOneDeleted, got)
 	}
@@ -2184,5 +2184,52 @@ func TestCursorRollbackOfMainDeleteSurvivesRestart(t *testing.T) {
 	reloaded := reloadTableFromPersistence(t, "tcursorrollbackreload", persistence)
 	if got := reloaded.Count(); got != 1 {
 		t.Fatalf("reloaded count after cursor rollback = %d, want 1; rollback was not represented in WAL", got)
+	}
+}
+
+// Rebuild warms indexes while its unpublished replacement shard is locked.
+// Computed index inputs must bind recursively without entering that lock again.
+func TestIndexComputedReadersRespectHeldShardLock(t *testing.T) {
+	for _, mapped := range []bool{false, true} {
+		t.Run(fmt.Sprintf("mapped=%t", mapped), func(t *testing.T) {
+			shard := &storageShard{t: &table{}, srState: SHARED, main_count: 1,
+				columns: map[string]ColumnStorage{
+					"raw": &StorageSCMER{values: []scm.Scmer{scm.NewInt(7)}},
+				}}
+			release := shard.GetExclusive()
+			defer release()
+			shard.mu.Lock()
+			shard.columns["input"] = &StorageComputeProxy{
+				shard: shard, colName: "input", inputCols: []string{"raw"}, count: 1,
+				delta: map[uint32]scm.Scmer{0: scm.NewInt(7)},
+			}
+			shard.columns["computed"] = &StorageComputeProxy{
+				shard: shard, colName: "computed", inputCols: []string{"input"}, count: 1,
+				delta: map[uint32]scm.Scmer{0: scm.NewInt(14)},
+			}
+			index := &StorageIndex{t: shard, Cols: []string{"computed"}}
+			if mapped {
+				index.Cols = []string{".mapped"}
+				index.ColMapCols = [][]string{{"computed"}}
+				index.ColMapFn = []scm.Scmer{scm.NewFunc(func(args ...scm.Scmer) scm.Scmer { return args[0] })}
+			}
+			done := make(chan []colGetter, 1)
+			go func() { done <- index.buildGetters(nil, nil) }()
+			var getters []colGetter
+			select {
+			case getters = <-done:
+				shard.mu.Unlock()
+			case <-time.After(time.Second):
+				// Release the lock before failing so the baseline worker can exit.
+				shard.mu.Unlock()
+				getters = <-done
+				t.Error("index reader recursively acquired the held shard lock")
+			}
+			shard.mu.RLock()
+			defer shard.mu.RUnlock()
+			if got := getters[0].get(0); got.Int() != 14 {
+				t.Fatalf("computed index value = %v, want 14", got)
+			}
+		})
 	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -92,9 +92,10 @@ func (f ColumnReaderFunc) GetValueRange(recid uint32, count uint32, target []scm
 
 // TxColumnReaderProvider optionally exposes a transaction-bound reader.
 // Storages that do not depend on tx/session context can ignore it and rely on
-// the legacy GetCachedReader path.
+// the legacy GetCachedReader path. The boolean records an already-held shard
+// lock and must propagate when binding computed-column dependencies.
 type TxColumnReaderProvider interface {
-	GetCachedReaderTx(*TxContext) ColumnReader
+	GetCachedReaderTx(*TxContext, bool) ColumnReader
 }
 
 func scmerToTxContext(v scm.Scmer) *TxContext {

--- a/storage/table.go
+++ b/storage/table.go
@@ -2971,7 +2971,7 @@ func (t *table) ProcessUniqueCollision(columns []string, values [][]scm.Scmer, m
 								}
 							}
 						} else {
-							params[i] = s.ColumnReaderTx(currentTx, p)(uid)
+							params[i] = s.ColumnReaderTx(currentTx, p, false)(uid)
 						}
 					}
 					func() {

--- a/tests/storage/persistence/rebuild-kill-shutdown.yaml
+++ b/tests/storage/persistence/rebuild-kill-shutdown.yaml
@@ -142,6 +142,22 @@ test_cases:
     scm: '(rebuild (table "memcp-tests" "rks_rows") true false)'
     timeout: 20
 
+  - name: "Warm a computed result index before shutdown"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define query "SELECT SQL_CALC_FOUND_ROWS id FROM rks_rows WHERE payload LIKE '%payload%' ORDER BY id LIMIT 2")
+        (map (produceN 6) (lambda (_)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true nil)
+            (lambda (_row) true) (lambda (_fields) nil))))
+        (if (equal? (sess "found_rows") 20000) "ok"
+          (error (concat "unexpected prepared count: " (sess "found_rows")))))
+    expect: {data: ["ok"]}
+
   - name: "Second graceful shutdown completes"
     sql: "SHUTDOWN"
     restart_timeout: 30


### PR DESCRIPTION
Graceful shutdown can deadlock after warming computed result indexes, including WordPress SQL_CALC_FOUND_ROWS queries. Rebuild holds the replacement shard lock while initializing index readers; computed input readers lost that ownership and tried to acquire the same RWMutex again. The same reader setup can also re-enter a read lock with a writer waiting.

Propagate an explicit alreadyLocked flag through the column-reader factory/provider and recursive computed inputs. Index readers reuse their caller's lock. The read-locked path only accesses already-loaded columns and cannot load or attach data under a read lock; existing transaction write ownership still supports its previous initialization path. All reader API call sites are updated together. The change is in reader binding, with no new row-loop synchronization or persistence-format changes.

Validation:
- Added raw and expression-mapped computed-index regression cases: both failed on the baseline by recursively acquiring the held lock. Nested computed inputs pass after the fix, normally and with the race detector.
- Targeted computed-proxy, rebuild-preservation and runtime-binding Go tests pass.
- The 19-case rebuild/cancellation/crash/restart SQL suite passes, with a new warmed computed-result index before shutdown. Restart retains all 22,000 SAFE rows and checksum 242011000.
- An independent 22,000-row WordPress search reproduction hung during baseline shutdown; after the fix the same workload exits normally in 63 ms. GDB identified buildGetters -> GetCachedReaderTx -> ColumnReaderTx -> RWMutex.RLock as the blocked chain.

Full SQL/JIT suites and broad performance comparisons are delegated to CI. Disk-deletion call sites and serialized layouts are unchanged.

Additional hosting validation: built the combined PHP host with PR 857, using external PHP 8.5 ZTS and four PHP threads. Targeted PHP integration tests pass. An isolated copy of the real WordPress database (20,002 posts and 200,000 revisions) served 270 warm HTTP requests across nine public/admin routes without detected errors, then shut down gracefully in 2.006 seconds. Initial cold-start PHP timeouts remain a separate issue; this fix does not claim to resolve them.
