### PR TITLE
Fix named-session guards recompiling valid cached plans

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -2736,13 +2736,20 @@ the lowerer can cost it. */
 				(lambda () (begin
 					(define compile_bindings (if (nil? planning_session) nil (planning_session "__memcp_queryplan_compile_bindings")))
 					(define observed (if (nil? planning_session) nil (planning_session "__memcp_queryplan_observed_session_keys")))
-					(if (and (not (nil? compile_bindings)) (not (nil? observed)))
-						(observed key true)
-						nil)
 					(define direct (if (nil? planning_session) nil (planning_session key)))
-					(if (not (nil? direct))
-						direct
-						(if (nil? compile_bindings) nil (compile_bindings key)))))
+					(define value (if (not (nil? direct)) direct
+						(if (nil? compile_bindings) nil (compile_bindings key))))
+					(if (and (not (nil? compile_bindings)) (not (nil? observed)))
+						(begin
+							/* Snapshot the value actually consumed by costing, not just vN
+							literal parameters. The uncovered-binding guard reads this snapshot:
+							missing named values would emit (= runtime_value nil), rejecting even
+							the compiling request and recompiling on every execution. Record only
+							observed inputs; do not copy opaque execution/preparation state. */
+							(compile_bindings key value)
+							(observed key true))
+						nil)
+					value))
 				(lambda (_e) nil))
 			((quote session) key) (planner_literal_value (list (quote session) key) planning_session)
 			((symbol session_globalvar) key) (coalesceNil

--- a/tests/performance/query-cache-feedback-churn.yaml
+++ b/tests/performance/query-cache-feedback-churn.yaml
@@ -5,6 +5,10 @@ metadata:
   description: "Warm ordered queries amid unrelated bound-predicate learning"
   isolated: true
 setup:
+  - sql: "DROP TABLE IF EXISTS qfc_access"
+  - sql: "CREATE TABLE qfc_access (viewer INT, domain_id INT) ENGINE=sloppy"
+  - sql: "INSERT INTO qfc_access VALUES (999,NULL),(998,998),(997,999)"
+  - scm: '(rebuild (table "memcp-tests" "qfc_access") true false)'
   - sql: "DROP TABLE IF EXISTS qfc_clock"
   - sql: "CREATE TABLE qfc_clock (id INT PRIMARY KEY) ENGINE=sloppy"
   - sql: "INSERT INTO qfc_clock (id) VALUES (999)"
@@ -18,6 +22,27 @@ setup:
         (rebuild (table "memcp-tests" "qfc_document") true false)
         (globalvars "qfc_sequence" 1000))
 test_cases:
+  - name: "Named session ACL counts do not recompile on every cached execution"
+    performance_rows: 1000
+    threshold_ms: 5000
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (sess "viewer" 999)
+        (define q "SELECT COUNT(*) AS n FROM qfc_clock a LEFT JOIN qfc_document z ON z.id=a.id WHERE COALESCE((SELECT CASE WHEN EXISTS(SELECT 1 FROM qfc_access x WHERE x.viewer=@viewer AND x.domain_id IS NULL LIMIT 1) THEN TRUE ELSE EXISTS(SELECT 1 FROM qfc_access y WHERE y.viewer=@viewer AND y.domain_id=b.id LIMIT 1) END FROM qfc_document b WHERE b.id=a.id LIMIT 1),FALSE)")
+        (define rows (newsession))
+        (rows "n" 0)
+        (reduce (produceN 16) (lambda (_ i)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+            (lambda (row) (rows "n" (+ (rows "n") (cadr row)))) (lambda (_fields) nil))) nil)
+        (if (equal? (rows "n") 16) true (error "named session ACL count changed results")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
   - name: "Changing runtime cutoffs retain a singleton ordered plan"
     performance_rows: 1000
     threshold_ms: 1000
@@ -97,5 +122,6 @@ test_cases:
       rows: 1
       result_contains: ["true"]
 cleanup:
+  - sql: "DROP TABLE IF EXISTS qfc_access"
   - sql: "DROP TABLE IF EXISTS qfc_clock"
   - sql: "DROP TABLE IF EXISTS qfc_document"

--- a/tests/planner/core/query-cache-feedback-isolation.yaml
+++ b/tests/planner/core/query-cache-feedback-isolation.yaml
@@ -5,6 +5,10 @@ metadata:
   description: "Unrelated learned predicates must not invalidate cached ordered plans"
   isolated: true
 setup:
+  - sql: "DROP TABLE IF EXISTS qfi_access"
+  - sql: "CREATE TABLE qfi_access (viewer INT, domain_id INT) ENGINE=sloppy"
+  - sql: "INSERT INTO qfi_access VALUES (999,NULL),(998,998),(997,999)"
+  - scm: '(rebuild (table "memcp-tests" "qfi_access") true false)'
   - sql: "DROP TABLE IF EXISTS qfi_single"
   - sql: "CREATE TABLE qfi_single (id INT PRIMARY KEY) ENGINE=sloppy"
   - sql: "INSERT INTO qfi_single VALUES (999)"
@@ -17,6 +21,99 @@ setup:
           (map (produceN 1000) (lambda (i) (list i (if (< i 10) "needle" "ordinary")))))
         (rebuild (table "memcp-tests" "qfi_document") true false))
 test_cases:
+  - name: "Observed named bindings guard their compile-time value, including false and NULL"
+    scm: |
+      (begin
+        (define sess (newsession))
+        (sess "viewer" 999)
+        (sess "enabled" false)
+        (define planning (sql_queryplan_compile_session sess nil))
+        (define values (list
+          (planner_literal_value (quote (session "viewer")) planning)
+          (planner_literal_value (quote (session "enabled")) planning)
+          (planner_literal_value (quote (session "missing")) planning)))
+        (if (not (equal? values (list 999 false nil))) (error "planner read incorrect bindings") nil)
+        (define guard (sql_queryplan_compile_formula
+          (sql_queryplan_conjoin_guards (sql_queryplan_uncovered_binding_conditions planning))))
+        (define original (guard sess nil nil nil))
+        (sess "viewer" 998)
+        (define changed (guard sess nil nil nil))
+        (sess "viewer" 999)
+        (sess "missing" 1)
+        (define formerly_null (guard sess nil nil nil))
+        (sess "missing" nil)
+        (sess "enabled" true)
+        (define formerly_false (guard sess nil nil nil))
+        (if (and original (not changed) (not formerly_null) (not formerly_false)) true
+          (error "named binding guard lost the observed value or accepted a changed binding")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+  - name: "Named lookup bindings reuse plans but still change visible rows"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT a.id,b.label FROM qfi_single a LEFT JOIN qfi_document b ON b.id=a.id WHERE b.id=@viewer ORDER BY a.id LIMIT 2")
+        (define rows (newsession))
+        (define run (lambda (viewer) (begin
+          (sess "viewer" viewer)
+          (rows "n" 0)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+            (lambda (row) (rows "n" (+ (rows "n") 1))) (lambda (_fields) nil))
+          (rows "n"))))
+        (define first (run 999))
+        (run 999)
+        (define entry (car (cache (car (cache)))))
+        (define before (count (entry "variants")))
+        (define repeated (run 999))
+        (define after (count (entry "variants")))
+        (define changed (run 998))
+        (define restored (run 999))
+        (define missing (run nil))
+        (if (and (equal? first 1) (equal? repeated 1) (equal? changed 0)
+          (equal? restored 1) (equal? missing 0) (equal? before after)) true
+          (error (concat "ACL binding results or plan reuse failed: " first "/" repeated "/"
+            changed "/" restored "/" missing " variants " before " -> " after)))))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+  - name: "Named ACL count guards accept their own compilation and reuse the variant"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT COUNT(*) AS n FROM qfi_single a LEFT JOIN qfi_document z ON z.id=a.id WHERE COALESCE((SELECT CASE WHEN EXISTS(SELECT 1 FROM qfi_access x WHERE x.viewer=@viewer AND x.domain_id IS NULL LIMIT 1) THEN TRUE ELSE EXISTS(SELECT 1 FROM qfi_access y WHERE y.viewer=@viewer AND y.domain_id=b.id LIMIT 1) END FROM qfi_document b WHERE b.id=a.id LIMIT 1),FALSE)")
+        (define rows (newsession))
+        (define run (lambda (viewer) (begin
+          (sess "viewer" viewer)
+          (rows "n" -1)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+            (lambda (row) (rows "n" (cadr row))) (lambda (_fields) nil))
+          (rows "n"))))
+        (define first (run 999))
+        (run 999)
+        (define entry (car (cache (car (cache)))))
+        (define before (count (entry "variants")))
+        (define repeated (run 999))
+        (define after (count (entry "variants")))
+        (define changed (run 998))
+        (define scoped (run 997))
+        (define restored (run 999))
+        (if (and (equal? first 1) (equal? repeated 1) (equal? changed 0)
+          (equal? scoped 1) (equal? restored 1)
+          (equal? before after)) true
+          (error (concat "ACL count results or cache reuse failed: " first "/" repeated "/"
+            changed "/" scoped "/" restored " variants " before " -> " after)))))
+    expect:
+      rows: 1
+      result_contains: ["true"]
   - name: "Truthy guard literals are not references to statistic bindings"
     scm: |
       (begin
@@ -208,5 +305,6 @@ test_cases:
     expect:
       data: [true]
 cleanup:
+  - sql: "DROP TABLE IF EXISTS qfi_access"
   - sql: "DROP TABLE IF EXISTS qfi_single"
   - sql: "DROP TABLE IF EXISTS qfi_document"


### PR DESCRIPTION
## Fix

Record the actual value whenever `planner_literal_value` observes a session input for costing. The existing uncovered-binding guard then compares against the same value that the compiler used.

Previously the compile-binding snapshot contained only generated `vN` parameters. Named SQL session values were copied into the planning session and read correctly by costing, but were missing from the snapshot used to emit an exact fallback guard. A non-NULL ACL user could consequently produce `(equal? (session "viewer") nil)`: even the compiling request missed its new guard, and repeated identical executions kept recompiling and evicting variants.

This is compile-time bookkeeping, not a new operator rule or cost-model weight. Existing generalized cost guards, exact fallback guards, table-growth guards and logical/physical boundaries remain intact. Only observed inputs are recorded; no broad copy of transaction/preparation state is introduced.

## Regression coverage

- New self-asserting YAML guard test: named numeric value, false and NULL; a guard accepts its own compile-time binding and rejects changed bindings. Confirmed RED on dcbbcd6e5, GREEN with this patch.
- End-to-end anonymous compound ACL COUNT: CASE + EXISTS + scalar lookup; repeated identical requests stabilize at one variant. On baseline the variant count grows from 3 to 4. Checks admin, denied and scoped users, then restoration of the original user.
- Named lookup binding changes, including NULL, preserve visible rows and cache reuse.
- New automatic performance A/B case in the existing feedback-churn suite: 16 complete named-session ACL COUNT executions per sample, with explicit count correctness validation. Existing thresholds and cases unchanged.

The new nested COUNT NULL-binding probe also exposed an independent pre-existing empty-aggregate bug (no row instead of count zero), tracked separately in #860. This PR retains NULL coverage for guard invalidation and lookup execution; its ACL COUNT case uses non-NULL authenticated identities. It does not claim to fix #860.

## Manual A/B before opening the PR

Baseline dcbbcd6e5 versus this branch, same JIT binary, separate servers loading baseline/fixed libraries. Identical rebuilt fixture: 1 driving row, 1,000 domain rows, 3 ACL rows. Two warmups, nine measured samples per case, alternating A/B order. Every sample creates its own query-plan cache and performs 16 complete executions; timings include HTTP overhead. Medians:

| Case | Baseline | Fixed | Change |
|---|---:|---:|---:|
| Named-session ACL COUNT (new regression) | 516.311 ms | 142.327 ms | -72.4% |
| Changing cutoffs, ordered singleton | 4.046 ms | 4.164 ms | +2.9% |
| Changing cutoffs, ACL COUNT | 626.879 ms | 610.111 ms | -2.7% |
| Ordered cache amid unrelated feedback | 5.670 ms | 5.015 ms | -11.6% |

The improvement is repeated compilation avoided, not a claim that the entire query or its guard is allocation-free. No deployment change or post-fix production latency claim is included.

## Validation

- Scheme formatting / bracket check and git diff check.
- Startup Scheme tests: 1276/1276, JIT and interpreter builds.
- Targeted YAML guard/feedback tests: 11/11 with JIT; interpreter validation also run.
- Targeted growth guard and ordered lookup predicate suites.
- Targeted performance suite with PERF_TEST=1.
- Full SQL, JIT and performance A/B suites delegated to CI; no local full-suite run and no weakened gates.
