### PR TITLE
Enforce PHP quotas and configure tuning through the dashboard

### DIFF
--- a/README-PHP.md
+++ b/README-PHP.md
@@ -97,6 +97,47 @@ objects are released after each request; OPcache stays warm. Long-lived PHP
 application workers are not enabled by this integration. Native extension
 crashes affect the entire process, including MemCP.
 
+## PHP quotas, concurrency and tuning
+
+The following startup flags apply globally to all `servePHP` mounts:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--php-threads=N` | `4` | Fixed maximum simultaneous PHP executions; excess requests wait. |
+| `--php-memory-limit=SIZE` | `256M` | Per-request PHP allocation ceiling, including retained MemCP PDO results. Accepts bytes or K/M/G suffixes, minimum 8 MiB; unlimited values are rejected. |
+| `--php-max-wait=DURATION` | `30s` | Time waiting for a PHP thread before HTTP 503; `0s` waits indefinitely. This is not the execution timeout. |
+| `--php-output-buffer=BYTES` | `4096` | PHP output buffering; `0` disables it for applications requiring unbuffered output. |
+| `--php-opcache-memory=MIB` | `128` | Shared opcode-cache allocation, minimum 32 MiB. |
+
+MemCP sets both `memory_limit` and PHP 8.5's startup-only
+[`max_memory_limit`](https://www.php.net/manual/en/ini.core.php#ini.max-memory-limit)
+to the selected quota. A script can lower its limit but cannot raise it above
+the ceiling or disable it with `ini_set()`. These host settings override the
+corresponding external `php.ini` values. Zend's allocator must remain enabled;
+`USE_ZEND_ALLOC` must be unset or `1`; other values, including an empty value,
+are rejected.
+
+The quota includes unfetched PDO statement buffers, not just strings returned
+by `fetch()`. Results transfer to the PHP request heap after the Go call returns;
+an allocation failure frees the temporary bridge buffer before PHP aborts the
+request. PDO teardown rolls back unfinished transactions. The authenticated
+in-process SQL bridge remains in use; no MySQL socket round trip is introduced.
+
+This is an allocation quota, **not a process-wide RAM limit or tenant sandbox**.
+At four threads and 256 MiB, PHP request heaps may total about 1 GiB, plus the
+shared opcode cache, interpreter overhead, transient bridge buffers, and MemCP
+storage/query memory. The bridge retains its 64 MiB per-result bound during
+transfer. Native extension allocations and child processes, such as an external
+`php dbcheck.php`, are outside this quota. An OS memory limit on this shared
+process also limits MemCP and can terminate the database process.
+
+OPcache is enabled with room for 20,000 scripts and a 16 MiB interned-string
+buffer. PHP JIT is disabled. Timestamp validation stays enabled on every request
+(`opcache.revalidate_freq=0`) so redeployments do not require disabling cache
+validation or restarting the database. Output buffering batches small writes;
+streaming endpoints can finish their output buffers and call `flush()` as usual.
+Other PHP settings and extension loading remain in the external `php.ini`.
+
 ## Per-directory routing and access rules
 
 The PHP host reads `.htaccess` before serving either PHP or static files.
@@ -145,7 +186,6 @@ short_open_tag=Off
 upload_max_filesize=256M
 post_max_size=272M
 max_execution_time=900
-memory_limit=512M
 ```
 
 `short_open_tag=Off` also allows XML declarations in PHP templates. For a local
@@ -227,8 +267,9 @@ reset. Reusable cell/byte buffers are each bounded to 64 KiB of retained capacit
 larger buffers are released after the query. Metadata keys are cleared between
 queries. Rows are written directly into the collector's flat cell array.
 
-Results are limited to 64 MiB and copied into independent C-owned memory in one
-batch. Existing PDO statements retain their own data when another query reuses
+Results are limited to 64 MiB and copied through a temporary C-owned buffer
+into the PHP request heap, where they count against the memory quota. Existing
+PDO statements retain their own data when another query reuses
 the collector; fetching rows never calls back into Go. Strings preserve arbitrary
 bytes. Use SQL pagination for larger results. The 30-second query timeout,
 process-list tracking, cancellation and transaction handling remain active.

--- a/README-PHP.md
+++ b/README-PHP.md
@@ -69,7 +69,7 @@ For example, place this in a Scheme module loaded after `lib/main.scm`:
 
 ```sh
 ./memcp-php --no-repl -data /path/to/persistent/memcp-data \
-  --api-port=8080 --php-threads=4 lib/main.scm /path/to/apps.scm
+  --api-port=8080 lib/main.scm /path/to/apps.scm
 ```
 
 The arguments are document root, optional URL prefix, and optional fallback PHP
@@ -89,7 +89,7 @@ root; dotfiles, PHP source backups and escaping symlinks are rejected. Routing
 and HTTP authentication can run in Scheme before invoking the PHP handler.
 
 The shared PHP runtime starts lazily after Scheme bootstrap, on its first
-request. `--php-threads` configures its fixed thread count. SIGTERM/SIGINT drains
+request. `(settings "PHPThreads")` configures its fixed thread count. SIGTERM/SIGINT drains
 the Scheme HTTP servers before shutting down PHP and storage.
 
 The host uses classic PHP request lifecycles. Request globals and ordinary
@@ -99,15 +99,24 @@ crashes affect the entire process, including MemCP.
 
 ## PHP quotas, concurrency and tuning
 
-The following startup flags apply globally to all `servePHP` mounts:
+Configure PHP globally through `(settings)` or the **PHP** group in the dashboard.
+Changes take effect after restarting MemCP. The existing settings mechanism saves
+values to `data/settings.json` on orderly shutdown and loads them on startup.
+PHP tuning CLI flags are no longer supported.
 
-| Flag | Default | Meaning |
+| Setting | Default | Meaning |
 | --- | --- | --- |
-| `--php-threads=N` | `4` | Fixed maximum simultaneous PHP executions; excess requests wait. |
-| `--php-memory-limit=SIZE` | `256M` | Per-request PHP allocation ceiling, including retained MemCP PDO results. Accepts bytes or K/M/G suffixes, minimum 8 MiB; unlimited values are rejected. |
-| `--php-max-wait=DURATION` | `30s` | Time waiting for a PHP thread before HTTP 503; `0s` waits indefinitely. This is not the execution timeout. |
-| `--php-output-buffer=BYTES` | `4096` | PHP output buffering; `0` disables it for applications requiring unbuffered output. |
-| `--php-opcache-memory=MIB` | `128` | Shared opcode-cache allocation, minimum 32 MiB. |
+| `PHPThreads` | `4` | Maximum simultaneous PHP executions; excess requests wait. |
+| `PHPMemoryLimit` | `1073741824` (1 GiB) | Per-request allocation ceiling including retained PDO results; minimum 8 MiB. |
+| `PHPMaxWaitMilliseconds` | `30000` | Queue timeout before HTTP 503; `0` waits indefinitely. |
+| `PHPOutputBuffer` | `4096` | Output buffer bytes; `0` disables buffering. |
+| `PHPOpcacheMemory` | `536870912` (512 MiB) | Shared opcode cache bytes; minimum 32 MiB, rounded up to whole MiB. |
+
+For example: `(settings "PHPMemoryLimit" 1073741824)` sets the request quota
+to 1 GiB. The dashboard accepts `1024MiB` or `1GiB` in this field and stores
+numeric bytes. Existing memory budget fields also accept sizes such as `10MB`
+(10,000,000 bytes) and `10MiB` (10,485,760 bytes). Save by leaving the field or
+pressing Enter. Invalid sizes are rejected without changing the setting.
 
 MemCP sets both `memory_limit` and PHP 8.5's startup-only
 [`max_memory_limit`](https://www.php.net/manual/en/ini.core.php#ini.max-memory-limit)
@@ -124,7 +133,7 @@ request. PDO teardown rolls back unfinished transactions. The authenticated
 in-process SQL bridge remains in use; no MySQL socket round trip is introduced.
 
 This is an allocation quota, **not a process-wide RAM limit or tenant sandbox**.
-At four threads and 256 MiB, PHP request heaps may total about 1 GiB, plus the
+At four threads and 1 GiB, PHP request heaps may total about 4 GiB, plus the
 shared opcode cache, interpreter overhead, transient bridge buffers, and MemCP
 storage/query memory. The bridge retains its 64 MiB per-result bound during
 transfer. Native extension allocations and child processes, such as an external

--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -532,7 +532,8 @@ body{display:flex;flex-direction:column}
 <tbody></tbody>
 </table>
 </div>
-<div class="settings-status" id="settings-status"></div>
+<p class="desc">Memory sizes accept MB (decimal) and MiB (binary), for example 10MB or 1GiB. Press Enter or leave a field to apply it. Settings are written to disk when MemCP shuts down cleanly.</p>
+<div class="settings-status" id="settings-status" role="status"></div>
 <div class="settings-grid" id="settings-grid"></div>
 <div class="detail-section" style="margin-top:28px">
 <h3>Storage Failure Hooks</h3>
@@ -1355,41 +1356,48 @@ renderStorageFailureHooks();
 
 /* settings grouped by topic */
 var settingsGroups=[
+{group:"PHP (changes require a restart)",items:[
+{key:"PHPMemoryLimit",label:"Memory per request",desc:"Includes retained PDO results. Minimum 8 MiB; default 1 GiB.",type:"bytes",min:8388608},
+{key:"PHPOpcacheMemory",label:"Shared opcode cache",desc:"Shared by all PHP requests. Minimum 32 MiB; rounded up to whole MiB.",type:"bytes",min:33554432},
+{key:"PHPThreads",label:"Concurrent PHP requests",desc:"Global thread limit. Additional requests wait.",type:"number",min:1},
+{key:"PHPMaxWaitMilliseconds",label:"Queue timeout (milliseconds)",desc:"Wait for a free PHP thread before HTTP 503. 0 waits indefinitely.",type:"number",min:0},
+{key:"PHPOutputBuffer",label:"Output buffer per request",desc:"0 disables buffering.",type:"bytes",min:0}
+]},
 {group:"Memory",items:[
-{key:"MaxRamPercent",desc:"Total memory budget (% of system RAM, 0=50%)",type:"number"},
-{key:"MaxRamBytes",desc:"Override total budget in bytes (0=use percent)",type:"number"},
-{key:"MaxPersistPercent",desc:"Persisted shard budget (% of RAM, 0=30%)",type:"number"},
-{key:"MaxPersistBytes",desc:"Override persisted budget in bytes (0=use percent)",type:"number"}
+{key:"MaxRamPercent",label:"Total memory (% of RAM)",desc:"Total memory budget (% of system RAM, 0=50%)",type:"number"},
+{key:"MaxRamBytes",label:"Total memory limit",desc:"Override total budget (0 uses the percentage)",type:"bytes",min:0},
+{key:"MaxPersistPercent",label:"Persisted data cache (% of RAM)",desc:"Persisted shard budget (% of RAM, 0=30%)",type:"number"},
+{key:"MaxPersistBytes",label:"Persisted data cache limit",desc:"Override persisted data budget (0 uses the percentage)",type:"bytes",min:0}
 ]},
 {group:"Storage",items:[
-{key:"ShardSize",desc:"Max rows per shard before splitting",type:"number"},
-{key:"PartitionMaxDimensions",desc:"Max partition dimensions for table sharding",type:"number"},
-{key:"DefaultEngine",desc:"Default storage engine for new tables",type:"select",options:["safe","logged","sloppy","memory"]}
+{key:"ShardSize",label:"Target rows per shard",desc:"Max rows per shard before splitting",type:"number"},
+{key:"PartitionMaxDimensions",label:"Maximum partition dimensions",desc:"Max partition dimensions for table sharding",type:"number"},
+{key:"DefaultEngine",label:"Default storage engine",desc:"Default storage engine for new tables",type:"select",options:["safe","logged","sloppy","memory"]}
 ]},
 {group:"Query Optimizer",items:[
-{key:"AnalyzeMinItems",desc:"Min table size for cardinality estimation",type:"number"},
-{key:"IndexThreshold",desc:"Min shard rows before creating an adaptive index (0=5); below this a full scan is cheaper",type:"number"},
-{key:"ExplainWidth",desc:"Max chars per expression before EXPLAIN expands to multiple lines (default 20)",type:"number"}
+{key:"AnalyzeMinItems",label:"Minimum rows for analysis",desc:"Min table size for cardinality estimation",type:"number"},
+{key:"IndexThreshold",label:"Index creation threshold",desc:"Min shard rows before creating an adaptive index (0=5); below this a full scan is cheaper",type:"number"},
+{key:"ExplainWidth",label:"EXPLAIN line width",desc:"Max chars per expression before EXPLAIN expands to multiple lines (default 20)",type:"number"}
 ]},
 {group:"Metrics",items:[
-{key:"MetricsTracing",desc:"Periodically record metrics to system_statistic.perf_metrics",type:"bool"},
-{key:"MetricsTracingInterval",desc:"Metrics sampling interval in seconds (0=60s)",type:"number"}
+{key:"MetricsTracing",label:"Record performance metrics",desc:"Periodically record metrics to system_statistic.perf_metrics",type:"bool"},
+{key:"MetricsTracingInterval",label:"Metrics interval (seconds)",desc:"Metrics sampling interval in seconds (0=60s)",type:"number"}
 ]},
 {group:"Error Log",items:[
-{key:"ErrorQueryLog",desc:"Log failed queries to system_statistic.errors (view in Errors tab)",type:"bool"},
-{key:"MaxErrorQueryLog",desc:"Max rows to keep in error log (0=unlimited, trimmed every 15min)",type:"number"}
+{key:"ErrorQueryLog",label:"Record failed queries",desc:"Log failed queries to system_statistic.errors (view in Errors tab)",type:"bool"},
+{key:"MaxErrorQueryLog",label:"Maximum error log entries",desc:"Max rows to keep in error log (0=unlimited, trimmed every 15min)",type:"number"}
 ]},
 {group:"Shutdown",items:[
-{key:"ShutdownDrainSeconds",desc:"Seconds to wait for in-flight requests during shutdown (0=10s)",type:"number"}
+{key:"ShutdownDrainSeconds",label:"Shutdown grace period (seconds)",desc:"Seconds to wait for in-flight requests during shutdown (0=10s)",type:"number"}
 ]},
 {group:"Debugging",items:[
-{key:"Backtrace",desc:"Enable detailed error backtraces (requires restart)",type:"bool"},
-{key:"Trace",desc:"Enable Scheme runtime tracing to file",type:"bool"},
-{key:"TracePrint",desc:"Print trace timing to stdout/log",type:"bool"},
-{key:"TracePrintMaxLength",desc:"TracePrint payload bytes retained before a visible truncation marker (0=unlimited)",type:"number"},
-{key:"ScanDebugging",desc:"Log every scan/scan_order: db+table+boundaries+index",type:"bool"},
-{key:"PrintLog",desc:"Log (print) output to system_statistic.logs (view in Log tab)",type:"bool"},
-{key:"MaxPrintLog",desc:"Max rows to keep in print log (0=unlimited, trimmed every 15min)",type:"number"}
+{key:"Backtrace",label:"Detailed backtraces",desc:"Enable detailed error backtraces (requires restart)",type:"bool"},
+{key:"Trace",label:"Write execution trace",desc:"Enable Scheme runtime tracing to file",type:"bool"},
+{key:"TracePrint",label:"Print query timings",desc:"Print trace timing to stdout/log",type:"bool"},
+{key:"TracePrintMaxLength",label:"Maximum trace record size",desc:"Trace payload retained before truncation (0 is unlimited)",type:"bytes",min:0},
+{key:"ScanDebugging",label:"Log individual scans",desc:"Log every scan/scan_order: db+table+boundaries+index",type:"bool"},
+{key:"PrintLog",label:"Record console output",desc:"Log (print) output to system_statistic.logs (view in Log tab)",type:"bool"},
+{key:"MaxPrintLog",label:"Maximum console log entries",desc:"Max rows to keep in print log (0=unlimited, trimmed every 15min)",type:"number"}
 ]}
 ];
 
@@ -1877,6 +1885,21 @@ h+="<tr><td>"+esc(s.name||"")+"</td><td>"+esc(s.port||"")+"</td><td>"+esc(s.rout
 tb.innerHTML=h||"<tr><td colspan='4' style='color:#888;text-align:center'>No services registered</td></tr>";
 }
 
+function parseSettingBytes(text){
+var match=/^\s*(\d+(?:[.,]\d+)?)\s*(B|KB|MB|GB|TB|KiB|MiB|GiB|TiB)?\s*$/i.exec(text);
+if(!match)throw new Error("Enter a size such as 10MB, 1.5GiB or 4096. Use 0 where allowed.");
+var unit=(match[2]||"B").toUpperCase();
+var factors={B:1,KB:1e3,MB:1e6,GB:1e9,TB:1e12,KIB:1024,MIB:1048576,GIB:1073741824,TIB:1099511627776};
+var value=Number(match[1].replace(",","."))*factors[unit];
+if(!Number.isSafeInteger(value)||value<0)throw new Error("Size must be a whole number of bytes within the supported range.");
+return value;
+}
+function formatSettingBytes(value){
+if(!value)return "0";
+var units=[[1099511627776,"TiB"],[1073741824,"GiB"],[1048576,"MiB"],[1024,"KiB"],[1e12,"TB"],[1e9,"GB"],[1e6,"MB"],[1e3,"KB"]];
+for(var i=0;i<units.length;i++)if(value>=units[i][0]&&value%units[i][0]===0)return (value/units[i][0])+" "+units[i][1];
+return value+" B";
+}
 function renderSettings(data){
 var grid=document.getElementById("settings-grid");
 var h="";
@@ -1886,7 +1909,7 @@ h+="<div class='settings-group-header'>"+esc(grp.group)+"</div>";
 for(var i=0;i<grp.items.length;i++){
 var s=grp.items[i];
 var val=data[s.key];
-h+="<div class='setting-card'><div class='info'><div class='name'>"+esc(s.key)+"</div><div class='desc'>"+esc(s.desc)+"</div></div>";
+h+="<div class='setting-card'><div class='info'><div class='name'>"+esc(s.label||s.key.replace(/([a-z])([A-Z])/g,"$1 $2"))+"</div><div class='desc'>"+esc(s.desc)+"</div></div>";
 if(s.type==="bool"){
 h+="<label class='toggle'><input type='checkbox' data-key='"+esc(s.key)+"'"+(val?" checked":"")+"><span class='slider'></span></label>";
 }else if(s.type==="select"){
@@ -1895,8 +1918,10 @@ for(var j=0;j<s.options.length;j++){
 h+="<option value='"+esc(s.options[j])+"'"+(val===s.options[j]?" selected":"")+">"+esc(s.options[j])+"</option>";
 }
 h+="</select>";
+}else if(s.type==="bytes"){
+h+="<input type='text' data-type='bytes' data-min='"+(s.min||0)+"' data-key='"+esc(s.key)+"' aria-label='"+esc(s.label||s.key)+"' title='MB = 1,000,000 bytes; MiB = 1,048,576 bytes. Save with Enter or by leaving the field.' value='"+esc(formatSettingBytes(val))+"'>";
 }else{
-h+="<input type='number' data-key='"+esc(s.key)+"' value='"+(val||0)+"'>";
+h+="<input type='number' step='1' min='"+(s.min||0)+"' data-key='"+esc(s.key)+"' aria-label='"+esc(s.label||s.key)+"' value='"+(val||0)+"'>";
 }
 h+="</div>";
 }
@@ -1907,12 +1932,24 @@ function saveSettingEl(el){
 var key=el.getAttribute("data-key");
 var value;
 if(el.type==="checkbox")value=el.checked;
-else if(el.type==="number")value=Number(el.value);
+else if(el.dataset.type==="bytes"){
+try{
+value=parseSettingBytes(el.value);
+if(value<Number(el.dataset.min))throw new Error("Minimum: "+formatSettingBytes(Number(el.dataset.min)));
+el.setCustomValidity("");
+}catch(e){el.setCustomValidity(e.message);el.reportValidity();return;}
+}
+else if(el.type==="number"){
+value=Number(el.value);
+if(el.value.trim()===""||!Number.isSafeInteger(value)||value<Number(el.min)){el.setCustomValidity("Enter a whole number.");el.reportValidity();return;}
+el.setCustomValidity("");
+}
 else value=el.value;
 var statusEl=document.getElementById("settings-status");
 statusEl.textContent="Saving "+key+"...";
 saveSetting(key,value,function(){
-statusEl.textContent=key+" saved";
+statusEl.textContent=key+" saved"+(key.indexOf("PHP")===0?" — restart MemCP to apply":"");
+if(el.dataset.type==="bytes")el.value=formatSettingBytes(value);
 setTimeout(function(){statusEl.textContent=""},2000);
 });
 }
@@ -1920,13 +1957,11 @@ setTimeout(function(){statusEl.textContent=""},2000);
 grid.querySelectorAll("input[type='checkbox'],select").forEach(function(el){
 el.addEventListener("change",function(){saveSettingEl(el)});
 });
-/* number inputs: debounced on input */
-grid.querySelectorAll("input[type='number']").forEach(function(el){
-var timer=null;
-el.addEventListener("input",function(){
-if(timer)clearTimeout(timer);
-timer=setTimeout(function(){saveSettingEl(el)},500);
-});
+/* Save complete values, so typing a unit does not submit a partial size. */
+grid.querySelectorAll("input[type='number'],input[data-type='bytes']").forEach(function(el){
+el.addEventListener("input",function(){el.setCustomValidity("")});
+el.addEventListener("change",function(){saveSettingEl(el)});
+el.addEventListener("keydown",function(e){if(e.key==="Enter"){e.preventDefault();el.blur();}});
 });
 }
 

--- a/main.go
+++ b/main.go
@@ -1267,11 +1267,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  --root-password-file=PATH  Read the initial root password from a file\n")
 		fmt.Fprintf(os.Stderr, "  --disable-mysql        Disable MySQL protocol server\n")
 		fmt.Fprintf(os.Stderr, "  --serve PATH           Mount a PHP application at /; keep /dashboard (make php)\n")
-		fmt.Fprintf(os.Stderr, "  --php-threads=N        Global maximum PHP threads (default 4)\n")
-		fmt.Fprintln(os.Stderr, "  --php-memory-limit=256M  Per-request PHP memory ceiling, including retained PDO results")
-		fmt.Fprintln(os.Stderr, "  --php-max-wait=30s      Maximum wait for a PHP thread (0s: unlimited)")
-		fmt.Fprintln(os.Stderr, "  --php-output-buffer=4096  PHP output buffer bytes (0: disabled)")
-		fmt.Fprintln(os.Stderr, "  --php-opcache-memory=128  Shared PHP opcode cache in MiB")
 		fmt.Fprintf(os.Stderr, "... and much more (please refer to your module's documentation)\n\n")
 	}
 

--- a/main.go
+++ b/main.go
@@ -1267,7 +1267,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  --root-password-file=PATH  Read the initial root password from a file\n")
 		fmt.Fprintf(os.Stderr, "  --disable-mysql        Disable MySQL protocol server\n")
 		fmt.Fprintf(os.Stderr, "  --serve PATH           Mount a PHP application at /; keep /dashboard (make php)\n")
-		fmt.Fprintf(os.Stderr, "  --php-threads=N        PHP threads (default 4)\n")
+		fmt.Fprintf(os.Stderr, "  --php-threads=N        Global maximum PHP threads (default 4)\n")
+		fmt.Fprintln(os.Stderr, "  --php-memory-limit=256M  Per-request PHP memory ceiling, including retained PDO results")
+		fmt.Fprintln(os.Stderr, "  --php-max-wait=30s      Maximum wait for a PHP thread (0s: unlimited)")
+		fmt.Fprintln(os.Stderr, "  --php-output-buffer=4096  PHP output buffer bytes (0: disabled)")
+		fmt.Fprintln(os.Stderr, "  --php-opcache-memory=128  Shared PHP opcode cache in MiB")
 		fmt.Fprintf(os.Stderr, "... and much more (please refer to your module's documentation)\n\n")
 	}
 

--- a/php.go
+++ b/php.go
@@ -8,6 +8,7 @@ package main
 import "os"
 import "fmt"
 import "sync"
+import "time"
 import "path"
 import "strconv"
 import "strings"
@@ -19,7 +20,89 @@ import "github.com/launix-de/memcp/phpbridge"
 
 var phpLifecycle sync.Mutex
 var phpReady = make(chan struct{})
-var phpThreads = 4
+
+type phpConfig struct {
+	threads       int
+	memoryLimit   int64
+	maxWait       time.Duration
+	outputBuffer  int
+	opcacheMemory int
+}
+
+var phpSettings phpConfig
+
+func parsePHPConfig(args []string) (phpConfig, error) {
+	c := phpConfig{4, 256 << 20, 30 * time.Second, 4096, 128}
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "--php-") {
+			continue
+		}
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return c, fmt.Errorf("%s requires =VALUE", key)
+		}
+		switch key {
+		case "--php-threads", "--php-output-buffer", "--php-opcache-memory":
+			n, err := strconv.Atoi(value)
+			if err != nil || n < 0 || (key != "--php-output-buffer" && n == 0) {
+				return c, fmt.Errorf("invalid %s: %q", key, value)
+			}
+			switch key {
+			case "--php-threads":
+				c.threads = n
+			case "--php-output-buffer":
+				c.outputBuffer = n
+			case "--php-opcache-memory":
+				if n < 32 {
+					return c, fmt.Errorf("php-opcache-memory must be at least 32 MiB")
+				}
+				c.opcacheMemory = n
+			}
+		case "--php-memory-limit":
+			shift := uint(0)
+			if len(value) > 0 {
+				switch value[len(value)-1] {
+				case 'k', 'K':
+					shift = 10
+				case 'm', 'M':
+					shift = 20
+				case 'g', 'G':
+					shift = 30
+				}
+				if shift > 0 {
+					value = value[:len(value)-1]
+				}
+			}
+			n, err := strconv.ParseUint(value, 10, int(63-shift))
+			if err != nil || n<<shift < 8<<20 {
+				return c, fmt.Errorf("php-memory-limit must be finite and at least 8 MiB (e.g. 256M)")
+			}
+			c.memoryLimit = int64(n << shift)
+		case "--php-max-wait":
+			d, err := time.ParseDuration(value)
+			if err != nil || d < 0 {
+				return c, fmt.Errorf("php-max-wait must be a nonnegative duration")
+			}
+			c.maxWait = d
+		default:
+			return c, fmt.Errorf("unsupported PHP option %s", key)
+		}
+	}
+	return c, nil
+}
+
+func (c phpConfig) ini() map[string]string {
+	limit := strconv.FormatInt(c.memoryLimit, 10)
+	return map[string]string{
+		"expose_php": "0", "display_errors": "0", "log_errors": "1",
+		"memory_limit": limit, "max_memory_limit": limit,
+		"output_buffering": strconv.Itoa(c.outputBuffer), "implicit_flush": "0",
+		"opcache.enable": "1", "opcache.memory_consumption": strconv.Itoa(c.opcacheMemory),
+		"opcache.interned_strings_buffer": "16", "opcache.max_accelerated_files": "20000",
+		"opcache.validate_timestamps": "1", "opcache.revalidate_freq": "0", "opcache.jit": "disable",
+	}
+}
+
 var phpStarted, phpStopping bool
 var phpInitErr error
 var phpAccessCachesMu sync.Mutex
@@ -28,20 +111,14 @@ var phpAccessCaches []*phpAccessCache
 // HTTP listeners belong to Scheme's serve. This only publishes PHP settings
 // after Scheme initialization; the first PHP request starts the shared runtime.
 func startPHP(args []string) error {
-	for _, arg := range args {
-		if !strings.HasPrefix(arg, "--php-") {
-			continue
-		}
-		key, value, ok := strings.Cut(arg, "=")
-		if !ok || key != "--php-threads" {
-			return fmt.Errorf("%s is not supported; mount (servePHP directory prefix front_controller) in a Scheme HTTP handler", key)
-		}
-		n, err := strconv.Atoi(value)
-		if err != nil || n < 1 {
-			return fmt.Errorf("php-threads must be positive")
-		}
-		phpThreads = n
+	settings, err := parsePHPConfig(args)
+	if err != nil {
+		return err
 	}
+	if allocator, present := os.LookupEnv("USE_ZEND_ALLOC"); present && allocator != "1" {
+		return fmt.Errorf("PHP memory quota requires USE_ZEND_ALLOC to be unset or 1")
+	}
+	phpSettings = settings
 	close(phpReady)
 	return nil
 }
@@ -59,9 +136,7 @@ func ensurePHP() error {
 		phpInitErr = err
 		return err
 	}
-	if err := frankenphp.Init(frankenphp.WithNumThreads(phpThreads), frankenphp.WithMaxThreads(phpThreads), frankenphp.WithPhpIni(map[string]string{
-		"expose_php": "0", "display_errors": "0", "log_errors": "1", "opcache.enable": "1",
-	})); err != nil {
+	if err := frankenphp.Init(frankenphp.WithNumThreads(phpSettings.threads), frankenphp.WithMaxThreads(phpSettings.threads), frankenphp.WithMaxWaitTime(phpSettings.maxWait), frankenphp.WithPhpIni(phpSettings.ini())); err != nil {
 		phpInitErr = err
 		return err
 	}

--- a/php.go
+++ b/php.go
@@ -16,6 +16,7 @@ import "net/http"
 import "path/filepath"
 import "github.com/dunglas/frankenphp"
 import "github.com/launix-de/memcp/scm"
+import "github.com/launix-de/memcp/storage"
 import "github.com/launix-de/memcp/phpbridge"
 
 var phpLifecycle sync.Mutex
@@ -31,62 +32,20 @@ type phpConfig struct {
 
 var phpSettings phpConfig
 
-func parsePHPConfig(args []string) (phpConfig, error) {
-	c := phpConfig{4, 256 << 20, 30 * time.Second, 4096, 128}
-	for _, arg := range args {
-		if !strings.HasPrefix(arg, "--php-") {
-			continue
-		}
-		key, value, ok := strings.Cut(arg, "=")
-		if !ok {
-			return c, fmt.Errorf("%s requires =VALUE", key)
-		}
-		switch key {
-		case "--php-threads", "--php-output-buffer", "--php-opcache-memory":
-			n, err := strconv.Atoi(value)
-			if err != nil || n < 0 || (key != "--php-output-buffer" && n == 0) {
-				return c, fmt.Errorf("invalid %s: %q", key, value)
-			}
-			switch key {
-			case "--php-threads":
-				c.threads = n
-			case "--php-output-buffer":
-				c.outputBuffer = n
-			case "--php-opcache-memory":
-				if n < 32 {
-					return c, fmt.Errorf("php-opcache-memory must be at least 32 MiB")
-				}
-				c.opcacheMemory = n
-			}
-		case "--php-memory-limit":
-			shift := uint(0)
-			if len(value) > 0 {
-				switch value[len(value)-1] {
-				case 'k', 'K':
-					shift = 10
-				case 'm', 'M':
-					shift = 20
-				case 'g', 'G':
-					shift = 30
-				}
-				if shift > 0 {
-					value = value[:len(value)-1]
-				}
-			}
-			n, err := strconv.ParseUint(value, 10, int(63-shift))
-			if err != nil || n<<shift < 8<<20 {
-				return c, fmt.Errorf("php-memory-limit must be finite and at least 8 MiB (e.g. 256M)")
-			}
-			c.memoryLimit = int64(n << shift)
-		case "--php-max-wait":
-			d, err := time.ParseDuration(value)
-			if err != nil || d < 0 {
-				return c, fmt.Errorf("php-max-wait must be a nonnegative duration")
-			}
-			c.maxWait = d
-		default:
-			return c, fmt.Errorf("unsupported PHP option %s", key)
-		}
+func loadPHPConfig() (phpConfig, error) {
+	values := storage.PHPStartupSettings()
+	c := phpConfig{int(values.Threads), values.MemoryLimit, time.Duration(values.MaxWaitMilliseconds) * time.Millisecond, int(values.OutputBuffer), int((values.OpcacheMemory + (1 << 20) - 1) >> 20)}
+	if values.Threads < 1 ||
+		values.Threads > 1024 ||
+		values.MemoryLimit < 8<<20 ||
+		values.MemoryLimit > 9007199254740991 ||
+		values.MaxWaitMilliseconds < 0 ||
+		values.MaxWaitMilliseconds > 86400000 ||
+		values.OutputBuffer < 0 ||
+		values.OutputBuffer > 2147483647 ||
+		values.OpcacheMemory < 32<<20 ||
+		values.OpcacheMemory > 1<<40 {
+		return c, fmt.Errorf("invalid PHP settings: check PHPThreads, PHPMemoryLimit, PHPMaxWaitMilliseconds, PHPOutputBuffer and PHPOpcacheMemory")
 	}
 	return c, nil
 }
@@ -111,7 +70,12 @@ var phpAccessCaches []*phpAccessCache
 // HTTP listeners belong to Scheme's serve. This only publishes PHP settings
 // after Scheme initialization; the first PHP request starts the shared runtime.
 func startPHP(args []string) error {
-	settings, err := parsePHPConfig(args)
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--php-") {
+			return fmt.Errorf("PHP flags have been removed; configure PHP through (settings) or the dashboard")
+		}
+	}
+	settings, err := loadPHPConfig()
 	if err != nil {
 		return err
 	}

--- a/php_test.go
+++ b/php_test.go
@@ -144,9 +144,9 @@ func testPHPIntegration(t *testing.T, front, cli string, queueTimeout bool) {
 			t.Fatal(err)
 		}
 	}
-	cmd := exec.Command(binary, "--no-repl", apiFlag, "--mysql-port="+mysqlPort, "--mysql-socket="+socketPath, "-data", filepath.Join(dir, "data"), "-c", `(createdatabase "memcp-tests" true)`, "--php-threads=4", "--php-memory-limit=32M", "--php-max-wait=5s", "lib/main.scm", mountFile)
+	cmd := exec.Command(binary, "--no-repl", apiFlag, "--mysql-port="+mysqlPort, "--mysql-socket="+socketPath, "-data", filepath.Join(dir, "data"), "-c", `(createdatabase "memcp-tests" true)`, "-c", `(settings "PHPMemoryLimit" 33554432)`, "-c", `(settings "PHPMaxWaitMilliseconds" 5000)`, "lib/main.scm", mountFile)
 	if queueTimeout {
-		cmd.Args = append(cmd.Args, "--php-max-wait=100ms")
+		cmd.Args = append(cmd.Args, "-c", `(settings "PHPMaxWaitMilliseconds" 100)`)
 	}
 	if cli != "" {
 		workingDir, err := os.Getwd()
@@ -368,21 +368,6 @@ func testPHPIntegration(t *testing.T, front, cli string, queueTimeout bool) {
 		if status, body, err := get("/app/probe.php?action=verify"); err != nil || status != 200 {
 			t.Fatalf("pool failed to recover: %d %s %v", status, body, err)
 		}
-	}
-}
-
-func TestPHPConfig(t *testing.T) {
-	for _, option := range []string{"--php-memory-limit=-1", "--php-memory-limit=0", "--php-memory-limit=999999999999999999G", "--php-memory-limit=1M", "--php-threads=0", "--php-threads=-1", "--php-max-wait=-1s", "--php-output-buffer=-1", "--php-opcache-memory=0", "--php-unknown=1", "--php-threads"} {
-		if _, err := parsePHPConfig([]string{option}); err == nil {
-			t.Errorf("accepted %s", option)
-		}
-	}
-	c, err := parsePHPConfig([]string{"--php-threads=2", "--php-memory-limit=64M", "--php-max-wait=1s", "--php-output-buffer=0", "--php-opcache-memory=64"})
-	if err != nil || c.threads != 2 || c.memoryLimit != 64<<20 || c.maxWait != time.Second || c.outputBuffer != 0 || c.opcacheMemory != 64 {
-		t.Fatalf("config: %+v %v", c, err)
-	}
-	if c.ini()["max_memory_limit"] != "67108864" {
-		t.Fatal("missing immutable memory ceiling")
 	}
 }
 

--- a/php_test.go
+++ b/php_test.go
@@ -26,13 +26,13 @@ func TestPHPIntegration(t *testing.T) {
 		if front != "" {
 			name = "front-controller"
 		}
-		t.Run(name, func(t *testing.T) { testPHPIntegration(t, front, "") })
+		t.Run(name, func(t *testing.T) { testPHPIntegration(t, front, "", false) })
 	}
 }
 
 func TestPHPServeCLI(t *testing.T) {
 	for _, mode := range []string{"split", "equals"} {
-		t.Run(mode, func(t *testing.T) { testPHPIntegration(t, "index.php", mode) })
+		t.Run(mode, func(t *testing.T) { testPHPIntegration(t, "index.php", mode, false) })
 	}
 }
 
@@ -49,7 +49,9 @@ func TestPHPServeCLIRequiresPath(t *testing.T) {
 	}
 }
 
-func testPHPIntegration(t *testing.T, front, cli string) {
+func TestPHPWaitTimeout(t *testing.T) { testPHPIntegration(t, "", "", true) }
+
+func testPHPIntegration(t *testing.T, front, cli string, queueTimeout bool) {
 	binary, err := filepath.Abs("memcp-php")
 	if err != nil {
 		t.Fatal(err)
@@ -142,7 +144,10 @@ func testPHPIntegration(t *testing.T, front, cli string) {
 			t.Fatal(err)
 		}
 	}
-	cmd := exec.Command(binary, "--no-repl", apiFlag, "--mysql-port="+mysqlPort, "--mysql-socket="+socketPath, "-data", filepath.Join(dir, "data"), "-c", `(createdatabase "memcp-tests" true)`, "--php-threads=4", "lib/main.scm", mountFile)
+	cmd := exec.Command(binary, "--no-repl", apiFlag, "--mysql-port="+mysqlPort, "--mysql-socket="+socketPath, "-data", filepath.Join(dir, "data"), "-c", `(createdatabase "memcp-tests" true)`, "--php-threads=4", "--php-memory-limit=32M", "--php-max-wait=5s", "lib/main.scm", mountFile)
+	if queueTimeout {
+		cmd.Args = append(cmd.Args, "--php-max-wait=100ms")
+	}
 	if cli != "" {
 		workingDir, err := os.Getwd()
 		if err != nil {
@@ -249,13 +254,13 @@ func testPHPIntegration(t *testing.T, front, cli string) {
 			}
 		}
 	}
-	for _, action := range []string{"setup", "pdo", "wire", "route-dsn", "buffers", "latency", "abandon", "verify"} {
+	for _, action := range []string{"setup", "quota", "oom-php", "oom-pdo", "pdo", "wire", "route-dsn", "buffers", "latency", "abandon", "verify"} {
 		status, body, err := get("/app/probe.php?action=" + action)
 		want := 200
-		if action == "abandon" {
+		if action == "abandon" || strings.HasPrefix(action, "oom-") {
 			want = 500
 		}
-		if err != nil || status != want {
+		if err != nil || status != want || (strings.HasPrefix(action, "oom-") && strings.Contains(body, "Memory ceiling was not enforced")) {
 			t.Fatalf("%s: status %d, %s, %v", action, status, body, err)
 		}
 	}
@@ -312,12 +317,17 @@ func testPHPIntegration(t *testing.T, front, cli string) {
 		t.Fatalf("mount boundary: %d %v", status, err)
 	}
 	var wg sync.WaitGroup
-	var intervals [4]struct{ Start, End float64 }
-	for i := 0; i < 4; i++ {
+	var intervals [12]struct{ Start, End float64 }
+	var rejected [12]bool
+	for i := range intervals {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			status, body, err := get(fmt.Sprintf("/app/probe.php?action=parallel&value=%d", i))
+			if queueTimeout && err == nil && status == 503 {
+				rejected[i] = true
+				return
+			}
 			if err != nil || status != 200 {
 				t.Errorf("parallel: %d %s %v", status, body, err)
 			}
@@ -329,6 +339,15 @@ func testPHPIntegration(t *testing.T, front, cli string) {
 	wg.Wait()
 	overlap := false
 	for i, a := range intervals {
+		active := 0
+		for _, b := range intervals {
+			if b.Start <= a.Start && a.Start < b.End {
+				active++
+			}
+		}
+		if active > 4 {
+			t.Errorf("PHP thread cap exceeded: %d", active)
+		}
 		for j, b := range intervals {
 			if i != j && a.Start < b.End && b.Start < a.End {
 				overlap = true
@@ -337,5 +356,47 @@ func testPHPIntegration(t *testing.T, front, cli string) {
 	}
 	if !overlap {
 		t.Error("PHP requests did not overlap")
+	}
+	if queueTimeout {
+		found := false
+		for _, r := range rejected {
+			found = found || r
+		}
+		if !found {
+			t.Error("saturated PHP pool did not time out queued requests")
+		}
+		if status, body, err := get("/app/probe.php?action=verify"); err != nil || status != 200 {
+			t.Fatalf("pool failed to recover: %d %s %v", status, body, err)
+		}
+	}
+}
+
+func TestPHPConfig(t *testing.T) {
+	for _, option := range []string{"--php-memory-limit=-1", "--php-memory-limit=0", "--php-memory-limit=999999999999999999G", "--php-memory-limit=1M", "--php-threads=0", "--php-threads=-1", "--php-max-wait=-1s", "--php-output-buffer=-1", "--php-opcache-memory=0", "--php-unknown=1", "--php-threads"} {
+		if _, err := parsePHPConfig([]string{option}); err == nil {
+			t.Errorf("accepted %s", option)
+		}
+	}
+	c, err := parsePHPConfig([]string{"--php-threads=2", "--php-memory-limit=64M", "--php-max-wait=1s", "--php-output-buffer=0", "--php-opcache-memory=64"})
+	if err != nil || c.threads != 2 || c.memoryLimit != 64<<20 || c.maxWait != time.Second || c.outputBuffer != 0 || c.opcacheMemory != 64 {
+		t.Fatalf("config: %+v %v", c, err)
+	}
+	if c.ini()["max_memory_limit"] != "67108864" {
+		t.Fatal("missing immutable memory ceiling")
+	}
+}
+
+func TestPHPQuotaRequiresZendAllocator(t *testing.T) {
+	for _, value := range []string{"0", "", "false"} {
+		t.Run("value="+value, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "./memcp-php", "--no-repl", "--disable-api", "--disable-mysql", "--mysql-socket=", "-data", t.TempDir())
+			cmd.Env = append(os.Environ(), "USE_ZEND_ALLOC="+value)
+			output, err := cmd.CombinedOutput()
+			if err == nil || !strings.Contains(string(output), "PHP memory quota requires USE_ZEND_ALLOC") {
+				t.Fatalf("allocator bypass: %v %s", err, output)
+			}
+		})
 	}
 }

--- a/phpbridge/bridge.go
+++ b/phpbridge/bridge.go
@@ -271,6 +271,8 @@ func memcp_query(handle C.uintptr_t, sql *C.char, length C.size_t) (r *C.memcp_r
 		r.transaction = 1
 	}
 	r.columns = C.size_t(b.columnCount)
+	r.cells_length = C.size_t(len(b.cells))
+	r.bytes_length = C.size_t(len(b.data))
 	if len(b.cells) > 0 {
 		r.cells = (*C.memcp_cell)(C.calloc(C.size_t(len(b.cells)), C.size_t(unsafe.Sizeof(C.memcp_cell{}))))
 		copy(unsafe.Slice(r.cells, len(b.cells)), b.cells)

--- a/phpbridge/bridge.h
+++ b/phpbridge/bridge.h
@@ -18,6 +18,7 @@ typedef struct {
 	int64_t affected, insert_id;
 	int transaction;
 	size_t columns, rows;
+	size_t cells_length, bytes_length;
 	memcp_cell *cells; /* column names followed by row-major values */
 	char *bytes;
 	char *error;

--- a/phpbridge/pdo.c
+++ b/phpbridge/pdo.c
@@ -3,6 +3,9 @@
 /* Copyright (C) 2026 Carl-Philip Hänsch
  * SPDX-License-Identifier: GPL-3.0-or-later */
 #include <php.h>
+#if PHP_VERSION_ID < 80500
+#error "MemCP PHP quotas require PHP 8.5 or newer (max_memory_limit)"
+#endif
 #include <ext/pdo/php_pdo_driver.h>
 #include "bridge.h"
 #include "_cgo_export.h"
@@ -23,6 +26,34 @@ typedef struct {
 void memcp_result_free(memcp_result *r) {
 	if (!r) return;
 	free(r->cells); free(r->bytes); free(r->error); free(r);
+}
+
+/* Transfer retained results into Zend's request heap only after Go has returned.
+ * A PHP allocation bailout must never unwind through an active Go stack. The
+ * temporary C buffer is freed on OOM too, and an unclaimed connection is closed. */
+static memcp_result *request_result(memcp_result *r) {
+	const size_t cells_size = r->cells_length * sizeof(memcp_cell);
+	const size_t error_size = r->error ? strlen(r->error) + 1 : 0;
+	memcp_result *owned = NULL;
+	zend_try {
+		owned = emalloc(sizeof(*r) + cells_size + r->bytes_length + error_size);
+	} zend_catch {
+		if (r->handle) memcp_close(r->handle);
+		memcp_result_free(r);
+		zend_bailout();
+	} zend_end_try();
+	*owned = *r;
+	char *buffer = (char *)(owned + 1);
+	owned->cells = cells_size ? (memcp_cell *)buffer : NULL;
+	if (cells_size) memcpy(buffer, r->cells, cells_size);
+	buffer += cells_size;
+	owned->bytes = r->bytes_length ? buffer : NULL;
+	if (r->bytes_length) memcpy(buffer, r->bytes, r->bytes_length);
+	buffer += r->bytes_length;
+	owned->error = error_size ? buffer : NULL;
+	if (error_size) memcpy(buffer, r->error, error_size);
+	memcp_result_free(r);
+	return owned;
 }
 
 static bool accept_result(pdo_dbh_t *dbh, pdo_stmt_t *stmt, memcp_result *r) {
@@ -49,7 +80,7 @@ static void fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) {
 
 static int close_cursor(pdo_stmt_t *stmt) {
 	memcp_stmt *s = stmt->driver_data;
-	memcp_result_free(s->result); s->result = NULL; s->position = 0;
+	if (s->result) efree(s->result); s->result = NULL; s->position = 0;
 	return 1;
 }
 
@@ -67,8 +98,8 @@ static int execute_stmt(pdo_stmt_t *stmt) {
 	if (s->parameters_required && (!stmt->bound_params || zend_hash_num_elements(stmt->bound_params) == 0)) {
 		pdo_raise_impl_error(stmt->dbh, stmt, "HY093", "Statement requires bound parameters"); return 0;
 	}
-	memcp_result *r = memcp_query(db->handle, ZSTR_VAL(stmt->active_query_string), ZSTR_LEN(stmt->active_query_string));
-	if (!accept_result(stmt->dbh, stmt, r)) { memcp_result_free(r); return 0; }
+	memcp_result *r = request_result(memcp_query(db->handle, ZSTR_VAL(stmt->active_query_string), ZSTR_LEN(stmt->active_query_string)));
+	if (!accept_result(stmt->dbh, stmt, r)) { efree(r); return 0; }
 	s->result = r;
 	php_pdo_stmt_set_column_count(stmt, (int)r->columns);
 	stmt->row_count = r->affected;
@@ -137,9 +168,9 @@ static bool prepare(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *op
 
 static zend_long execute(pdo_dbh_t *dbh, const zend_string *sql) {
 	memcp_db *db = dbh->driver_data;
-	memcp_result *r = memcp_query(db->handle, (char *)ZSTR_VAL(sql), ZSTR_LEN(sql));
+	memcp_result *r = request_result(memcp_query(db->handle, (char *)ZSTR_VAL(sql), ZSTR_LEN(sql)));
 	zend_long count = accept_result(dbh, NULL, r) ? r->affected : -1;
-	memcp_result_free(r); return count;
+	efree(r); return count;
 }
 
 /* Hex literals preserve arbitrary bytes and cannot be affected by SQL quote
@@ -208,14 +239,14 @@ static int connect_db(pdo_dbh_t *dbh, zval *options) {
 	dbh->driver_data = ecalloc(1, sizeof(memcp_db));
 	dbh->methods = &database_methods;
 	memcp_db *db = dbh->driver_data;
-	memcp_result *r = memcp_open((char *)dbh->data_source + sizeof(prefix)-1,
-		(char *)(dbh->username ? dbh->username : ""), (char *)(dbh->password ? dbh->password : ""));
+	memcp_result *r = request_result(memcp_open((char *)dbh->data_source + sizeof(prefix)-1,
+		(char *)(dbh->username ? dbh->username : ""), (char *)(dbh->password ? dbh->password : "")));
 	if (!accept_result(dbh, NULL, r)) {
 		pdo_throw_exception(0, r->error, &dbh->error_code);
-		memcp_result_free(r); return 0;
+		efree(r); return 0;
 	}
 	db->handle = r->handle;
-	memcp_result_free(r);
+	efree(r);
 	dbh->max_escaped_char_length = 2;
 	return 1;
 }

--- a/storage/settings.go
+++ b/storage/settings.go
@@ -16,21 +16,25 @@ Copyright (C) 2024-2026  Carl-Philip Hänsch
 */
 package storage
 
-import (
-	"bufio"
-	"encoding/json"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
-
-	"github.com/dc0d/onexit"
-	"github.com/launix-de/memcp/scm"
-)
+import "os"
+import "fmt"
+import "sync"
+import "time"
+import "bufio"
+import "strconv"
+import "strings"
+import "encoding/json"
+import "path/filepath"
+import "github.com/dc0d/onexit"
+import "github.com/launix-de/memcp/scm"
 
 type SettingsT struct {
+	PHPThreads             int64 // Global PHP startup setting; changes require a restart.
+	PHPMemoryLimit         int64 // Global PHP startup setting; changes require a restart.
+	PHPMaxWaitMilliseconds int64 // Global PHP startup setting; changes require a restart.
+	PHPOutputBuffer        int64 // Global PHP startup setting; changes require a restart.
+	PHPOpcacheMemory       int64 // Global PHP startup setting; changes require a restart.
+
 	Backtrace              bool
 	Trace                  bool
 	TracePrint             bool
@@ -130,6 +134,12 @@ func (r CreateTableTriggerRegistration) triggerDescription() TriggerDescription 
 }
 
 var Settings = SettingsT{
+	PHPThreads:             4,
+	PHPMemoryLimit:         1073741824,
+	PHPMaxWaitMilliseconds: 30000,
+	PHPOutputBuffer:        4096,
+	PHPOpcacheMemory:       536870912,
+
 	PartitionMaxDimensions: 10,
 	DefaultEngine:          "safe",
 	ShardSize:              60000,
@@ -138,6 +148,32 @@ var Settings = SettingsT{
 	ExplainWidth:           20,
 	JoinReorderDPBudget:    256,
 }
+
+// settingsMu serializes settings API changes and PHP startup snapshots.
+var settingsMu sync.Mutex
+
+// PHPConfig holds one consistent snapshot for initializing the shared PHP runtime.
+type PHPConfig struct {
+	Threads, MemoryLimit, MaxWaitMilliseconds, OutputBuffer, OpcacheMemory int64
+}
+
+func PHPStartupSettings() PHPConfig {
+	settingsMu.Lock()
+	defer settingsMu.Unlock()
+	return PHPConfig{Settings.PHPThreads, Settings.PHPMemoryLimit, Settings.PHPMaxWaitMilliseconds, Settings.PHPOutputBuffer, Settings.PHPOpcacheMemory}
+}
+
+func validatePHPSetting(key string, value scm.Scmer, minimum, maximum int64) int64 {
+	if !value.IsInt() && !value.IsFloat() {
+		panic(key + " requires a numeric value")
+	}
+	n := scm.ToFloat(value)
+	if n < float64(minimum) || n > float64(maximum) || n != float64(int64(n)) {
+		panic(fmt.Sprintf("%s must be a whole number between %d and %d", key, minimum, maximum))
+	}
+	return int64(n)
+}
+
 var createTableTriggerMu sync.Mutex
 
 func registerCreateTableTrigger(reg CreateTableTriggerRegistration) {
@@ -188,9 +224,17 @@ func InitSettings() {
 }
 
 func ChangeSettings(a ...scm.Scmer) scm.Scmer {
+	settingsMu.Lock()
+	defer settingsMu.Unlock()
 	// schema, filename
 	if len(a) == 0 {
 		return scm.NewSlice([]scm.Scmer{
+			scm.NewString("PHPThreads"), scm.NewInt(Settings.PHPThreads),
+			scm.NewString("PHPMemoryLimit"), scm.NewInt(Settings.PHPMemoryLimit),
+			scm.NewString("PHPMaxWaitMilliseconds"), scm.NewInt(Settings.PHPMaxWaitMilliseconds),
+			scm.NewString("PHPOutputBuffer"), scm.NewInt(Settings.PHPOutputBuffer),
+			scm.NewString("PHPOpcacheMemory"), scm.NewInt(Settings.PHPOpcacheMemory),
+
 			scm.NewString("Backtrace"), scm.NewBool(Settings.Backtrace),
 			scm.NewString("Trace"), scm.NewBool(Settings.Trace),
 			scm.NewString("TracePrint"), scm.NewBool(Settings.TracePrint),
@@ -220,6 +264,16 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 		})
 	} else if len(a) == 1 {
 		switch scm.String(a[0]) {
+		case "PHPThreads":
+			return scm.NewInt(Settings.PHPThreads)
+		case "PHPMemoryLimit":
+			return scm.NewInt(Settings.PHPMemoryLimit)
+		case "PHPMaxWaitMilliseconds":
+			return scm.NewInt(Settings.PHPMaxWaitMilliseconds)
+		case "PHPOutputBuffer":
+			return scm.NewInt(Settings.PHPOutputBuffer)
+		case "PHPOpcacheMemory":
+			return scm.NewInt(Settings.PHPOpcacheMemory)
 		case "Backtrace":
 			return scm.NewBool(Settings.Backtrace)
 		case "Trace":
@@ -277,6 +331,16 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 		}
 	} else {
 		switch scm.String(a[0]) {
+		case "PHPThreads":
+			Settings.PHPThreads = validatePHPSetting("PHPThreads", a[1], 1, 1024)
+		case "PHPMemoryLimit":
+			Settings.PHPMemoryLimit = validatePHPSetting("PHPMemoryLimit", a[1], 8388608, 9007199254740991)
+		case "PHPMaxWaitMilliseconds":
+			Settings.PHPMaxWaitMilliseconds = validatePHPSetting("PHPMaxWaitMilliseconds", a[1], 0, 86400000)
+		case "PHPOutputBuffer":
+			Settings.PHPOutputBuffer = validatePHPSetting("PHPOutputBuffer", a[1], 0, 2147483647)
+		case "PHPOpcacheMemory":
+			Settings.PHPOpcacheMemory = validatePHPSetting("PHPOpcacheMemory", a[1], 33554432, 1099511627776)
 		case "Backtrace":
 			scm.SettingsHaveGoodBacktraces = Settings.Backtrace
 			Settings.Backtrace = scm.ToBool(a[1])

--- a/storage/settings_test.go
+++ b/storage/settings_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Carl-Philip Hänsch
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package storage
+
+import "testing"
+import "encoding/json"
+import "github.com/launix-de/memcp/scm"
+
+func TestPHPSettings(t *testing.T) {
+	keys := []string{"PHPThreads", "PHPMemoryLimit", "PHPMaxWaitMilliseconds", "PHPOutputBuffer", "PHPOpcacheMemory"}
+	snapshot := PHPStartupSettings()
+	original := []int64{snapshot.Threads, snapshot.MemoryLimit, snapshot.MaxWaitMilliseconds, snapshot.OutputBuffer, snapshot.OpcacheMemory}
+	defer func() {
+		for i, key := range keys {
+			ChangeSettings(scm.NewString(key), scm.NewInt(original[i]))
+		}
+	}()
+	values := []int64{2, 1024 << 20, 100, 0, 512 << 20}
+	for i, key := range keys {
+		ChangeSettings(scm.NewString(key), scm.NewInt(values[i]))
+		if got := ChangeSettings(scm.NewString(key)).Int(); got != values[i] {
+			t.Fatalf("%s: %d", key, got)
+		}
+	}
+	data, err := json.Marshal(Settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored SettingsT
+	if err = json.Unmarshal(data, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if restored.PHPMemoryLimit != 1024<<20 || restored.PHPOpcacheMemory != 512<<20 || restored.PHPThreads != 2 || restored.PHPMaxWaitMilliseconds != 100 || restored.PHPOutputBuffer != 0 {
+		t.Fatal("PHP settings lost during persistence")
+	}
+	for _, tc := range []struct {
+		key   string
+		value scm.Scmer
+	}{
+		{"PHPThreads", scm.NewInt(0)}, {"PHPThreads", scm.NewFloat(1.5)},
+		{"PHPThreads", scm.NewString("4junk")}, {"PHPMemoryLimit", scm.NewInt(-1)},
+		{"PHPMemoryLimit", scm.NewInt(1 << 20)}, {"PHPMaxWaitMilliseconds", scm.NewInt(-1)},
+		{"PHPOutputBuffer", scm.NewInt(-1)}, {"PHPOpcacheMemory", scm.NewInt(1 << 20)},
+	} {
+		before := ChangeSettings(scm.NewString(tc.key))
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("accepted invalid %s", tc.key)
+				}
+			}()
+			ChangeSettings(scm.NewString(tc.key), tc.value)
+		}()
+		if ChangeSettings(scm.NewString(tc.key)) != before {
+			t.Errorf("invalid value changed %s", tc.key)
+		}
+	}
+}

--- a/tests/php/integration.php
+++ b/tests/php/integration.php
@@ -30,6 +30,26 @@ try {
     if ($action === 'setup') {
         $db->exec('CREATE TABLE php_test (id INT PRIMARY KEY AUTO_INCREMENT, value TEXT)');
         $db->exec("CREATE USER php_reader IDENTIFIED BY 'reader-password'");
+     } elseif ($action === 'quota') {
+        check((int)ini_get('max_memory_limit') === 32*1024*1024, 'Host memory ceiling');
+        @ini_set('max_memory_limit', '-1');
+        @ini_set('memory_limit', '-1');
+        check((int)ini_get('memory_limit') === 32*1024*1024, 'Unlimited memory bypass');
+        @ini_set('memory_limit', '64M');
+        check((int)ini_get('memory_limit') === 32*1024*1024, 'Raised memory bypass');
+        check((int)ini_get('output_buffering') === 4096, 'Output buffering preset');
+        $before = memory_get_usage();
+        $held = $db->query("SELECT REPEAT('q', 1048576) AS payload");
+        check(memory_get_usage() - $before >= 1048576, 'Unfetched PDO result must count against quota');
+        $held->closeCursor();
+        check(memory_get_usage() - $before < 131072, 'Closed PDO cursor releases its quota');
+    } elseif ($action === 'oom-php' || $action === 'oom-pdo') {
+        $db->beginTransaction();
+        $db->exec("INSERT INTO php_test(value) VALUES ('oom rollback')");
+        if ($action === 'oom-php') { $huge = str_repeat('x', 64*1024*1024); }
+        $held = [];
+        for ($i = 0; $i < 64; $i++) { $held[] = $db->query("SELECT REPEAT('q', 1048576) AS payload"); }
+        throw new RuntimeException('Memory ceiling was not enforced');
     } elseif ($action === 'pdo') {
         $reader = new PDO('memcp:dbname=memcp-tests', 'php_reader', 'reader-password');
         fails(fn() => $reader->query('SELECT COUNT(*) FROM php_test'));


### PR DESCRIPTION
PHP scripts could raise their own `memory_limit`, and retained MemCP PDO results lived outside Zend's accounting. The host now enforces a configurable per-request ceiling with PHP 8.5's startup-only `max_memory_limit`, including unfetched PDO buffers, while retaining authenticated in-process SQL calls.

The global defaults are four PHP threads, a 1 GiB request ceiling, a 30-second queue wait (503 when exceeded), 4 KiB output buffering, and 512 MiB shared OPcache. The existing `(settings)` API and dashboard expose these settings, which take effect after restarting MemCP. PHP tuning flags are removed. Memory fields accept decimal and binary units such as `10MB` and `1.5GiB`, validate complete input on blur/Enter, and display readable sizes; existing settings have descriptive labels. The existing fixed thread cap remains in place; saturation and recovery are now tested. OPcache uses a 16 MiB interned-string buffer and a 20,000-script capacity setting, with PHP JIT disabled and timestamp validation on every request for redeployments.

The bridge transfers completed results to Zend-owned storage after Go returns. On an allocation bailout it frees the temporary native buffer before unwinding PHP; it also closes an unclaimed connection if opening one exhausts memory. Request teardown rolls back interrupted transactions. Zend allocator bypass settings are rejected. No external PHP/FrankenPHP source is patched.

Validation:
- PHP integration: attempts to disable/raise the quota, unfetched result accounting and release, PHP allocation OOM, PDO-buffer OOM, transaction rollback and subsequent requests, 12 concurrent requests against four threads, queue timeout/recovery, allocator configuration failures, and existing PDO/HTTP tests.
- Initial quota implementation, full hook-equivalent suite: `MEMCP_FAIL_FAST=1 ./git-pre-commit`; 27 previously noncritical deep-subquery/RDF/SPARQL/Turtle cases remain marked noncritical, with no severity or expectation changes.
- Settings follow-up: `go test ./storage -run TestPHPSettings`, PHP integration suite, and Playwright checks for byte units, fractional/comma input, invalid input, save/reload, and PHP fields. A separate real PHP restart test verifies unchanged active limits, JSON persistence at shutdown, and application after restart. Full regression checks run in CI.
- Playwright: existing EUR/Foployment deployment renders and the original large EUR archive uploads under the new 256 MiB ceiling. Application sources are unchanged.

Manual A/B on this host, before PR creation (256 MiB quota / 128 MiB cache at measurement time; subsequent settings/UI changes do not modify request processing): parent `dcbbcd6e5` vs this change, external PHP ZTS 8.5.10 and the same php.ini, four threads, sequential localhost HTTP keep-alive requests, 20 warmups and 200 measured requests per case. Each version starts against the same dedicated empty MemCP fixture. The PHP page either emits 2,000 `<div class="row">entry</div>` fragments (56,000 bytes), performs 20 direct PDO `SELECT 42 AS answer` calls and emits the final value, or fetches `SELECT REPEAT('x', 1048576) AS payload` and emits its length.

| Case | Baseline median | Proposed median | Change |
| --- | ---: | ---: | ---: |
| Many small output writes | 0.3398 ms | 0.2653 ms | -21.9% |
| 20 small direct SQL calls | 0.6150 ms | 0.6401 ms | +4.1% |
| 1 MiB direct SQL result | 0.3570 ms | 0.3870 ms | +8.4% |

The extra copy/accounting has a measurable SQL cost; the RAM bridge remains in-process. These microbenchmarks do not assert a 22% speedup for the complete EUR application.

Limits: the quota covers PHP request allocations and retained bridge buffers, not total process RSS, MemCP query/storage memory, native-extension allocations or spawned processes. OPcache is shared and separately sized. This is not a tenant sandbox; limiting the entire process at OS level would also limit MemCP. The host presets override the corresponding php.ini entries; other PHP settings remain external.
