### PR TITLE
fix: bound ordered index scans by their equality prefix

### DIFF
--- a/storage/index.go
+++ b/storage/index.go
@@ -1876,7 +1876,17 @@ start_scan:
 	// membership walk cheaper even when the RecSet is small relative to the
 	// whole table; whole-table density is therefore the wrong crossover input.
 	mainEnd := int(s.t.main_count)
-	if lastSorted >= 0 && !indexBounds.upperLast().IsNil() && mainIdx < mainEnd {
+	// An unbounded trailing ORDER BY key does not remove the upper end of
+	// an earlier equality prefix. Resolve that end before treating the main
+	// interval as exact or using its size to choose a RecSet traversal.
+	hasUpperBound := lastSorted >= 0 && !indexBounds.upperLast().IsNil()
+	for i := 0; i < lastSorted && !hasUpperBound; i++ {
+		if s.columnIsSorted(i) {
+			hasUpperBound = scanAccessBoundaryIsPoint(bounds, i) ||
+				!bounds.boundValue(i, false).IsNil() || !bounds.boundValue(i, true).IsNil()
+		}
+	}
+	if hasUpperBound && mainIdx < mainEnd {
 		mainEnd = mainIdx + sort.Search(mainEnd-mainIdx, func(offset int) bool {
 			recid := getRecid(mainIdx + offset)
 			_, beyond := s.rowWithinBounds(bounds, indexBounds, cmpCols, lastSorted, sortedMask, unboundedMask, lowerInclusive, upperInclusive, func(col int) scm.Scmer {

--- a/tests/storage/indexes/ordered-prefix-boundaries.yaml
+++ b/tests/storage/indexes/ordered-prefix-boundaries.yaml
@@ -1,0 +1,292 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+metadata:
+  description: Ordered index scans retain equality-prefix bounds with unbounded trailing
+    sort keys
+  isolated: true
+  restart_after_setup: true
+setup:
+- sql: DROP TABLE IF EXISTS ordered_prefix_posts
+- sql: CREATE TABLE ordered_prefix_posts (id INT PRIMARY KEY, kind VARCHAR(20), status
+    VARCHAR(20), stamp INT) ENGINE=sloppy
+- scm: |-
+    (insert (table "memcp-tests" "ordered_prefix_posts") '("id" "kind" "status" "stamp")
+      (map (produceN 22000) (lambda (i)
+        (list (+ i 1) (if (< i 2000) "post" "revision")
+          (if (< i 2000) (if (equal? (mod i 2) 0) "publish" "private") (if (equal? i 21999) "leaked" "inherit")) i))))
+- sql: INSERT INTO ordered_prefix_posts VALUES (22001, NULL, 'publish', 99999), (22002,
+    NULL, 'private', 99998)
+- scm: (rebuild)
+test_cases:
+- name: Warm ordered equality prefix descending
+  warmup: 10
+  timing_samples: 30
+  threshold_ms: 100
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+    OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  expect:
+    rows: 4
+    data:
+    - id: 2000
+    - id: 1999
+    - id: 1998
+    - id: 1997
+- name: Warm ordered equality prefix ascending
+  warmup: 10
+  timing_samples: 30
+  threshold_ms: 100
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+    OR status = 'private') ORDER BY stamp ASC LIMIT 4
+  expect:
+    rows: 4
+    data:
+    - id: 1
+    - id: 2
+    - id: 3
+    - id: 4
+- name: Warm ordered equality prefix two trailing keys
+  warmup: 10
+  timing_samples: 30
+  threshold_ms: 100
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+    OR status = 'private') ORDER BY stamp DESC, id DESC LIMIT 4
+  expect:
+    rows: 4
+    data:
+    - id: 2000
+    - id: 1999
+    - id: 1998
+    - id: 1997
+- name: missing prefix
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp DESC
+    LIMIT 4
+  expect:
+    rows: 0
+    data: []
+  setup:
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'missing' ORDER BY stamp
+      DESC LIMIT 4
+- name: upper one-sided range
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000 ORDER
+    BY stamp DESC LIMIT 4
+  expect:
+    rows: 4
+    data:
+    - id: 1000
+    - id: 999
+    - id: 998
+    - id: 997
+  setup:
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp < 1000
+      ORDER BY stamp DESC LIMIT 4
+- name: lower one-sided range
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996 ORDER
+    BY stamp DESC LIMIT 4
+  expect:
+    rows: 4
+    data:
+    - id: 2000
+    - id: 1999
+    - id: 1998
+    - id: 1997
+  setup:
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND stamp >= 1996
+      ORDER BY stamp DESC LIMIT 4
+- name: Unknown ordering column must fail
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+    OR status = 'private') ORDER BY missing_sort_key LIMIT 1
+  expect:
+    error: true
+- name: Residual match outside equality prefix must not leak
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+    OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  expect:
+    data:
+    - id: 2000
+    - id: 1999
+    - id: 1998
+    - id: 1997
+    rows: 4
+  setup:
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private' OR status = 'leaked') ORDER BY stamp DESC LIMIT 4
+- name: NULL equality prefix with unbounded ordering
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+    LIMIT 4
+  expect:
+    data:
+    - id: 22001
+    - id: 22002
+    rows: 2
+  setup:
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL ORDER BY stamp DESC
+      LIMIT 4
+- name: Two equality keys before unbounded ordering
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+    ORDER BY stamp DESC, id DESC LIMIT 4
+  expect:
+    data:
+    - id: 2000
+    - id: 1998
+    - id: 1996
+    - id: 1994
+    rows: 4
+  setup:
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
+      ORDER BY stamp DESC, id DESC LIMIT 4
+- name: Main prefix and delta merge exclude other prefixes
+  setup:
+  - sql: INSERT INTO ordered_prefix_posts VALUES (22003, 'post', 'private', 30000),
+      (22004, 'revision', 'private', 30001)
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+    OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  expect:
+    rows: 4
+    data:
+    - id: 22003
+    - id: 2000
+    - id: 1999
+    - id: 1998
+- name: Prefix boundary survives rebuild into main storage
+  setup:
+  - scm: (rebuild)
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+      OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND (status = 'publish'
+    OR status = 'private') ORDER BY stamp DESC LIMIT 4
+  expect:
+    rows: 4
+    data:
+    - id: 22003
+    - id: 2000
+    - id: 1999
+    - id: 1998
+cleanup:
+- sql: DROP TABLE IF EXISTS ordered_prefix_posts


### PR DESCRIPTION
An ordered index scan with a constrained equality prefix and unbounded trailing sort keys could include later prefix groups. The warmed regression `WHERE kind = 'missing' ORDER BY stamp DESC LIMIT 4` returned four unrelated rows on master. In the WordPress fixture, a four-row recent-post query visited 160,034 candidates.

Determine whether an earlier sorted key still bounds the upper end of the index interval. Resolve that end during index-iteration setup, before the exact-interval fast path and RecSet traversal cost selection use it.

The new storage-index suite covers ascending/descending order, two trailing sort keys, absent and NULL prefixes, one-sided ranges, two equality keys, residual filters, inserts and rebuild, plus an invalid ordering-column case. Three cases also provide warm performance coverage.

## Manual A/B measurement

Measured before opening this PR: master dcbbcd6e5 versus candidate 79cc4c7a6, same host and WordPress wp_posts fixture (220,055 rows, including 200,000 revisions), same authenticated mysqli connection setup, identical SQL, TracePrint enabled. Each variant used 10 warmups followed by 30 samples. Values below are median SQL execution times; result fetching is included. The application/database fixture was retained across the binary upgrade.

| Query | Master ms | Candidate ms | Change |
|---|---:|---:|---:|
| Previous post, publish OR private | 1670.786111 | 0.218411 | -99.99% |
| Next post, publish OR private | 205.484831 | 8.112448 | -96.05% |
| Recent posts, publish OR private, LIMIT 4 | 1703.989411 | 0.294792 | -99.98% |
| ID point lookup control | 0.063060 | 0.063847 | +1.25% |

All ordered-result hashes and FOUND_ROWS totals agree across the two variants. The point lookup is an unchanged control, not an attributed improvement. Raw measurements are retained locally as `fix-ab-baseline.json` and `fix-ab-candidate.json` in the WordPress analysis workspace.

## Validation

- Master reproduces the absent-prefix correctness failure; candidate passes all 12 new cases, including warm performance samples.
- 111 related SQL cases pass across index-prefix-dedup, ordered-lookup-boundaries, and in-list-like-prefix suites.
- Targeted Go tests for row bounds, inclusiveness, equality prefixes, sorted matchers and interpolation pass.
- PHP host builds successfully. Full test suites are delegated to CI.

End-to-end validation after deployment: authenticated `/?p=20674` improved from 3547.05 ms to 88.56 ms median (-97.5%), with 10 warmups and 30 measured requests in each version. All 30 candidate responses returned HTTP 200 without detected database errors or login forms.


## Investigation of the first JIT CI failure

The failing wide aggregate was measured once without warming its aggregate cache: 28.277 → 92.072 ms. The log also reports a 65.221 ms repartitioning of that table. The secondary missing-candidate message followed the suite abort. Ordinary Go A/B passed the same case (146.653 → 47.335 ms).

Additional controlled measurement with the exact CI JIT compiler (84fe25ee), CGO_ENABLED=0 and the CI build flags: B/C/C/B blocks, ten fresh fixtures per block, twenty independent first aggregate fills per variant. Wide aggregate median: **21.583 → 20.547 ms**; uncached simple arithmetic aggregate: **8.285 → 9.280 ms**. All results agree. EXPLAIN/IR/PHYSICAL/REORDER are byte-identical in all four blocks. The wide-table scan has no index bounds and does not enter the changed prefix-end calculation.

Targeted fixed-size cold SUM and forum-hierarchy checks also pass on both versions. Cold SUM first-fill samples varied on both sides (base 19.950/51.169 ms, candidate 20.590/40.554 ms). These observations do not reproduce a systematic regression; they do not prove the exact source of the initial CI outlier. The failed CI job has been rerun with unchanged code and thresholds.


The unchanged JIT rerun is now green: wide aggregate **38.052 → 27.150 ms**, uncached arithmetic **19.356 → 15.875 ms**, cold SUM **45.270 → 49.370 ms**, forum hierarchy **6.083 → 6.317 ms**. All applicable PR checks pass. No code, test expectations or performance limits were changed in response to the failed run.
