### PR TITLE
Reuse plans across session values covered by shared cost guards

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -264,6 +264,15 @@ per guard evaluation. If a useful generalized inequality is unavailable, an
 exact parameter/statistics-input guard is the conservative fallback; an old
 specialized plan must never be selected after an unguarded cost input changes.
 
+Coverage of session inputs is transitive through shared guard bindings. A
+surviving cost formula which consumes a bound statistic also covers the runtime
+inputs used to obtain that statistic; do not additionally guard their raw values
+for equality. Otherwise cost-equivalent users or clock ticks churn plan variants.
+Retain the complete producer dependency closure and evaluate it in lexical
+dependency order, once per validation. Discarded costing work provides no
+coverage. Quoted data is not executable: helpers interpreting an opaque metadata
+argument must explicitly declare the session inputs that argument represents.
+
 When an unknown cardinality interval crosses a costly operator boundary, the
 cache formula may execute one query-local observation *before* guard dispatch.
 That preparation is not part of the guard: it produces a physical value such

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -134,7 +134,7 @@ deduplicate immutable ASTs without serializing the growing expressions. */
 				(define covered_bindings (planning_session "__memcp_queryplan_guarded_session_keys"))
 				(if (nil? covered_bindings)
 					nil
-					(reduce (query_expr_session_reads condition) (lambda (_ expr)
+					(reduce (planner_guard_runtime_session_reads condition) (lambda (_ expr)
 						(covered_bindings (if (nil? condition_catalog) (string expr) expr) true)) nil))
 				condition)))))
 
@@ -234,7 +234,19 @@ an override intended for a sibling edge. */
 /* Runtime statistic expressions recur throughout dynamic-programming costs.
 Bind each unique expression once in the final guard instead of rereading the
 catalog for every comparison. The binding catalog is compile-local as well. */
-(define planner_guard_runtime_binding (lambda (expr planning_session)
+(define planner_guard_runtime_session_reads (lambda (expr)
+	(match expr
+		((symbol quote) _value) '()
+		_ (begin
+			(define read (query_session_read_expr expr))
+			(if (not (nil? read)) (list read)
+				(match expr
+					(cons head tail) (merge_unique (cons
+						(planner_guard_runtime_session_reads head)
+						(map tail planner_guard_runtime_session_reads)))
+					_ '())))))))
+
+(define planner_guard_runtime_binding (lambda (expr planning_session dependencies)
 	(begin
 		(define planning_session (planner_effective_session planning_session))
 		(define bindings (if (nil? planning_session) nil (planning_session "__memcp_queryplan_guard_bindings")))
@@ -248,7 +260,11 @@ catalog for every comparison. The binding catalog is compile-local as well. */
 					(begin
 						(define binding (list
 							(symbol (concat "__queryplan_guard_value_" (stable_structural_hash expr false)))
-							expr))
+							expr
+							/* Opaque metadata consumers declare their interpreted inputs;
+							ordinary quoted data must not count as a runtime session read. */
+							(merge_unique (list (planner_guard_runtime_session_reads expr)
+								(coalesceNil dependencies '())))))
 						(if (nil? binding_catalog)
 							(bindings key binding)
 							(begin

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -2736,13 +2736,20 @@ the lowerer can cost it. */
 				(lambda () (begin
 					(define compile_bindings (if (nil? planning_session) nil (planning_session "__memcp_queryplan_compile_bindings")))
 					(define observed (if (nil? planning_session) nil (planning_session "__memcp_queryplan_observed_session_keys")))
-					(if (and (not (nil? compile_bindings)) (not (nil? observed)))
-						(observed key true)
-						nil)
 					(define direct (if (nil? planning_session) nil (planning_session key)))
-					(if (not (nil? direct))
-						direct
-						(if (nil? compile_bindings) nil (compile_bindings key)))))
+					(define value (if (not (nil? direct)) direct
+						(if (nil? compile_bindings) nil (compile_bindings key))))
+					(if (and (not (nil? compile_bindings)) (not (nil? observed)))
+						(begin
+							/* Snapshot the value actually consumed by costing, not just vN
+							literal parameters. The uncovered-binding guard reads this snapshot:
+							missing named values would emit (= runtime_value nil), rejecting even
+							the compiling request and recompiling on every execution. Record only
+							observed inputs; do not copy opaque execution/preparation state. */
+							(compile_bindings key value)
+							(observed key true))
+						nil)
+					value))
 				(lambda (_e) nil))
 			((quote session) key) (planner_literal_value (list (quote session) key) planning_session)
 			((symbol session_globalvar) key) (coalesceNil

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -463,7 +463,8 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 				(planner_quoted_value local_sources)
 				default_alias
 				(planner_quoted_value local_predicates)
-				(planner_quoted_value src) (quote session)) planning_session))))
+				(planner_quoted_value src) (quote session)) planning_session
+			(query_expr_session_reads (list local_predicates local_sources))))))
 
 (define join_optimizer_selectivity_expr (lambda (sources default_alias predicate planning_session)
 	(begin
@@ -498,7 +499,7 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 								(list (quote table) (source_schema src) (source_relation src))
 								(planner_quoted_value (car access)) (cons (quote list) (cadr access))
 								(planner_quoted_value '()) (list (quote lambda) '() true) 0)
-							(planner_quoted_value (quote value)) fallback) planning_session))))))))
+							(planner_quoted_value (quote value)) fallback) planning_session nil))))))))
 
 (define join_optimizer_alias_subset? (lambda (required available)
 	(reduce (coalesceNil required '()) (lambda (ok alias)
@@ -6765,13 +6766,13 @@ sampling guard for a choice that no cardinality change can reverse. */
 							driver_rows group_rows stage_count))
 						(define driver_rows_expr (planner_guard_runtime_binding
 							(aggregate_pushdown_runtime_driver_rows_expr driver residual)
-							planning_session))
+							planning_session nil))
 						(define group_rows_expr (planner_guard_runtime_binding
 							(list (quote planner_aggregate_pushdown_group_estimate)
 								(planner_quoted_value driver)
 								(planner_quoted_value keys)
 								driver_rows_expr)
-							planning_session))
+							planning_session nil))
 						(if (planner_guarded_choice chosen
 							(list (quote aggregate_pushdown_cost_preferred?)
 								driver_rows_expr group_rows_expr stage_count)

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -341,16 +341,25 @@ semantics for multiple independent cache assumptions. */
 						(cadr dependency) (nth dependency 2) (coalesceNil (nth dependency 3) false)))))
 				(sql_queryplan_conjoin_guards dependency_guards))))))
 
+/* Bindings are registered producer-first. Walk backwards from surviving
+decision guards to retain their complete dependency closure, not unused cost
+enumeration work. A guarded derived estimate covers its session inputs too:
+adding a raw value equality would needlessly partition the cache per user. */
+(define sql_queryplan_guard_live_bindings (lambda (guard bindings)
+	(reduce (reverse bindings) (lambda (live binding)
+		(if (or (sql_queryplan_guard_references_symbol? guard (car binding))
+			(reduce live (lambda (needed consumer)
+				(or needed (sql_queryplan_guard_references_symbol? (cadr consumer) (car binding)))) false))
+			(cons binding live) live)) '())))
+
 (define sql_queryplan_guard_from_session (lambda (planning_session)
 	(begin
 		(define condition_accumulator (planning_session "__memcp_queryplan_guard_conditions"))
 		(define condition_catalog (planning_session "__memcp_queryplan_guard_condition_catalog"))
-		(define conditions (merge (list
-			(if (nil? condition_catalog)
+		(define conditions (if (nil? condition_catalog)
 				(map (condition_accumulator) (lambda (key) (condition_accumulator key)))
 				(map (produceN (coalesceNil (condition_accumulator "count") 0))
-					(lambda (idx) (condition_accumulator (concat "condition:" idx)))))
-			(sql_queryplan_uncovered_binding_conditions planning_session))))
+					(lambda (idx) (condition_accumulator (concat "condition:" idx))))))
 		(define statistics_guard (sql_queryplan_statistics_guard_from_session planning_session))
 		(define raw_guard (sql_queryplan_conjoin_guards
 			(merge (list conditions (list statistics_guard)))))
@@ -363,13 +372,19 @@ semantics for multiple independent cache assumptions. */
 		/* Cost enumeration may bind expressions which no surviving guard uses.
 		Materializing those lambda arguments would retain the discarded planning
 		work on every cached execution. */
-		(define bindings (filter all_bindings (lambda (binding)
-			(sql_queryplan_guard_references_symbol? raw_guard (car binding)))))
-		(sql_queryplan_runtime_guard_expr (if (empty_list? bindings)
-			raw_guard
-			(cons
-				(list (quote lambda) (map bindings car) raw_guard)
-				(map bindings cadr)))))))
+		(define bindings (sql_queryplan_guard_live_bindings raw_guard all_bindings))
+		(define covered (planning_session "__memcp_queryplan_guarded_session_keys"))
+		(reduce bindings (lambda (_ binding)
+			(reduce (nth binding 2) (lambda (_ expr)
+				(covered (if (nil? condition_catalog) (string expr) expr) true)) nil)) nil)
+		(define complete_guard (sql_queryplan_conjoin_guards
+			(cons raw_guard (sql_queryplan_uncovered_binding_conditions planning_session))))
+		/* Nested lexical bindings let a cost formula consume an earlier shared
+		statistic. One flat lambda evaluates all arguments in the outer scope and
+		cannot represent that dependency. The optimizer can inline these lets. */
+		(sql_queryplan_runtime_guard_expr
+			(reduce (reverse bindings) (lambda (body binding)
+				(list (list (quote lambda) (list (car binding)) body) (cadr binding))) complete_guard)))))
 
 (define sql_invoke_parse_fn (lambda (parse_fn schema parse_query policy planning_session tx)
 	(if (list? parse_fn)

--- a/tests/performance/query-cache-feedback-churn.yaml
+++ b/tests/performance/query-cache-feedback-churn.yaml
@@ -22,6 +22,28 @@ setup:
         (rebuild (table "memcp-tests" "qfc_document") true false)
         (globalvars "qfc_sequence" 1000))
 test_cases:
+  - name: "ACL counts share a cost regime across different named session bindings"
+    performance_rows: 1000
+    threshold_ms: 5000
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT COUNT(*) AS n FROM qfc_clock a LEFT JOIN qfc_document z ON z.id=a.id WHERE a.id>@clock AND COALESCE((SELECT CASE WHEN EXISTS(SELECT 1 FROM qfc_access x WHERE x.viewer=@viewer AND x.domain_id IS NULL LIMIT 1) THEN TRUE ELSE EXISTS(SELECT 1 FROM qfc_access y WHERE y.viewer=@viewer AND y.domain_id=b.id LIMIT 1) END FROM qfc_document b WHERE b.id=a.id LIMIT 1),FALSE)")
+        (define rows (newsession))
+        (rows "n" 0)
+        (reduce (produceN 16) (lambda (_ i) (begin
+          (sess "viewer" (+ 999 i))
+          (sess "clock" i)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+            (lambda (row) (rows "n" (+ (rows "n") (cadr row)))) (lambda (_fields) nil)))) nil)
+        (if (equal? (rows "n") 1) true (error "changing named ACL bindings changed counts")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
   - name: "Named session ACL counts do not recompile on every cached execution"
     performance_rows: 1000
     threshold_ms: 5000

--- a/tests/performance/query-cache-feedback-churn.yaml
+++ b/tests/performance/query-cache-feedback-churn.yaml
@@ -5,6 +5,10 @@ metadata:
   description: "Warm ordered queries amid unrelated bound-predicate learning"
   isolated: true
 setup:
+  - sql: "DROP TABLE IF EXISTS qfc_access"
+  - sql: "CREATE TABLE qfc_access (viewer INT, domain_id INT) ENGINE=sloppy"
+  - sql: "INSERT INTO qfc_access VALUES (999,NULL),(998,998),(997,999)"
+  - scm: '(rebuild (table "memcp-tests" "qfc_access") true false)'
   - sql: "DROP TABLE IF EXISTS qfc_clock"
   - sql: "CREATE TABLE qfc_clock (id INT PRIMARY KEY) ENGINE=sloppy"
   - sql: "INSERT INTO qfc_clock (id) VALUES (999)"
@@ -18,6 +22,27 @@ setup:
         (rebuild (table "memcp-tests" "qfc_document") true false)
         (globalvars "qfc_sequence" 1000))
 test_cases:
+  - name: "Named session ACL counts do not recompile on every cached execution"
+    performance_rows: 1000
+    threshold_ms: 5000
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (sess "viewer" 999)
+        (define q "SELECT COUNT(*) AS n FROM qfc_clock a LEFT JOIN qfc_document z ON z.id=a.id WHERE COALESCE((SELECT CASE WHEN EXISTS(SELECT 1 FROM qfc_access x WHERE x.viewer=@viewer AND x.domain_id IS NULL LIMIT 1) THEN TRUE ELSE EXISTS(SELECT 1 FROM qfc_access y WHERE y.viewer=@viewer AND y.domain_id=b.id LIMIT 1) END FROM qfc_document b WHERE b.id=a.id LIMIT 1),FALSE)")
+        (define rows (newsession))
+        (rows "n" 0)
+        (reduce (produceN 16) (lambda (_ i)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+            (lambda (row) (rows "n" (+ (rows "n") (cadr row)))) (lambda (_fields) nil))) nil)
+        (if (equal? (rows "n") 16) true (error "named session ACL count changed results")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
   - name: "Changing runtime cutoffs retain a singleton ordered plan"
     performance_rows: 1000
     threshold_ms: 1000
@@ -97,5 +122,6 @@ test_cases:
       rows: 1
       result_contains: ["true"]
 cleanup:
+  - sql: "DROP TABLE IF EXISTS qfc_access"
   - sql: "DROP TABLE IF EXISTS qfc_clock"
   - sql: "DROP TABLE IF EXISTS qfc_document"

--- a/tests/planner/core/query-cache-feedback-isolation.yaml
+++ b/tests/planner/core/query-cache-feedback-isolation.yaml
@@ -21,6 +21,100 @@ setup:
           (map (produceN 1000) (lambda (i) (list i (if (< i 10) "needle" "ordinary")))))
         (rebuild (table "memcp-tests" "qfi_document") true false))
 test_cases:
+  - name: "A shared cost guard covers its runtime binding without an identity guard"
+    scm: |
+      (begin
+        (define sess (newsession))
+        (sess "viewer" 10)
+        (define planning (sql_queryplan_compile_session sess nil))
+        (define input (planner_literal_value (quote (session "viewer")) planning))
+        (define value (planner_guard_runtime_binding (quote (session "viewer")) planning nil))
+        (define cost (planner_guard_runtime_binding (list (quote *) value 2) planning nil))
+        (planner_guarded_choice (< (* input 2) 100) (list (quote <) cost 100) planning)
+        (define guard (sql_queryplan_compile_formula (sql_queryplan_guard_from_session planning)))
+        (define original (guard sess nil nil nil))
+        (sess "viewer" 20)
+        (define same_region (guard sess nil nil nil))
+        (sess "viewer" 60)
+        (define crossed (guard sess nil nil nil))
+        (if (and original same_region (not crossed)) true
+          (error "shared cost guard did not preserve the decision region")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+  - name: "ACL counts reuse their cost regime across named users and clock ticks"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT COUNT(*) AS n FROM qfi_single a LEFT JOIN qfi_document z ON z.id=a.id WHERE a.id>@clock AND COALESCE((SELECT CASE WHEN EXISTS(SELECT 1 FROM qfi_access x WHERE x.viewer=@viewer AND x.domain_id IS NULL LIMIT 1) THEN TRUE ELSE EXISTS(SELECT 1 FROM qfi_access y WHERE y.viewer=@viewer AND y.domain_id=b.id LIMIT 1) END FROM qfi_document b WHERE b.id=a.id LIMIT 1),FALSE)")
+        (define rows (newsession))
+        (define run (lambda (viewer clock) (begin
+          (sess "viewer" viewer)
+          (sess "clock" clock)
+          (rows "n" -1)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+            (lambda (row) (rows "n" (cadr row))) (lambda (_fields) nil))
+          (rows "n"))))
+        (define first (run 999 0))
+        (run 999 0)
+        (define entry (car (cache (car (cache)))))
+        (define before (count (entry "variants")))
+        (define allowed (run 997 1))
+        (define denied (run 998 2))
+        (define expired (run 999 1000))
+        (define restored (run 999 0))
+        (define other_users (reduce (produceN 200) (lambda (valid i)
+          (and valid (equal? (run (+ 1000 i) i) 0))) true))
+        (if (and (equal? first 1) (equal? allowed 1) (equal? denied 0)
+          (equal? expired 0) (equal? restored 1) other_users
+          (equal? before (count (entry "variants")))) true
+          (error (concat "cost-equivalent session bindings changed variants/results: "
+            before " -> " (count (entry "variants")) " values " first "/" allowed "/"
+            denied "/" expired "/" restored)))))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+  - name: "Quoted session-shaped data is not a covered runtime dependency"
+    scm: |
+      (begin
+        (define sess (newsession))
+        (sess "viewer" 10)
+        (define planning (sql_queryplan_compile_session sess nil))
+        (define input (planner_literal_value (quote (session "viewer")) planning))
+        (planner_record_guard_condition
+          (quote (equal? (quote (session "viewer")) (quote (session "viewer")))) planning)
+        (define guard (sql_queryplan_compile_formula (sql_queryplan_guard_from_session planning)))
+        (define original (guard sess nil nil nil))
+        (sess "viewer" (+ input 1))
+        (if (and original (not (guard sess nil nil nil))
+          (empty_list? (planner_guard_runtime_session_reads
+            (quote (quote (session "viewer")))))) true
+          (error "quoted data was mistaken for a runtime session dependency")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+  - name: "Discarded cost bindings cannot suppress an uncovered specialization guard"
+    scm: |
+      (begin
+        (define sess (newsession))
+        (sess "viewer" 10)
+        (define planning (sql_queryplan_compile_session sess nil))
+        (define input (planner_literal_value (quote (session "viewer")) planning))
+        (define unused (planner_guard_runtime_binding (quote (session "viewer")) planning nil))
+        (define raw (sql_queryplan_guard_from_session planning))
+        (define guard (sql_queryplan_compile_formula raw))
+        (define original (guard sess nil nil nil))
+        (sess "viewer" (+ input 1))
+        (if (and original (not (guard sess nil nil nil))
+          (not (sql_queryplan_guard_references_symbol? raw unused))) true
+          (error "discarded cost binding incorrectly covered an input")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
   - name: "Observed named bindings guard their compile-time value, including false and NULL"
     scm: |
       (begin

--- a/tests/planner/core/query-cache-feedback-isolation.yaml
+++ b/tests/planner/core/query-cache-feedback-isolation.yaml
@@ -5,6 +5,10 @@ metadata:
   description: "Unrelated learned predicates must not invalidate cached ordered plans"
   isolated: true
 setup:
+  - sql: "DROP TABLE IF EXISTS qfi_access"
+  - sql: "CREATE TABLE qfi_access (viewer INT, domain_id INT) ENGINE=sloppy"
+  - sql: "INSERT INTO qfi_access VALUES (999,NULL),(998,998),(997,999)"
+  - scm: '(rebuild (table "memcp-tests" "qfi_access") true false)'
   - sql: "DROP TABLE IF EXISTS qfi_single"
   - sql: "CREATE TABLE qfi_single (id INT PRIMARY KEY) ENGINE=sloppy"
   - sql: "INSERT INTO qfi_single VALUES (999)"
@@ -17,6 +21,99 @@ setup:
           (map (produceN 1000) (lambda (i) (list i (if (< i 10) "needle" "ordinary")))))
         (rebuild (table "memcp-tests" "qfi_document") true false))
 test_cases:
+  - name: "Observed named bindings guard their compile-time value, including false and NULL"
+    scm: |
+      (begin
+        (define sess (newsession))
+        (sess "viewer" 999)
+        (sess "enabled" false)
+        (define planning (sql_queryplan_compile_session sess nil))
+        (define values (list
+          (planner_literal_value (quote (session "viewer")) planning)
+          (planner_literal_value (quote (session "enabled")) planning)
+          (planner_literal_value (quote (session "missing")) planning)))
+        (if (not (equal? values (list 999 false nil))) (error "planner read incorrect bindings") nil)
+        (define guard (sql_queryplan_compile_formula
+          (sql_queryplan_conjoin_guards (sql_queryplan_uncovered_binding_conditions planning))))
+        (define original (guard sess nil nil nil))
+        (sess "viewer" 998)
+        (define changed (guard sess nil nil nil))
+        (sess "viewer" 999)
+        (sess "missing" 1)
+        (define formerly_null (guard sess nil nil nil))
+        (sess "missing" nil)
+        (sess "enabled" true)
+        (define formerly_false (guard sess nil nil nil))
+        (if (and original (not changed) (not formerly_null) (not formerly_false)) true
+          (error "named binding guard lost the observed value or accepted a changed binding")))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+  - name: "Named lookup bindings reuse plans but still change visible rows"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT a.id,b.label FROM qfi_single a LEFT JOIN qfi_document b ON b.id=a.id WHERE b.id=@viewer ORDER BY a.id LIMIT 2")
+        (define rows (newsession))
+        (define run (lambda (viewer) (begin
+          (sess "viewer" viewer)
+          (rows "n" 0)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+            (lambda (row) (rows "n" (+ (rows "n") 1))) (lambda (_fields) nil))
+          (rows "n"))))
+        (define first (run 999))
+        (run 999)
+        (define entry (car (cache (car (cache)))))
+        (define before (count (entry "variants")))
+        (define repeated (run 999))
+        (define after (count (entry "variants")))
+        (define changed (run 998))
+        (define restored (run 999))
+        (define missing (run nil))
+        (if (and (equal? first 1) (equal? repeated 1) (equal? changed 0)
+          (equal? restored 1) (equal? missing 0) (equal? before after)) true
+          (error (concat "ACL binding results or plan reuse failed: " first "/" repeated "/"
+            changed "/" restored "/" missing " variants " before " -> " after)))))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+  - name: "Named ACL count guards accept their own compilation and reuse the variant"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define q "SELECT COUNT(*) AS n FROM qfi_single a LEFT JOIN qfi_document z ON z.id=a.id WHERE COALESCE((SELECT CASE WHEN EXISTS(SELECT 1 FROM qfi_access x WHERE x.viewer=@viewer AND x.domain_id IS NULL LIMIT 1) THEN TRUE ELSE EXISTS(SELECT 1 FROM qfi_access y WHERE y.viewer=@viewer AND y.domain_id=b.id LIMIT 1) END FROM qfi_document b WHERE b.id=a.id LIMIT 1),FALSE)")
+        (define rows (newsession))
+        (define run (lambda (viewer) (begin
+          (sess "viewer" viewer)
+          (rows "n" -1)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "memcp-tests" q nil "root" sess true)
+            (lambda (row) (rows "n" (cadr row))) (lambda (_fields) nil))
+          (rows "n"))))
+        (define first (run 999))
+        (run 999)
+        (define entry (car (cache (car (cache)))))
+        (define before (count (entry "variants")))
+        (define repeated (run 999))
+        (define after (count (entry "variants")))
+        (define changed (run 998))
+        (define scoped (run 997))
+        (define restored (run 999))
+        (if (and (equal? first 1) (equal? repeated 1) (equal? changed 0)
+          (equal? scoped 1) (equal? restored 1)
+          (equal? before after)) true
+          (error (concat "ACL count results or cache reuse failed: " first "/" repeated "/"
+            changed "/" scoped "/" restored " variants " before " -> " after)))))
+    expect:
+      rows: 1
+      result_contains: ["true"]
   - name: "Truthy guard literals are not references to statistic bindings"
     scm: |
       (begin
@@ -208,5 +305,6 @@ test_cases:
     expect:
       data: [true]
 cleanup:
+  - sql: "DROP TABLE IF EXISTS qfi_access"
   - sql: "DROP TABLE IF EXISTS qfi_single"
   - sql: "DROP TABLE IF EXISTS qfi_document"

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -624,14 +624,15 @@ test_cases:
         (define planning (sql_queryplan_compile_session (newsession) nil))
         (define guard (with_session planning (lambda ()
           (begin
-            (planner_guard_runtime_binding (list (quote +) 1 2))
-            (define used (planner_guard_runtime_binding (list (quote -) 5 3)))
-            (planner_record_guard_condition (list (quote equal?) used 2))
+            (planner_guard_runtime_binding (list (quote +) 1 2) planning nil)
+            (define used (planner_guard_runtime_binding (list (quote -) 5 3) planning nil))
+            (planner_record_guard_condition (list (quote equal?) used 2) planning)
             (sql_queryplan_guard_from_session planning)))))
         (match guard
           (cons (cons (symbol lambda) (cons parameters (cons _body '()))) arguments)
-            (and (equal? (count parameters) 1) (equal? (count arguments) 1))
-          _ false))
+            (if (and (equal? (count parameters) 1) (equal? (count arguments) 1)) true
+              (error "guard retained discarded bindings"))
+          _ (error "guard omitted its required binding")))
     expect:
       data: [true]
 


### PR DESCRIPTION
## Follow-up to #861 (target: master)

Built on #861. That patch fixes the wrong NULL snapshot; this patch fixes redundant session-identity guards when a surviving cost formula already checks the input through a shared statistic binding.

An ACL user's identity and the current clock value remain runtime inputs of the plan. Changing them within the same guarded cost regime must not force a separate variant per user or clock tick.

## Root cause and fix

Guard conditions refer to shared cost variables. Coverage was collected only from the condition itself, not from the definitions of those variables. It therefore missed the session reads underneath a derived cardinality and emitted an additional exact identity guard.

- Shared bindings carry their actual runtime session dependencies. Opaque metadata consumers explicitly declare interpreted dependencies; ordinary quoted data does not count as executable reads.
- Final guard assembly resolves the transitive producer closure of surviving guards. Dead costing bindings neither execute nor claim input coverage.
- Dependencies already protected by those live cost formulas do not receive a redundant raw-value equality.
- Lexically nested bindings let one derived cost consume a previously bound statistic. The old single flat lambda evaluated all binding arguments in the outer scope and could not represent these dependencies correctly.
- Document the contract in INVARIANTS.md and adjacent code comments.

No operator is forced and no Costgen weight changes. All existing decision conditions remain. This is **not** a blanket deletion of exact fallback guards and does not claim to derive every missing cost crossover in the planner. True executable specialization still needs protection (including the existing custom-parser constant-specialization test); sampled choices without an adequate generalized condition remain guarded. This patch specifically removes duplicate identity specialization where a live cost condition already covers the input.

## Tests

- RED on #861, GREEN here: nested shared input -> cost formula -> decision guard. A different input in the same cost region passes; crossing the decision threshold fails.
- RED on #861, GREEN here: compound ACL COUNT + changing user and clock. Admin, scoped and denied users, expiry and restoration, plus 200 different user bindings all retain one warmed variant and correct results. Baseline grew from 1 to 3 variants even for the initial user switches.
- Quoted session-shaped data must not suppress a guard (also reproduced red before fixing direct-condition dependency discovery).
- Discarded cost bindings cannot claim coverage or remain in emitted guards.
- Existing prepared-statement binding-liveness test now passes explicit compile context and raises an error on failure, rather than relying on unchecked SCM expect.data.
- New performance A/B case, 16 complete requests with different named session values. Existing cases and thresholds unchanged.
- Targeted guard, growth, session reminder, session keytable, EXISTS/session and prepared-statement suites; full suites left to CI.

## Manual A/B before opening this PR

Same JIT binary for both sides, separate servers loading the relevant Scheme libraries. Identical rebuilt fixture: 1 driving row, 1,000 domain rows, 3 ACL rows. Two warmups and nine measured samples per case, alternating A/B order. Each sample creates a cache and executes 16 full queries. Medians include HTTP overhead, not just guard arithmetic. Separate paired runs below must not be mixed as if their absolute timings came from one run.

### Incremental improvement over #861 (72d1556ac)

| Case | #861 | Follow-up | Change |
|---|---:|---:|---:|
| Different named users + clock ticks | 663.808 ms | 212.856 ms | -67.9% |
| Repeated identical named user | 277.860 ms | 218.648 ms | -21.3% |
| Ordered singleton, changing cutoffs | 4.230 ms | 4.247 ms | +0.4% |
| ACL COUNT, changing cutoffs | 610.480 ms | 580.410 ms | -4.9% |
| Unrelated-feedback control | 2.527 ms | 2.506 ms | -0.9% |

### Combined change against master dcbbcd6e5

| Case | Master | This branch | Change |
|---|---:|---:|---:|
| Different named users + clock ticks | 685.119 ms | 276.619 ms | -59.6% |
| Repeated identical named user | 732.526 ms | 284.994 ms | -61.1% |
| Ordered singleton, changing cutoffs | 5.227 ms | 3.885 ms | -25.7% |
| ACL COUNT, changing cutoffs | 813.754 ms | 733.822 ms | -9.8% |
| Unrelated-feedback control | 3.008 ms | 2.879 ms | -4.3% |

The production instance has not been restarted or changed by this follow-up; these are anonymous regression-fixture measurements, not a claim of recovered production end-to-end latency. Independent COUNT/NULL issue #860 remains separate.
