### PR TITLE
Fix empty dashboard database list caused by obsolete user scan

### DIFF
--- a/.github/workflows/jit-test.yml
+++ b/.github/workflows/jit-test.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install requests PyYAML
+          # Browser repositories are unrelated to these Ubuntu build dependencies.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y mariadb-client
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,8 @@ jobs:
           PHP_VERSION: 8.5.10
           PHP_SHA256: 6a8bebaa4d5a979a38db29a9373e9851f60c6b11f72172c585947e78f3081957
         run: |
+          # Browser repositories are unrelated to these Ubuntu build dependencies.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y build-essential pkg-config bison re2c libsqlite3-dev libonig-dev libzip-dev libicu-dev libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev
           cd "$RUNNER_TEMP"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install requests PyYAML
+          # Browser repositories are unrelated to these Ubuntu build dependencies.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y mariadb-client
 
@@ -90,6 +92,8 @@ jobs:
 
       - name: Install package tooling
         run: |
+          # Browser repositories are unrelated to these Ubuntu build dependencies.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y lintian mariadb-client rpm
 

--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -1237,7 +1237,6 @@ return r.json();
 }
 
 var SCM_SERVICES='(if (nil? service_registry) "[]" (dashboard_json_array (map (service_registry) (lambda (name) (begin (set v (service_registry name)) (json_encode_assoc (list "name" name "port" (car v) "route" (car (cdr v)) "protocols" (car (cdr (cdr v))))))))))';
-var SCM_USERS='(begin (set j (scan nil (table "system" "user") (list) (lambda () true) (list "username" "admin") (lambda (u adm) (begin (set dbs_str (scan nil (table "system" "access") (list "username") (lambda (au) (equal?? au u)) (list "database") (lambda (db) (json_encode db)) (lambda (a b) (if (equal? a "") b (concat a "," b))) "")) (concat "{\\"username\\":" (json_encode u) ",\\"admin\\":" (if (equal? adm 0) "false" "true") ",\\"databases\\":[" dbs_str "]}")) ) (lambda (acc item) (if (or (nil? item) (equal? item "")) acc (if (equal? acc "") item (concat acc "," item)))) "")) (concat "[" j "]"))';
 
 function scmFetch(expr,cb){
 fetch(base+"/scm",{method:"POST",credentials:"same-origin",body:expr})
@@ -1246,7 +1245,7 @@ fetch(base+"/scm",{method:"POST",credentials:"same-origin",body:expr})
 .catch(function(e){console.error("SCM error:",e);});
 }
 
-function fetchUsers(cb){scmFetch(SCM_USERS,cb);}
+function fetchUsers(cb){apiFetch(base+"/dashboard/api/users",cb);}
 
 function sqlFetch(query,cb){
 fetch(base+"/sql/system",{method:"POST",credentials:"same-origin",body:query})

--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -161,6 +161,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(lambda (req res) (begin
 		(define session (req "__session"))
 		(match (req "path")
+			/* API: user/access overview shared by the Users and Databases views. */
+			"/dashboard/api/users" (begin
+				(if (dashboard_check_admin req)
+					(dashboard_send_json res (dashboard_json_array
+						(scan nil (table "system" "user") '(369435906932736) '()
+							'() (lambda () true) '("username")
+							(lambda (acc username) (cons (dashboard_build_user_json username) acc))
+							'() (lambda (a b) (merge (list a b))))))
+					(dashboard_send_401 res))
+			)
 			/* API: persistent storage failure hooks (admin only) */
 			"/dashboard/api/storage-failure-hooks/save" (begin
 				(if (dashboard_check_admin req) (begin

--- a/tests/sql/security/mysql-auth-tx-nil.yaml
+++ b/tests/sql/security/mysql-auth-tx-nil.yaml
@@ -82,5 +82,51 @@ test_cases:
         "ok"
         (error "an empty authentication scan result must be rejected"))
 
+
+  - name: "Dashboard users API returns admin and non-admin rows for the database access column"
+    scm: |
+      (begin
+        (define response (newsession))
+        (http_handler
+          (lambda (key) (match key
+            "path" "/dashboard/api/users"
+            "username" "root"
+            "password" "admin"
+            "__session" (newsession)
+            nil))
+          (lambda (key) (match key
+            "header" (lambda (name value) (response name value))
+            "status" (lambda (value) (response "status" value))
+            "print" (lambda (value) (response "body" value))
+            nil)))
+        (define users (json_decode (response "body")))
+        (define admins (filter users (lambda (u) (equal? (u "username") "root"))))
+        (define readers (filter users (lambda (u) (equal? (u "username") "auth_scan_nil_repro"))))
+        (if (and
+            (equal? (response "Content-Type") "application/json")
+            (equal? (count admins) 1) ((car admins) "admin")
+            (equal? (count readers) 1) (not ((car readers) "admin"))
+            (empty_list? ((car readers) "databases")))
+          "ok" (error "dashboard user overview returned incorrect access metadata")))
+
+  - name: "Dashboard users API rejects non-admin and unauthenticated requests"
+    scm: |
+      (map '("auth_scan_nil_repro" "") (lambda (username) (begin
+        (define response (newsession))
+        (http_handler
+          (lambda (key) (match key
+            "path" "/dashboard/api/users"
+            "username" username
+            "password" "secret123"
+            "__session" (newsession)
+            nil))
+          (lambda (key) (match key
+            "header" (lambda (name value) (response name value))
+            "status" (lambda (value) (response "status" value))
+            "print" (lambda (value) (response "body" value))
+            nil)))
+        (if (and (equal? (response "status") 401) (equal? (response "body") "Unauthorized"))
+          "ok" (error "dashboard exposed user overview without admin credentials")))))
+
 cleanup:
   - sql: "DELETE FROM system.user WHERE username IN ('auth_scan_nil_repro', 'auth_scan_nil_other')"


### PR DESCRIPTION
The admin Databases view fetched database metadata successfully, then waited for the user/access overview before rendering any rows. That overview still sent a handwritten `scan` expression with the obsolete signature from `assets/dashboard.html`; the server returned `scan access values: expected list, got <custom 10>`, so the render callback never ran. The Users view shared the broken call.

Replace the embedded scan with an admin-protected `/dashboard/api/users` endpoint in `lib/dashboard.scm`. It uses the existing user JSON builder and the current scan contract. Both views now receive a JSON array through the common API client, keeping scan details out of browser code.

During validation, dependency installation repeatedly failed on the GitHub runner's unrelated Google Chrome APT index (`Hash Sum mismatch`). Ordinary/JIT test, packaging and PHP setup now remove only that unused Chrome source before updating Ubuntu package indexes. Package integrity checks remain enabled. Both test variants and downstream jobs completed successfully after this correction.

Validation:
- All CI checks on final commit `2d0ea30b2` are green: ordinary/JIT SQL suites, ordinary/JIT Go tests, both performance A/B jobs, PHP, packaging, alternative storage and both regression guards.
- Reproduced on master after #865: database endpoint returned rows while the original browser expression failed.
- Authentication/dashboard regression suite: 9/9 passed with both ordinary and JIT builds, including user metadata and rejection of non-admin/missing credentials.
- Real HTTP endpoint returns the root row; anonymous HTTP request returns 401.
- All dashboard script blocks parse; the actual JavaScript `fetchUsers` callback receives parsed rows from the running server.
- Full local `make test` completed successfully (exit 0); the existing 27 noncritical RDF failures retain their classification.
- Modified workflow YAML and shell blocks validated.
