### PR TITLE
Preserve learned scan work and align membership cost guards

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -692,6 +692,19 @@ the current table population, not a new exact observation. In particular,
 learned LIKE matches must never be relabeled as `index_hook_candidates`: those
 are distinct pre-residual work bounds, not the predicate's output cardinality.
 
+Complete scans also publish `filter_input_selectivity` and `filter_input_rows`
+for their pre-residual candidate work. These are costing observations, not
+membership proofs. Count candidates at existing batch boundaries, independently
+of accepted output rows. Unknown shards retain full-input work. Restricted
+RecSets, LIMIT probes and other incomplete scans cannot train this table-wide
+quantity. Physical work is generation-local and is not restored from persisted
+result hints. Its latest observation replaces the previous work value: an
+autoindex becoming effective must not wait for the output-selectivity EMA.
+The central metadata reader returns both quantities without shard access;
+guards consuming this work must cover changes to it as well as result rates.
+UNION adds branch work independently of output cardinality. Costgen consumes
+the same work features and must not infer matcher input from result rows.
+
 See [the Omnestum analysis and measurement report](ADAPTIVE_SELECTIVITY.md) for
 representation limits and the persistence/RecSet follow-up.
 

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -363,6 +363,7 @@ bounded scalar metadata; this lookup never scans, loads columns or builds indexe
 						(define value_expr (list (list (quote lambda) (list (quote estimate))
 							(list (quote list)
 								(list (quote qassoc_get) (quote estimate) (list (quote quote) (quote value)) nil)
+								(list (quote qassoc_get) (quote estimate) (list (quote quote) (quote filter_input_selectivity)) nil)
 								(list (quote qassoc_get) (quote estimate) (list (quote quote) (quote source)) nil))) read_expr))
 						(planner_record_guard_condition
 							(list (quote equal?) value_expr (list (quote quote)
@@ -3381,6 +3382,14 @@ planning preserves the proven bound without consulting index availability. */
 					(min 1 (coalesceNil (qassoc_get base (quote estimated_rows) nil) 1)))
 				(quote capped) false)))))
 
+/* Result cardinality and the input consumed by a residual matcher are distinct
+cost inputs. Learned output rates must not erase measured access work. Neither
+quantity proves membership: the residual predicate is always retained. */
+(define planner_filter_input_rows (lambda (estimate fallback)
+	(coalesceNil (qassoc_get estimate (quote filter_input_rows) nil)
+		(if (equal? (qassoc_get estimate (quote population) nil) (quote index_hook_candidates))
+			(qassoc_get estimate (quote rows) fallback) fallback))))
+
 (define planner_stage_filter_estimate (lambda (input max_rows tx planning_session)
 	(if (union_block? input)
 		(begin
@@ -3408,6 +3417,9 @@ planning preserves the proven bound without consulting index availability. */
 						(list (quote capped) capped)
 						(list (quote sampled) sampled_rows)
 						(list (quote input) input_rows)
+						(list (quote filter_input_rows) (planner_add_estimates
+							(map available (lambda (estimate)
+								(planner_filter_input_rows estimate (qassoc_get estimate (quote input) nil))))))
 						(list (quote estimated_rows) estimated_rows)
 						(list (quote population) (planner_merge_estimate_population available))
 						(list (quote coverage) (planner_merge_estimate_coverage available))))))
@@ -3738,11 +3750,8 @@ carrier crossover. */
 		candidate bound, not over the complete source. Keep the logical cardinality
 		separate: an approximate hook upper bound is physical work, not proof that
 		those rows satisfy LIKE/MATCH. */
-		(define index_filter_rows (if (and
-			(equal? estimate_population (quote index_hook_candidates))
-			(and (number? estimate_rows) (number? candidate_rows)))
-			(min candidate_rows estimate_rows)
-			candidate_rows))
+		(define index_filter_rows (min candidate_rows
+			(planner_filter_input_rows candidate_estimate candidate_rows)))
 		(define index_filter_fraction (if (and (number? candidate_rows) (> candidate_rows 0))
 			(min 1 (/ index_filter_rows candidate_rows)) 1))
 		(define driver_work (membership_driver_work_profile driver sources block planning_session))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -3844,22 +3844,18 @@ request bindings and current autoindex statistics. It never builds the
 candidate RecSet. */
 (define membership_runtime_source_rows_expr (lambda (src condition fallback_rows)
 	(begin
-		/* Membership carrier selection needs a directional selectivity estimate,
-		not hundreds of successful executions of a potentially nested ACL filter.
-		A single match supplies the runtime existence signal; table statistics and
-		text-pattern priors provide the cardinality direction without repeatedly
-		executing a potentially nested ACL filter during cold planning. */
-		(define estimate_expr (query_scoped_source_filter_estimate_expr src condition 1))
+		/* Repeat the cost input, not a different heuristic: a learned zero must
+		remain zero in the guard. Using a word-length prior here after costing
+		used feedback makes the newly compiled plan reject itself forever.
+		Budget zero also forbids scans/index builds inside cache validation. */
+		(define estimate_expr (query_scoped_source_filter_estimate_expr src condition 0))
 		(define text_prior (expr_text_pattern_expr condition))
-		(if (nil? text_prior)
-			(list (quote planner_estimated_matching_rows)
-				estimate_expr fallback_rows fallback_rows)
-			/* A zero-match text probe must inspect the complete source even with a
-			one-match cap. Text predicates already have a calibrated cardinality
-			prior, so use it directly instead of executing a cold planning scan. */
+		(define fallback (if (nil? text_prior) fallback_rows
 			(list (quote max) 1
 				(list (quote *) fallback_rows
-					(list (quote text_pattern_selectivity_prior) text_prior)))))))
+					(list (quote text_pattern_selectivity_prior) text_prior)))))
+		(list (quote planner_estimated_matching_rows)
+			estimate_expr fallback_rows fallback))))
 
 (define membership_runtime_stage_rows_expr (lambda (input fallback_rows)
 	(if (union_block? input)

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -634,7 +634,9 @@ func (t *storageShard) collectRecSet(access scanAccess, conditionCols []string, 
 	}
 	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
 	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
+	var feedbackCandidates int64
 	t.iterateIndexMatchAware(currentTx, access, maxInsertIndex, buf, true, &exactLikeMain, func(batch []uint32) bool {
+		feedbackCandidates += int64(len(batch))
 		for _, idx := range batch {
 			if idx >= visibleUpper {
 				continue
@@ -646,7 +648,7 @@ func (t *storageShard) collectRecSet(access scanAccess, conditionCols []string, 
 	part := builder.finish()
 	// The builder already counted distinct output IDs; no extra element work.
 	if access.feedback != nil {
-		t.filterFeedback.observe(access.feedback, int64(visibleUpper)-int64(t.deletions.Count()), part.count)
+		t.filterFeedback.observe(access.feedback, int64(visibleUpper)-int64(t.deletions.Count()), part.count, feedbackCandidates)
 	}
 	return part
 }

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -2396,7 +2396,7 @@ func (t *storageShard) scan(access scanAccess, conditionCols []string, condition
 		}
 		mapper.FlushSideEffects()
 		if feedbackCandidates <= feedbackPopulation {
-			t.filterFeedback.observe(access.feedback, feedbackPopulation, outCount)
+			t.filterFeedback.observe(access.feedback, feedbackPopulation, outCount, feedbackCandidates)
 		}
 		return scm.NewNil(), outCount, candidateCount
 	}
@@ -2431,7 +2431,7 @@ func (t *storageShard) scan(access scanAccess, conditionCols []string, condition
 	}
 	mapper.FlushSideEffects()
 	if feedbackCandidates <= feedbackPopulation {
-		t.filterFeedback.observe(access.feedback, feedbackPopulation, outCount)
+		t.filterFeedback.observe(access.feedback, feedbackPopulation, outCount, feedbackCandidates)
 	}
 	return akkumulator, outCount, candidateCount
 }

--- a/storage/scan_feedback.go
+++ b/storage/scan_feedback.go
@@ -48,8 +48,12 @@ type filterObservation struct {
 	value      float64
 	population int64
 	observed   int64
-	samples    uint32
-	generation uint64
+	// Pre-residual input work is independent of output selectivity. This is
+	// generation-local costing telemetry, never a semantic membership bound.
+	filterInput float64
+	workKnown   bool
+	samples     uint32
+	generation  uint64
 }
 
 type filterFeedbackPart struct {
@@ -265,16 +269,17 @@ func filterFeedbackSlot(key string) uint64 {
 
 // Called exactly once after successful completion, never from an element loop.
 // One failed CAS drops a sample instead of spinning against concurrent queries.
-func (cache *filterFeedbackCache) observe(key *filterObservation, population, matched int64) {
+func (cache *filterFeedbackCache) observe(key *filterObservation, population, matched, candidates int64) {
 	if key == nil || population <= 0 || matched < 0 || matched > population {
 		return
 	}
 	cell := &cache[filterFeedbackSlot(key.key)]
 	old := cell.Load()
 	measured := float64(matched) / float64(population)
+	work := math.Min(1, math.Max(measured, float64(candidates)/float64(population)))
 	// Repeating the identical population/rate cannot improve the estimate. Do
 	// not allocate or dirty a shared cache line just to count redundant samples.
-	if old != nil && old.key == key.key && old.generation == key.generation && old.population == population && old.value == measured {
+	if old != nil && old.key == key.key && old.generation == key.generation && old.population == population && old.value == measured && old.workKnown && old.filterInput == work {
 		return
 	}
 	next := *key
@@ -284,8 +289,11 @@ func (cache *filterFeedbackCache) observe(key *filterObservation, population, ma
 	// A complete first observation replaces the cold prior. Subsequent complete
 	// observations use the requested 99/1 EMA; no per-batch weighting bias.
 	next.value = measured
+	next.filterInput, next.workKnown = work, true
 	if old != nil && old.key == key.key && old.generation == key.generation {
 		next.value = .99*old.value + .01*measured
+		// Access work can change abruptly when an autoindex becomes effective.
+		// Do not smear that change over 100 queries using the result-rate EMA.
 		next.samples = old.samples
 		if next.samples < 1000000 {
 			next.samples++
@@ -310,6 +318,7 @@ func (t *table) publishFilterFeedback(key *filterObservation) {
 	next.population = 0
 	next.observed = 0
 	next.samples = 0
+	next.filterInput, next.workKnown = 0, false
 	for _, shard := range topology.shards {
 		if shard == nil {
 			continue
@@ -319,26 +328,34 @@ func (t *table) publishFilterFeedback(key *filterObservation) {
 			continue
 		}
 		value := key.value
+		work := 1.0 // Missing shards receive no speculative index discount.
 		entry := shard.filterFeedback[filterFeedbackSlot(key.key)].Load()
 		if entry != nil && entry.key == key.key && entry.generation == key.generation {
 			value = entry.value
 			population = entry.population
 			next.observed += population
 			next.samples += entry.samples
+			if entry.workKnown {
+				work = entry.filterInput
+				next.workKnown = true
+			}
 		}
 		next.value += float64(population) * value
+		next.filterInput += float64(population) * work
 		next.population += population
 	}
 	// Cold shards may not yet expose their main count. Retain the prior for
 	// the remaining table population instead of extrapolating warm shards alone.
 	if missing := int64(t.CountEstimate()) - next.population; missing > 0 {
 		next.value += float64(missing) * key.value
+		next.filterInput += float64(missing)
 		next.population += missing
 	}
 	if next.population <= 0 || next.samples == 0 {
 		return
 	}
 	next.value /= float64(next.population)
+	next.filterInput /= float64(next.population)
 	old := t.filterFeedback.Load()
 	if old != nil && old.schema == t.filterSchemaFingerprint() {
 		previous := old.entries[filterFeedbackSlot(key.key)]
@@ -431,6 +448,23 @@ func (t *table) filterSelectivity(key *filterObservation) (float64, string, bool
 	return math.Max(0, math.Min(1, estimate)), "like_length_histogram", true
 }
 
+// Internal companion to the single public statistics reader. No shard access,
+// and no inference of physical work from another predicate's LIKE histogram.
+func (t *table) filterInputSelectivity(key *filterObservation) scm.Scmer {
+	if key == nil {
+		return scm.NewNil()
+	}
+	snapshot := t.filterFeedback.Load()
+	if snapshot == nil || snapshot.schema != t.filterSchemaFingerprint() {
+		return scm.NewNil()
+	}
+	entry := snapshot.entries[filterFeedbackSlot(key.key)]
+	if entry == nil || entry.key != key.key || !entry.workKnown || entry.generation != t.plannerStatsToken.Load() {
+		return scm.NewNil()
+	}
+	return scm.NewFloat(entry.filterInput)
+}
+
 // Geometric classes retain discrimination for very small selectivities. A
 // changed class invalidates cached costing, while small EMA changes do not.
 func filterFeedbackClass(value float64) uint64 {
@@ -499,6 +533,9 @@ func (s *tableFilterFeedback) updateFingerprint() {
 		if entry != nil {
 			s.fingerprint = plannerFingerprintString(s.fingerprint, entry.key)
 			s.fingerprint = plannerFingerprintMix(s.fingerprint, filterFeedbackClass(entry.value))
+			if entry.workKnown {
+				s.fingerprint = plannerFingerprintMix(s.fingerprint, filterFeedbackClass(entry.filterInput)+1)
+			}
 			s.fingerprint = plannerFingerprintMix(s.fingerprint, plannerFractionBucket(float64(entry.observed)/float64(entry.population)))
 		}
 	}

--- a/storage/scan_feedback_test.go
+++ b/storage/scan_feedback_test.go
@@ -41,20 +41,20 @@ func TestFilterFeedbackMixAndWeightedMerge(t *testing.T) {
 	tbl := feedbackTestTable(100, 900)
 	key := &filterObservation{key: "predicate", value: .1, generation: tbl.plannerStatsToken.Load()}
 	shards := tbl.topology.Load().shards
-	shards[0].filterFeedback.observe(key, 100, 100)
-	shards[1].filterFeedback.observe(key, 900, 0)
+	shards[0].filterFeedback.observe(key, 100, 100, 100)
+	shards[1].filterFeedback.observe(key, 900, 0, 900)
 	tbl.publishFilterFeedback(key)
 	value, source, known := tbl.filterSelectivity(key)
 	if !known || source != "scan_feedback" || math.Abs(value-.1) > 1e-12 {
 		t.Fatalf("weighted estimate %v %s %v", value, source, known)
 	}
-	shards[0].filterFeedback.observe(key, 100, 0)
+	shards[0].filterFeedback.observe(key, 100, 0, 100)
 	entry := shards[0].filterFeedback[filterFeedbackSlot(key.key)].Load()
 	if entry.value != .99 || entry.samples != 2 {
 		t.Fatalf("EMA = %+v", entry)
 	}
 	// The immutable old entry remains unchanged after publishing its successor.
-	shards[0].filterFeedback.observe(key, 100, 0)
+	shards[0].filterFeedback.observe(key, 100, 0, 100)
 	if entry.value != .99 {
 		t.Fatal("published observation was mutated")
 	}
@@ -68,16 +68,16 @@ func TestFilterFeedbackUnknownShardAndInvalidSamples(t *testing.T) {
 	tbl := feedbackTestTable(100, 900)
 	key := &filterObservation{key: "predicate", value: .1, generation: tbl.plannerStatsToken.Load()}
 	shard := tbl.topology.Load().shards[0]
-	shard.filterFeedback.observe(key, 100, 50)
+	shard.filterFeedback.observe(key, 100, 50, 100)
 	tbl.publishFilterFeedback(key)
 	value, _, _ := tbl.filterSelectivity(key)
 	if math.Abs(value-.14) > 1e-12 {
 		t.Fatalf("missing shard prior = %v", value)
 	}
 	before := shard.filterFeedback[filterFeedbackSlot(key.key)].Load()
-	shard.filterFeedback.observe(key, 0, 0)
-	shard.filterFeedback.observe(key, 100, 101)
-	shard.filterFeedback.observe(key, 100, -1)
+	shard.filterFeedback.observe(key, 0, 0, 0)
+	shard.filterFeedback.observe(key, 100, 101, 100)
+	shard.filterFeedback.observe(key, 100, -1, 100)
 	if shard.filterFeedback[filterFeedbackSlot(key.key)].Load() != before {
 		t.Fatal("invalid observation published")
 	}
@@ -87,7 +87,7 @@ func TestFilterFeedbackHistogramInterpolation(t *testing.T) {
 	tbl := feedbackTestTable(10000)
 	add := func(key string, length int, matched int64) {
 		k := &filterObservation{key: key, family: "label:contains", length: length, generation: tbl.plannerStatsToken.Load()}
-		tbl.topology.Load().shards[0].filterFeedback.observe(k, 10000, matched)
+		tbl.topology.Load().shards[0].filterFeedback.observe(k, 10000, matched, 10000)
 		tbl.publishFilterFeedback(k)
 	}
 	add("short", 2, 5000)
@@ -117,7 +117,7 @@ func TestFilterFeedbackConcurrentPublication(t *testing.T) {
 		go func() {
 			defer workers.Done()
 			for i := 0; i < 100; i++ {
-				tbl.topology.Load().shards[0].filterFeedback.observe(key, 100, int64(i))
+				tbl.topology.Load().shards[0].filterFeedback.observe(key, 100, int64(i), 100)
 				tbl.publishFilterFeedback(key)
 				if _, err := json.Marshal(tbl.persistFilterFeedback()); err != nil {
 					t.Error(err)
@@ -257,7 +257,7 @@ func TestFilterFeedbackCheckpoint(t *testing.T) {
 	tbl.Name = "documents"
 	tbl.publishShowColumnsSnapshot()
 	key := &filterObservation{key: "contains-word", family: "name:contains", length: 4, generation: tbl.plannerStatsToken.Load()}
-	tbl.topology.Load().shards[0].filterFeedback.observe(key, 1000, 123)
+	tbl.topology.Load().shards[0].filterFeedback.observe(key, 1000, 123, 1000)
 	tbl.publishFilterFeedback(key)
 	// Maintenance changes the runtime generation before schema checkpointing.
 	tbl.plannerStatsToken.Add(1)
@@ -373,16 +373,16 @@ func TestFilterFeedbackUnchangedMeasurementDoesNotWrite(t *testing.T) {
 	tbl := feedbackTestTable(100)
 	key := &filterObservation{key: "stable", generation: tbl.plannerStatsToken.Load()}
 	shard := tbl.topology.Load().shards[0]
-	shard.filterFeedback.observe(key, 100, 90)
+	shard.filterFeedback.observe(key, 100, 90, 100)
 	tbl.publishFilterFeedback(key)
 	beforeShard := shard.filterFeedback[filterFeedbackSlot(key.key)].Load()
 	beforeTable := tbl.filterFeedback.Load()
-	shard.filterFeedback.observe(key, 100, 90)
+	shard.filterFeedback.observe(key, 100, 90, 100)
 	tbl.publishFilterFeedback(key)
 	if beforeShard != shard.filterFeedback[filterFeedbackSlot(key.key)].Load() || beforeTable != tbl.filterFeedback.Load() {
 		t.Fatal("identical observation dirtied a published cache cell")
 	}
-	shard.filterFeedback.observe(key, 200, 180)
+	shard.filterFeedback.observe(key, 200, 180, 200)
 	if beforeShard == shard.filterFeedback[filterFeedbackSlot(key.key)].Load() {
 		t.Fatal("changed population was ignored")
 	}
@@ -393,12 +393,12 @@ func TestFilterFeedbackSameLengthWordsRetainExactRates(t *testing.T) {
 	shard := tbl.topology.Load().shards[0]
 	common := &filterObservation{key: "alpha", family: "label:contains", length: 5, generation: tbl.plannerStatsToken.Load()}
 	rare := &filterObservation{key: "bravo", family: common.family, length: 5, generation: common.generation}
-	shard.filterFeedback.observe(common, 1000, 900)
+	shard.filterFeedback.observe(common, 1000, 900, 1000)
 	tbl.publishFilterFeedback(common)
-	shard.filterFeedback.observe(rare, 1000, 10)
+	shard.filterFeedback.observe(rare, 1000, 10, 1000)
 	tbl.publishFilterFeedback(rare)
 	for i := 0; i < 20; i++ {
-		shard.filterFeedback.observe(common, 1000, 900)
+		shard.filterFeedback.observe(common, 1000, 900, 1000)
 		tbl.publishFilterFeedback(common)
 	}
 	for key, want := range map[*filterObservation]float64{common: .9, rare: .01} {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1100,19 +1100,26 @@ func Init(en scm.Env) {
 			// Read feedback before touching shards or constructing callback frames.
 			// A learned output rate is not an index-hook candidate bound: never label
 			// it index_hook_candidates or pretend that a new population was sampled.
-			value, source, known := t.filterSelectivity(bindFilterFeedback(
-				mustScmerSlice(accessSchema, "selectivity access schema"), accessValues))
+			feedbackKey := bindFilterFeedback(mustScmerSlice(accessSchema, "selectivity access schema"), accessValues)
+			value, source, known := t.filterSelectivity(feedbackKey)
 			// Same-predicate observations (including historical measurements) can
 			// replace sampling. A LIKE-length histogram describes OTHER words: it
 			// is only a prior and must not suppress an explicitly permitted sample.
 			// Metadata-only consumers still receive that prior with its provenance.
 			if known && (source != "like_length_histogram" || scm.ToInt(a[6]) == 0) {
+				work := t.filterInputSelectivity(feedbackKey)
+				workRows := scm.NewNil()
+				if !work.IsNil() {
+					workRows = scm.NewFloat(float64(input) * work.Float())
+				}
 				confidence := .9
 				if source != "scan_feedback" {
 					confidence = .35
 				}
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewSlice([]scm.Scmer{scm.NewSymbol("value"), scm.NewFloat(value)}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("filter_input_selectivity"), work}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("filter_input_rows"), workRows}),
 					scm.NewSlice([]scm.Scmer{scm.NewSymbol("confidence"), scm.NewFloat(confidence)}),
 					scm.NewSlice([]scm.Scmer{scm.NewSymbol("source"), scm.NewSymbol(source)}),
 					scm.NewSlice([]scm.Scmer{scm.NewSymbol("known"), scm.NewBool(true)}),

--- a/tests/performance/batch-observation-cost.yaml
+++ b/tests/performance/batch-observation-cost.yaml
@@ -94,6 +94,10 @@ test_cases:
       data: [{id: 19996}, {id: 19994}]
 
   - name: "Absent search exhausts candidates without manufacturing a page"
+    performance_rows: 20000
+    warmup: 3
+    timing_samples: 9
+    threshold_ms: 1000
     sql: |
       SELECT d.id, label.allowed FROM boc_document d
       LEFT JOIN boc_acl label ON label.id = d.domain_id

--- a/tests/performance/batch-observation-cost.yaml
+++ b/tests/performance/batch-observation-cost.yaml
@@ -94,11 +94,7 @@ test_cases:
       data: [{id: 19996}, {id: 19994}]
 
   - name: "Absent search exhausts candidates without manufacturing a page"
-    performance_rows: 20000
-    warmup: 3
-    timing_samples: 9
-    threshold_ms: 1000
-    sql: |
+    sql: &boc_absent_query |
       SELECT d.id, label.allowed FROM boc_document d
       LEFT JOIN boc_acl label ON label.id = d.domain_id
       WHERE d.file_id IN (
@@ -106,6 +102,17 @@ test_cases:
         UNION SELECT id FROM boc_file WHERE body LIKE '%absent%'
       ) AND EXISTS (SELECT 1 FROM boc_acl a WHERE a.id = d.domain_id AND a.allowed = 1)
       ORDER BY d.rank_value DESC LIMIT 5
+    expect:
+      rows: 0
+
+  # Keep the original correctness/compile-size gate above intact. A separate
+  # timed case additionally protects against guards recompiling every request.
+  - name: "Cached absent search retains learned-zero plan guards"
+    performance_rows: 20000
+    warmup: 3
+    timing_samples: 9
+    threshold_ms: 1000
+    sql: *boc_absent_query
     expect:
       rows: 0
 

--- a/tests/planner/joins/filter-input-feedback.yaml
+++ b/tests/planner/joins/filter-input-feedback.yaml
@@ -1,0 +1,116 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "Keep pre-residual scan work separate from learned output cardinality"
+
+setup:
+  - sql: "DROP TABLE IF EXISTS fif_rows"
+  - sql: "CREATE TABLE fif_rows (id INT PRIMARY KEY, label TEXT)"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "fif_rows") '("id" "label")
+          (map (produceN 1000) (lambda (i) (list i (if (< i 10) "needle" "unrelated")))))
+        (rebuild (table "memcp-tests" "fif_rows") true false))
+cleanup:
+  - sql: "DROP TABLE fif_rows"
+
+test_cases:
+  - name: "Complete indexed scan reports input work independently from output rows"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "fif_rows"))
+        (define callback (quote (lambda (id) (and (>= id 900) (or (equal? id 905) (equal? id 915))))))
+        (define access (eval (compile_scan_access '("id") callback)))
+        (define values (map (cadr access) (lambda (v) (eval v))))
+        (define n (scan nil tbl (car access) values '("id") (eval callback) '() scan_count 0 + false))
+        (define estimate (scan_selectivity_estimate nil tbl (car access) values '()
+          (lambda () (error "feedback read must not scan")) 0))
+        (if (and (equal? n 2) (equal? (qassoc_get estimate 'rows nil) 2)
+          (equal? (qassoc_get estimate 'filter_input_rows nil) 100)) true
+          (error (concat "lost independent filter input work: " (serialize estimate)))))
+    expect:
+      result_contains: ["true"]
+
+  - name: "Costing keeps learned input work separate from exact output and unknown work"
+    scm: |
+      (begin
+        (define learned (list (list 'rows 2) (list 'filter_input_rows 100) (list 'population 'table_rows)))
+        (define unknown (list (list 'rows 2) (list 'population 'table_rows)))
+        (define bound (list (list 'rows 40) (list 'population 'index_hook_candidates)))
+        (if (and (equal? (planner_filter_input_rows learned 1000) 100)
+          (equal? (planner_filter_input_rows unknown 1000) 1000)
+          (equal? (planner_filter_input_rows bound 1000) 40)) true
+          (error "result cardinality was substituted for pre-residual work")))
+    expect:
+      result_contains: ["true"]
+
+  - name: "Complete LIKE RecSet retains index-reduced work after learning"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "fif_rows"))
+        (define callback (quote (lambda (label) (strlike label "%needle%" "utf8mb4_general_ci"))))
+        (define access (eval (compile_scan_access '("label") callback)))
+        (define values (map (cadr access) (lambda (v) (eval v))))
+        (map (produceN 4) (lambda (i)
+          (recset_count (scan_recset nil tbl (car access) values '("label") (eval callback)))))
+        (define result (scan_recset nil tbl (car access) values '("label") (eval callback)))
+        (define estimate (scan_selectivity_estimate nil tbl (car access) values '()
+          (lambda () (error "feedback read must not scan")) 0))
+        (if (and (equal? (recset_count result) 10)
+          (equal? (qassoc_get estimate 'rows nil) 10)
+          (number? (qassoc_get estimate 'filter_input_rows nil))
+          (<= (qassoc_get estimate 'filter_input_rows 1000) 100)) true
+          (error (concat "learned LIKE lost index work: " (serialize estimate)))))
+    expect:
+      result_contains: ["true"]
+
+  - name: "Restricted RecSets cannot overwrite whole-table work observations"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "fif_rows"))
+        (define callback (quote (lambda (label) (strlike label "%needle%" "utf8mb4_general_ci"))))
+        (define access (eval (compile_scan_access '("label") callback)))
+        (define values (map (cadr access) (lambda (v) (eval v))))
+        (define read (lambda () (scan_selectivity_estimate nil tbl (car access) values '()
+          (lambda () (error "metadata must not evaluate a filter")) 0)))
+        (define before (read))
+        (define ids (eval (compile_scan_access '("id") (quote (lambda (id) (< id 5))))))
+        (define subset (scan_recset nil tbl (car ids) (map (cadr ids) (lambda (v) (eval v)))
+          '("id") (lambda (id) (< id 5))))
+        (define result (scan_recset nil subset (car access) values '("label") (eval callback)))
+        (if (and (equal? (recset_count result) 5) (equal? before (read))) true
+          (error "restricted input contaminated whole-table metadata")))
+    expect:
+      result_contains: ["true"]
+
+  - name: "Rebuild retains result hints but invalidates physical access work"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "fif_rows"))
+        (rebuild tbl true false)
+        (define access (eval (compile_scan_access '("label")
+          (quote (lambda (label) (strlike label "%needle%" "utf8mb4_general_ci"))))))
+        (define estimate (scan_selectivity_estimate nil tbl (car access)
+          (map (cadr access) (lambda (v) (eval v))) '()
+          (lambda () (error "historical metadata must not sample")) 0))
+        (if (nil? (qassoc_get estimate 'filter_input_rows nil)) true
+          (error "retired physical access work was reused after rebuild")))
+    expect:
+      result_contains: ["true"]
+
+  - name: "Membership cost guard preserves learned zero instead of reverting to a text prior"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "fif_rows"))
+        (define callback (quote (lambda (label) (strlike label "%absent%" "utf8mb4_general_ci"))))
+        (define access (eval (compile_scan_access '("label") callback)))
+        (scan_recset nil tbl (car access) (map (cadr access) (lambda (v) (eval v))) '("label") (eval callback))
+        (define src (list "a" "memcp-tests" "fif_rows" false nil))
+        (define predicate (list 'strlike (list 'get_column "a" false "label" false) "%absent%" "utf8mb4_general_ci"))
+        (define expression (membership_runtime_source_rows_expr src predicate 1000))
+        (define compiled (sql_queryplan_compile_formula expression))
+        (if (equal? (compiled (newsession) nil nil nil) 0) true
+          (error "guard replaced measured zero with a text prior")))
+    expect:
+      result_contains: ["true"]

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -1378,6 +1378,10 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 		driverWorkRows = *row.ExpectedDriverRowsVisited
 	}
 	scanRows := *row.CandidateInputRows + driverWorkRows
+	// These pre-residual work features come from the planner's central statistics
+	// reader (index candidate estimates or complete-scan input observations).
+	// CandidateRows is OUTPUT cardinality: never substitute it for matcher work,
+	// nor reset observed work to the full population when feedback becomes known.
 	candidateFilterValues := *row.CandidateInputRows * *row.CandidateFilterColumns
 	if row.CandidateFilterValueRows != nil {
 		candidateFilterValues = *row.CandidateFilterValueRows


### PR DESCRIPTION
## Summary

Preserve pre-residual scan work when the central selectivity reader starts returning learned output cardinalities. These are different cost inputs: learning how many rows match must not erase how many candidates reach the residual matcher.

- Complete scans and table-input RecSet scans record candidate counts at existing batch boundaries, in the existing bounded immutable feedback cells. No extra per-row locks/atomics, index-existence gate, second public statistics API, or planner-driven index construction.
- Expose generation-local `filter_input_selectivity` / `filter_input_rows` separately from output `value` / `rows`. Unknown shards receive full-input work; historical persisted result hints do not carry physical-work discounts. Restricted RecSets do not train table-wide work.
- Forward work through UNION and physical work features. Costgen already consumes those features; document the contract there without changing fitted coefficients. Add the new consumed input to feedback guards.
- Fix a latent guard inconsistency exposed by the corrected costs: membership compilation used learned zero while its runtime guard reconstructed a nonzero word-length prior. Every newly compiled variant rejected itself. Guards now read the central metadata with budget zero and use priors only on a miss; no sampling inside validation.

This is a statistics/cost-input fix, not a claim that all search queries now choose an optimal plan. The coarse downstream ACL charge and ORDER-correlated hit-density model remain follow-ups. No production instance was restarted or modified.

## Tests first

`tests/planner/joins/filter-input-feedback.yaml` reproduces missing work metadata on baseline `e9aba6eed`; the final six cases pass on the branch. The learned-zero guard case also fails on baseline. Coverage includes a range candidate set with a stricter residual, warmed LIKE, work/output distinction, restricted RecSet non-contamination, rebuild invalidation and learned-zero guard consistency. All SCM cases explicitly throw on mismatch.

An additional timed copy of the no-hit ACL/UNION page query participates in performance A/B; the original correctness/time/plan-size gates remain intact. Existing Go test changes only update calls for the extra observation argument.

## Manual A/B

Baseline `e9aba6eed` versus this branch; identical standard Go build/toolchain (not JIT), separate local HTTP instances and fixture directories, same YAML setup, three additional warmups, nine alternating sequential timed samples per side. Whole-request HTTP latency in milliseconds; response hashes matched for every pair. Full suites are CI-owned.

| Existing workload | Baseline median | Branch median | Change |
|---|---:|---:|---:|
| Selective text UNION, rejecting ACL, projected LEFT JOIN, ordered page | 42.950 | 42.695 | -0.6% |
| Unbounded text membership / ACL COUNT | 2.165 | 2.079 | -4.0% |
| Broad search / ACL ordered page | 2.443 | 2.283 | -6.6% |
| Repeated broad cached search | 2.287 | 2.447 | +7.0% |
| OFFSET after search and ACL | 100.297 | 98.522 | -1.8% |
| No-hit search / ACL ordered page | 0.969 | 0.978 | +0.9% |

These small changes mostly overlap normal variation: **no major speedup is claimed**. The intermediate work-only patch regressed the last workload from ~1.2 to ~51 ms. Isolating cache execution proved repeated recompilation; its cached guards all returned false because they used a prior instead of the measured zero. The guard fix removes that regression rather than weakening a performance gate.

## Local validation

- New regression suite: 6/6.
- Existing adaptive-filter-selectivity: 15/15.
- Existing compound ACL membership: 35/35.
- Existing batch-observation suite with performance enabled and the additional no-hit timing case: 9/9.
- Existing RecSet operator suite: 34/34.
- Existing selective text/ACL suite with performance enabled: 2/2.
- Targeted existing storage feedback Go tests pass; Costgen package compiles.
- Changed Scheme lint and `git diff --check` pass.

CI still needs to validate full SQL, JIT, and performance A/B. No local full suite was run.
