### PR TITLE
Cost disjoint OR branches and seek complete equality prefixes

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4073,7 +4073,210 @@ plan construction or timing during compilation. */
 							(list (list "plan" "prefiltered_difference") (list "total_ns" eager_ns))))) planning_session)
 					(equal? chosen "prefiltered_difference")))))))
 
+/* A WHERE disjunction is a physical access alternative, not a UNION in the
+logical IR. Split one conjunct only (never expand a Cartesian DNF). Distinct
+constant equality guards on the same column prove disjoint truth sets, so the
+ordered merge preserves SQL bag multiplicity without a deduplication buffer.
+Use SQL equality for the proof: case/accent-equivalent strings are not disjoint.
+NULL never proves disjointness. Parameter values observed at compilation are
+protected by session-value guards before a split plan can enter the cache. */
+(define ordered_or_literal_point (lambda (src expr planning_session)
+	(match (expression_syntax expr)
+		'(op left right) (if (has? (list (quote equal?) (quote equal??)) op)
+			(begin
+				(define left_col (direct_column_name_for_alias src left))
+				(define right_col (direct_column_name_for_alias src right))
+				(define col (if (nil? left_col) right_col left_col))
+				(define value (planner_literal_value (if (nil? left_col) left right) planning_session))
+				(define meta (if (or (nil? col) (not (source_is_base_table? src))) nil
+					(find (get_schema (source_schema src) (source_relation src))
+						(lambda (candidate) (equal?? (candidate "Field") col)) nil)))
+				(define typ (if (nil? meta) "" (toLower (meta "RawType"))))
+				/* Cross-type SQL coercion is not transitive: e.g. numeric 1
+				matches both string '1' and '01'. Prove within a typed domain. */
+				(if (or
+					(and (string? value) (has? '("char" "varchar" "text" "tinytext" "mediumtext" "longtext") typ))
+					(and (number? value) (> value -9007199254740992) (< value 9007199254740992)
+						(has? '("int" "integer" "bigint" "smallint" "tinyint" "mediumint" "float" "double" "decimal" "numeric") typ)))
+					(list col value) nil)) nil)
+		_ nil)))
+
+(define ordered_or_disjoint? (lambda (src left right planning_session)
+	(reduce (split_and_terms left) (lambda (proven term)
+		(or proven (begin
+			(define a (ordered_or_literal_point src term planning_session))
+			(if (nil? a) false
+				(reduce (split_and_terms right) (lambda (different other)
+					(or different (begin
+						(define b (ordered_or_literal_point src other planning_session))
+						(and (not (nil? b)) (equal? (car a) (car b))
+							(or (and (string? (cadr a)) (string? (cadr b)))
+								(and (number? (cadr a)) (number? (cadr b))))
+							(equal? (equal?? (cadr a) (cadr b)) false))))) false))))) false)))
+
+(define ordered_or_pairwise_disjoint? (lambda (src branches planning_session)
+	(match branches
+		(cons first rest) (and
+			(reduce rest (lambda (safe branch) (and safe (ordered_or_disjoint? src first branch planning_session))) true)
+			(ordered_or_pairwise_disjoint? src rest planning_session))
+		_ true)))
+
+(define ordered_or_branches (lambda (src condition planning_session)
+	(begin
+		(define terms (split_and_terms condition))
+		(reduce terms (lambda (found term)
+			(if (not (nil? found)) found
+				(match (expression_syntax term)
+					(cons (quote or) branches)
+					(if (and (> (count branches) 1) (ordered_or_pairwise_disjoint? src branches planning_session))
+						(map branches (lambda (branch)
+							(combine_where_terms (map terms (lambda (other)
+								(if (expression_equal? other term) branch other))) true))) nil)
+					_ nil))) nil))))
+
+/* Cost the same sorted prefix which compile_scan_plan can enforce. Remaining
+OR/LIKE terms stay residual; sampling their total selectivity must never be
+mistaken for an index's candidate population. */
+(define ordered_or_scan_work (lambda (block condition)
+	(begin
+		(define src (car (qb_sources block)))
+		(define planning_session (planner_context_session (qb_facts block)))
+		(define tx (planner_context_tx (qb_facts block)))
+		(define columns (extract_columns_for_alias src condition))
+		(define params (map columns (lambda (col) (scan_callback_symbol_for_alias (source_alias src) col))))
+		(define lowered (expression_syntax (lower_column_expr_for_alias src condition)))
+		(define bounds (sort (coalesceNil (scan_plan_collect lowered params columns '()) '()) scan_plan_boundary_order))
+		(define prefix (scan_plan_exact_prefix bounds))
+		(define covered? (lambda (term)
+			(begin
+				(define boundary (scan_plan_comparison (expression_syntax (lower_column_expr_for_alias src term)) params columns))
+				(and (not (nil? boundary))
+					(reduce prefix (lambda (found have)
+						(or found (scan_plan_boundary_covers have boundary))) false)))))
+		(define terms (split_and_terms condition))
+		(define indexed (combine_where_terms (filter terms covered?) true))
+		(define residual (combine_where_terms (filter terms (lambda (term) (not (covered? term)))) true))
+		(define total (planner_source_row_count src))
+		(define candidates (if (equal? indexed true) total
+			(coalesceNil (qassoc_get (planner_source_filter_estimate src indexed 512 tx planning_session)
+				(quote estimated_rows) nil) total)))
+		(define matches (if (equal? residual true) candidates
+			(coalesceNil (qassoc_get (planner_source_filter_estimate src condition 512 tx planning_session)
+				(quote estimated_rows) nil) candidates)))
+		(define limit_value (planner_literal_value (qb_limit block) planning_session))
+		(define offset_value (planner_literal_value (coalesceNil (qb_offset block) 0) planning_session))
+		(define window (if (and (number? limit_value) (>= limit_value 0) (number? offset_value))
+			(+ limit_value offset_value) nil))
+		(define ordered (reduce bounds (lambda (ok boundary) (and ok (equal? (boundary "kind") "equal"))) true))
+		(define visited (if (and ordered (number? window) (> matches 0))
+			(min candidates (* candidates (min 1 (/ window matches)))) candidates))
+		(define output_rows (if (number? window) (min window matches) matches))
+		(define work (physical_expression_work_profile src residual planning_session))
+		(define sort_width (count (coalesceNil (qb_order block) '())))
+		(define sort_units (if ordered 0 (* sort_width (membership_ordered_recset_sort_work matches))))
+		(list 1 visited
+			(* visited (count (extract_columns_for_alias src residual)))
+			(* output_rows (count (merge_unique (map (projection_exprs (expand_query_block_fields (qb_sources block) (qb_fields block)))
+				(lambda (expr) (extract_columns_for_alias src expr))))))
+			(+ (* visited (qassoc_get work (quote operations) 0)) sort_units)
+			(* visited (qassoc_get work (quote broad_text_matches) 0))
+			(* visited (qassoc_get work (quote broad_text_average_bytes) 0))
+			output_rows))))
+
+/* Work vector: ordered invocations, visited rows, filter values, mapped
+values, scalar/comparison operations, text matches, text bytes, output rows.
+All prices are existing costgen-calibrated primitives; merge comparisons use
+scalar comparison work rather than an uncalibrated multiplier. */
+(define ordered_or_work_cost (lambda (work)
+	(planner_cost (* (nth work 0) planner_membership_ordered_scan_invocation_ns)
+		(+ (* (nth work 1) planner_membership_scan_row_ns)
+			(* (nth work 2) planner_membership_filter_column_row_ns)
+			(* (nth work 3) planner_membership_map_column_row_ns)
+			(* (nth work 4) planner_membership_expression_operation_row_ns)
+			(* (nth work 5) planner_membership_broad_text_match_row_ns)
+			(* (nth work 6) planner_membership_broad_text_match_byte_ns))
+		0 0 0 0 0 0 (nth work 7) 0.65)))
+
+(define ordered_or_merge_work (lambda (block works)
+	(begin
+		(define combined (map (produceN 8) (lambda (i)
+			(reduce works (lambda (total work) (+ total (nth work i))) 0))))
+		(define comparisons (* (nth combined 7)
+			(count (coalesceNil (qb_order block) '()))
+			(membership_integer_log2_ceil_from (count works) 1 0)))
+		(map (produceN 8) (lambda (i) (+ (nth combined i) (if (equal? i 4) comparisons 0)))))))
+
+(define ordered_or_multi_plan (lambda (block branches)
+	(begin
+		(define src (car (qb_sources block)))
+		(define alias (source_alias src))
+		(define fields (expand_query_block_fields (qb_sources block) (qb_fields block)))
+		(define orders (coalesceNil (qb_order block) '()))
+		(define sortcols (scan_order_sort_columns_for_alias src orders))
+		(define mapcols (merge_unique (map (projection_exprs fields) (lambda (expr) (extract_columns_for_alias src expr)))))
+		(define filtercols (map branches (lambda (branch) (extract_columns_for_alias src branch))))
+		(define callbacks (mapIndex branches (lambda (i branch)
+			(list (quote lambda) (map (nth filtercols i) (lambda (col) (scan_callback_symbol_for_alias alias col)))
+				(lower_column_expr_for_alias src branch)))))
+		(define mapper (list (quote lambda)
+			(cons (quote __scan_acc) (map mapcols (lambda (col) (scan_callback_symbol_for_alias alias col))))
+			(list (quote resultrow) (cons (quote list) (map_assoc fields (lambda (_title expr) (lower_column_expr_for_alias src expr)))))))
+		(compile_scan_plan (quote scan_order_multi) (physical_query_tx_symbol)
+			(cons (quote list) (map branches (lambda (_) (source_table_expr src))))
+			(cons (quote list) (map filtercols (lambda (cols) (cons (quote list) cols))))
+			(cons (quote list) callbacks)
+			(cons (quote list) (map branches (lambda (_) (cons (quote list) sortcols))))
+			(cons (quote list) (order_relations_for_source src orders))
+			nil nil 0 (coalesceNil (qb_offset block) 0) (coalesceNil (qb_limit block) -1)
+			(cons (quote list) (map branches (lambda (_) (cons (quote list) mapcols))))
+			(cons (quote list) (map branches (lambda (_) mapper))) nil false nil))))
+
 (define lower_single_source_query_block (lambda (block)
+	(begin
+		(define src (car (qb_sources block)))
+		(define condition (combine_where (qb_where block) (source_join_expr src)))
+		(define candidates (ordered_or_branches src condition (planner_context_session (qb_facts block))))
+		(define branches (if (and
+			(not (nil? candidates))
+			(source_is_base_table? src) (not (source_outer? src))
+			(empty_list? (qb_group block)) (nil? (qb_having block))
+			(not (query_block_has_aggregates? block)) (empty_list? (qb_stages block))
+			(empty_list? (expr_probe_stages (list condition (qb_fields block) (qb_order block))))
+			(or (not (empty_list? (qb_order block))) (query_limit_active? (qb_offset block) (qb_limit block)))
+			(order_items_belong_to_source? src (coalesceNil (qb_order block) '()))
+			(number? (planner_source_row_count src))
+			(reduce (merge (list (list condition) (projection_exprs (qb_fields block))
+				(order_exprs (qb_order block))))
+				(lambda (safe expr) (and safe (begin
+					(define cols (extract_columns_for_alias src expr))
+					(scan_plan_computed_safe (expression_syntax (lower_column_expr_for_alias src expr))
+						(map cols (lambda (col) (scan_callback_symbol_for_alias (source_alias src) col))))))) true))
+			candidates nil))
+		(if (nil? branches) (lower_single_source_scan_plan block)
+			(begin
+				(define planning_session (planner_context_session (qb_facts block)))
+				(planner_record_table_statistics_guards (list src) planning_session)
+				(planner_record_session_value_guards (list condition (qb_limit block) (qb_offset block)) planning_session)
+				(define filter_work (ordered_or_scan_work block condition))
+				(define multi_work (ordered_or_merge_work block (map branches (lambda (branch) (ordered_or_scan_work block branch)))))
+				(define filter_cost (ordered_or_work_cost filter_work))
+				(define multi_cost (ordered_or_work_cost multi_work))
+				(define normal (if (planner_cost_better? multi_cost filter_cost) "scan_order_multi" "scan_order"))
+				(define id (concat "ordered_or:" (source_alias src) ":" (stable_structural_hash condition true)))
+				(define chosen (planner_physical_choice id normal '("scan_order" "scan_order_multi") planning_session))
+				(planner_record_physical_decision (list
+					(list "decision_id" id) (list "decision" "ordered_or")
+					(list "decision_site" "single_source") (list "chosen" chosen)
+					(list "normally_chosen" normal) (list "reason" "disjoint_constant_guards_cost")
+					(list "inputs" (list (list "branch_count" (count branches))
+						(list "ordered_or_work" (if (equal? chosen "scan_order_multi") multi_work filter_work))))
+					(list "alternatives" (list
+						(list (list "plan" "scan_order") (list "cost" (planner_cost_explain filter_cost)))
+						(list (list "plan" "scan_order_multi") (list "cost" (planner_cost_explain multi_cost)))))) planning_session)
+				(if (equal? chosen "scan_order_multi") (ordered_or_multi_plan block branches)
+					(lower_single_source_scan_plan block)))))))
+
+(define lower_single_source_scan_plan (lambda (block)
 	(begin
 		(define src (car (qb_sources block)))
 		(define fields (expand_query_block_fields (qb_sources block) (qb_fields block)))
@@ -5186,12 +5389,12 @@ until the caller has selected this physical alternative. */
 						not introduce a dependency on an irrelevant session value.
 						Table-statistics guards still protect against data growth. */
 						(if (<= base_rows 1) 1
-						(begin
-							(define estimate
-								(planner_source_filter_estimate src local_condition 512
-									planning_tx planning_session))
-							(max 1 (planner_estimated_matching_rows estimate
-								base_rows base_rows)))))))) nil))
+							(begin
+								(define estimate
+									(planner_source_filter_estimate src local_condition 512
+										planning_tx planning_session))
+								(max 1 (planner_estimated_matching_rows estimate
+									base_rows base_rows)))))))) nil))
 		/* A local driver predicate is only the first acceptance stage. Every
 		later input may reject the driver row as well, so price ordered braking
 		from the product of the independently estimated inner selectivities.
@@ -9856,45 +10059,48 @@ RecSet node is written into logical IR. */
 (define physical_operator_family_for_decision (lambda (plan decision)
 	(begin
 		(define kind (qassoc_get decision "decision" nil))
-		(if (equal? kind "semijoin_carrier")
-			(if (semijoin_plan_has_operator? plan "recset_project_join")
-				(if (semijoin_plan_has_operator? plan "initialize_cache_table") "prejoin_recset" "projected_recset")
-				(if (semijoin_plan_has_operator? plan "createcolumn") "predicate_cache" "unknown"))
-			(if (equal? kind "membership_carrier")
-				(begin
-					(define chosen (qassoc_get decision "chosen" nil))
-					/* A compound query may contain key indexes and projected RecSets for
-					unrelated ACL stages. Validate the primitive required by this decision's
-					chosen alternative instead of assigning the whole plan to the first
-					operator family found globally. Falling back to the global classifier
-					still makes a genuinely unreachable forced alternative fail calibration. */
-					(if (or
-						(and (equal? chosen "ordered_batch_accept")
-							(physical_expr_has_head? plan (quote scan_order_batch_accept)))
-						(and (equal? chosen "prefiltered_candidate_keyset")
-							(physical_prefiltered_membership_expr? plan))
-						(and (equal? chosen "candidate_keyset")
-							(physical_expr_has_head? plan (quote recset_project_join)))
-						(and (equal? chosen "driver_order_membership_probe")
-							(physical_expr_has_head? plan (quote recset_key_index)))
-						(and (equal? chosen "driver_filter_join_probe")
-							(not (physical_expr_has_head? plan (quote scan_order_batch_accept)))))
-						chosen
-						(physical_membership_operator_family plan)))
-				(if (equal? kind "scan_join_order")
-					(if (physical_expr_has_head? plan (quote scan_join_order))
-						(if (equal? (qassoc_get decision "chosen" nil)
-							"scan_join_order_batched_probe")
-							"scan_join_order_batched_probe" "scan_join_order")
-						"legacy_join_tree")
-					(if (equal? kind "direct_group_join")
-						(if (physical_expr_has_group_relation? plan)
-							"group_carrier" "direct_group_join")
-						(if (equal? kind "scan_lookup")
-							(if (physical_expr_has_head? plan (quote scan_lookup))
-								"scan_lookup"
-								(if (physical_expr_has_head? plan (quote scan_order)) "scan_order" "unknown"))
-							"unknown"))))))))
+		(if (equal? kind "ordered_or")
+			(if (physical_expr_has_head? plan (quote scan_order_multi)) "scan_order_multi"
+				(if (physical_expr_has_head? plan (quote scan_order)) "scan_order" "unknown"))
+			(if (equal? kind "semijoin_carrier")
+				(if (semijoin_plan_has_operator? plan "recset_project_join")
+					(if (semijoin_plan_has_operator? plan "initialize_cache_table") "prejoin_recset" "projected_recset")
+					(if (semijoin_plan_has_operator? plan "createcolumn") "predicate_cache" "unknown"))
+				(if (equal? kind "membership_carrier")
+					(begin
+						(define chosen (qassoc_get decision "chosen" nil))
+						/* A compound query may contain key indexes and projected RecSets for
+						unrelated ACL stages. Validate the primitive required by this decision's
+						chosen alternative instead of assigning the whole plan to the first
+						operator family found globally. Falling back to the global classifier
+						still makes a genuinely unreachable forced alternative fail calibration. */
+						(if (or
+							(and (equal? chosen "ordered_batch_accept")
+								(physical_expr_has_head? plan (quote scan_order_batch_accept)))
+							(and (equal? chosen "prefiltered_candidate_keyset")
+								(physical_prefiltered_membership_expr? plan))
+							(and (equal? chosen "candidate_keyset")
+								(physical_expr_has_head? plan (quote recset_project_join)))
+							(and (equal? chosen "driver_order_membership_probe")
+								(physical_expr_has_head? plan (quote recset_key_index)))
+							(and (equal? chosen "driver_filter_join_probe")
+								(not (physical_expr_has_head? plan (quote scan_order_batch_accept)))))
+							chosen
+							(physical_membership_operator_family plan)))
+					(if (equal? kind "scan_join_order")
+						(if (physical_expr_has_head? plan (quote scan_join_order))
+							(if (equal? (qassoc_get decision "chosen" nil)
+								"scan_join_order_batched_probe")
+								"scan_join_order_batched_probe" "scan_join_order")
+							"legacy_join_tree")
+						(if (equal? kind "direct_group_join")
+							(if (physical_expr_has_group_relation? plan)
+								"group_carrier" "direct_group_join")
+							(if (equal? kind "scan_lookup")
+								(if (physical_expr_has_head? plan (quote scan_lookup))
+									"scan_lookup"
+									(if (physical_expr_has_head? plan (quote scan_order)) "scan_order" "unknown"))
+								"unknown")))))))))
 
 (define physical_expr_has_group_relation? (lambda (expr)
 	(match expr
@@ -10076,6 +10282,7 @@ protocol callback receives only the calibration row. */
 							"estimated_ns" estimated_ns
 							"whole_query_execution_ns" (quote __calibration_whole_query_execution_ns)
 							"operator_ns" nil
+							"ordered_or_work" (cons (quote list) (coalesceNil (physical_calibration_input decision "ordered_or_work") '()))
 							"measurement_scope" (if shared_suite "shared_sequential_diagnostic" "isolated_variant_request")
 							"fit_eligible" (not shared_suite)
 							"candidate_input_rows" (physical_calibration_input decision "candidate_input_rows")

--- a/storage/index.go
+++ b/storage/index.go
@@ -1895,6 +1895,37 @@ start_scan:
 			return beyond
 		})
 	}
+	// Complete a multi-column equality seek before entering the row loop.
+	// Trailing unbounded ordering keys do not constrain this interval. The
+	// first-key interpolation above remains a useful narrowing step, but is
+	// not an exact lower bound for a composite equality prefix.
+	completePointPrefix := firstSorted >= 0
+	pointKeys := 0
+	trailingOrder := false
+	for i := 0; i < cmpCols && completePointPrefix; i++ {
+		if !s.columnIsSorted(i) {
+			continue
+		}
+		if i < 64 && unboundedMask&(uint64(1)<<i) != 0 {
+			trailingOrder = true
+			continue
+		}
+		if trailingOrder || !scanAccessBoundaryIsPoint(bounds, i) || bounds.boundValue(i, false).IsNil() {
+			completePointPrefix = false
+			break
+		}
+		pointKeys++
+	}
+	completePointPrefix = completePointPrefix && pointKeys > 1
+	if completePointPrefix {
+		mainIdx += sort.Search(mainEnd-mainIdx, func(offset int) bool {
+			recid := getRecid(mainIdx + offset)
+			inRange, beyond := s.rowWithinBounds(bounds, indexBounds, cmpCols, lastSorted, sortedMask, unboundedMask, lowerInclusive, upperInclusive, func(col int) scm.Scmer {
+				return cols[col].get(recid)
+			})
+			return inRange || beyond
+		})
+	}
 	mainStart := mainIdx
 	indexSpanRows = int64(mainEnd-mainStart) + int64(maxInsertIndex)
 	if candidateSpan != nil {
@@ -1938,12 +1969,12 @@ start_scan:
 	matchers := s.bindRowMatchers(tx, bounds, indexBounds, upperInclusive, cols, snapIndexHooks, true, exactMain)
 	// For one constrained sorted key, the two binary searches define the exact
 	// main-row interval. Non-sorted access hooks still run in emitRowMatchers.
-	// Composite prefixes keep their row checks because their lower search uses
-	// only the first sorted key.
-	mainRangeCovered := false
+	// Complete non-NULL equality prefixes now have the same exact interval.
+	// Other composite shapes retain their per-row boundary checks.
+	mainRangeCovered := completePointPrefix
 	if firstSorted >= 0 && lastSorted < 64 {
 		constrainedSorted := sortedMask &^ unboundedMask
-		mainRangeCovered = constrainedSorted == uint64(1)<<firstSorted
+		mainRangeCovered = mainRangeCovered || constrainedSorted == uint64(1)<<firstSorted
 	}
 	adaptiveSwitchRows := int64(0)
 	if options != nil && hasRecSetBoundary && maxInsertIndex == 0 {

--- a/tests/performance/wordpress-search.yaml
+++ b/tests/performance/wordpress-search.yaml
@@ -8,6 +8,9 @@ metadata:
     text
   isolated: true
   ci: true
+  physical_calibration: true
+  cache_state: warm_operator_state
+  compile_state: cached_plan_execution_only
   restart_after_setup: true
 setup:
 - sql: DROP TABLE IF EXISTS wordpress_search_posts
@@ -143,5 +146,78 @@ test_cases:
   expect:
     data:
     - ok
+# These are ordinary SQL checks in CI and forced two-plan observations in costgen.
+- name: Costed disjoint OR search branches
+  physical_calibration: true
+  calibration_decision: ordered_or
+  warmup: 10
+  repetitions: 30
+  threshold_ms: 200
+  sql: |-
+    SELECT ID FROM wordpress_search_posts
+    WHERE (post_title LIKE '%quasarless%' OR post_excerpt LIKE '%quasarless%' OR post_content LIKE '%quasarless%')
+      AND post_password = ''
+      AND ((post_type = 'attachment' AND post_status = 'publish')
+        OR (post_type = 'page' AND post_status = 'publish')
+        OR (post_type = 'post' AND post_status = 'publish'))
+    ORDER BY post_title LIKE '%quasarless%' DESC, post_date DESC, ID LIMIT 10
+  expect:
+    rows: 0
+    data: []
+- name: Costed broad OR keeps cheap ordered filter
+  physical_calibration: true
+  calibration_decision: ordered_or
+  warmup: 10
+  repetitions: 10
+  sql: |-
+    SELECT ID FROM wordpress_search_posts
+    WHERE post_type = 'revision' OR post_type = 'post'
+    ORDER BY ID LIMIT 2
+  expect:
+    rows: 2
+    data:
+    - ID: 2
+    - ID: 3
+- name: Cached OR split becomes overlapping after a session binding changes
+  scm: "(begin\n  (define cache (newcachemap))\n  (define sess (newsession))\n  (sess\
+    \ \"username\" \"root\")\n  (sess \"schema\" \"memcp-tests\")\n  (define query\
+    \ \"SELECT ID FROM wordpress_search_posts\\nWHERE ((post_title LIKE '%nightjar%')\
+    \ OR (post_excerpt LIKE '%nightjar%') OR (post_content LIKE '%nightjar%'))\\n\
+    \  AND post_password = ''\\n  AND ((post_type = @kind AND post_status = 'publish')\\\
+    n    OR (post_type = 'page' AND post_status = 'publish')\\n    OR (post_type =\
+    \ 'post' AND post_status = 'publish'))\\nORDER BY post_title LIKE '%nightjar%'\
+    \ DESC, post_date DESC LIMIT 10\")\n  (define run (lambda (kind) (begin\n    (sess\
+    \ \"kind\" kind)\n    (sess \"ids\" \"\")\n    (sql_execute_formula sess nil\n\
+    \      (cached_parse cache (list parse_sql) \"memcp-tests\" query nil \"root\"\
+    \ sess true)\n      (lambda (row) (sess \"ids\" (concat (sess \"ids\") (cadr row)\
+    \ \",\")))\n      (lambda (_fields) nil))\n    (sess \"ids\"))))\n  (define first\
+    \ (run \"attachment\"))\n  (define overlap (run \"post\"))\n  (define restored\
+    \ (run \"attachment\"))\n  (if (and (equal? first \"1774,1183,592,1971,1577,1380,986,789,395,198,\"\
+    )\n    (equal? overlap first) (equal? restored first)) \"ok\"\n    (error (concat\
+    \ \"cached OR proof leaked across bindings: \" first \" / \" overlap \" / \" restored))))"
+  expect:
+    data:
+    - ok
+- name: Selective disjoint OR chooses the ordered merge
+  sql: "EXPLAIN PHYSICAL SELECT ID FROM wordpress_search_posts\nWHERE (post_title\
+    \ LIKE '%quasarless%' OR post_excerpt LIKE '%quasarless%' OR post_content LIKE\
+    \ '%quasarless%')\n  AND post_password = ''\n  AND ((post_type = 'attachment'\
+    \ AND post_status = 'publish')\n    OR (post_type = 'page' AND post_status = 'publish')\n\
+    \    OR (post_type = 'post' AND post_status = 'publish'))\nORDER BY post_title\
+    \ LIKE '%quasarless%' DESC, post_date DESC, ID LIMIT 10"
+  expect:
+    rows: 1
+    result_contains:
+    - (chosen scan_order_multi)
+- name: Broad OR keeps the single ordered scan
+  sql: 'EXPLAIN PHYSICAL SELECT ID FROM wordpress_search_posts
+
+    WHERE post_type = ''revision'' OR post_type = ''post''
+
+    ORDER BY ID LIMIT 2'
+  expect:
+    rows: 1
+    result_contains:
+    - (chosen scan_order)
 cleanup:
 - sql: DROP TABLE wordpress_search_posts

--- a/tests/storage/indexes/or-index-scan.yaml
+++ b/tests/storage/indexes/or-index-scan.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 metadata:
   version: "1.0"
   description: "OR-based multi-range index scanning with dedup"
@@ -162,3 +165,73 @@ test_cases:
     sql: "SELECT * FROM or_test WHERE a=10 OR"
     expect:
       error: true
+
+  - name: Disjoint branches preserve ordered offset and duplicate projected values
+    sql: EXPLAIN PHYSICAL CALIBRATE SELECT b FROM or_test WHERE a=10 OR a=20 ORDER BY b DESC, a LIMIT 1 OFFSET 1
+    expect:
+      rows: 2
+      data:
+        - plan: scan_order
+          rows: 1
+          result_equal: true
+          operator_consistent: true
+        - plan: scan_order_multi
+          rows: 1
+          result_equal: true
+          operator_consistent: true
+
+  - name: Disjoint branches preserve computed ordering
+    sql: EXPLAIN PHYSICAL CALIBRATE SELECT a FROM or_test WHERE a=10 OR a=20 ORDER BY b+1 DESC, a LIMIT 3
+    expect:
+      rows: 2
+      data:
+        - plan: scan_order
+          rows: 3
+          result_equal: true
+          operator_consistent: true
+        - plan: scan_order_multi
+          rows: 3
+          result_equal: true
+          operator_consistent: true
+
+  - name: Disjoint branches preserve repeated projected rows
+    sql: EXPLAIN PHYSICAL CALIBRATE SELECT 1 AS n FROM or_test WHERE a=10 OR a=20 ORDER BY a,b
+    expect:
+      rows: 2
+      data:
+        - plan: scan_order
+          rows: 4
+          result_equal: true
+        - plan: scan_order_multi
+          rows: 4
+          result_equal: true
+
+  - name: Overlapping cross-column branches stay in one scan
+    sql: EXPLAIN PHYSICAL SELECT a FROM or_test WHERE a=10 OR b=100 ORDER BY a LIMIT 3
+    expect:
+      rows: 1
+      result_not_contains: ['ordered_or:', 'scan_order_multi']
+
+  - name: SQL case-insensitive equality cannot prove disjointness
+    sql: EXPLAIN PHYSICAL SELECT a FROM or_test WHERE c='alpha' OR c='ALPHA' ORDER BY a LIMIT 3
+    expect:
+      rows: 1
+      result_not_contains: ['ordered_or:', 'scan_order_multi']
+
+  - name: NULL equality cannot establish a disjoint branch
+    sql: EXPLAIN PHYSICAL SELECT a FROM or_test WHERE c='alpha' OR c=NULL ORDER BY a LIMIT 3
+    expect:
+      rows: 1
+      result_not_contains: ['ordered_or:', 'scan_order_multi']
+
+  - name: A small table keeps the cheaper single scan
+    sql: EXPLAIN PHYSICAL SELECT a FROM or_test WHERE a=10 OR a=20 ORDER BY a,b LIMIT 2
+    expect:
+      rows: 1
+      result_contains: ['(chosen scan_order)', '(plan scan_order_multi)']
+
+  - name: Numeric coercion of distinct strings cannot prove disjointness
+    sql: EXPLAIN PHYSICAL SELECT a FROM or_test WHERE a='10' OR a='010' ORDER BY a LIMIT 3
+    expect:
+      rows: 1
+      result_not_contains: ['ordered_or:', 'scan_order_multi']

--- a/tests/storage/indexes/ordered-prefix-boundaries.yaml
+++ b/tests/storage/indexes/ordered-prefix-boundaries.yaml
@@ -243,6 +243,22 @@ test_cases:
       ORDER BY stamp DESC, id DESC LIMIT 4
   - sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'private'
       ORDER BY stamp DESC, id DESC LIMIT 4
+- name: Complete composite prefix skips preceding groups in both sort directions
+  warmup: 10
+  timing_samples: 30
+  threshold_ms: 100
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'publish' ORDER BY stamp ASC, id DESC LIMIT 3 OFFSET 1
+  expect:
+    rows: 3
+    data: [{id: 3}, {id: 5}, {id: 7}]
+- name: Missing second equality key yields an empty interval
+  warmup: 10
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind = 'post' AND status = 'missing' ORDER BY stamp DESC LIMIT 4
+  expect: {rows: 0, data: []}
+- name: Composite NULL prefix keeps its boundary checks
+  warmup: 10
+  sql: SELECT id FROM ordered_prefix_posts WHERE kind IS NULL AND status = 'publish' ORDER BY stamp DESC LIMIT 4
+  expect: {rows: 1, data: [{id: 22001}]}
 - name: Main prefix and delta merge exclude other prefixes
   setup:
   - sql: INSERT INTO ordered_prefix_posts VALUES (22003, 'post', 'private', 30000),

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -123,6 +123,8 @@ type suite struct {
 }
 
 type calibrationRow struct {
+	OrderedOrWork []float64 `json:"ordered_or_work"`
+
 	CaseName                         string   `json:"case_name"`
 	Error                            string   `json:"error"`
 	CacheState                       string   `json:"cache_state"`
@@ -309,6 +311,10 @@ func main() {
 			fatal(err)
 		}
 	}
+	orderedOrObservations := filterDecisionObservations(observations, "ordered_or")
+	if err := validateDecisionOrdering(orderedOrObservations, currentConstants); err != nil {
+		fatal(fmt.Errorf("ordered_or: %w", err))
+	}
 	if *validateOnly {
 		fmt.Printf("Validated %d forced-plan observations across %d suites; coefficients unchanged.\n", len(observations), len(suites))
 		return
@@ -371,6 +377,10 @@ func main() {
 		}
 	}
 	printDecisionOrdering(membershipObservations, c)
+	if err := validateDecisionOrdering(orderedOrObservations, c); err != nil {
+		fatal(fmt.Errorf("ordered_or: %w", err))
+	}
+	printDecisionOrdering(orderedOrObservations, c)
 	orderedJoinObservations := filterDecisionObservations(observations, "scan_join_order")
 	if len(orderedJoinObservations) > 0 {
 		// scan_join_order deliberately reuses the calibrated scan/map/expression
@@ -1104,7 +1114,10 @@ func validateRaceWinner(row calibrationRow, decisionID, plan string) error {
 	if row.EstimatedNS == nil || row.WholeQueryExecutionNS <= 0 {
 		return fmt.Errorf("forced race variant has incomplete measurements: %+v", row)
 	}
-	if row.Decision == "scan_join_order" {
+	if row.Decision == "ordered_or" {
+		_, err := rowFeatures(row)
+		return err
+	} else if row.Decision == "scan_join_order" {
 		if row.JoinInputRows == nil || row.JoinProbeRows == nil || row.JoinEstimatedRows == nil ||
 			row.JoinOutputRows == nil || row.JoinMapWidth == nil || row.JoinTableCount == nil ||
 			row.JoinLegacyProbeRows == nil {
@@ -1283,6 +1296,31 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 }
 
 func rowFeatures(row calibrationRow) ([]float64, error) {
+	if row.Decision == "ordered_or" {
+		if row.Plan != "scan_order" && row.Plan != "scan_order_multi" {
+			return nil, fmt.Errorf("unsupported ordered OR plan %q", row.Plan)
+		}
+		if len(row.OrderedOrWork) != 8 {
+			return nil, fmt.Errorf("ordered OR requires eight primitive work quantities")
+		}
+		for _, value := range row.OrderedOrWork {
+			if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 {
+				return nil, fmt.Errorf("invalid ordered OR work quantity %v", value)
+			}
+		}
+		// Same primitive prices as ordered_or_work_cost; comparison work also
+		// includes sorting/merging. No separate, uncalibrated OR coefficient.
+		features := make([]float64, 25)
+		features[15] = row.OrderedOrWork[0]
+		features[1] = row.OrderedOrWork[1]
+		features[2] = row.OrderedOrWork[2]
+		features[3] = row.OrderedOrWork[3]
+		features[4] = row.OrderedOrWork[4]
+		features[13] = row.OrderedOrWork[5]
+		features[14] = row.OrderedOrWork[6]
+		return features, nil
+	}
+
 	// Semijoin formulas reuse existing primitive coefficients. These rows
 	// validate complete alternatives and must not become membership-fit inputs.
 	if row.Decision == "semijoin_carrier" {
@@ -2111,6 +2149,11 @@ func decisionAlternatives(rows []observation) (map[string]map[string]observation
 				return nil, fmt.Errorf("plan %q belongs to scan_join_order, got decision %q", row.plan, row.decision)
 			}
 			groups[row.caseName][row.plan] = row
+		case "scan_order", "scan_order_multi":
+			if row.decision != "ordered_or" {
+				return nil, fmt.Errorf("plan %q belongs to ordered_or, got decision %q", row.plan, row.decision)
+			}
+			groups[row.caseName][row.plan] = row
 		case "group_carrier", "direct_group_join":
 			if row.decision != "direct_group_join" {
 				return nil, fmt.Errorf("plan %q belongs to direct_group_join, got decision %q", row.plan, row.decision)
@@ -2121,6 +2164,15 @@ func decisionAlternatives(rows []observation) (map[string]map[string]observation
 		}
 	}
 	for name, plans := range groups {
+		if decisions[name] == "ordered_or" {
+			if _, ok := plans["scan_order"]; !ok {
+				return nil, fmt.Errorf("incomplete ordered OR alternatives for %q", name)
+			}
+			if _, ok := plans["scan_order_multi"]; !ok {
+				return nil, fmt.Errorf("incomplete ordered OR alternatives for %q", name)
+			}
+			continue
+		}
 		if decisions[name] == "scan_join_order" {
 			if _, legacy := plans["legacy_join_tree"]; !legacy {
 				return nil, fmt.Errorf("incomplete ordered join alternatives for %q", name)
@@ -2318,7 +2370,7 @@ func plansStatisticallyEquivalent(plans map[string]observation, left, right stri
 	if !leftOK || !rightOK || leftRow.censored || rightRow.censored {
 		return false
 	}
-	if math.Max(leftRow.y, rightRow.y) <= calibrationDecisionRiskBudgetNS {
+	if leftRow.decision != "ordered_or" && math.Max(leftRow.y, rightRow.y) <= calibrationDecisionRiskBudgetNS {
 		return true
 	}
 	difference := math.Abs(leftRow.y - rightRow.y)

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -709,3 +709,41 @@ func TestSemijoinCalibrationDoesNotRequireMembershipFeatures(t *testing.T) {
 		}
 	}
 }
+
+func TestOrderedOrWorkUsesExistingPrimitivePrices(t *testing.T) {
+	row := calibrationRow{Decision: "ordered_or", Plan: "scan_order_multi", OrderedOrWork: []float64{3, 100, 200, 20, 400, 100, 10000, 10}}
+	features, err := rowFeatures(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := constants{orderedScanInvocationNS: 10, scanRowNS: 2, filterColumnRowNS: 3, mapColumnRowNS: 4, expressionOperationNS: 5, broadTextMatchRowNS: 6, broadTextMatchByteNS: 7}
+	if got := estimatedNS(observation{decision: "ordered_or", plan: row.Plan, x: features}, c); got != 73510 {
+		t.Fatalf("cost %v, want 73510", got)
+	}
+	for _, work := range [][]float64{nil, {1, 2}, {1, 2, 3, 4, 5, 6, -1, 8}} {
+		row.OrderedOrWork = work
+		if _, err := rowFeatures(row); err == nil {
+			t.Fatalf("accepted incomplete or negative work: %v", work)
+		}
+	}
+	row.Plan = "unknown"
+	row.OrderedOrWork = make([]float64, 8)
+	if _, err := rowFeatures(row); err == nil {
+		t.Fatal("accepted unknown operator")
+	}
+}
+
+func TestOrderedOrRejectsWrongWinnerBelowMembershipRiskBudget(t *testing.T) {
+	rows := []observation{
+		{caseName: "or", decision: "ordered_or", plan: "scan_order", y: 27000000, x: make([]float64, 25)},
+		{caseName: "or", decision: "ordered_or", plan: "scan_order_multi", y: 2000000, x: make([]float64, 25)},
+	}
+	rows[0].x[15], rows[1].x[15] = 1, 3
+	if err := validateDecisionOrdering(rows, constants{orderedScanInvocationNS: 1}); err == nil {
+		t.Fatal("accepted a materially wrong ordered OR winner")
+	}
+	rows[0].x[1] = 100
+	if err := validateDecisionOrdering(rows, constants{orderedScanInvocationNS: 1, scanRowNS: 1}); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
WordPress search keeps text predicates and a disjunction of post types in one scan today. Add a costed physical alternative that splits a provably disjoint OR conjunct into ordered branches of `scan_order_multi`, retaining the single scan when cheaper. Logical IR and SQL_CALC_FOUND_ROWS behavior remain unchanged.

The proof uses same-column equalities in compatible typed domains, SQL string equality, and guarded parameter values. Overlap, NULL and cross-type coercion retain the original filter. The merged plan preserves bag multiplicity, projection, collation, computed ORDER BY, and global OFFSET/LIMIT. Only one OR conjunct is expanded; this is not general DNF expansion.

Profiling exposed a prerequisite in the existing index iterator: the lower seek used only the first equality key, then decoded preceding composite-key groups row by row. Complete the binary lower seek for non-NULL equality prefixes before iteration. This enables the existing exact-interval loop; it adds no per-row branch, allocation, JIT rewrite, or synchronization. Other range/NULL shapes retain their boundary checks.

Costing separates index candidates from residual selectivity and uses existing costgen primitive prices, including filtering, text work, sorting and merging. Forced alternatives expose work quantities to costgen. Validation checks result equivalence, emitted operators and measured winner ordering; OR races do not inherit the membership family's 100 ms indifference budget. No constants were hand-tuned. Absolute estimates remain approximate.

### Manual A/B before opening this PR

Baseline: `e9aba6eed` (master at development start). Same machine, fresh instances, identical `tests/performance/wordpress-search.yaml` setup: 22,000 rows, 20,000 revisions, sloppy engine, rebuild. Each query used 10 warmup requests and 30 measured requests; numbers are median HTTP SQL round trips, including cached plan execution and result serialization. No TracePrint/ScanDebugging during this A/B. Both versions returned identical results. The main-query projection was `ID, post_title LIKE '%term%' AS score, post_date AS dt`, ordered by score/date descending, LIMIT 10, with the fixture's password and type/status predicates. The second measurement adds SQL_CALC_FOUND_ROWS to that same query.

| Query | Master | PR | Speedup | Change |
|---|---:|---:|---:|---:|
| nightjar-main | 56.02 ms | 5.02 ms | 11.15× | -91.0% |
| nightjar-calc_found_rows | 56.86 ms | 4.34 ms | 13.10× | -92.4% |
| quasarless-main | 56.38 ms | 3.91 ms | 14.41× | -93.1% |
| quasarless-calc_found_rows | 109.46 ms | 31.68 ms | 3.46× | -71.1% |

The absent-search count remains a separate eager query and limits the combined gain. These are MemCP-vs-MemCP measurements, not a new MariaDB comparison.

### Targeted validation

- `tests/storage/indexes/or-index-scan.yaml`: 20 cases, including forced alternatives, duplicates, computed ordering, overlap, NULL, and coercion.
- `tests/storage/indexes/ordered-prefix-boundaries.yaml`: warm composite seeks, missing prefixes, NULL, ranges, delta merge and rebuild.
- `tests/performance/wordpress-search.yaml`: warm search, FOUND_ROWS, automatic plan selection and a cached disjoint-to-overlapping session binding transition.
- `go test ./tools/costgen -count=1` and targeted storage boundary/RecSet tests.
- `go run ./tools/costgen --suite wordpress-search --validate-only`: both alternatives for selective and broad OR cases; result/operator/winner checks pass.
- Scheme formatter and `git diff --check`.

Full suites and cross-query performance A/B are delegated to CI as requested.


### CI performance triage

The first normal performance run reported the cold `typed-filter-buffer` wide aggregate at 74.11 → 247.59 ms; all WordPress cases passed (the disjoint OR race improved 65.91 → 6.15 ms). SQL full tests and JIT performance A/B passed. A targeted local check repeated the wide aggregate's first fill on six fresh identical fixtures, alternating baseline/candidate/candidate/baseline/baseline/candidate, with no warmup as required by that case. Baseline: 43.20, 32.64, 50.27 ms; candidate: 34.99, 35.37, 56.76 ms; all results matched. This does not reproduce a systematic regression. The failed CI job was rerun without modifying code or thresholds; its result is pending.
