### PR TITLE
Use SQL for dashboard log clearing

### DIFF
--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -737,7 +737,7 @@ if(arcb)arcb.addEventListener("change",function(){syncDashboardPolling();});
 var btn=document.getElementById("btn-clear-errors");
 if(btn)btn.addEventListener("click",function(){
 if(!confirm("Clear all error log entries?"))return;
-scmFetch('(begin (scan "system_statistic" "errors" \'() (lambda () true) \'("$update") (lambda ($update) ($update))) (error_log_counter "count" 0) true)',function(){loadErrors()});
+execSQL("system_statistic","DELETE FROM `errors`",function(){loadErrors()});
 });
 /* Error Log inline settings — auto-save */
 var elEnable=document.getElementById("el-setting-enable");
@@ -801,7 +801,7 @@ if(cb)cb.addEventListener("change",function(){syncDashboardPolling();});
 var btn=document.getElementById("btn-clear-logs");
 if(btn)btn.addEventListener("click",function(){
 if(!confirm("Clear all log entries?"))return;
-scmFetch('(begin (scan "system_statistic" "logs" \'() (lambda () true) \'("$update") (lambda ($update) ($update))) true)',function(){loadLogs()});
+execSQL("system_statistic","DELETE FROM `logs`",function(){loadLogs()});
 });
 /* Print Log inline settings — auto-save */
 var plEnable=document.getElementById("pl-setting-enable");

--- a/tests/integration/regressions/dashboard-log-actions.yaml
+++ b/tests/integration/regressions/dashboard-log-actions.yaml
@@ -1,0 +1,76 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Execute the SQL extracted from the real dashboard, confined to memcp-tests.
+
+metadata:
+  version: '1.0'
+  description: Dashboard log clear actions execute their actual browser SQL against
+    isolated log fixtures
+  isolated: true
+setup:
+- sql: DROP TABLE IF EXISTS `errors`
+- sql: CREATE TABLE `errors` (message TEXT) ENGINE=SLOPPY
+- sql: INSERT INTO `errors` VALUES ('first'), ('second')
+- sql: DROP TABLE IF EXISTS `logs`
+- sql: CREATE TABLE `logs` (message TEXT) ENGINE=SLOPPY
+- sql: INSERT INTO `logs` VALUES ('first'), ('second')
+test_cases:
+- name: Browser errors clear query deletes only its target and accepts an empty table
+  scm: |-
+    (begin
+      (define query (match (readfile "../assets/dashboard.html")
+      (regex "execSQL[(]\"system_statistic\",\"([^\"]*)\",function[(][)][{]loadErrors[(][)]" _ query) query
+      _ (error "dashboard clear action must use the SQL API")))
+      (map '(1 2) (lambda (_)
+        (eval (parse_sql "memcp-tests" query
+          (lambda (db tbl write)
+            (if (and (equal? db "memcp-tests") (equal? tbl "errors") write)
+              true (error "unexpected clear-query access"))))))))
+- name: Clearing errors preserves print logs
+  sql: SELECT (SELECT COUNT(*) FROM errors) AS errors, (SELECT COUNT(*) FROM logs)
+    AS logs
+  expect:
+    rows: 1
+    data:
+    - errors: 0
+      logs: 2
+- name: Browser logs clear query deletes only its target and accepts an empty table
+  scm: |-
+    (begin
+      (define query (match (readfile "../assets/dashboard.html")
+      (regex "execSQL[(]\"system_statistic\",\"([^\"]*)\",function[(][)][{]loadLogs[(][)]" _ query) query
+      _ (error "dashboard clear action must use the SQL API")))
+      (map '(1 2) (lambda (_)
+        (eval (parse_sql "memcp-tests" query
+          (lambda (db tbl write)
+            (if (and (equal? db "memcp-tests") (equal? tbl "logs") write)
+              true (error "unexpected clear-query access"))))))))
+- name: Both log fixtures are empty
+  sql: SELECT (SELECT COUNT(*) FROM errors) AS errors, (SELECT COUNT(*) FROM logs)
+    AS logs
+  expect:
+    rows: 1
+    data:
+    - errors: 0
+      logs: 0
+- name: Browser errors clear query respects denied SQL policy
+  scm: |-
+    (eval (parse_sql "memcp-tests"
+      (match (readfile "../assets/dashboard.html")
+      (regex "execSQL[(]\"system_statistic\",\"([^\"]*)\",function[(][)][{]loadErrors[(][)]" _ query) query
+      _ (error "dashboard clear action must use the SQL API"))
+      (lambda (db tbl write) (error "access denied"))))
+  expect:
+    error: true
+- name: Browser logs clear query respects denied SQL policy
+  scm: |-
+    (eval (parse_sql "memcp-tests"
+      (match (readfile "../assets/dashboard.html")
+      (regex "execSQL[(]\"system_statistic\",\"([^\"]*)\",function[(][)][{]loadLogs[(][)]" _ query) query
+      _ (error "dashboard clear action must use the SQL API"))
+      (lambda (db tbl write) (error "access denied"))))
+  expect:
+    error: true
+cleanup:
+- sql: DROP TABLE IF EXISTS `errors`
+- sql: DROP TABLE IF EXISTS `logs`


### PR DESCRIPTION
The dashboard's Clear Errors and Clear Logs buttons still sent Scheme snippets using the obsolete scan signature. Both actions now send `DELETE FROM` through the existing SQL API and reuse its success refresh and visible error handling. No new endpoint or physical scan code is needed.

The cumulative error counter is no longer reset when stored error rows are deleted: it measures newly occurring errors for the errors/second gauge, independently of whether logging is enabled. Resetting it could produce a negative delta on the next sample.

The browser audit found no remaining direct scan calls. Remaining Scheme requests access the runtime service registry, engine settings, or the explicitly selected Scheme console; they have no equivalent existing SQL interface.

Validation:
- New regression suite extracts the real browser SQL and executes it only against fixtures in `memcp-tests`: 6/6 passed, covering both deletes, empty-table repetition, preservation of the other table and denied SQL policy. The original dashboard fails four cases.
- Actual JavaScript click handlers tested against a fresh server: cancellation makes no request, confirmation posts the correct SQL, success refreshes and failure displays an error without reporting success.
- Both real telemetry tables were emptied on that disposable server; the error-rate counter remained unchanged.
- All dashboard JavaScript blocks parse; test fixture-name and whitespace checks pass.
- Full local `make test` completed successfully (exit 0); the existing 27 noncritical RDF failures retain their classification.
- All applicable CI checks on `48de2a940` passed: ordinary/JIT SQL suites, ordinary/JIT Go tests, both performance A/B jobs, packaging, alternative storage and regression guards. PHP was correctly skipped by the unchanged change-selection gate.
