### PR TITLE
Fix JIT register exhaustion in SQL cache and policy compilation

### DIFF
--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -2169,6 +2169,30 @@ func jitKnownSliceHeader(ctx *JITContext, value *JITValueDesc) JITValueDesc {
 		ctx.EmitMovRegImm64(capReg, uint64(capacity))
 	} else if value.Loc == LocStackPair {
 		ctx.ReclaimUntrackedRegs()
+		if bits.OnesCount64(ctx.FreeRegs&ctx.AllRegs&^ctx.ProtectedRegs) < 3 {
+			// A nested consumer may have only one or two scratch registers left.
+			// Decode into a stable header so consumers can load just the fields
+			// they use, without reserving pointer, length and capacity together.
+			off := ctx.AllocStack(24)
+			base := ctx.StackReg
+			if value.StackOff < 0 {
+				base = ctx.FrameReg
+			}
+			ctx.EmitMovRegMem(ctx.ScratchReg, base, value.StackOff)
+			ctx.EmitStoreRegMem(ctx.ScratchReg, ctx.StackReg, off)
+			ctx.EmitMovRegMem(ctx.ScratchReg, base, value.StackOff+8)
+			ctx.EmitShrRegImm8(ctx.ScratchReg, 8+sliceCapBits)
+			ctx.EmitStoreRegMem(ctx.ScratchReg, ctx.StackReg, off+8)
+			ctx.EmitMovRegMem(ctx.ScratchReg, base, value.StackOff+8)
+			ctx.EmitShrRegImm8(ctx.ScratchReg, 8)
+			ctx.EmitAndRegImm32(ctx.ScratchReg, int32(sliceCapMask))
+			ctx.EmitStoreRegMem(ctx.ScratchReg, ctx.StackReg, off+16)
+			ctx.setStackPointer(jitStackRootFrameSP, off-ctx.DynamicSP, true)
+			return JITValueDesc{
+				Loc: LocStackTriple, Type: tagSlice, StackOff: off, Rooted: true,
+				KnownSliceLen: value.KnownSliceLen, KnownSliceCap: value.KnownSliceCap, SliceSizeKnown: value.SliceSizeKnown,
+			}
+		}
 		ptrReg = ctx.AllocReg()
 		lenReg = ctx.AllocRegExcept(ptrReg)
 		capReg = ctx.AllocRegExcept(ptrReg, lenReg)
@@ -2682,6 +2706,15 @@ func jitEmitDynamicCallableAt(ctx *JITContext, callable JITValueDesc, operandVal
 	// loop state. Keep the callable in a branch-stable home, then restore this
 	// snapshot before emitting each mutually exclusive arm.
 	ctx.StabilizeDescAcrossNestedCall(&callable)
+	// Dispatch needs scratch registers even when a surrounding expression or
+	// generated loop has pinned its live values. The callable and operands are
+	// already stack-backed; save the outer register contract until every arm
+	// has committed its result to callResult.
+	var boundary JITRegisterBoundary
+	releaseOuter := bits.OnesCount64(ctx.FreeRegs&ctx.AllRegs&^ctx.ProtectedRegs) < 6
+	if releaseOuter {
+		boundary = ctx.PreserveRegisters(JITRegisterBoundaryOptions{ReleaseHomes: true})
+	}
 	fallbackLabel := ctx.ReserveLabel()
 	endLabel := ctx.ReserveLabel()
 
@@ -2816,6 +2849,9 @@ func jitEmitDynamicCallableAt(ctx *JITContext, callable JITValueDesc, operandVal
 	ctx.FreeDesc(&fallbackResult)
 	ctx.RestoreAllocState(dispatchState)
 	ctx.MarkLabel(endLabel)
+	if releaseOuter {
+		boundary.Restore(ctx)
+	}
 	var out JITValueDesc
 	if result.Loc == LocStackPair {
 		out = result

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -1383,6 +1383,34 @@ func TestJITExpressionRecursiveMatchKeepsEarlierFixedListBranch(t *testing.T) {
 	}
 }
 
+func TestJITMatchSingletonAfterReduce(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t, `(lambda (terms predicate)
+		(begin
+			(define kept (reduce terms (lambda (acc term)
+				(if (predicate term) acc (append_unique acc term))) '()))
+			(if (predicate kept) false
+				(match kept
+					'() true
+					(cons single '()) single
+					_ (cons 'and kept)))))`)
+	predicate := NewFunc(func(args ...Scmer) Scmer { return NewBool(args[0].IsBool() && args[0].Bool()) })
+	column := NewSlice([]Scmer{NewSymbol("get_column"), NewString("a"), NewBool(false), NewString("x"), NewBool(false)})
+	for _, test := range []struct {
+		input []Scmer
+		want  Scmer
+	}{
+		{nil, NewBool(true)},
+		{[]Scmer{NewBool(true)}, NewBool(true)},
+		{[]Scmer{NewBool(true), column}, column},
+		{[]Scmer{column, column}, column},
+		{[]Scmer{column, NewString("other")}, NewSlice([]Scmer{NewSymbol("and"), column, NewString("other")})},
+	} {
+		if got := Apply(compiled, NewSlice(test.input), predicate); !Equal(got, test.want) {
+			t.Fatalf("match after reduce of %s returned %s, want %s", String(NewSlice(test.input)), String(got), String(test.want))
+		}
+	}
+}
+
 func TestJITExpressionWideMatchPreservesEveryCapture(t *testing.T) {
 	compiled := compileJITExpressionTestProc(t, `(lambda (query) (match query
 		((symbol query-block) schema tables fields condition group having order limit offset hidden stages facts)

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -635,6 +635,46 @@ func TestJITDynamicNativeFuncPreservesClosureContextAcrossGC(t *testing.T) {
 	}
 }
 
+func TestJITNestedCallPreservesPointerValues(t *testing.T) {
+	for _, source := range []string{
+		`(lambda (a b c value) (concat a (concat b (concat c (nth (list value "tail") 0)))))`,
+		`(lambda (a b c callback) (concat a (concat b (concat c (callback "value")))))`,
+	} {
+		t.Run(source, func(t *testing.T) {
+			compiled := compileJITExpressionTestProc(t, source)
+			value := NewString("value")
+			if strings.Contains(source, "callback") {
+				value = NewFunc(func(args ...Scmer) Scmer {
+					return jitCallbackTestSafepoint(args...)
+				})
+			}
+			got := Apply(compiled, NewString("a"), NewString("b"), NewString("c"), value)
+			if String(got) != "abcvalue" {
+				t.Fatalf("nested call returned %s", String(got))
+			}
+		})
+	}
+}
+
+func TestJITConditionalCallbackPreservesPointerValues(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t, `(lambda (callback a b c)
+		(if a (if (and b (callback c)) (list a b c) (list c b a)) (list a b c)))`)
+	for _, enabled := range []bool{true, false} {
+		callback := NewFunc(func(args ...Scmer) Scmer {
+			_ = jitCallbackTestSafepoint(args...)
+			return NewBool(enabled)
+		})
+		a, b, c := NewString("first"), NewString("second"), NewString("third")
+		want := NewSlice([]Scmer{a, b, c})
+		if !enabled {
+			want = NewSlice([]Scmer{c, b, a})
+		}
+		if got := Apply(compiled, callback, a, b, c); !Equal(got, want) {
+			t.Fatalf("conditional callback returned %s, want %s", String(got), String(want))
+		}
+	}
+}
+
 func BenchmarkJITDynamicNativeFuncCall(b *testing.B) {
 	compiled := compileJITExpressionTestProc(b, `(lambda (callback value) (callback value))`)
 	callback := NewFunc(func(args ...Scmer) Scmer { return args[0] })

--- a/scm/jit_match.go
+++ b/scm/jit_match.go
@@ -178,6 +178,26 @@ func jitEmitMatchTag(ctx *JITContext, value *JITValueDesc, tag uint8, failLabel 
 	return jitEmitMatchBool(ctx, condition, failLabel)
 }
 
+// Header extraction can leave ptr/len/cap on the stack under register pressure.
+// Length guards need only len; materializing the whole triple would recreate
+// the register pressure that caused it to be parked in the first place.
+func jitMatchCompareLength(ctx *JITContext, slice *JITValueDesc, length int32) {
+	ctx.SyncDesc(slice)
+	switch slice.Loc {
+	case LocStackTriple:
+		base := ctx.StackReg
+		if slice.StackOff < 0 {
+			base = ctx.FrameReg
+		}
+		ctx.EmitMovRegMem(ctx.ScratchReg, base, slice.StackOff+8)
+		ctx.EmitCmpRegImm32(ctx.ScratchReg, length)
+	case LocRegTriple:
+		ctx.EmitCmpRegImm32(slice.Reg2, length)
+	default:
+		panic("jit: match length requires a Go slice header")
+	}
+}
+
 func jitMatchLoadElement(ctx *JITContext, slice *JITValueDesc, index int) JITValueDesc {
 	ctx.EnsureDesc(slice)
 	if slice.Loc != LocRegTriple {
@@ -449,7 +469,7 @@ func jitMatchFixedList(ctx *JITContext, value JITValueDesc, patterns []Scmer, en
 			return jitMatchOutcome{}
 		}
 	} else {
-		ctx.EmitCmpRegImm32(header.Reg2, int32(len(patterns)))
+		jitMatchCompareLength(ctx, &header, int32(len(patterns)))
 		ctx.EmitJump(CondNotEqual, failLabel)
 		listOutcome.always = false
 	}
@@ -512,7 +532,7 @@ func jitMatchCons(ctx *JITContext, value JITValueDesc, patterns []Scmer, env *JI
 			return jitMatchOutcome{}
 		}
 	} else {
-		ctx.EmitCmpRegImm32(header.Reg2, 0)
+		jitMatchCompareLength(ctx, &header, 0)
 		ctx.EmitJump(CondEqual, failLabel)
 		listOutcome.always = false
 	}

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -211,6 +211,25 @@ func newJITStackMapTestContext(code []byte) *JITContext {
 	}
 }
 
+func TestJITKnownSliceHeaderWithTwoRegistersKeepsPreciseRoot(t *testing.T) {
+	ctx := newJITStackMapTestContext(make([]byte, 256))
+	source := JITValueDesc{Loc: LocStackPair, Type: tagSlice, StackOff: -16, Rooted: true}
+	header := jitKnownSliceHeader(ctx, &source)
+	if header.Loc != LocStackTriple || !header.Rooted {
+		t.Fatalf("slice header did not get a stable stack home: %#v", header)
+	}
+	for word := int32(0); word < 3; word++ {
+		root := jitStackRoot{base: jitStackRootFrameSP, offset: header.StackOff + word*8}
+		_, pointer := ctx.StackRoots[root]
+		if pointer != (word == 0) {
+			t.Fatalf("slice header word %d pointer=%v; only the backing array is a GC root", word, pointer)
+		}
+	}
+	if ctx.FreeRegs != ctx.AllRegs {
+		t.Fatal("stack header extraction consumed the caller's remaining registers")
+	}
+}
+
 func TestJITUnboxedScalarStabilizationDoesNotCreateGCStackRoot(t *testing.T) {
 	t.Run("control flow", func(t *testing.T) {
 		code := make([]byte, 128)

--- a/scm/list.go
+++ b/scm/list.go
@@ -3155,9 +3155,11 @@ func init_list() {
 					} else {
 						d1 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d0}, 3)
 					}
-					ctx.BindReg(d1.Reg, &d1)
-					ctx.BindReg(d1.Reg2, &d1)
-					ctx.BindReg(d1.Reg3, &d1)
+					if d1.Loc == LocRegTriple {
+						ctx.BindReg(d1.Reg, &d1)
+						ctx.BindReg(d1.Reg2, &d1)
+						ctx.BindReg(d1.Reg3, &d1)
+					}
 					ctx.StabilizeDescForControlFlow(&d1)
 					ctx.FreeDesc(&d0)
 					d2 = args[1]
@@ -3804,9 +3806,11 @@ func init_list() {
 					} else {
 						d1 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d0}, 3)
 					}
-					ctx.BindReg(d1.Reg, &d1)
-					ctx.BindReg(d1.Reg2, &d1)
-					ctx.BindReg(d1.Reg3, &d1)
+					if d1.Loc == LocRegTriple {
+						ctx.BindReg(d1.Reg, &d1)
+						ctx.BindReg(d1.Reg2, &d1)
+						ctx.BindReg(d1.Reg3, &d1)
+					}
 					ctx.StabilizeDescForControlFlow(&d1)
 					ctx.FreeDesc(&d0)
 					d2 = args[1]
@@ -4578,9 +4582,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -6663,9 +6669,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					var d4 JITValueDesc
@@ -7269,9 +7277,11 @@ func init_list() {
 				} else {
 					d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 				}
-				ctx.BindReg(d3.Reg, &d3)
-				ctx.BindReg(d3.Reg2, &d3)
-				ctx.BindReg(d3.Reg3, &d3)
+				if d3.Loc == LocRegTriple {
+					ctx.BindReg(d3.Reg, &d3)
+					ctx.BindReg(d3.Reg2, &d3)
+					ctx.BindReg(d3.Reg3, &d3)
+				}
 				ctx.FreeDesc(&d2)
 				callResults4 := JITEmitGoCallResults(ctx, GoFuncAddr(JITCloneScmerSlice), []JITValueDesc{d3}, []uint8{3}, []uint8{1})
 				d5 := callResults4[0]
@@ -7538,9 +7548,11 @@ func init_list() {
 					} else {
 						d7 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d6}, 3)
 					}
-					ctx.BindReg(d7.Reg, &d7)
-					ctx.BindReg(d7.Reg2, &d7)
-					ctx.BindReg(d7.Reg3, &d7)
+					if d7.Loc == LocRegTriple {
+						ctx.BindReg(d7.Reg, &d7)
+						ctx.BindReg(d7.Reg2, &d7)
+						ctx.BindReg(d7.Reg3, &d7)
+					}
 					ctx.FreeDesc(&d6)
 					callResults8 := JITEmitGoCallResults(ctx, GoFuncAddr(JITCloneScmerSlice), []JITValueDesc{d7}, []uint8{3}, []uint8{1})
 					d9 = callResults8[0]
@@ -9983,9 +9995,11 @@ func init_list() {
 					} else {
 						d1 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d0}, 3)
 					}
-					ctx.BindReg(d1.Reg, &d1)
-					ctx.BindReg(d1.Reg2, &d1)
-					ctx.BindReg(d1.Reg3, &d1)
+					if d1.Loc == LocRegTriple {
+						ctx.BindReg(d1.Reg, &d1)
+						ctx.BindReg(d1.Reg2, &d1)
+						ctx.BindReg(d1.Reg3, &d1)
+					}
 					ctx.StabilizeDescForControlFlow(&d1)
 					ctx.FreeDesc(&d0)
 					var d2 JITValueDesc
@@ -10343,9 +10357,11 @@ func init_list() {
 					} else {
 						d1 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d0}, 3)
 					}
-					ctx.BindReg(d1.Reg, &d1)
-					ctx.BindReg(d1.Reg2, &d1)
-					ctx.BindReg(d1.Reg3, &d1)
+					if d1.Loc == LocRegTriple {
+						ctx.BindReg(d1.Reg, &d1)
+						ctx.BindReg(d1.Reg2, &d1)
+						ctx.BindReg(d1.Reg3, &d1)
+					}
 					ctx.StabilizeDescForControlFlow(&d1)
 					ctx.FreeDesc(&d0)
 					var d2 JITValueDesc
@@ -10798,9 +10814,11 @@ func init_list() {
 					} else {
 						d1 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d0}, 3)
 					}
-					ctx.BindReg(d1.Reg, &d1)
-					ctx.BindReg(d1.Reg2, &d1)
-					ctx.BindReg(d1.Reg3, &d1)
+					if d1.Loc == LocRegTriple {
+						ctx.BindReg(d1.Reg, &d1)
+						ctx.BindReg(d1.Reg2, &d1)
+						ctx.BindReg(d1.Reg3, &d1)
+					}
 					ctx.StabilizeDescForControlFlow(&d1)
 					ctx.FreeDesc(&d0)
 					var d2 JITValueDesc
@@ -11505,9 +11523,11 @@ func init_list() {
 					} else {
 						d31 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d30}, 3)
 					}
-					ctx.BindReg(d31.Reg, &d31)
-					ctx.BindReg(d31.Reg2, &d31)
-					ctx.BindReg(d31.Reg3, &d31)
+					if d31.Loc == LocRegTriple {
+						ctx.BindReg(d31.Reg, &d31)
+						ctx.BindReg(d31.Reg2, &d31)
+						ctx.BindReg(d31.Reg3, &d31)
+					}
 					ctx.StabilizeDescForControlFlow(&d31)
 					ctx.FreeDesc(&d30)
 					if ps.General {
@@ -12089,9 +12109,11 @@ func init_list() {
 					} else {
 						d88 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d86}, 3)
 					}
-					ctx.BindReg(d88.Reg, &d88)
-					ctx.BindReg(d88.Reg2, &d88)
-					ctx.BindReg(d88.Reg3, &d88)
+					if d88.Loc == LocRegTriple {
+						ctx.BindReg(d88.Reg, &d88)
+						ctx.BindReg(d88.Reg2, &d88)
+						ctx.BindReg(d88.Reg3, &d88)
+					}
 					ctx.FreeDesc(&d86)
 					var d89 JITValueDesc
 					if d88.SliceSizeKnown {
@@ -13773,9 +13795,11 @@ func init_list() {
 					} else {
 						d268 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d266}, 3)
 					}
-					ctx.BindReg(d268.Reg, &d268)
-					ctx.BindReg(d268.Reg2, &d268)
-					ctx.BindReg(d268.Reg3, &d268)
+					if d268.Loc == LocRegTriple {
+						ctx.BindReg(d268.Reg, &d268)
+						ctx.BindReg(d268.Reg2, &d268)
+						ctx.BindReg(d268.Reg3, &d268)
+					}
 					ctx.StabilizeDescForControlFlow(&d268)
 					ctx.FreeDesc(&d266)
 					var d269 JITValueDesc
@@ -15501,9 +15525,11 @@ func init_list() {
 					} else {
 						d37 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d36}, 3)
 					}
-					ctx.BindReg(d37.Reg, &d37)
-					ctx.BindReg(d37.Reg2, &d37)
-					ctx.BindReg(d37.Reg3, &d37)
+					if d37.Loc == LocRegTriple {
+						ctx.BindReg(d37.Reg, &d37)
+						ctx.BindReg(d37.Reg2, &d37)
+						ctx.BindReg(d37.Reg3, &d37)
+					}
 					ctx.StabilizeDescForControlFlow(&d37)
 					ctx.FreeDesc(&d36)
 					if ps.General {
@@ -16238,9 +16264,11 @@ func init_list() {
 					} else {
 						d111 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d109}, 3)
 					}
-					ctx.BindReg(d111.Reg, &d111)
-					ctx.BindReg(d111.Reg2, &d111)
-					ctx.BindReg(d111.Reg3, &d111)
+					if d111.Loc == LocRegTriple {
+						ctx.BindReg(d111.Reg, &d111)
+						ctx.BindReg(d111.Reg2, &d111)
+						ctx.BindReg(d111.Reg3, &d111)
+					}
 					ctx.FreeDesc(&d109)
 					var d112 JITValueDesc
 					if d111.SliceSizeKnown {
@@ -17408,9 +17436,11 @@ func init_list() {
 					} else {
 						d227 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d225}, 3)
 					}
-					ctx.BindReg(d227.Reg, &d227)
-					ctx.BindReg(d227.Reg2, &d227)
-					ctx.BindReg(d227.Reg3, &d227)
+					if d227.Loc == LocRegTriple {
+						ctx.BindReg(d227.Reg, &d227)
+						ctx.BindReg(d227.Reg2, &d227)
+						ctx.BindReg(d227.Reg3, &d227)
+					}
 					ctx.FreeDesc(&d225)
 					callResults228 := JITEmitGoCallResults(ctx, GoFuncAddr(JITAppendScmerSlice), []JITValueDesc{d4, d227}, []uint8{3}, []uint8{1})
 					d229 = callResults228[0]
@@ -18401,9 +18431,11 @@ func init_list() {
 					} else {
 						d49 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d48}, 3)
 					}
-					ctx.BindReg(d49.Reg, &d49)
-					ctx.BindReg(d49.Reg2, &d49)
-					ctx.BindReg(d49.Reg3, &d49)
+					if d49.Loc == LocRegTriple {
+						ctx.BindReg(d49.Reg, &d49)
+						ctx.BindReg(d49.Reg2, &d49)
+						ctx.BindReg(d49.Reg3, &d49)
+					}
 					ctx.StabilizeDescForControlFlow(&d49)
 					ctx.FreeDesc(&d48)
 					if ps.General {
@@ -19230,9 +19262,11 @@ func init_list() {
 					} else {
 						d131 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d129}, 3)
 					}
-					ctx.BindReg(d131.Reg, &d131)
-					ctx.BindReg(d131.Reg2, &d131)
-					ctx.BindReg(d131.Reg3, &d131)
+					if d131.Loc == LocRegTriple {
+						ctx.BindReg(d131.Reg, &d131)
+						ctx.BindReg(d131.Reg2, &d131)
+						ctx.BindReg(d131.Reg3, &d131)
+					}
 					ctx.FreeDesc(&d129)
 					var d132 JITValueDesc
 					if d131.SliceSizeKnown {
@@ -20492,9 +20526,11 @@ func init_list() {
 					} else {
 						d255 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d253}, 3)
 					}
-					ctx.BindReg(d255.Reg, &d255)
-					ctx.BindReg(d255.Reg2, &d255)
-					ctx.BindReg(d255.Reg3, &d255)
+					if d255.Loc == LocRegTriple {
+						ctx.BindReg(d255.Reg, &d255)
+						ctx.BindReg(d255.Reg2, &d255)
+						ctx.BindReg(d255.Reg3, &d255)
+					}
 					ctx.StabilizeDescForControlFlow(&d255)
 					ctx.FreeDesc(&d253)
 					var d256 JITValueDesc
@@ -26864,9 +26900,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					var d4 JITValueDesc
@@ -27857,9 +27895,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					var d5 JITValueDesc
@@ -29361,9 +29401,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -31058,9 +31100,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					var d4 JITValueDesc
@@ -32045,9 +32089,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					var d4 JITValueDesc
@@ -32957,9 +33003,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -40436,9 +40484,11 @@ func init_list() {
 					} else {
 						d101 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d100}, 3)
 					}
-					ctx.BindReg(d101.Reg, &d101)
-					ctx.BindReg(d101.Reg2, &d101)
-					ctx.BindReg(d101.Reg3, &d101)
+					if d101.Loc == LocRegTriple {
+						ctx.BindReg(d101.Reg, &d101)
+						ctx.BindReg(d101.Reg2, &d101)
+						ctx.BindReg(d101.Reg3, &d101)
+					}
 					ctx.StabilizeDescForControlFlow(&d101)
 					ctx.FreeDesc(&d100)
 					var d102 JITValueDesc
@@ -44342,9 +44392,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					var d4 JITValueDesc
@@ -45364,9 +45416,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -52597,9 +52651,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					var d4 JITValueDesc
@@ -55771,9 +55827,11 @@ func init_list() {
 					} else {
 						d10 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d9}, 3)
 					}
-					ctx.BindReg(d10.Reg, &d10)
-					ctx.BindReg(d10.Reg2, &d10)
-					ctx.BindReg(d10.Reg3, &d10)
+					if d10.Loc == LocRegTriple {
+						ctx.BindReg(d10.Reg, &d10)
+						ctx.BindReg(d10.Reg2, &d10)
+						ctx.BindReg(d10.Reg3, &d10)
+					}
 					ctx.StabilizeDescForControlFlow(&d10)
 					ctx.FreeDesc(&d9)
 					var d11 JITValueDesc
@@ -56239,9 +56297,11 @@ func init_list() {
 					} else {
 						d61 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d59}, 3)
 					}
-					ctx.BindReg(d61.Reg, &d61)
-					ctx.BindReg(d61.Reg2, &d61)
-					ctx.BindReg(d61.Reg3, &d61)
+					if d61.Loc == LocRegTriple {
+						ctx.BindReg(d61.Reg, &d61)
+						ctx.BindReg(d61.Reg2, &d61)
+						ctx.BindReg(d61.Reg3, &d61)
+					}
 					ctx.FreeDesc(&d59)
 					if ps.General {
 						ctx.SyncDesc(&d15)
@@ -58239,9 +58299,11 @@ func init_list() {
 					} else {
 						d276 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d274}, 3)
 					}
-					ctx.BindReg(d276.Reg, &d276)
-					ctx.BindReg(d276.Reg2, &d276)
-					ctx.BindReg(d276.Reg3, &d276)
+					if d276.Loc == LocRegTriple {
+						ctx.BindReg(d276.Reg, &d276)
+						ctx.BindReg(d276.Reg2, &d276)
+						ctx.BindReg(d276.Reg3, &d276)
+					}
 					ctx.StabilizeDescForControlFlow(&d276)
 					ctx.FreeDesc(&d274)
 					var d277 JITValueDesc
@@ -62033,9 +62095,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -63729,9 +63793,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -65297,9 +65363,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -68940,9 +69008,11 @@ func init_list() {
 					} else {
 						d9 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d8}, 3)
 					}
-					ctx.BindReg(d9.Reg, &d9)
-					ctx.BindReg(d9.Reg2, &d9)
-					ctx.BindReg(d9.Reg3, &d9)
+					if d9.Loc == LocRegTriple {
+						ctx.BindReg(d9.Reg, &d9)
+						ctx.BindReg(d9.Reg2, &d9)
+						ctx.BindReg(d9.Reg3, &d9)
+					}
 					ctx.StabilizeDescForControlFlow(&d9)
 					ctx.FreeDesc(&d8)
 					d10 = args[1]
@@ -72457,9 +72527,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -74368,9 +74440,11 @@ func init_list() {
 				} else {
 					d9 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d8}, 3)
 				}
-				ctx.BindReg(d9.Reg, &d9)
-				ctx.BindReg(d9.Reg2, &d9)
-				ctx.BindReg(d9.Reg3, &d9)
+				if d9.Loc == LocRegTriple {
+					ctx.BindReg(d9.Reg, &d9)
+					ctx.BindReg(d9.Reg2, &d9)
+					ctx.BindReg(d9.Reg3, &d9)
+				}
 				ctx.StabilizeDescForControlFlow(&d9)
 				ctx.FreeDesc(&d8)
 				ctx.ReclaimUntrackedRegs()
@@ -74448,9 +74522,11 @@ func init_list() {
 				} else {
 					d14 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d13}, 3)
 				}
-				ctx.BindReg(d14.Reg, &d14)
-				ctx.BindReg(d14.Reg2, &d14)
-				ctx.BindReg(d14.Reg3, &d14)
+				if d14.Loc == LocRegTriple {
+					ctx.BindReg(d14.Reg, &d14)
+					ctx.BindReg(d14.Reg2, &d14)
+					ctx.BindReg(d14.Reg3, &d14)
+				}
 				ctx.StabilizeDescForControlFlow(&d14)
 				ctx.FreeDesc(&d13)
 				ctx.ReclaimUntrackedRegs()
@@ -75843,9 +75919,11 @@ func init_list() {
 				} else {
 					d9 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d8}, 3)
 				}
-				ctx.BindReg(d9.Reg, &d9)
-				ctx.BindReg(d9.Reg2, &d9)
-				ctx.BindReg(d9.Reg3, &d9)
+				if d9.Loc == LocRegTriple {
+					ctx.BindReg(d9.Reg, &d9)
+					ctx.BindReg(d9.Reg2, &d9)
+					ctx.BindReg(d9.Reg3, &d9)
+				}
 				ctx.StabilizeDescForControlFlow(&d9)
 				ctx.FreeDesc(&d8)
 				ctx.ReclaimUntrackedRegs()
@@ -75923,9 +76001,11 @@ func init_list() {
 				} else {
 					d14 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d13}, 3)
 				}
-				ctx.BindReg(d14.Reg, &d14)
-				ctx.BindReg(d14.Reg2, &d14)
-				ctx.BindReg(d14.Reg3, &d14)
+				if d14.Loc == LocRegTriple {
+					ctx.BindReg(d14.Reg, &d14)
+					ctx.BindReg(d14.Reg2, &d14)
+					ctx.BindReg(d14.Reg3, &d14)
+				}
 				ctx.StabilizeDescForControlFlow(&d14)
 				ctx.FreeDesc(&d13)
 				ctx.ReclaimUntrackedRegs()
@@ -77372,9 +77452,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -108501,9 +108583,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -109722,9 +109806,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -111335,9 +111421,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -112295,9 +112383,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -113372,9 +113462,11 @@ func init_list() {
 					} else {
 						d7 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d6}, 3)
 					}
-					ctx.BindReg(d7.Reg, &d7)
-					ctx.BindReg(d7.Reg2, &d7)
-					ctx.BindReg(d7.Reg3, &d7)
+					if d7.Loc == LocRegTriple {
+						ctx.BindReg(d7.Reg, &d7)
+						ctx.BindReg(d7.Reg2, &d7)
+						ctx.BindReg(d7.Reg3, &d7)
+					}
 					ctx.StabilizeDescForControlFlow(&d7)
 					ctx.FreeDesc(&d6)
 					d8 = args[1]
@@ -116584,9 +116676,11 @@ func init_list() {
 					} else {
 						d7 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d6}, 3)
 					}
-					ctx.BindReg(d7.Reg, &d7)
-					ctx.BindReg(d7.Reg2, &d7)
-					ctx.BindReg(d7.Reg3, &d7)
+					if d7.Loc == LocRegTriple {
+						ctx.BindReg(d7.Reg, &d7)
+						ctx.BindReg(d7.Reg2, &d7)
+						ctx.BindReg(d7.Reg3, &d7)
+					}
 					ctx.StabilizeDescForControlFlow(&d7)
 					ctx.FreeDesc(&d6)
 					d8 = args[1]
@@ -121080,9 +121174,11 @@ func init_list() {
 					} else {
 						d41 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d40}, 3)
 					}
-					ctx.BindReg(d41.Reg, &d41)
-					ctx.BindReg(d41.Reg2, &d41)
-					ctx.BindReg(d41.Reg3, &d41)
+					if d41.Loc == LocRegTriple {
+						ctx.BindReg(d41.Reg, &d41)
+						ctx.BindReg(d41.Reg2, &d41)
+						ctx.BindReg(d41.Reg3, &d41)
+					}
 					ctx.StabilizeDescForControlFlow(&d41)
 					ctx.FreeDesc(&d40)
 					d42 = args[1]
@@ -121093,9 +121189,11 @@ func init_list() {
 					} else {
 						d43 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d42}, 3)
 					}
-					ctx.BindReg(d43.Reg, &d43)
-					ctx.BindReg(d43.Reg2, &d43)
-					ctx.BindReg(d43.Reg3, &d43)
+					if d43.Loc == LocRegTriple {
+						ctx.BindReg(d43.Reg, &d43)
+						ctx.BindReg(d43.Reg2, &d43)
+						ctx.BindReg(d43.Reg3, &d43)
+					}
 					ctx.StabilizeDescForControlFlow(&d43)
 					ctx.FreeDesc(&d42)
 					d44 = args[2]
@@ -128042,9 +128140,11 @@ func init_list() {
 					} else {
 						d7 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d6}, 3)
 					}
-					ctx.BindReg(d7.Reg, &d7)
-					ctx.BindReg(d7.Reg2, &d7)
-					ctx.BindReg(d7.Reg3, &d7)
+					if d7.Loc == LocRegTriple {
+						ctx.BindReg(d7.Reg, &d7)
+						ctx.BindReg(d7.Reg2, &d7)
+						ctx.BindReg(d7.Reg3, &d7)
+					}
 					ctx.StabilizeDescForControlFlow(&d7)
 					ctx.FreeDesc(&d6)
 					d8 = args[1]
@@ -132483,9 +132583,11 @@ func init_list() {
 					} else {
 						d7 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d6}, 3)
 					}
-					ctx.BindReg(d7.Reg, &d7)
-					ctx.BindReg(d7.Reg2, &d7)
-					ctx.BindReg(d7.Reg3, &d7)
+					if d7.Loc == LocRegTriple {
+						ctx.BindReg(d7.Reg, &d7)
+						ctx.BindReg(d7.Reg2, &d7)
+						ctx.BindReg(d7.Reg3, &d7)
+					}
 					ctx.StabilizeDescForControlFlow(&d7)
 					ctx.FreeDesc(&d6)
 					d8 = args[1]
@@ -136770,9 +136872,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -139065,9 +139169,11 @@ func init_list() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[2]
@@ -140081,9 +140187,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -140813,9 +140921,11 @@ func init_list() {
 					} else {
 						d94 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d86}, 3)
 					}
-					ctx.BindReg(d94.Reg, &d94)
-					ctx.BindReg(d94.Reg2, &d94)
-					ctx.BindReg(d94.Reg3, &d94)
+					if d94.Loc == LocRegTriple {
+						ctx.BindReg(d94.Reg, &d94)
+						ctx.BindReg(d94.Reg2, &d94)
+						ctx.BindReg(d94.Reg3, &d94)
+					}
 					ctx.FreeDesc(&d86)
 					callResults95 := JITEmitGoCallResults(ctx, GoFuncAddr(JITAppendScmerSlice), []JITValueDesc{d1, d94}, []uint8{3}, []uint8{1})
 					d96 = callResults95[0]
@@ -142474,9 +142584,11 @@ func init_list() {
 					} else {
 						d148 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d140}, 3)
 					}
-					ctx.BindReg(d148.Reg, &d148)
-					ctx.BindReg(d148.Reg2, &d148)
-					ctx.BindReg(d148.Reg3, &d148)
+					if d148.Loc == LocRegTriple {
+						ctx.BindReg(d148.Reg, &d148)
+						ctx.BindReg(d148.Reg2, &d148)
+						ctx.BindReg(d148.Reg3, &d148)
+					}
 					ctx.FreeDesc(&d140)
 					callResults149 := JITEmitGoCallResults(ctx, GoFuncAddr(JITAppendScmerSlice), []JITValueDesc{d2, d148}, []uint8{3}, []uint8{1})
 					d150 = callResults149[0]
@@ -143029,9 +143141,11 @@ func init_list() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]
@@ -143491,9 +143605,11 @@ func init_list() {
 					} else {
 						d63 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d55}, 3)
 					}
-					ctx.BindReg(d63.Reg, &d63)
-					ctx.BindReg(d63.Reg2, &d63)
-					ctx.BindReg(d63.Reg3, &d63)
+					if d63.Loc == LocRegTriple {
+						ctx.BindReg(d63.Reg, &d63)
+						ctx.BindReg(d63.Reg2, &d63)
+						ctx.BindReg(d63.Reg3, &d63)
+					}
 					ctx.StabilizeDescForControlFlow(&d63)
 					ctx.FreeDesc(&d55)
 					var d64 JITValueDesc
@@ -148463,9 +148579,11 @@ func init_list() {
 				} else {
 					d1 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d0}, 3)
 				}
-				ctx.BindReg(d1.Reg, &d1)
-				ctx.BindReg(d1.Reg2, &d1)
-				ctx.BindReg(d1.Reg3, &d1)
+				if d1.Loc == LocRegTriple {
+					ctx.BindReg(d1.Reg, &d1)
+					ctx.BindReg(d1.Reg2, &d1)
+					ctx.BindReg(d1.Reg3, &d1)
+				}
 				ctx.FreeDesc(&d0)
 				d2 := jitMaterializeVirtualGoSlice(ctx, args[1:])
 				callResults3 := JITEmitGoCallResults(ctx, GoFuncAddr(JITAppendScmerSlice), []JITValueDesc{d1, d2}, []uint8{3}, []uint8{1})
@@ -148722,9 +148840,11 @@ func init_list() {
 					} else {
 						d5 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d4}, 3)
 					}
-					ctx.BindReg(d5.Reg, &d5)
-					ctx.BindReg(d5.Reg2, &d5)
-					ctx.BindReg(d5.Reg3, &d5)
+					if d5.Loc == LocRegTriple {
+						ctx.BindReg(d5.Reg, &d5)
+						ctx.BindReg(d5.Reg2, &d5)
+						ctx.BindReg(d5.Reg3, &d5)
+					}
 					ctx.StabilizeDescForControlFlow(&d5)
 					ctx.FreeDesc(&d4)
 					d6 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args) - 1))}
@@ -151696,9 +151816,11 @@ func init_list() {
 					} else {
 						d65 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d64}, 3)
 					}
-					ctx.BindReg(d65.Reg, &d65)
-					ctx.BindReg(d65.Reg2, &d65)
-					ctx.BindReg(d65.Reg3, &d65)
+					if d65.Loc == LocRegTriple {
+						ctx.BindReg(d65.Reg, &d65)
+						ctx.BindReg(d65.Reg2, &d65)
+						ctx.BindReg(d65.Reg3, &d65)
+					}
 					ctx.FreeDesc(&d64)
 					stackArray66 = ctx.AllocStack(int32(0))
 					_ = stackArray66
@@ -152006,9 +152128,11 @@ func init_list() {
 					} else {
 						d82 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d81}, 3)
 					}
-					ctx.BindReg(d82.Reg, &d82)
-					ctx.BindReg(d82.Reg2, &d82)
-					ctx.BindReg(d82.Reg3, &d82)
+					if d82.Loc == LocRegTriple {
+						ctx.BindReg(d82.Reg, &d82)
+						ctx.BindReg(d82.Reg2, &d82)
+						ctx.BindReg(d82.Reg3, &d82)
+					}
 					ctx.FreeDesc(&d81)
 					stackArray83 = ctx.AllocStack(int32(0))
 					_ = stackArray83
@@ -153191,9 +153315,11 @@ func init_list() {
 					} else {
 						d221 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d219}, 3)
 					}
-					ctx.BindReg(d221.Reg, &d221)
-					ctx.BindReg(d221.Reg2, &d221)
-					ctx.BindReg(d221.Reg3, &d221)
+					if d221.Loc == LocRegTriple {
+						ctx.BindReg(d221.Reg, &d221)
+						ctx.BindReg(d221.Reg2, &d221)
+						ctx.BindReg(d221.Reg3, &d221)
+					}
 					ctx.StabilizeDescForControlFlow(&d221)
 					ctx.FreeDesc(&d219)
 					var d222 JITValueDesc
@@ -171849,9 +171975,11 @@ func init_list() {
 					} else {
 						d2502 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2500}, 3)
 					}
-					ctx.BindReg(d2502.Reg, &d2502)
-					ctx.BindReg(d2502.Reg2, &d2502)
-					ctx.BindReg(d2502.Reg3, &d2502)
+					if d2502.Loc == LocRegTriple {
+						ctx.BindReg(d2502.Reg, &d2502)
+						ctx.BindReg(d2502.Reg2, &d2502)
+						ctx.BindReg(d2502.Reg3, &d2502)
+					}
 					ctx.StabilizeDescForControlFlow(&d2502)
 					var d2503 JITValueDesc
 					if d2502.SliceSizeKnown {
@@ -185411,9 +185539,11 @@ func init_list() {
 					} else {
 						d1 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d0}, 3)
 					}
-					ctx.BindReg(d1.Reg, &d1)
-					ctx.BindReg(d1.Reg2, &d1)
-					ctx.BindReg(d1.Reg3, &d1)
+					if d1.Loc == LocRegTriple {
+						ctx.BindReg(d1.Reg, &d1)
+						ctx.BindReg(d1.Reg2, &d1)
+						ctx.BindReg(d1.Reg3, &d1)
+					}
 					ctx.StabilizeDescForControlFlow(&d1)
 					ctx.FreeDesc(&d0)
 					ctx.EnsureDesc(&d1)

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -2321,9 +2321,11 @@ func init_list_assoc_extra() {
 				} else {
 					d8 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d7}, 3)
 				}
-				ctx.BindReg(d8.Reg, &d8)
-				ctx.BindReg(d8.Reg2, &d8)
-				ctx.BindReg(d8.Reg3, &d8)
+				if d8.Loc == LocRegTriple {
+					ctx.BindReg(d8.Reg, &d8)
+					ctx.BindReg(d8.Reg2, &d8)
+					ctx.BindReg(d8.Reg3, &d8)
+				}
 				ctx.FreeDesc(&d7)
 				ctx.EnsureDesc(&d0)
 				ctx.EnsureDesc(&d1)
@@ -4358,9 +4360,11 @@ func init_list_assoc_extra() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -5487,9 +5491,11 @@ func init_list_assoc_extra() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -6646,9 +6652,11 @@ func init_list_assoc_extra() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -7869,9 +7877,11 @@ func init_list_assoc_extra() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -8891,9 +8901,11 @@ func init_list_assoc_extra() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -4555,9 +4555,11 @@ func init() {
 				} else {
 					d2 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d1}, 3)
 				}
-				ctx.BindReg(d2.Reg, &d2)
-				ctx.BindReg(d2.Reg2, &d2)
-				ctx.BindReg(d2.Reg3, &d2)
+				if d2.Loc == LocRegTriple {
+					ctx.BindReg(d2.Reg, &d2)
+					ctx.BindReg(d2.Reg2, &d2)
+					ctx.BindReg(d2.Reg3, &d2)
+				}
 				ctx.FreeDesc(&d1)
 				ctx.EnsureDesc(&d0)
 				ctx.EnsureDesc(&d2)
@@ -4665,9 +4667,11 @@ func init() {
 				} else {
 					d2 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d1}, 3)
 				}
-				ctx.BindReg(d2.Reg, &d2)
-				ctx.BindReg(d2.Reg2, &d2)
-				ctx.BindReg(d2.Reg3, &d2)
+				if d2.Loc == LocRegTriple {
+					ctx.BindReg(d2.Reg, &d2)
+					ctx.BindReg(d2.Reg2, &d2)
+					ctx.BindReg(d2.Reg3, &d2)
+				}
 				ctx.FreeDesc(&d1)
 				ctx.EnsureDesc(&d0)
 				ctx.EnsureDesc(&d2)
@@ -5784,9 +5788,11 @@ func init() {
 					} else {
 						d5 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d4}, 3)
 					}
-					ctx.BindReg(d5.Reg, &d5)
-					ctx.BindReg(d5.Reg2, &d5)
-					ctx.BindReg(d5.Reg3, &d5)
+					if d5.Loc == LocRegTriple {
+						ctx.BindReg(d5.Reg, &d5)
+						ctx.BindReg(d5.Reg2, &d5)
+						ctx.BindReg(d5.Reg3, &d5)
+					}
 					ctx.FreeDesc(&d4)
 					callResults6 := JITEmitGoCallResults(ctx, GoFuncAddr(JITCloneScmerSlice), []JITValueDesc{d5}, []uint8{3}, []uint8{1})
 					d7 = callResults6[0]
@@ -6846,9 +6852,11 @@ func init() {
 					} else {
 						d127 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d17}, 3)
 					}
-					ctx.BindReg(d127.Reg, &d127)
-					ctx.BindReg(d127.Reg2, &d127)
-					ctx.BindReg(d127.Reg3, &d127)
+					if d127.Loc == LocRegTriple {
+						ctx.BindReg(d127.Reg, &d127)
+						ctx.BindReg(d127.Reg2, &d127)
+						ctx.BindReg(d127.Reg3, &d127)
+					}
 					callResults128 := JITEmitGoCallResults(ctx, GoFuncAddr(JITCloneScmerSlice), []JITValueDesc{d127}, []uint8{3}, []uint8{1})
 					d129 = callResults128[0]
 					d130 = JITValueDesc{Loc: LocStackTriple, Type: tagSlice, StackOff: int32(bbs[3].PhiBase) + int32(0)}
@@ -7085,9 +7093,11 @@ func init() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -8130,9 +8140,11 @@ func init() {
 					} else {
 						d118 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d14}, 3)
 					}
-					ctx.BindReg(d118.Reg, &d118)
-					ctx.BindReg(d118.Reg2, &d118)
-					ctx.BindReg(d118.Reg3, &d118)
+					if d118.Loc == LocRegTriple {
+						ctx.BindReg(d118.Reg, &d118)
+						ctx.BindReg(d118.Reg2, &d118)
+						ctx.BindReg(d118.Reg3, &d118)
+					}
 					ctx.StabilizeDescForControlFlow(&d118)
 					if ps.General {
 						ctx.SyncDesc(&d118)

--- a/scm/vector.go
+++ b/scm/vector.go
@@ -540,9 +540,11 @@ func init_vector() {
 					} else {
 						d17 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d16}, 3)
 					}
-					ctx.BindReg(d17.Reg, &d17)
-					ctx.BindReg(d17.Reg2, &d17)
-					ctx.BindReg(d17.Reg3, &d17)
+					if d17.Loc == LocRegTriple {
+						ctx.BindReg(d17.Reg, &d17)
+						ctx.BindReg(d17.Reg2, &d17)
+						ctx.BindReg(d17.Reg3, &d17)
+					}
 					ctx.StabilizeDescForControlFlow(&d17)
 					ctx.FreeDesc(&d16)
 					d18 = args[1]
@@ -553,9 +555,11 @@ func init_vector() {
 					} else {
 						d19 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d18}, 3)
 					}
-					ctx.BindReg(d19.Reg, &d19)
-					ctx.BindReg(d19.Reg2, &d19)
-					ctx.BindReg(d19.Reg3, &d19)
+					if d19.Loc == LocRegTriple {
+						ctx.BindReg(d19.Reg, &d19)
+						ctx.BindReg(d19.Reg2, &d19)
+						ctx.BindReg(d19.Reg3, &d19)
+					}
 					ctx.StabilizeDescForControlFlow(&d19)
 					ctx.FreeDesc(&d18)
 					d20 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}

--- a/scm/window.go
+++ b/scm/window.go
@@ -584,9 +584,11 @@ func init_window() {
 					} else {
 						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
 					}
-					ctx.BindReg(d3.Reg, &d3)
-					ctx.BindReg(d3.Reg2, &d3)
-					ctx.BindReg(d3.Reg3, &d3)
+					if d3.Loc == LocRegTriple {
+						ctx.BindReg(d3.Reg, &d3)
+						ctx.BindReg(d3.Reg2, &d3)
+						ctx.BindReg(d3.Reg3, &d3)
+					}
 					ctx.StabilizeDescForControlFlow(&d3)
 					ctx.FreeDesc(&d2)
 					d4 = args[1]
@@ -600,9 +602,11 @@ func init_window() {
 					} else {
 						d6 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d5}, 3)
 					}
-					ctx.BindReg(d6.Reg, &d6)
-					ctx.BindReg(d6.Reg2, &d6)
-					ctx.BindReg(d6.Reg3, &d6)
+					if d6.Loc == LocRegTriple {
+						ctx.BindReg(d6.Reg, &d6)
+						ctx.BindReg(d6.Reg2, &d6)
+						ctx.BindReg(d6.Reg3, &d6)
+					}
 					ctx.StabilizeDescForControlFlow(&d6)
 					ctx.FreeDesc(&d5)
 					var d7 JITValueDesc
@@ -7579,9 +7583,11 @@ func init_window() {
 					} else {
 						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
 					}
-					ctx.BindReg(d4.Reg, &d4)
-					ctx.BindReg(d4.Reg2, &d4)
-					ctx.BindReg(d4.Reg3, &d4)
+					if d4.Loc == LocRegTriple {
+						ctx.BindReg(d4.Reg, &d4)
+						ctx.BindReg(d4.Reg2, &d4)
+						ctx.BindReg(d4.Reg3, &d4)
+					}
 					ctx.StabilizeDescForControlFlow(&d4)
 					ctx.FreeDesc(&d3)
 					d5 = args[1]

--- a/tests/sql/expressions/jit-register-pressure.yaml
+++ b/tests/sql/expressions/jit-register-pressure.yaml
@@ -1,0 +1,46 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "SQL frontend stays native under nested JIT register pressure"
+setup:
+  - sql: "DROP TABLE IF EXISTS jit_register_pressure"
+  - sql: "CREATE TABLE jit_register_pressure (id INT PRIMARY KEY)"
+test_cases:
+  - name: "Query cache dispatcher compiles natively"
+    scm: |
+      (if (equal? (jit? (jit cached_parse)) (jit-enabled?))
+        true (error "cached_parse exhausted JIT registers"))
+  - name: "Table policy compiler and its closure compile natively"
+    scm: |
+      (if (equal? (jit? (jit sql_compile_table_policy)) (jit-enabled?))
+        true (error "sql_compile_table_policy exhausted JIT registers"))
+  - name: "Compiled policy preserves captures and catalog memoization"
+    scm: |
+      (begin
+        (define calls (newsession))
+        (calls "count" 0)
+        (define compile_policy (jit sql_compile_table_policy))
+        (define check (compile_policy (lambda (schema tbl write)
+          (begin
+            (calls "count" (+ (calls "count") 1))
+            (if (and (equal? schema "memcp-tests") (equal? tbl "jit_register_pressure"))
+              true (error "policy arguments changed"))))))
+        (check "memcp-tests" "jit_register_pressure" false)
+        (check "memcp-tests" "jit_register_pressure" false)
+        (check "memcp-tests" "jit_register_pressure" true)
+        (if (equal? (calls "count") 2) true (error "policy memoization changed")))
+  - name: "Compiled read policy still rejects access"
+    scm: |
+      (((jit sql_compile_table_policy) (lambda (schema tbl write) (error "denied")))
+        "memcp-tests" "jit_register_pressure" false)
+    expect:
+      error: true
+  - name: "Compiled write policy still rejects access"
+    scm: |
+      (((jit sql_compile_table_policy) (lambda (schema tbl write) (error "denied")))
+        "memcp-tests" "jit_register_pressure" true)
+    expect:
+      error: true
+cleanup:
+  - sql: "DROP TABLE IF EXISTS jit_register_pressure"

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -7383,9 +7383,11 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			g.emit("} else {")
 			g.emit("\t%s = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{%s}, 3)", dv, arg.goVar)
 			g.emit("}")
-			g.emit("ctx.BindReg(%s.Reg, &%s)", dv, dv)
-			g.emit("ctx.BindReg(%s.Reg2, &%s)", dv, dv)
-			g.emit("ctx.BindReg(%s.Reg3, &%s)", dv, dv)
+			g.emit("if %s.Loc == LocRegTriple {", dv)
+			g.emit("\tctx.BindReg(%s.Reg, &%s)", dv, dv)
+			g.emit("\tctx.BindReg(%s.Reg2, &%s)", dv, dv)
+			g.emit("\tctx.BindReg(%s.Reg3, &%s)", dv, dv)
+			g.emit("}")
 			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice", sliceInput: arg.sourceInput, hasSliceInput: arg.hasSourceInput}
 		case "GetTag":
 			arg := g.vals[v.Call.Args[0].Name()]


### PR DESCRIPTION
Nested list header extraction and dynamic callable dispatch can exhaust the JIT register bank while outer expressions hold live values. On `e9aba6eed`, both `cached_parse` and `sql_compile_table_policy` silently fall back to the interpreter; the new SQL regressions fail for both. With this change, both compile natively, including the policy closure.

- Decode known slice headers into a precisely rooted stack home when fewer than three scratch registers remain. Generated consumers accept that stack descriptor and load only the fields they need.
- Match fixed lists and cons patterns using the actual header location, including a direct stack load for spilled lengths.
- Save and release outer registers, including planned homes, around dynamic dispatch under register pressure. All dispatch arms commit to a rooted result slot before restoring the outer register state.
- Add regressions for native SQL frontend compilation, policy memoization and access denial, slice-header GC roots, and nested callbacks across GC/stack growth. Generated emitter changes come from `make jitgen`.

### Manual A/B measurements

Baseline `e9aba6eed` versus this change, both built with the same patched Go 1.27 Scheme JIT and PHP 8.5 configuration. Same machine, fresh private database per run, 1,024 rows `(id, a=id*3)`, identical queries, sequential baseline/candidate runs, three pairs; no concurrent builds. Repeated for final commit `b04e3c8d4`, including the stack-header pattern-matching fix. Values below are medians of the three run medians.

| Workload | Baseline | Change | Difference |
| --- | ---: | ---: | ---: |
| Cached `cached_parse` dispatch, per call | 6.171 µs | 1.952 µs | −68.4% / 3.16× |
| HTTP indexed point query | 129.683 µs | 130.629 µs | +0.7% |
| HTTP aggregate query | 141.034 µs | 137.317 µs | −2.6% |
| HTTP `EXPLAIN COMPILE` point query | 697.811 µs | 669.788 µs | −4.0% |

HTTP cases: 50 warmups and 1,000 samples per run. Point query: `SELECT a FROM jit_spill WHERE id=42`; aggregate: `SELECT SUM(a) AS total FROM jit_spill`; compile: `EXPLAIN COMPILE SELECT a FROM jit_spill WHERE id=42`. Cache-dispatch measurement: 10 warmup batches, 100 sampled batches, 1,000 `cached_parse` calls per batch via `/scm`, exact query shape, a shared session within each batch, and a `jit?` check on the returned plan. Across the three pairs, cache dispatch ranges were 6.146–6.269 µs baseline and 1.900–1.953 µs candidate. HTTP timings vary more (aggregate baseline 127.989–147.902 µs, candidate 127.353–141.991 µs). This isolates the repaired cache dispatcher; the approximately 3× improvement does not describe the entire PHP/HTTP request.

### Validation

- Baseline: both new native-compilation assertions fail. Candidate: all five register-pressure SQL cases pass, including denied read/write policies.
- `GOEXPERIMENT=jit go test ./scm ./storage -run 'TestJIT|TestFilterBufferWideArithmetic' -count=1` using the patched Go toolchain; includes register/GC/stack tests and scan-fusion admission/compaction checks.
- `go test ./tools/jitgen`.
- Follow-up regression: `boolean-tautology-folding.yaml` failed 2/7 cases before the matcher fix and passes 7/7 afterward; the JIT matcher tests cover empty, singleton, duplicate, and multi-element reduce results.
- JIT SQL suites: `jit-register-pressure.yaml`, `merge-singleton-append.yaml`, `basic-sql.yaml`, `boolean-tautology-folding.yaml` (50 cases across the original and follow-up runs).
- `make jit`, `make jitgen`, `go fmt ./...`, `git diff --check`.

Full normal/JIT integration suites and performance gates run in CI.

