### PR TITLE
Fix inclusive RAM accounting and cascading eviction ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,31 @@ curl -s -u root:admin "http://localhost:[PORT]/sql/DBNAME" -d "SELECT 1"
 - Join pipelines: drive ordered/filtered side; hash/range-probe the other; keep fuse-friendly structure; precompute hidden computed columns for FK/PK group reuse.
 
 ## Memory & CPU Efficiency
+
+### Inclusive size and eviction ownership contract (2026)
+
+- `ComputeSize()` includes the object's retained allocations and all owned
+  children. It is never an eviction weight or an exclusive registration size.
+- A global ledger charges each allocation once. Where children have their own
+  registrations, subtract them explicitly at the registration boundary.
+- Dashboard/show resident totals include indexes, temporary columns, decoded
+  dictionaries and blob caches, whether evictable or not. Do not substitute
+  cached planner sizes or the eviction ledger for these totals; never load cold
+  columns just to measure resident memory.
+- A parent eviction offer includes all children released by that action. Parent
+  and child offers can overlap; actual releases are booked exactly once, only
+  after successful cleanup. A failed TryLock cannot authorize deregistration.
+- Memory bytes, reclaimable bytes and replacement-cost weights are distinct.
+  Changing accounting does not authorize changing the policy weights.
+- `storageShard.tempColumnBytes` is protected by the shard mutex. It records
+  per-shard portions of a separately registered temporary column so the manager
+  can offer/release those portions without blocking on column computation.
+- Resident payload estimates and process RSS are not interchangeable. Keep
+  allocator/runtime/stack and unassigned process memory visible; do not force
+  agreement by rescaling database sizes.
+- Full ownership traversal is an explicit diagnostic/maintenance operation,
+  not a query, scan-row, guard, or planner-statistics hot path. Reuse published
+  scalar statistics and incremental cache-ledger updates in those paths.
 - Design principle: Cache misses are more expensive than lightweight compression. Prefer compact encodings (e.g., bit-packing 3/5‑bit integers) and sequential scans over scattered, cache‑cold access.
 - Use columnar storage to keep footprints small and hot; compress where it reduces cache lines touched even if it adds tiny (de)compression overhead.
 - Pull function calls out of loops whenever possible

--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -120,9 +120,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	)
 ))
 
-/* helper: sum size_bytes across all shards of a table */
+/* Resident table total includes metadata and all child allocations. Never use
+eviction registrations or planner snapshots as a substitute for resident RAM. */
 (define dashboard_table_size (lambda (db tbl)
-	(reduce ((show db tbl true) "shards") (lambda (acc shard) (+ acc (shard "size_bytes"))) 0)
+	((show db tbl true) "size_bytes")
 ))
 
 /* helper: join list of JSON strings into a JSON array */

--- a/storage/blob-ram.go
+++ b/storage/blob-ram.go
@@ -21,6 +21,7 @@ import "sync"
 import "time"
 import "strings"
 import "sync/atomic"
+import "unsafe"
 import "github.com/launix-de/memcp/scm"
 
 // One optional RAM owner per immutable OverlayBlob generation. It deliberately
@@ -102,6 +103,18 @@ func (c *blobRAMCache) size() int64 {
 		return 0
 	}
 	return blobRAMRegistrationBytes + int64(len(c.entries))*blobRAMEntryBytes + c.payloadBytes
+}
+
+// ComputeSize is inclusive. The fixed object survives payload eviction; only
+// cachedBytes is registered as the independently reclaimable child portion.
+func (c *blobRAMCache) ComputeSize() uint {
+	return uint(unsafe.Sizeof(*c)) + c.cachedBytes()
+}
+
+func (c *blobRAMCache) cachedBytes() uint {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return uint(c.size())
 }
 
 func blobRAMLastUsed(pointer any) time.Time {

--- a/storage/cache.go
+++ b/storage/cache.go
@@ -51,7 +51,10 @@ const (
 //   - Division cannot distinguish between "slightly less important" items
 //
 // Phase 1 (heap) pulls candidates by evictionScore (max-heap).
-// Phase 2 sorts candidates by dynamicScore = age * evictionScore - telemetry*1000.
+// Phase 2 sorts candidates by dynamicScore = age * typeWeight - telemetry*50.
+// Bytes select the bounded comparison window; priority and reuse rank it.
+// Neither score is a memory size. Parent offers include cascading releases,
+// while item.size is exclusive ledger ownership (children register separately).
 // Callers that need a minimum lifetime set it explicitly. Query-local cache
 // consumers should instead retain a Go reference for the duration of their use.
 //
@@ -706,7 +709,9 @@ func (cm *CacheManager) applyEviction(candidate evictionCandidate, mode eviction
 	before := cm.currentMemory
 	result := item.object.evict(mode, item.size, freedByType)
 	if !result.success {
-		return 0
+		// A parent can shed children before another busy child prevents full
+		// eviction. Account only the bytes actually removed, even on that retry.
+		return before - cm.currentMemory
 	}
 	if result.fullyEvicted {
 		cm.removeInternal(item.pointer, freedByType)

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -121,7 +121,7 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 			}
 			// update CacheManager size for temp columns
 			if c.IsTemp {
-				GlobalCache.SetSize(c, t.tempColumnMemory(c, shardlist))
+				t.updateTempColumnMemory(c, shardlist)
 			}
 			if metadataChanged {
 				t.ddlMu.Lock()
@@ -145,20 +145,36 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 	panic("column " + t.Name + "." + name + " does not exist")
 }
 
-func (t *table) tempColumnMemory(column *column, shards []*storageShard) int64 {
-	var size int64
+// Publish changed portions in shard mutation order. An absolute table sum
+// published after unlocking all shards could resurrect bytes already evicted
+// in the meantime. Unchanged cached columns do not send a manager operation.
+func (t *table) updateTempColumnMemory(col *column, shards []*storageShard) {
 	for _, shard := range shards {
 		if shard == nil {
 			continue
 		}
-		shard.mu.RLock()
-		storage := shard.columns[column.Name]
+		shard.mu.Lock()
+		storage := shard.columns[col.Name]
+		var part int64
 		if storage != nil {
-			size += int64(ownedColumnMemory(storage))
+			part = int64(ownedColumnMemory(storage))
 		}
-		shard.mu.RUnlock()
+		if shard.tempColumnBytes == nil {
+			shard.tempColumnBytes = make(map[*column]int64)
+		}
+		delta := part - shard.tempColumnBytes[col]
+		shard.tempColumnBytes[col] = part
+		var ready, done chan struct{}
+		if delta != 0 && GlobalCache.opChan != nil && !GlobalCache.stopped.Load() {
+			ready, done = make(chan struct{}), make(chan struct{})
+			GlobalCache.opChan <- cacheOp{updatePtr: col, updateDelta: delta, ready: ready, done: done}
+		}
+		shard.mu.Unlock()
+		if ready != nil {
+			close(ready)
+			<-done
+		}
 	}
-	return size
 }
 
 func (t *table) ComputeColumn(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer) {

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -371,10 +371,15 @@ func (p *StorageComputeProxy) orcCol() *column {
 }
 
 func (p *StorageComputeProxy) ComputeSize() uint {
-	var sz uint = 128 // struct overhead
+	sz := uint(unsafe.Sizeof(*p))
 	sz += p.validMask.ComputeSize()
 	p.mu.RLock()
-	sz += uint(len(p.delta)) * 24 // rough estimate per map entry
+	// Map bookkeeping plus owned Scmer payloads; the shard/computor references
+	// are non-owning and must not recursively recount the catalog/plan graph.
+	sz += uint(len(p.delta)) * 32
+	for _, value := range p.delta {
+		sz += scm.ComputeSize(value)
+	}
 	if p.main != nil {
 		sz += p.main.ComputeSize()
 	}

--- a/storage/database.go
+++ b/storage/database.go
@@ -1820,16 +1820,16 @@ func registerCreatedTable(t *table) {
 	// to avoid deadlock: AddItem → run() → evict → keytableCleanup → TryLock(schemalock)
 	if t.isEphemeralQueryTable() {
 		schemaName := t.schema.Name
-		GlobalCache.AddItem(t, int64(t.ComputeSize()), TypeTempKeytable, func(ptr any, freedByType *[numEvictableTypes]int64) bool {
+		GlobalCache.AddItem(t, int64(t.exclusiveSize()), TypeTempKeytable, func(ptr any, freedByType *[numEvictableTypes]int64) bool {
 			return keytableCleanup(ptr.(*table), schemaName, freedByType)
 		}, keytableLastUsed, nil)
 	} else if t.PersistencyMode == Cache {
 		// Register the initial shard so eviction can reach it before the first rebuild.
-		GlobalCache.AddItem(t.Shards[0], int64(t.Shards[0].ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+		GlobalCache.AddItem(t.Shards[0], int64(t.Shards[0].exclusiveSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 	} else if t.PersistencyMode != Memory {
 		// The initial writable generation owns WAL/delta memory before its first
 		// rebuild just as much as a rebuilt shard does.
-		GlobalCache.AddItem(t.Shards[0], int64(t.Shards[0].ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
+		GlobalCache.AddItem(t.Shards[0], int64(t.Shards[0].exclusiveSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 	}
 }
 
@@ -1956,9 +1956,19 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 			db.schemalock.Unlock()
 			return false
 		}
+		// Release child caches while the catalog entry is still recoverable.
+		// A busy child must not leave a removed table with untracked indexes.
+		if !tbl.evictShardChildren(freedByType) {
+			atomic.StoreInt64(&tbl.cacheUsers, 0)
+			db.schemalock.Unlock()
+			return false
+		}
 		db.tables.Remove(tbl.Name)
 		db.saveLockedAndUnlock(tbl.schemaSaveMode())
 	} else if !tbl.beginCacheEviction() {
+		return false
+	} else if !tbl.evictShardChildren(freedByType) {
+		atomic.StoreInt64(&tbl.cacheUsers, 0)
 		return false
 	}
 	// remove all shard+index+temp column registrations for this table (recursive)
@@ -1969,17 +1979,9 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 	}
 	for _, s := range tbl.Shards {
 		GlobalCache.removeInternal(s, freedByType)
-		for _, idx := range s.Indexes {
-			GlobalCache.removeInternal(idx, freedByType)
-			idx.evict(evictFull, 0, freedByType)
-		}
 	}
 	for _, s := range tbl.PShards {
 		GlobalCache.removeInternal(s, freedByType)
-		for _, idx := range s.Indexes {
-			GlobalCache.removeInternal(idx, freedByType)
-			idx.evict(evictFull, 0, freedByType)
-		}
 	}
 	for _, s := range tbl.Shards {
 		s.RemoveFromDisk()
@@ -2002,4 +2004,21 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 func keytableLastUsed(ptr any) time.Time {
 	tbl := ptr.(*table)
 	return time.Unix(0, int64(atomic.LoadUint64(&tbl.lastAccessed)))
+}
+
+func (t *table) evictShardChildren(freedByType *[numEvictableTypes]int64) bool {
+	for _, shard := range t.ActiveShards() {
+		if shard == nil {
+			continue
+		}
+		if !shard.mu.TryLock() {
+			return false
+		}
+		ok := shard.evictChildrenLocked(freedByType)
+		shard.mu.Unlock()
+		if !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/storage/index.go
+++ b/storage/index.go
@@ -23,6 +23,7 @@ import "math/bits"
 import "sort"
 import "sync"
 import "time"
+import "unsafe"
 import "strings"
 import "sync/atomic"
 
@@ -410,17 +411,33 @@ func (idx *StorageIndex) storeSavings(value float64) {
 }
 
 func (idx *StorageIndex) ComputeSize() uint {
-	var sz uint = 24 * 8 // heuristic
-	for _, state := range []*storageIndexState{&idx.baseState} {
-		if !idx.Native {
-			sz += state.mainIndexes.ComputeSize()
-		}
-		if state.mainIndexPositions.count > 0 {
-			sz += state.mainIndexPositions.ComputeSize()
-		}
-		sz += uint(state.indexHookBytes.Load())
-		sz += idx.computeDeltaBtreeSize(state)
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	return idx.computeSizeLocked()
+}
+
+// Inclusive owned allocations. The shard and immutable source values referenced
+// by bounds/revisions are borrowed, not recursively owned by the index. This
+// walk runs at publication and explicit diagnostics, never per matched row.
+func (idx *StorageIndex) computeSizeLocked() uint {
+	state := &idx.baseState
+	sz := uint(unsafe.Sizeof(*idx))
+	sz += uint(cap(idx.Cols)+cap(idx.ColOrderMeta)) * uint(unsafe.Sizeof(""))
+	sz += uint(cap(idx.ColMapCols)) * uint(unsafe.Sizeof([]string{}))
+	for _, cols := range idx.ColMapCols {
+		sz += uint(cap(cols)) * uint(unsafe.Sizeof(""))
 	}
+	sz += uint(cap(idx.ColMapFn)) * uint(unsafe.Sizeof(scm.Scmer{}))
+	sz += uint(cap(idx.ColMatchers)) * uint(unsafe.Sizeof((*IndexAnalyzer)(nil))) * 2
+	sz += uint(cap(idx.ColOrder)) * uint(unsafe.Sizeof((func(scm.Scmer, scm.Scmer) bool)(nil)))
+	// StorageInt structs are embedded; only their backing allocations add RAM.
+	sz += state.mainIndexes.ComputeSize() - uint(unsafe.Sizeof(state.mainIndexes))
+	sz += state.mainIndexPositions.ComputeSize() - uint(unsafe.Sizeof(state.mainIndexPositions))
+	sz += uint(cap(state.minVals)+cap(state.maxVals)) * uint(unsafe.Sizeof(scm.Scmer{}))
+	sz += uint(cap(state.indexHooks)) * uint(unsafe.Sizeof((*IndexHook)(nil))) * 2
+	sz += uint(cap(state.computedRevisions)) * uint(unsafe.Sizeof(computedRevision{}))
+	sz += uint(state.indexHookBytes.Load())
+	sz += idx.computeDeltaBtreeSize(state)
 	return sz
 }
 
@@ -1276,7 +1293,7 @@ func (s *StorageIndex) buildMainIndexPositionsLocked(state *storageIndexState) u
 		}
 		base += chunkCount
 	}
-	return state.mainIndexPositions.ComputeSize()
+	return state.mainIndexPositions.ComputeSize() - uint(unsafe.Sizeof(state.mainIndexPositions))
 }
 
 func recSetSortWork(rows int64) int64 {

--- a/storage/memory_ownership_test.go
+++ b/storage/memory_ownership_test.go
@@ -55,13 +55,13 @@ func TestShardMemoryExcludesSeparatelyOwnedTempColumn(t *testing.T) {
 	}}
 	shard := &storageShard{
 		t:            table,
-		columns:      map[string]ColumnStorage{"base": &StorageConst{value: scm.NewInt(1), count: 1}},
+		columns:      map[string]ColumnStorage{"base": &StorageConst{value: scm.NewInt(1), count: 1}, "cached": nil},
 		deltaColumns: make(map[string]int),
 		srState:      SHARED,
 	}
-	before := shard.ComputeSize()
+	before := shard.exclusiveSize()
 	shard.columns["cached"] = &StorageConst{value: scm.NewString("separately-owned"), count: 1}
-	after := shard.ComputeSize()
+	after := shard.exclusiveSize()
 	if after != before {
 		t.Fatalf("shard owns separately accounted temp-column bytes: before=%d after=%d", before, after)
 	}
@@ -77,9 +77,9 @@ func TestShardMemoryExcludesMaterializedCompressedDictionary(t *testing.T) {
 		deltaColumns: make(map[string]int),
 		srState:      SHARED,
 	}
-	before := shard.ComputeSize()
+	before := shard.exclusiveSize()
 	strings.dictionary = "materialized-dictionary"
-	if after := shard.ComputeSize(); after != before {
+	if after := shard.exclusiveSize(); after != before {
 		t.Fatalf("shard size grew with separately owned dictionary: before=%d after=%d", before, after)
 	}
 }
@@ -109,12 +109,13 @@ func TestShardMemoryExcludesSeparatelyOwnedIndex(t *testing.T) {
 		columns:      make(map[string]ColumnStorage),
 		deltaColumns: make(map[string]int),
 		srState:      SHARED,
+		Indexes:      make([]*StorageIndex, 1), // reserve the parent-owned pointer slot
 	}
-	before := shard.ComputeSize()
+	before := shard.exclusiveSize()
 	idx := &StorageIndex{}
 	idx.baseState.mainIndexes.initValuesUInt32(1024, 0, 1023)
-	shard.Indexes = []*StorageIndex{idx}
-	after := shard.ComputeSize()
+	shard.Indexes[0] = idx
+	after := shard.exclusiveSize()
 	if after != before {
 		t.Fatalf("shard owns separately accounted index bytes: before=%d after=%d index=%d",
 			before, after, idx.ComputeSize())
@@ -153,4 +154,92 @@ func TestScmerCustomHandleDoesNotClaimOwnedPayload(t *testing.T) {
 	if got := scm.ComputeSize(NewTableScmer(tbl)); got != 16 {
 		t.Fatalf("custom handle size = %d, want one Scmer slot", got)
 	}
+}
+
+func TestShardInclusiveSizeAndBusyChildEviction(t *testing.T) {
+	defer setupGCTest(t)()
+	shard := &storageShard{columns: make(map[string]ColumnStorage), srState: SHARED}
+	index := &StorageIndex{}
+	index.baseState.mainIndexes.initValuesUInt32(1024, 0, 1023)
+	shard.Indexes = []*StorageIndex{index}
+	if got, want := shard.ComputeSize(), shard.exclusiveSize()+index.ComputeSize(); got != want {
+		t.Fatalf("inclusive shard size %d != base plus index %d", got, want)
+	}
+	// Registration goes through the manager; the failed TryLock below returns
+	// before cleanup touches the manager's single-owner map.
+	GlobalCache.AddItem(index, int64(index.ComputeSize()), TypeIndex, indexCleanup, indexLastUsed, indexGetScore)
+	index.mu.Lock()
+	// Cleanup must not deregister the index when its lock cannot be acquired.
+	if shardCleanup(shard, nil) {
+		t.Fatal("busy index must prevent full shard release")
+	}
+	index.mu.Unlock()
+	if got := GlobalCache.Stat().CountByType[TypeIndex]; got < 1 {
+		t.Fatal("busy index disappeared from memory ledger")
+	}
+	GlobalCache.Remove(index)
+}
+
+func TestShardFullOfferAndReleaseCountChildrenExactlyOnce(t *testing.T) {
+	defer setupGCTest(t)()
+	shard := &storageShard{columns: make(map[string]ColumnStorage), srState: SHARED}
+	index := &StorageIndex{}
+	index.baseState.mainIndexes.initValuesUInt32(1024, 0, 1023)
+	shard.Indexes = []*StorageIndex{index}
+	GlobalCache.AddItem(index, int64(index.ComputeSize()), TypeIndex, indexCleanup, indexLastUsed, indexGetScore)
+	GlobalCache.AddItem(shard, int64(shard.exclusiveSize()), TypeShard, shardCleanup, shardLastUsed, nil)
+	// Stop the worker before exercising its single-owner internals directly.
+	GlobalCache.Stop()
+	defer resumeOwnershipTestCache()
+	parent := GlobalCache.itemMap[shard]
+	offer := shard.evictionOffer(parent.size)
+	want := parent.size + GlobalCache.itemMap[index].size
+	if offer.partialBytes != 0 || offer.fullBytes != want {
+		t.Fatalf("parent offer %+v, want full union %d", offer, want)
+	}
+	var byType [numEvictableTypes]int64
+	freed := GlobalCache.applyEviction(evictionCandidate{item: parent, offer: offer}, evictFull, &byType)
+	if freed != want || byType[TypeShard]+byType[TypeIndex] != want {
+		t.Fatalf("release counted wrong: actual=%d types=%v want=%d", freed, byType, want)
+	}
+	if GlobalCache.itemMap[index] != nil || GlobalCache.itemMap[shard] != nil {
+		t.Fatal("evicted owner remains registered")
+	}
+}
+
+func TestChildCacheCleanupRetainsResidentTempColumnAccounting(t *testing.T) {
+	defer setupGCTest(t)()
+	col := &column{}
+	shard := &storageShard{
+		columns:         make(map[string]ColumnStorage),
+		tempColumnBytes: map[*column]int64{col: 512},
+	}
+	GlobalCache.AddItem(col, 512, TypeTempColumn,
+		func(any, *[numEvictableTypes]int64) bool { return true },
+		func(any) time.Time { return time.Time{} }, nil)
+	GlobalCache.Stop()
+	defer resumeOwnershipTestCache()
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+	if !shard.evictChildrenLocked(nil) {
+		t.Fatal("empty child-cache cleanup failed")
+	}
+	// Another shard can still veto a table eviction. No payload has been
+	// detached here, so its separate registration must retain all its bytes.
+	if got := GlobalCache.itemMap[col].size; got != 512 || shard.tempColumnBytes[col] != 512 {
+		t.Fatalf("resident payload prematurely subtracted: registration=%d", got)
+	}
+	shard.releaseTempColumnBytesLocked(nil)
+	if got := GlobalCache.itemMap[col].size; got != 0 {
+		t.Fatalf("detached shard portion remains charged: %d", got)
+	}
+}
+
+// Tests pause the single-owner worker to inspect its ledger without racing it.
+// Resume with the same registrations so subsequent tests retain their owners.
+func resumeOwnershipTestCache() {
+	GlobalCache.opChan = make(chan cacheOp, 1024)
+	GlobalCache.runDone = make(chan struct{})
+	GlobalCache.stopped.Store(false)
+	go GlobalCache.run()
 }

--- a/storage/overlay-blob.go
+++ b/storage/overlay-blob.go
@@ -48,7 +48,14 @@ type OverlayBlob struct {
 const maxInlineBlobBytes = 2 * 1024
 
 func (s *OverlayBlob) ComputeSize() uint {
-	return uint(unsafe.Sizeof(*s)) + uint(unsafe.Sizeof(blobRAMCache{})) + s.size + s.Base.ComputeSize()
+	size := uint(unsafe.Sizeof(*s)) + s.size
+	if s.ram != nil {
+		size += s.ram.ComputeSize()
+	}
+	if s.Base != nil {
+		size += s.Base.ComputeSize()
+	}
+	return size
 }
 
 func (s *OverlayBlob) String() string {

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -1242,12 +1242,12 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maint
 		if t.PersistencyMode == Cache && !t.isEphemeralQueryTable() {
 			for _, s := range newshards {
 				atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
-				GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+				GlobalCache.AddItem(s, int64(s.exclusiveSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 			}
 		} else if t.PersistencyMode != Memory && !t.isEphemeralQueryTable() {
 			for _, s := range newshards {
 				atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
-				GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
+				GlobalCache.AddItem(s, int64(s.exclusiveSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 			}
 		}
 	}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -23,6 +23,7 @@ import "sync/atomic"
 import "time"
 import "strings"
 import "reflect"
+import "unsafe"
 import "runtime"
 import "encoding/json"
 import "encoding/binary"
@@ -49,6 +50,9 @@ type storageShard struct {
 	// must treat s.mu as the only authority for shard-local state and must not
 	// read Go maps here lock-free.
 	columns map[string]ColumnStorage
+	// Published alongside temp-column size accounting, under mu. Eviction uses
+	// these exclusive per-shard portions without blocking on a computing column.
+	tempColumnBytes map[*column]int64
 	// delta storage
 	deltaColumns map[string]int
 	inserts      [][]scm.Scmer                       // items added to storage
@@ -287,10 +291,14 @@ func (s *storageShard) recordNextInsertRange(oldStartRecid, newStartRecid uint32
 	s.nextTranslationMu.Unlock()
 }
 
-// computeSizeLocked computes the shard's memory footprint without acquiring s.mu.
+// exclusiveSizeLocked is EXCLUSIVE ownership for CacheManager registration, not
+// the shard's resident total or the bytes a cascading eviction can release.
+// Children have separate registrations and must not be charged twice globally.
 // Caller must already hold s.mu (read or write).
-func (s *storageShard) computeSizeLocked() uint {
-	var result uint = 14*8 + 32*8 // heuristic for columns map
+func (s *storageShard) exclusiveSizeLocked() uint {
+	// Fixed layout is exact; Go map bucket overhead remains an estimate.
+	result := uint(unsafe.Sizeof(*s)) + 64*uint(len(s.columns)+len(s.deltaColumns)+len(s.tempColumnBytes))
+	result += uint(cap(s.Indexes)) * uint(unsafe.Sizeof((*StorageIndex)(nil)))
 	if s.srState != COLD {
 		for name, c := range s.columns {
 			if c != nil && s.ownsColumnMemory(name) {
@@ -309,7 +317,73 @@ func (s *storageShard) computeSizeLocked() uint {
 func (s *storageShard) ComputeSize() uint {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.computeSizeLocked()
+	return s.residentMemoryLocked().total()
+}
+
+func (s *storageShard) exclusiveSize() uint {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.exclusiveSizeLocked()
+}
+
+// residentMemoryLocked includes every child owner, irrespective of eviction
+// eligibility or weight. It never loads a cold column. Caller holds s.mu.
+func (s *storageShard) residentMemoryLocked() memoryOwnerSnapshot {
+	m := memoryOwnerSnapshot{base: s.exclusiveSizeLocked()}
+	for name, column := range s.columns {
+		if column == nil {
+			continue
+		}
+		if !s.ownsColumnMemory(name) {
+			m.tempColumns += ownedColumnMemory(column)
+		}
+		m.stringDictionaries += materializedDictionaryMemory(column)
+		visitColumnCaches(column, false, func(owner any) bool {
+			if blob, ok := owner.(*blobRAMCache); ok {
+				m.blobCaches += blob.cachedBytes()
+			}
+			return true
+		})
+	}
+	for _, index := range s.Indexes {
+		if index != nil {
+			m.indexes += index.ComputeSize()
+		}
+	}
+	return m
+}
+
+// Child ownership follows storage wrappers, not just the outer column type.
+// These callbacks must not acquire a shard lock or call the public manager API.
+func visitColumnCaches(column any, nonblocking bool, visit func(any) bool) bool {
+	switch c := column.(type) {
+	case *StorageString:
+		if c.compressed {
+			return visit(c)
+		}
+	case *OverlayBlob:
+		if c.ram != nil && !visit(c.ram) {
+			return false
+		}
+		if c.Base != nil {
+			return visitColumnCaches(c.Base, nonblocking, visit)
+		}
+	case *StoragePrefix:
+		return visitColumnCaches(&c.values, nonblocking, visit)
+	case *StorageComputeProxy:
+		if nonblocking {
+			if !c.mu.TryRLock() {
+				return false
+			}
+		} else {
+			c.mu.RLock()
+		}
+		defer c.mu.RUnlock()
+		if c.main != nil {
+			return visitColumnCaches(c.main, nonblocking, visit)
+		}
+	}
+	return true
 }
 
 func (s *storageShard) ownsColumnMemory(name string) bool {
@@ -333,6 +407,12 @@ func ownedColumnMemory(storage ColumnStorage) uint {
 	}
 	size := storage.ComputeSize()
 	materialized := materializedDictionaryMemory(storage)
+	visitColumnCaches(storage, false, func(owner any) bool {
+		if blob, ok := owner.(*blobRAMCache); ok {
+			materialized += blob.cachedBytes()
+		}
+		return true
+	})
 	if materialized <= size {
 		size -= materialized
 	}
@@ -390,7 +470,7 @@ func (s *storageShard) statsSnapshotRLocked() shardStatsSnapshot {
 		delta:     len(s.inserts),
 		deletions: s.deletions.Count(),
 		state:     s.srState,
-		size:      s.computeSizeLocked(),
+		size:      s.exclusiveSizeLocked(),
 	}
 }
 
@@ -808,9 +888,9 @@ func (s *storageShard) ensureLoaded() {
 	atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
 	// register with CacheManager (skip Memory-engine shards and temp tables)
 	if s.t.PersistencyMode == Cache && !s.t.isEphemeralQueryTable() {
-		GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+		GlobalCache.AddItem(s, int64(s.exclusiveSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 	} else if s.t.PersistencyMode != Memory && !s.t.isEphemeralQueryTable() {
-		GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
+		GlobalCache.AddItem(s, int64(s.exclusiveSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 	}
 }
 
@@ -831,25 +911,117 @@ func shardCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 		s.mu.Unlock()
 		return false // has unflushed deltas, skip eviction (rebuild will flush them)
 	}
+	if !s.evictChildrenLocked(freedByType) {
+		s.mu.Unlock()
+		return false
+	}
 	if s.logfile != nil {
 		s.logfile.Close()
 		s.logfile = nil
 	}
-	// remove indexes from CacheManager (recursive free)
-	for _, idx := range s.Indexes {
-		GlobalCache.removeInternal(idx, freedByType)
-		idx.evict(evictFull, 0, freedByType)
-	}
+	s.releaseTempColumnBytesLocked(freedByType)
 	// release column storage (deregister compressed string dicts first)
 	for col := range s.columns {
-		if str, ok := s.columns[col].(*StorageString); ok && str.compressed {
-			GlobalCache.removeInternal(str, freedByType)
-		}
 		s.columns[col] = nil
 	}
 	s.srState = COLD
 	s.mu.Unlock()
 	return true
+}
+
+// A shard's full offer includes its children. Exclusive ledger bytes are NOT
+// its reclamation potential. Children may be evicted separately first; the
+// manager revalidates registrations and books their union only once.
+func (s *storageShard) evictionOffer(currentSize int64) evictionOffer {
+	if !s.mu.TryRLock() {
+		return evictionOffer{}
+	}
+	defer s.mu.RUnlock()
+	if s.t != nil && (s.t.PersistencyMode == Memory ||
+		(s.t.PersistencyMode != Cache && (len(s.inserts) > 0 || s.deletions.Count() > 0))) {
+		return evictionOffer{}
+	}
+	full := currentSize
+	for _, index := range s.Indexes {
+		if item := GlobalCache.itemMap[index]; item != nil {
+			full += item.size
+		}
+	}
+	for column, size := range s.tempColumnBytes {
+		if item := GlobalCache.itemMap[column]; item != nil {
+			full += min(size, item.size)
+		}
+	}
+	for _, column := range s.columns {
+		if !visitColumnCaches(column, true, func(owner any) bool {
+			if item := GlobalCache.itemMap[owner]; item != nil {
+				full += item.size
+			}
+			return true
+		}) {
+			return evictionOffer{}
+		}
+	}
+	return evictionOffer{fullBytes: full}
+}
+
+func (s *storageShard) evict(mode evictionMode, currentSize int64, freedByType *[numEvictableTypes]int64) evictionResult {
+	if mode != evictFull {
+		return evictionResult{}
+	}
+	var ok bool
+	if s.t != nil && s.t.PersistencyMode == Cache {
+		ok = cacheShardCleanup(s, freedByType)
+	} else {
+		ok = shardCleanup(s, freedByType)
+	}
+	return evictionResult{success: ok, fullyEvicted: ok, freedBytes: currentSize}
+}
+
+// Called on the manager goroutine under the shard lock. A busy child remains
+// registered and prevents parent release. Never book a failed TryLock as freed.
+func (s *storageShard) evictChildrenLocked(freedByType *[numEvictableTypes]int64) bool {
+	for _, index := range s.Indexes {
+		if !index.evict(evictFull, 0, freedByType).success {
+			return false
+		}
+		GlobalCache.removeInternal(index, freedByType)
+	}
+	for _, column := range s.columns {
+		if !evictColumnCaches(column, freedByType) {
+			return false
+		}
+	}
+	return true
+}
+
+// Book temporary column payload only when this shard actually detaches it.
+// Merely evicting child caches is insufficient: another shard may prevent a
+// parent table eviction, leaving these column buffers resident and usable.
+func (s *storageShard) releaseTempColumnBytesLocked(freedByType *[numEvictableTypes]int64) {
+	for column, size := range s.tempColumnBytes {
+		if item := GlobalCache.itemMap[column]; item != nil {
+			freed := min(size, item.size)
+			GlobalCache.updateSizeInternal(column, -freed)
+			if freedByType != nil {
+				freedByType[TypeTempColumn] += freed
+			}
+		}
+	}
+	clear(s.tempColumnBytes)
+}
+
+func evictColumnCaches(column ColumnStorage, freedByType *[numEvictableTypes]int64) bool {
+	return visitColumnCaches(column, true, func(owner any) bool {
+		if item := GlobalCache.itemMap[owner]; item != nil {
+			result := item.object.evict(evictFull, item.size, freedByType)
+			if !result.success || !result.fullyEvicted {
+				return false
+			}
+			GlobalCache.removeInternal(owner, freedByType)
+		}
+		return true
+	})
 }
 
 func shardLastUsed(ptr any) time.Time {
@@ -863,21 +1035,18 @@ func cacheShardCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	if !s.mu.TryLock() {
 		return false // shard is in use, retry later
 	}
-	// remove indexes from CacheManager (recursive free)
-	for _, idx := range s.Indexes {
-		GlobalCache.removeInternal(idx, freedByType)
-		idx.evict(evictFull, 0, freedByType)
+	if !s.evictChildrenLocked(freedByType) {
+		s.mu.Unlock()
+		return false
 	}
 	// clear in-memory data (no disk backing to flush to)
+	s.releaseTempColumnBytesLocked(freedByType)
 	s.inserts = nil
 	s.plannerDeltaRows.Store(0)
 	s.deletions.Reset()
 	s.main_count = 0
 	s.plannerMainRows.Store(0)
 	for col := range s.columns {
-		if str, ok := s.columns[col].(*StorageString); ok && str.compressed {
-			GlobalCache.removeInternal(str, freedByType)
-		}
 		s.columns[col] = nil
 	}
 	// COLD: on next access ensureLoaded re-initialises as empty and re-registers
@@ -3342,7 +3511,7 @@ func transitionShardEngine(s *storageShard, oldMode, newMode PersistencyMode) {
 		s.removePersistence()
 		if newMode == Cache && !s.t.isEphemeralQueryTable() {
 			s.srState = SHARED
-			GlobalCache.AddItem(s, int64(s.computeSizeLocked()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+			GlobalCache.AddItem(s, int64(s.exclusiveSizeLocked()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 		} else {
 			s.srState = WRITE
 		}
@@ -3371,14 +3540,14 @@ func transitionShardEngine(s *storageShard, oldMode, newMode PersistencyMode) {
 		}
 		s.srState = SHARED
 		if !s.t.isEphemeralQueryTable() {
-			GlobalCache.AddItem(s, int64(s.computeSizeLocked()), TypeShard, shardCleanup, shardLastUsed, nil)
+			GlobalCache.AddItem(s, int64(s.exclusiveSizeLocked()), TypeShard, shardCleanup, shardLastUsed, nil)
 		}
 
 	case oldMode == Memory && newMode == Cache:
 		// Memory → Cache: register with CacheManager as TypeCacheEntry
 		s.srState = SHARED
 		if !s.t.isEphemeralQueryTable() {
-			GlobalCache.AddItem(s, int64(s.computeSizeLocked()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+			GlobalCache.AddItem(s, int64(s.exclusiveSizeLocked()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 		}
 
 	case oldMode == Cache && newMode == Memory:
@@ -3542,9 +3711,9 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 			// Re-register old shard with CacheManager if we deregistered it
 			if removedFromCache && t.t != nil {
 				if t.t.PersistencyMode == Cache && !t.t.isEphemeralQueryTable() {
-					GlobalCache.AddItem(t, int64(t.ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+					GlobalCache.AddItem(t, int64(t.exclusiveSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 				} else if t.t.PersistencyMode != Memory && !t.t.isEphemeralQueryTable() {
-					GlobalCache.AddItem(t, int64(t.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
+					GlobalCache.AddItem(t, int64(t.exclusiveSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 				}
 			}
 			panic(r)
@@ -3880,15 +4049,22 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 	if result.uuid != t.uuid {
 		writeBlobManifest(result)
 	}
+	// The replacement generation inherits the already registered temporary
+	// column portions. Recounting a repaired proxy later adjusts this baseline
+	// instead of charging the same column again after every rebuild.
+	t.mu.Lock()
+	result.tempColumnBytes = t.tempColumnBytes
+	t.tempColumnBytes = nil
+	t.mu.Unlock()
 	// Unlock result before registration (ComputeSize needs RLock)
 	result.mu.Unlock()
 	resultLocked = false
 	// Register the new shard with CacheManager
 	atomic.StoreUint64(&result.lastAccessed, uint64(time.Now().UnixNano()))
 	if result.t.PersistencyMode == Cache && !result.t.isEphemeralQueryTable() {
-		GlobalCache.AddItem(result, int64(result.ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+		GlobalCache.AddItem(result, int64(result.exclusiveSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 	} else if result.t.PersistencyMode != Memory && !result.t.isEphemeralQueryTable() {
-		GlobalCache.AddItem(result, int64(result.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
+		GlobalCache.AddItem(result, int64(result.exclusiveSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 	}
 	return result
 }

--- a/storage/storage-const.go
+++ b/storage/storage-const.go
@@ -38,7 +38,7 @@ func (s *StorageConst) String() string {
 }
 
 func (s *StorageConst) ComputeSize() uint {
-	return 48 + scm.ComputeSize(s.value)
+	return uint(unsafe.Sizeof(*s)-unsafe.Sizeof(s.value)) + scm.ComputeSize(s.value)
 }
 
 func (s *StorageConst) GetValue(i uint32) scm.Scmer {

--- a/storage/storage-decimal.go
+++ b/storage/storage-decimal.go
@@ -98,7 +98,7 @@ func detectFloatScale(f float64) int8 {
 }
 
 func (s *StorageDecimal) ComputeSize() uint {
-	return s.inner.ComputeSize() + 2 // 1 byte magic + 1 byte scaleExp
+	return uint(unsafe.Sizeof(*s)-unsafe.Sizeof(s.inner)) + s.inner.ComputeSize()
 }
 
 func (s *StorageDecimal) String() string {

--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -101,12 +101,12 @@ func (s *StorageEnum) String() string {
 }
 
 func (s *StorageEnum) ComputeSize() uint {
-	var sz uint = 200 // struct overhead estimate
-	sz += 8 * uint(len(s.data))
-	sz += 4 * uint(len(s.jumpL1))
-	sz += 2 * uint(len(s.jumpL2))
+	sz := uint(unsafe.Sizeof(*s))
+	sz += 8 * uint(cap(s.data))
+	sz += 4 * uint(cap(s.jumpL1))
+	sz += 2 * uint(cap(s.jumpL2))
 	for i := uint8(0); i < s.k; i++ {
-		sz += scm.ComputeSize(s.values[i])
+		sz += scm.ComputeSize(s.values[i]) - uint(unsafe.Sizeof(s.values[i]))
 	}
 	return sz
 }

--- a/storage/storage-float.go
+++ b/storage/storage-float.go
@@ -34,7 +34,7 @@ type StorageFloat struct {
 }
 
 func (s *StorageFloat) ComputeSize() uint {
-	return 16 + 8*uint(len(s.values)) + 24 /* a slice */
+	return uint(unsafe.Sizeof(*s)) + 8*uint(cap(s.values))
 }
 
 func (s *StorageFloat) String() string {

--- a/storage/storage-int.go
+++ b/storage/storage-int.go
@@ -2415,7 +2415,7 @@ func (s *StorageInt) deserializeIntV0(f io.Reader) uint {
 }
 
 func (s *StorageInt) ComputeSize() uint {
-	return 8*uint(len(s.chunk)) + 64 // management overhead
+	return uint(unsafe.Sizeof(*s)) + 8*uint(cap(s.chunk))
 }
 
 func (s *StorageInt) String() string {

--- a/storage/storage-prefix.go
+++ b/storage/storage-prefix.go
@@ -30,7 +30,12 @@ type StoragePrefix struct {
 }
 
 func (s *StoragePrefix) ComputeSize() uint {
-	return s.prefixes.ComputeSize() + 24 + s.values.ComputeSize()
+	size := uint(unsafe.Sizeof(*s)-unsafe.Sizeof(s.prefixes)-unsafe.Sizeof(s.values)) + s.prefixes.ComputeSize() + s.values.ComputeSize()
+	size += uint(cap(s.prefixdictionary)) * uint(unsafe.Sizeof(string("")))
+	for _, prefix := range s.prefixdictionary {
+		size += uint(len(prefix))
+	}
+	return size
 }
 
 func (s *StoragePrefix) String() string {

--- a/storage/storage-scmer.go
+++ b/storage/storage-scmer.go
@@ -47,8 +47,8 @@ type StorageSCMER struct {
 }
 
 func (s *StorageSCMER) ComputeSize() uint {
-	// ! size of Scmer values is not considered
-	var sz uint = 80 + 24
+	// ComputeSize(v) includes its Scmer slot; charge spare capacity separately.
+	sz := uint(unsafe.Sizeof(*s)) + uint(cap(s.values)-len(s.values))*uint(unsafe.Sizeof(scm.Scmer{}))
 	for _, v := range s.values {
 		sz += scm.ComputeSize(v)
 	}

--- a/storage/storage-seq.go
+++ b/storage/storage-seq.go
@@ -40,7 +40,7 @@ type StorageSeq struct {
 }
 
 func (s *StorageSeq) ComputeSize() uint {
-	return s.recordId.ComputeSize() + s.start.ComputeSize() + s.stride.ComputeSize() + 8*8
+	return uint(unsafe.Sizeof(*s)-unsafe.Sizeof(s.recordId)-unsafe.Sizeof(s.start)-unsafe.Sizeof(s.stride)) + s.recordId.ComputeSize() + s.start.ComputeSize() + s.stride.ComputeSize()
 }
 
 func (s *StorageSeq) String() string {

--- a/storage/storage-sparse.go
+++ b/storage/storage-sparse.go
@@ -31,7 +31,7 @@ type StorageSparse struct {
 }
 
 func (s *StorageSparse) ComputeSize() uint {
-	var sz uint = 16 + 8 + 24 + s.recids.ComputeSize() + 8*uint(len(s.values))
+	sz := uint(unsafe.Sizeof(*s)-unsafe.Sizeof(s.recids)) + s.recids.ComputeSize() + uint(cap(s.values)-len(s.values))*uint(unsafe.Sizeof(scm.Scmer{}))
 	for _, v := range s.values {
 		sz += scm.ComputeSize(v)
 	}

--- a/storage/storage-string.go
+++ b/storage/storage-string.go
@@ -517,8 +517,11 @@ type StorageString struct {
 }
 
 func (s *StorageString) ComputeSize() uint {
-	base := s.values.ComputeSize() + 8 + uint(len(s.dictionary)) + 24 + s.starts.ComputeSize() + s.lens.ComputeSize() + 8*8
-	base += uint(len(s.compressedDict))
+	s.dictMu.RLock()
+	defer s.dictMu.RUnlock()
+	base := uint(unsafe.Sizeof(*s) - unsafe.Sizeof(s.values) - unsafe.Sizeof(s.starts) - unsafe.Sizeof(s.lens))
+	base += s.values.ComputeSize() + s.starts.ComputeSize() + s.lens.ComputeSize() + uint(len(s.dictionary))
+	base += uint(cap(s.compressedDict))
 	return base
 }
 
@@ -583,11 +586,14 @@ func (s *StorageString) EvictDictionary() int64 {
 // string dictionary.  The pointer is a *StorageString.
 func stringDictCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	s := ptr.(*StorageString)
-	freed := s.EvictDictionary()
-	if freed > 0 && freedByType != nil {
-		freedByType[TypeStringDict] += freed
+	// ensureDict can publish to the manager while holding dictMu. Never wait
+	// here, and let removeInternal book the successful release exactly once.
+	if !s.dictMu.TryLock() {
+		return false
 	}
-	return freed > 0
+	defer s.dictMu.Unlock()
+	s.dictionary = ""
+	return true
 }
 
 // stringDictLastUsed returns a zero time so that materialized dicts are

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3530,6 +3530,7 @@ func Init(en scm.Env) {
 			if len(a) == 0 {
 				memTotal, memAvail := ReadMemInfo()
 				processMem := ReadProcessRSS()
+				goMem := scm.CachedMemStats()
 				cs := GlobalCache.Stat()
 				maintenance := GlobalMaintenanceRAMBudget.Stat()
 				nonEvictable := processMem - cs.CurrentMemory
@@ -3540,6 +3541,16 @@ func Init(en scm.Env) {
 					scm.NewString("mem_available"), scm.NewInt(memAvail),
 					scm.NewString("mem_total"), scm.NewInt(memTotal),
 					scm.NewString("process_memory"), scm.NewInt(processMem),
+					// Runtime diagnostics explain why object payloads do not equal RSS.
+					// These cached runtime samples are a separate view (possibly older
+					// than RSS), not additional bytes to add to RSS. Never force a
+					// runtime-wide heap walk on the metrics polling path.
+					scm.NewString("go_heap_allocated"), scm.NewInt(int64(goMem.HeapAlloc)),
+					scm.NewString("go_heap_inuse"), scm.NewInt(int64(goMem.HeapInuse)),
+					scm.NewString("go_heap_idle"), scm.NewInt(int64(goMem.HeapIdle)),
+					scm.NewString("go_heap_released"), scm.NewInt(int64(goMem.HeapReleased)),
+					scm.NewString("go_stack_inuse"), scm.NewInt(int64(goMem.StackInuse)),
+					scm.NewString("cache_accounting_over_rss"), scm.NewInt(max(0, cs.CurrentMemory-processMem)),
 					scm.NewString("evictable_memory"), scm.NewInt(cs.CurrentMemory),
 					scm.NewString("non_evictable_process_memory"), scm.NewInt(nonEvictable),
 					scm.NewString("shard_memory"), scm.NewInt(cs.CurrentMemory),
@@ -3679,7 +3690,7 @@ func Init(en scm.Env) {
 							scm.NewString("name"), scm.NewString(t.Name),
 							scm.NewString("engine"), scm.NewString(engine),
 							scm.NewString("row_count"), scm.NewInt(stats.rowCount),
-							scm.NewString("size_bytes"), scm.NewInt(stats.sizeBytes),
+							scm.NewString("size_bytes"), scm.NewInt(int64(t.residentMemory().total())),
 							scm.NewString("collation"), scm.NewString(t.Collation),
 							scm.NewString("comment"), scm.NewString(t.Comment),
 						}))
@@ -3736,6 +3747,7 @@ func Init(en scm.Env) {
 					}
 					return scm.NewSlice([]scm.Scmer{
 						scm.NewString("columns"), t.ShowColumns(),
+						scm.NewString("size_bytes"), scm.NewInt(int64(t.residentMemory().total())),
 						scm.NewString("meta"), showBuildMeta(db, t),
 						scm.NewString("shards"), scm.NewSlice(shardRows),
 						scm.NewString("triggers"), scm.NewSlice(triggerRows),
@@ -3810,6 +3822,7 @@ func Init(en scm.Env) {
 						colRows = scm.NewSlice(colSlice)
 						idxSlice := make([]scm.Scmer, 0, len(s.Indexes))
 						for _, ix := range s.Indexes {
+							ix.mu.Lock()
 							orders := make([]scm.Scmer, len(ix.ColOrderMeta))
 							for i, order := range ix.ColOrderMeta {
 								orders[i] = scm.NewString(order)
@@ -3820,8 +3833,9 @@ func Init(en scm.Env) {
 								scm.NewString("active"), scm.NewBool(ix.baseState.active),
 								scm.NewString("native"), scm.NewBool(ix.Native),
 								scm.NewString("savings"), scm.NewFloat(ix.loadSavings()),
-								scm.NewString("size_bytes"), scm.NewInt(int64(ix.ComputeSize())),
+								scm.NewString("size_bytes"), scm.NewInt(int64(ix.computeSizeLocked())),
 							}))
+							ix.mu.Unlock()
 						}
 						indexRows = scm.NewSlice(idxSlice)
 						s.mu.RUnlock()
@@ -4332,18 +4346,19 @@ func (db *database) PrintMemUsage() string {
 		return b.String()
 	}
 	b.WriteString("Disjoint owner-payload estimate (not RSS; excludes Go runtime, allocator slack, stacks, and shared process overhead)\n")
-	b.WriteString("Table                    \tColumns\tShards\tBase\tIndexes\tTemp columns\tString dicts\tMetadata\tTotal\n")
+	b.WriteString("Table                    \tColumns\tShards\tBase\tIndexes\tTemp columns\tString dicts\tBlob caches\tMetadata\tTotal\n")
 	var total memoryOwnerSnapshot
 	db.schemalock.RLock()
 	defer db.schemalock.RUnlock()
 	for _, t := range db.tables.GetAll() {
 		snapshot := t.memoryOwnerSnapshotLocked()
-		b.WriteString(fmt.Sprintf("%-25s\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		b.WriteString(fmt.Sprintf("%-25s\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			t.Name, len(t.Columns), len(t.ActiveShards()),
 			units.BytesSize(float64(snapshot.base)),
 			units.BytesSize(float64(snapshot.indexes)),
 			units.BytesSize(float64(snapshot.tempColumns)),
 			units.BytesSize(float64(snapshot.stringDictionaries)),
+			units.BytesSize(float64(snapshot.blobCaches)),
 			units.BytesSize(float64(snapshot.metadata)),
 			units.BytesSize(float64(snapshot.total()))))
 		total.add(snapshot)
@@ -4370,6 +4385,7 @@ func (t *table) PrintMemUsage() string {
 	b.WriteString(fmt.Sprintf("indexes: %s\n", units.BytesSize(float64(snapshot.indexes))))
 	b.WriteString(fmt.Sprintf("temporary columns: %s\n", units.BytesSize(float64(snapshot.tempColumns))))
 	b.WriteString(fmt.Sprintf("materialized string dictionaries: %s\n", units.BytesSize(float64(snapshot.stringDictionaries))))
+	b.WriteString(fmt.Sprintf("decoded blob caches: %s\n", units.BytesSize(float64(snapshot.blobCaches))))
 	b.WriteString(fmt.Sprintf("table metadata estimate: %s\n", units.BytesSize(float64(snapshot.metadata))))
 	b.WriteString(fmt.Sprintf("total owner payload estimate: %s\n", units.BytesSize(float64(snapshot.total()))))
 	return b.String()
@@ -4380,11 +4396,12 @@ type memoryOwnerSnapshot struct {
 	indexes            uint
 	tempColumns        uint
 	stringDictionaries uint
+	blobCaches         uint
 	metadata           uint
 }
 
 func (m memoryOwnerSnapshot) total() uint {
-	return m.base + m.indexes + m.tempColumns + m.stringDictionaries + m.metadata
+	return m.base + m.indexes + m.tempColumns + m.stringDictionaries + m.blobCaches + m.metadata
 }
 
 func (m *memoryOwnerSnapshot) add(other memoryOwnerSnapshot) {
@@ -4392,6 +4409,7 @@ func (m *memoryOwnerSnapshot) add(other memoryOwnerSnapshot) {
 	m.indexes += other.indexes
 	m.tempColumns += other.tempColumns
 	m.stringDictionaries += other.stringDictionaries
+	m.blobCaches += other.blobCaches
 	m.metadata += other.metadata
 }
 
@@ -4400,30 +4418,26 @@ func (m *memoryOwnerSnapshot) add(other memoryOwnerSnapshot) {
 // of size ownership and remain independently applied by cache.go. The caller
 // holds the schema read lock so table topology and column ownership are stable.
 func (t *table) memoryOwnerSnapshotLocked() memoryOwnerSnapshot {
-	snapshot := memoryOwnerSnapshot{metadata: 10*8 + 32*uint(len(t.Columns))}
+	snapshot := memoryOwnerSnapshot{metadata: t.metadataMemory()}
 	for _, shard := range t.ActiveShards() {
 		if shard == nil {
 			continue
 		}
 		shard.mu.RLock()
-		snapshot.base += shard.computeSizeLocked()
-		for name, storage := range shard.columns {
-			if storage == nil {
-				continue
-			}
-			if !shard.ownsColumnMemory(name) {
-				snapshot.tempColumns += ownedColumnMemory(storage)
-			}
-			snapshot.stringDictionaries += materializedDictionaryMemory(storage)
-		}
-		for _, index := range shard.Indexes {
-			if index != nil {
-				snapshot.indexes += index.ComputeSize()
-			}
-		}
+		snapshot.add(shard.residentMemoryLocked())
 		shard.mu.RUnlock()
 	}
 	return snapshot
+}
+
+func (t *table) residentMemory() memoryOwnerSnapshot {
+	// Deliberately diagnostic-only: this visits resident owners and may walk
+	// delta values. Query planning uses statistics()/ShowColumns snapshots.
+	if t.schema != nil {
+		t.schema.schemalock.RLock()
+		defer t.schema.schemalock.RUnlock()
+	}
+	return t.memoryOwnerSnapshotLocked()
 }
 
 // fkExistenceCheck checks if values exist in tbl[filterCols]. Returns true if found or all NULL.
@@ -5095,13 +5109,23 @@ func showBuildShardRow(t *table, i int, s *storageShard) scm.Scmer {
 		})
 	}
 	stats := s.statsSnapshot()
+	// The display is a resident total, never the exclusive eviction ledger.
+	// Keep planner statistics and their immutable fast-path snapshots unchanged.
+	s.mu.RLock()
+	memory := s.residentMemoryLocked()
+	s.mu.RUnlock()
 	return scm.NewSlice([]scm.Scmer{
 		scm.NewString("shard"), scm.NewInt(int64(i)),
 		scm.NewString("state"), scm.NewString(sharedStateStr(stats.state)),
 		scm.NewString("main_count"), scm.NewInt(int64(stats.mainCount)),
 		scm.NewString("delta"), scm.NewInt(int64(stats.delta)),
 		scm.NewString("deletions"), scm.NewInt(int64(stats.deletions)),
-		scm.NewString("size_bytes"), scm.NewInt(int64(stats.size)),
+		scm.NewString("size_bytes"), scm.NewInt(int64(memory.total())),
+		scm.NewString("base_size_bytes"), scm.NewInt(int64(memory.base)),
+		scm.NewString("index_size_bytes"), scm.NewInt(int64(memory.indexes)),
+		scm.NewString("temp_column_size_bytes"), scm.NewInt(int64(memory.tempColumns)),
+		scm.NewString("dictionary_size_bytes"), scm.NewInt(int64(memory.stringDictionaries)),
+		scm.NewString("blob_cache_size_bytes"), scm.NewInt(int64(memory.blobCaches)),
 	})
 }
 

--- a/storage/table.go
+++ b/storage/table.go
@@ -1387,13 +1387,49 @@ func (t *table) CountExact() (result uint) {
 	return result
 }
 
-func (t table) ComputeSize() uint {
-	var size uint = 10*8 + 32*uint(len(t.Columns))
-	for _, s := range t.Shards {
-		size += s.ComputeSize()
+func (t *table) ComputeSize() uint {
+	return t.residentMemory().total()
+}
+
+// Registrations charge only exclusive allocations. ComputeSize is inclusive;
+// its separately registered descendants must not inflate the global ledger.
+func (t *table) exclusiveSize() uint {
+	size := t.metadataMemory()
+	for _, shard := range t.ActiveShards() {
+		if shard != nil {
+			size += shard.exclusiveSize()
+		}
 	}
-	for _, s := range t.PShards {
-		size += s.ComputeSize()
+	return size
+}
+
+func (t *table) evictionOffer(currentSize int64) evictionOffer {
+	if !t.isEphemeralQueryTable() {
+		return evictionOffer{}
+	}
+	full := currentSize
+	for _, shard := range t.ActiveShards() {
+		if shard != nil {
+			full += shard.evictionOffer(0).fullBytes
+		}
+	}
+	return evictionOffer{fullBytes: full}
+}
+
+func (t *table) evict(mode evictionMode, currentSize int64, freedByType *[numEvictableTypes]int64) evictionResult {
+	if mode != evictFull || !t.isEphemeralQueryTable() {
+		return evictionResult{}
+	}
+	ok := keytableCleanup(t, t.schema.Name, freedByType)
+	return evictionResult{success: ok, fullyEvicted: ok, freedBytes: currentSize}
+}
+
+// Schema metadata belongs to the table, never to every referencing shard.
+func (t *table) metadataMemory() uint {
+	size := uint(unsafe.Sizeof(*t)) + uint(len(t.Name))
+	size += uint(cap(t.Columns)) * uint(unsafe.Sizeof((*column)(nil)))
+	for _, c := range t.Columns {
+		size += uint(unsafe.Sizeof(*c)) + uint(len(c.Name))
 	}
 	return size
 }
@@ -2182,17 +2218,33 @@ func (t *table) registerTempColumn(cp *column) {
 					tbl.schema.schemalock.Unlock()
 					return false
 				}
+				for _, shard := range tbl.ActiveShards() {
+					if !shard.mu.TryLock() {
+						atomic.StoreInt64(&col.cacheUsers, 0)
+						tbl.schema.schemalock.Unlock()
+						return false
+					}
+					ok := evictColumnCaches(shard.columns[colName], freedByType)
+					shard.mu.Unlock()
+					if !ok {
+						atomic.StoreInt64(&col.cacheUsers, 0)
+						tbl.schema.schemalock.Unlock()
+						return false
+					}
+				}
 				tbl.removeComputeTriggers(colName)
 				tbl.removeORCDependencyTriggers(colName)
 				tbl.Columns = append(tbl.Columns[:i], tbl.Columns[i+1:]...)
 				for _, s := range tbl.Shards {
 					s.mu.Lock()
 					delete(s.columns, colName)
+					delete(s.tempColumnBytes, col)
 					s.mu.Unlock()
 				}
 				for _, s := range tbl.PShards {
 					s.mu.Lock()
 					delete(s.columns, colName)
+					delete(s.tempColumnBytes, col)
 					s.mu.Unlock()
 				}
 				tbl.invalidateShowColumnsSnapshot()

--- a/tests/storage/persistence/shard-memory-totals.yaml
+++ b/tests/storage/persistence/shard-memory-totals.yaml
@@ -1,0 +1,147 @@
+# Copyright (C) 2026 MemCP Contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+metadata:
+  version: "1.0"
+  description: "Resident memory includes index and computed-column child owners"
+  isolated: true
+setup:
+  - sql: "DROP TABLE IF EXISTS ram_multishard"
+  - sql: "DROP TABLE IF EXISTS ram_totals"
+  - sql: "CREATE TABLE ram_totals (id INT, payload TEXT) ENGINE=SAFE"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "ram_totals") '("id" "payload")
+          (map (produceN 2000) (lambda (i) (list i (sha256 (string i)))))
+          '() (lambda () true) false)
+        (rebuild (table "memcp-tests" "ram_totals") true false))
+test_cases:
+  - name: "Build LIKE index on a small base column"
+    sql: "SELECT COUNT(*) AS n FROM ram_totals WHERE payload LIKE '%abcd%'"
+    expect:
+      rows: 1
+  - name: "Shard total includes all columns and indexes"
+    scm: |
+      (begin
+        (define shard (show "memcp-tests" "ram_totals" 0 true))
+        (define columns (reduce (shard "columns") (lambda (n c) (+ n (c "size_bytes"))) 0))
+        (define indexes (reduce (shard "indexes") (lambda (n i) (+ n (i "size_bytes"))) 0))
+        (if (and (> indexes 0) (>= (shard "size_bytes") (+ columns indexes))) true
+          (error "shard total omits index memory")))
+    expect:
+      result_contains: ["true"]
+  - name: "Temporary column remains part of shard RAM"
+    scm: |
+      (begin
+        (createcolumn (table "memcp-tests" "ram_totals") "cached_length" "int" '() '("temp" true)
+          '("payload") (lambda (payload) (strlen payload)))
+        (define shard (show "memcp-tests" "ram_totals" 0 true))
+        (if (>= (shard "size_bytes")
+          (+ (reduce (shard "columns") (lambda (n c) (+ n (c "size_bytes"))) 0)
+             (reduce (shard "indexes") (lambda (n i) (+ n (i "size_bytes"))) 0))) true
+          (error "shard total omits temporary column memory")))
+    expect:
+      result_contains: ["true"]
+  - name: "Table listing includes current child owners without rebuild"
+    scm: |
+      (begin
+        (define rows (show "memcp-tests" true))
+        (define tbl (car (filter rows (lambda (r) (equal? (r "name") "ram_totals")))))
+        (define shards ((show "memcp-tests" "ram_totals" true) "shards"))
+        (if (>= (tbl "size_bytes") (reduce shards (lambda (n s) (+ n (s "size_bytes"))) 0)) true
+          (error "table total is stale or incomplete")))
+    expect:
+      result_contains: ["true"]
+  - name: "Resident categories partition the shard total"
+    scm: |
+      (begin
+        (define s (show "memcp-tests" "ram_totals" 0 true))
+        (if (equal? (s "size_bytes") (+ (s "base_size_bytes") (s "index_size_bytes")
+          (s "temp_column_size_bytes") (s "dictionary_size_bytes") (s "blob_cache_size_bytes"))) true
+          (error "resident categories overlap or omit memory")))
+  - name: "Prepare external blob payload"
+    sql: "UPDATE ram_totals SET payload = REPEAT('a long blob value ', 200) WHERE id < 4"
+  - name: "Publish blob column and populate its decoded cache"
+    scm: |
+      (begin
+        (rebuild (table "memcp-tests" "ram_totals") true false)
+        (for '(0) (lambda (i) (< i 3)) (lambda (i)
+          (begin
+            (scan nil (table "memcp-tests" "ram_totals") '() '() '() (lambda () true)
+              '("payload") (lambda (acc payload) (+ acc (strlen payload))) 0 + false)
+            (list (+ i 1))))))
+  - name: "Blob RAM participates in inclusive column and shard totals"
+    scm: |
+      (begin
+        (define s (show "memcp-tests" "ram_totals" 0 true))
+        (if (and (> (s "blob_cache_size_bytes") 0)
+          (>= (s "size_bytes") (+
+            (reduce (s "columns") (lambda (n c) (+ n (c "size_bytes"))) 0)
+            (reduce (s "indexes") (lambda (n i) (+ n (i "size_bytes"))) 0)))) true
+          (error "decoded blob RAM is omitted")))
+  - name: "Invalid shard lookup fails explicitly"
+    scm: '(show "memcp-tests" "ram_totals" 999999 true)'
+    expect:
+      error: true
+  - name: "Create small multishard fixture"
+    sql: "CREATE TABLE ram_multishard (id INT, payload TEXT) ENGINE=SAFE"
+  - name: "Split only 256 rows across small shards"
+    scm: |
+      (begin
+        (settings "ShardSize" 64)
+        (insert (table "memcp-tests" "ram_multishard") '("id" "payload")
+          (map (produceN 256) (lambda (i) (list i (sha256 (string i)))))
+          '() (lambda () true) false)
+        (rebuild (table "memcp-tests" "ram_multishard") true false)
+        (settings "ShardSize" 60000))
+  - name: "Build multi-shard child owners"
+    scm: |
+      (begin
+        (createcolumn (table "memcp-tests" "ram_multishard") "cached_length" "int" '() '("temp" true)
+          '("payload") (lambda (payload) (strlen payload))))
+  - name: "Warm multi-shard LIKE access"
+    sql: "SELECT id FROM ram_multishard WHERE payload LIKE '%ab%'"
+  - name: "Build multi-shard LIKE index"
+    sql: "SELECT id FROM ram_multishard WHERE payload LIKE '%cd%'"
+  - name: "Reuse multi-shard LIKE index"
+    sql: "SELECT id FROM ram_multishard WHERE payload LIKE '%ef%'"
+  - name: "All shards and child allocations contribute exactly once"
+    scm: |
+      (begin
+        (define t (show "memcp-tests" "ram_multishard" true))
+        (define shards (t "shards"))
+        (if (and (> (count shards) 1)
+          (> (reduce shards (lambda (n s) (+ n (s "index_size_bytes"))) 0) 0)
+          (> (reduce shards (lambda (n s) (+ n (s "temp_column_size_bytes"))) 0) 0)
+          (>= (t "size_bytes") (reduce shards (lambda (n s) (+ n (s "size_bytes"))) 0))) true
+          (error (concat "multi-shard owner accounting incomplete: " (serialize t)))))
+  - name: "Allow owners to become evictable"
+    scm: '(sleep 1.1)'
+  - name: "Exercise recursive eviction under pressure"
+    scm: '(settings "MaxRamBytes" 1)'
+  - name: "Restore normal budget"
+    scm: '(settings "MaxRamBytes" 0)'
+  - name: "Resident display must not reload evicted columns"
+    scm: |
+      (begin
+        (define first (show "memcp-tests" "ram_multishard" true))
+        (define second (show "memcp-tests" "ram_multishard" true))
+        (if (and
+          (> (count (filter (first "shards") (lambda (s) (equal? (s "state") "COLD")))) 0)
+          (equal? (first "size_bytes") (second "size_bytes"))) true
+          (error "diagnostic loads cold data or eviction did not run")))
+  - name: "All persisted rows survive eviction and reload"
+    sql: "SELECT COUNT(*) AS n, SUM(id) AS total, SUM(LENGTH(payload)) AS bytes FROM ram_multishard"
+    expect:
+      rows: 1
+      data: [{n: 256, total: 32640, bytes: 16384}]
+  - name: "Runtime accounting remains a distinct nonnegative view"
+    scm: |
+      (begin
+        (define s (stat))
+        (if (and (> (s "process_memory") 0) (> (s "go_heap_allocated") 0)
+          (>= (s "go_heap_inuse") (s "go_heap_allocated"))
+          (>= (s "cache_accounting_over_rss") 0)) true
+          (error "invalid process/runtime memory diagnostics")))
+cleanup:
+  - sql: "DROP TABLE IF EXISTS ram_multishard"
+  - sql: "DROP TABLE IF EXISTS ram_totals"


### PR DESCRIPTION
## Problem

A shard could report less RAM than one of its own LIKE indexes. The display used an exclusive eviction-registration size and table rows used a stale planner statistics snapshot. Resident temporary columns, decoded dictionaries and blob caches were not consistently represented in parent totals.

## Ownership contract

- `ComputeSize()` is inclusive: object layout and owned backing allocations/children. Separately registered children are subtracted explicitly for the global eviction ledger, not hidden inside the public size contract.
- Structured `show` shard/table sizes and the dashboard include resident indexes (including inverse positions/hooks), temporary columns, dictionaries and decoded blob caches. Cold columns are not loaded to inspect their size.
- Fixed layouts and backing capacities replace several stale constants/length-only counts. Embedded storage structs are not counted twice; decimal file-format bytes are not RAM.
- Full parent eviction offers include separately registered children. Busy indexes/nested caches stay registered; successful child releases are accounted once even if a later child prevents parent eviction. Wrapper traversal in the manager is nonblocking. Dictionary eviction no longer counts a release twice.
- Per-shard temporary-column portions are published in mutation order, transferred to replacement generations and subtracted only when their buffers are detached. Unchanged sizes do not send another manager operation.
- Existing eviction type weights and savings policy are unchanged. Bytes and replacement cost remain distinct.

The contract and the prohibition on full ownership walks in hot paths are documented in AGENTS.md. Full traversal is limited to explicit diagnostics/size publication, not query rows, cost guards or planner-statistics reads. `stat` exposes process RSS and cached Go heap/stack diagnostics as separate views.

## Scope and precision

This fixes resident storage ownership and cascading eviction accounting; it does not equate database payload with process RSS. Go map/bucket overhead and some allocator/native-runtime bookkeeping still use estimates. Runtime code, stacks, allocator slack, transient query/rebuild buffers and shared process allocations cannot be assigned to a table by summing storage payloads. Cached runtime samples may be older than the RSS reading. No rescaling or fabricated per-database attribution is used.

A separate disposable 8,000-row diagnostic run reported the main table as 522.5 KiB base + 265.8 KiB indexes + 1.635 KiB metadata = 789.9 KiB. The database owner estimate was 804.4 KiB. Process RSS was 137,089,024 bytes and the global eviction ledger 2,833,590 bytes: these are explicitly different measurements, not proof of exact heap reconciliation.

No live data, persistence format, retention setting or planner/calibration weight was changed.

## Test-first evidence

New isolated `tests/storage/persistence/shard-memory-totals.yaml` covers index-heavy shards, temporary columns, live table totals, disjoint categories, blob RAM, invalid shard access, a 256-row small-shard fixture, recursive eviction, cold diagnostics without reload, and exact persisted data after reload.

The initial three accounting assertions failed on the unchanged baseline before implementation. Re-running the expanded suite against current master `a056e7147` also fails the index/temp/table/blob/category assertions; the proposed code passes **22/22**.

Targeted validation (no local full suite):

- New ownership YAML: **22/22**.
- Existing memory-pressure YAML: **32/32**.
- Existing memory-engine YAML: **24/24**.
- Existing cache-engine YAML: **24/24**.
- Targeted Go ownership, index, RecSet/inverse traversal and eviction tests pass.
- Targeted race-enabled ownership/eviction tests pass.
- Build, changed Scheme lint and diff checks pass.

Known baseline issue: both unchanged master and this branch print startup unit failure 206, `membership text guards use the prior without emitting a zero-hit scan` (1275/1276). This unrelated assertion has not been disabled or modified. Full functional/JIT/performance suites belong to CI.

## Manual A/B hot-path check

Same machine (Ryzen 9 7900X3D), Go toolchain, existing benchmark fixtures, 200 ms/sample, three samples each; medians below. Baseline is `a056e7147`. These are microbenchmarks, not application end-to-end claims.

| Existing workload | Master | Proposed | Change |
| --- | ---: | ---: | ---: |
| Published table statistics | 0.769 ns | 0.854 ns | +0.085 ns |
| Planner statistics hash lookup | 30.78 ns | 31.85 ns | +1.07 ns |
| Scan COUNT, 60,000 rows | 132.10 us | 132.39 us | +0.22% |
| Filtered COUNT | 1.864 us | 2.045 us | +9.7% |
| Scan SUM | 580.76 us | 545.13 us | -6.1% |
| Scan take-right reducer | 136.82 us | 122.57 us | -10.4% |

Allocations/op are unchanged in every listed workload (statistics reads remain allocation-free). Short-sample variation is visible, so this is a check against accidentally adding a memory walk to scans, not a speedup claim; CI A/B remains enabled.
