### PR TITLE
JIT: keep SQL literal parameterization native (39% faster new-literal HTTP queries)

### DIFF
--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -2921,6 +2921,20 @@ func jitGeneratedEmitterInline(ctx *JITContext, declaration *Declaration, args [
 	if !jitEnabled || declaration == nil || declaration.Type == nil {
 		return false
 	}
+	// Dynamic callback argument slices cannot inline a compiler-only lambda:
+	// their SerialProc path needs a real callable. Materialize callbacks once
+	// at the declaration boundary instead of abandoning the enclosing JIT proc.
+	for index, arg := range args {
+		if arg.Loc == LocLambdaTemplate {
+			if param := jitDeclarationParam(declaration, index); param != nil && param.Kind == "func" {
+				for _, input := range param.Params {
+					if input != nil && input.Variadic {
+						return false
+					}
+				}
+			}
+		}
+	}
 	inline := declaration.RetainsCallArgs
 	knownTypes, knownShapes, knownArgs := 0, 0, 0
 	hasVirtualArgs := false

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -656,6 +656,20 @@ func TestJITNestedCallPreservesPointerValues(t *testing.T) {
 	}
 }
 
+func TestJITLoopMaterializesVariadicCallbacks(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t, `(lambda (limit marker)
+		(for (list 0 marker 2 3 4 5 6 7 8)
+			(lambda (i a b c d e f g h) (< i limit))
+			(lambda (i a b c d e f g h) (list (+ i 1) a b c d e f g h))))`)
+	marker := NewSlice([]Scmer{NewString("retained"), NewInt(42)})
+	for _, limit := range []int64{0, 1, 100} {
+		want := NewSlice([]Scmer{NewInt(limit), marker, NewInt(2), NewInt(3), NewInt(4), NewInt(5), NewInt(6), NewInt(7), NewInt(8)})
+		if got := Apply(compiled, NewInt(limit), marker); !Equal(got, want) {
+			t.Fatalf("wide loop returned %s, want %s", String(got), String(want))
+		}
+	}
+}
+
 func TestJITConditionalCallbackPreservesPointerValues(t *testing.T) {
 	compiled := compileJITExpressionTestProc(t, `(lambda (callback a b c)
 		(if a (if (and b (callback c)) (list a b c) (list c b a)) (list a b c)))`)

--- a/scm/jit_regex.go
+++ b/scm/jit_regex.go
@@ -989,6 +989,18 @@ func jitEmitConstantRegexpTest(ctx *JITContext, pattern *regexp.Regexp, value JI
 		return jitPlaceScmerIntoTarget(ctx, JITValueDesc{Loc: LocImm, Type: out.GetTag(), Imm: out}, result)
 	}
 	program := jitCompileRegexProgram(pattern)
+	value = ctx.stabilizeForNested(value)
+	// Regex state competes with enclosing branch results and planned homes.
+	// Commit bool/nil to a pointer-free slot before restoring those registers.
+	var outer JITRegisterBoundary
+	var savedResult JITValueDesc
+	requested := result
+	releaseOuter := bits.OnesCount64(ctx.FreeRegs&ctx.AllRegs&^ctx.ProtectedRegs) < 6
+	if releaseOuter {
+		savedResult = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: ctx.AllocSpill(16), NoHeapPointer: true}
+		outer = ctx.PreserveRegisters(JITRegisterBoundaryOptions{ReleaseHomes: true})
+		result = JITValueDesc{Loc: LocAny}
+	}
 	target := jitEnsureResultPair(ctx, result)
 	success := ctx.ReserveLabel()
 	fail := ctx.ReserveLabel()
@@ -1005,6 +1017,12 @@ func jitEmitConstantRegexpTest(ctx *JITContext, pattern *regexp.Regexp, value JI
 	ctx.EmitMakeNil(target)
 	ctx.MarkLabel(done)
 	target.Type = JITTypeUnknown
+	target.NoHeapPointer = true
+	if releaseOuter {
+		savedResult = jitPlaceScmerIntoTarget(ctx, target, savedResult)
+		outer.Restore(ctx)
+		return jitPlaceScmerIntoTarget(ctx, savedResult, requested)
+	}
 	return target
 }
 

--- a/scm/jit_regex_native_test.go
+++ b/scm/jit_regex_native_test.go
@@ -162,6 +162,24 @@ func TestJITNativeRegexpTestPreservesNil(t *testing.T) {
 	}
 }
 
+func TestJITNativeRegexpUnderNestedConditions(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t, `(lambda (value a b c)
+		(if a (if (and b (regexp_test value "^[a-z]+$"))
+			(list a b c true) (list a b c (regexp_test value "^42$"))) (list c)))`)
+	a, b, c := NewString("outer a"), NewString("outer b"), NewSlice([]Scmer{NewString("outer c")})
+	for _, test := range []struct{ input, want Scmer }{
+		{NewString("abc"), NewBool(true)},
+		{NewString("ABC"), NewBool(false)},
+		{NewInt(42), NewBool(true)},
+		{NewNil(), NewNil()},
+	} {
+		want := NewSlice([]Scmer{a, b, c, test.want})
+		if got := Apply(compiled, test.input, a, b, c); !Equal(got, want) {
+			t.Fatalf("nested regexp returned %s, want %s", String(got), String(want))
+		}
+	}
+}
+
 func compileNativeRegexCaptures(t *testing.T, pattern string) Scmer {
 	t.Helper()
 	captureCount := regexp.MustCompile(pattern).NumSubexp() + 1

--- a/tests/planner/core/query-cache-growth.yaml
+++ b/tests/planner/core/query-cache-growth.yaml
@@ -22,6 +22,10 @@ setup:
   - sql: "INSERT INTO cg_rows VALUES (1, 'needle-a'), (2, 'needle-b'), (3, 'other-a'), (4, 'other-b')"
   - scm: "(rebuild (table \"memcp-tests\" \"cg_rows\") true false)"
 test_cases:
+  - name: "Literal parameterizer compiles natively"
+    scm: |
+      (if (equal? (jit? (jit parameterize_sql_select_literals)) (jit-enabled?))
+        true (error "literal parameterizer fell back to the interpreter"))
   - name: "Same cached LIKE plan recompiles after cardinality growth"
     scm: |
       (begin
@@ -84,6 +88,22 @@ test_cases:
         (if (and (equal? normalized "SELECT id FROM items WHERE id >= ? AND label = ? ORDER BY id LIMIT ? OFFSET ?")
           (equal? bindings (list 12 "open" 5 2)) (equal? shape_hash (fnv_hash normalized)))
           "ok" (error (concat "parameterization mismatch: " normalized " / " bindings))))
+    expect:
+      data: ["ok"]
+  - name: "Uncached lexical parameterization batch"
+    warmup: 3
+    timing_samples: 7
+    threshold_ms: 100
+    scm: |
+      (reduce (produceN 100) (lambda (_ idx)
+        (match (parameterize_sql_select_literals
+          "SELECT id FROM items WHERE id >= 12 AND label = 'open' ORDER BY id LIMIT 5 OFFSET 2")
+          '(normalized bindings shape_hash)
+          (if (and
+            (equal? normalized "SELECT id FROM items WHERE id >= ? AND label = ? ORDER BY id LIMIT ? OFFSET ?")
+            (equal? bindings (list 12 "open" 5 2))
+            (equal? shape_hash (fnv_hash normalized)))
+            "ok" (error "parameterization batch changed the query")))) nil)
     expect:
       data: ["ok"]
   - name: "Literal parameterization preserves comments and identifiers"


### PR DESCRIPTION
The SQL literal parameterizer currently falls back to the interpreter: generated variadic callback calls attempt to materialize a compiler-only lambda template, and the callback subsequently exhausts registers while compiling nested regex tests. Materialize these callbacks once at the declaration boundary and preserve enclosing registers around regex tests when register headroom is insufficient. This keeps the parameterizer native and reduces HTTP latency for queries with new literal values.

The loop still uses the Go builtin with native callbacks. Regex results are committed to a pointer-free spill slot before restoring enclosing registers. This changes neither SQL normalization nor parser/planner semantics; the approximately 4 MB parser code size is not an optimization target.

### Manual A/B measurements

Baseline: master `a056e7147` (includes #870). Candidate: this branch. Same patched Go 1.27 JIT toolchain, CGO disabled, tags `nowatcher,nobrotli,nomercure`, fresh private server/data directory per run. Three sequential A/B pairs, alternating execution order; table below reports the median of the three run medians. These measurements were completed before opening this PR.

Fixture: 2,048 rebuilt rows, integer primary key `id`, `a = 3 * id`. Ordinary HTTP cases: 50 warmups and 1,000 samples per run. New-literal case: 100 warmups and 1,000 samples, each with a previously unused literal (`id=100..1199`), verifying returned values. Lexical cases: 5 warmup batches and 25 measured batches of 50 calls, reporting per-call time (including amortized HTTP overhead), with identical normalized SQL/bindings/hash.

| Case | Baseline µs | Candidate µs | Change |
| --- | ---: | ---: | ---: |
| HTTP point query, new literal | 244.175 | 149.495 | -38.8% / 1.63× |
| HTTP point query, repeated | 123.064 | 121.848 | -1.0% |
| HTTP SUM aggregate | 133.455 | 130.855 | -1.9% |
| HTTP EXPLAIN COMPILE point query | 652.048 | 638.513 | -2.1% |
| Lexical point query | 79.481 | 16.635 | -79.1% / 4.78× |
| Lexical bounds/string/LIMIT/OFFSET | 130.367 | 34.340 | -73.7% / 3.80× |
| Lexical 16-way OR | 321.672 | 105.286 | -67.3% / 3.06× |

All three new-literal HTTP runs improve: baseline 244.175 / 239.878 / 263.317 µs versus candidate 166.037 / 149.495 / 148.439 µs. Warm-hit differences are small and should be treated as noise, not claimed speedups. The baseline parameterizer reports `jit? = false`; all candidate runs report true. This is a Scheme-JIT optimization, not a PHP-interpreter benchmark.

### Validation

- JIT runtime/storage tests: `go test ./scm ./storage -run 'TestJIT|TestFilterBufferWideArithmetic' -count=1` with the patched JIT toolchain: pass.
- 78/78 targeted SQL cases: query-cache-growth, prepared-stmts, boolean-tautology-folding, jit-register-pressure.
- New native-compilation regression tests for wide variadic loop callbacks and nested regex tests retaining pointer-bearing outer values, including nil and non-string inputs.
- Query-cache suite now asserts native parameterizer compilation when JIT is enabled and includes a repeatable lexical performance case.
- Full suites and A/B performance guards run in CI, following the repository performance workflow.
