### PR TITLE
Preserve lib-generated filter dependencies for cache invalidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,9 @@ curl -s -u root:admin "http://localhost:[PORT]/sql/DBNAME" -d "SELECT 1"
   publication and protected by `table.mu` afterwards. Restored compute dependency
   triggers stay inert until registration atomically replaces their generated code
   and runtime target; current triggers reuse their code without recompilation.
+- `scanJoinInfo.unknownReads` is local to dependency registration and never shared
+  with scan execution. Access-header filter readsets are immutable plan data;
+  only cache registration reads them, not row or batch processing.
 
 - `OverlayBlob.ram` belongs to one immutable column generation. Its `blobRAMCache.mu`
   protects admission metadata, decoded strings, and byte/benefit accounting;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,11 @@ curl -s -u root:admin "http://localhost:[PORT]/sql/DBNAME" -d "SELECT 1"
 - `storageShard.filterFeedback` contains immutable observations published with one best-effort CAS after a complete shard scan. Readers may load these atomics without shard locks or concurrency rights; they must not inspect shard containers. `table.filterFeedback` publishes an immutable, bounded merged snapshot. Generation IDs are scalar planner-statistics tokens, never retained shard/topology pointers. No feedback synchronization or publication is permitted inside element or filter-batch loops. `tableShowColumnsSnapshot.filterSchema` is immutable column-semantics metadata published through the existing atomic snapshot. Optional `table.RestoredFilterFeedback` is touched only during schema loading before table publication and cleared after restoring historical aggregates; schema saves serialize an atomic table-feedback snapshot without accessing shard state.
 - When adding new storage fields, document the locking discipline and update this section.
 
+- `TriggerDescription.needsRegeneration` is initialized during JSON loading before
+  publication and protected by `table.mu` afterwards. Restored compute dependency
+  triggers stay inert until registration atomically replaces their generated code
+  and runtime target; current triggers reuse their code without recompilation.
+
 - `OverlayBlob.ram` belongs to one immutable column generation. Its `blobRAMCache.mu`
   protects admission metadata, decoded strings, and byte/benefit accounting;
   `lastUsed` is atomic and updated once per read batch. Cache callbacks use

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -834,6 +834,14 @@ must not capture a request's transaction or lexical bindings.
 `storage/` owns physical operators, immutable access-data representations,
 catalog observations, and data lifecycle. Constructors may pack and validate
 explicit access requirements, but must not choose a query plan or parse SQL.
+Scan lowering preserves its complete original filter-column readset as immutable
+access metadata before pruning index-enforced predicates. This readset is separate
+from residual callback inputs and is consumed only during cache dependency
+registration; it must not add column readers, predicate evaluations, or checks to
+scan loops. Storage must not reconstruct this readset from physical boundaries.
+Legacy/opaque access metadata without a complete readset cannot justify suppressing
+an update trigger based on a partial residual-column list. Existing proven
+selective target mappings remain valid independently of that change guard.
 `scm/` owns language semantics, generic expression metadata, closure handling,
 and JIT compilation. SQL keywords and SELECT parameterization policy do not
 belong in its tokenizer or optimizer. MySQL client probes pass through the same

--- a/lib/queryplan-physical-scan.scm
+++ b/lib/queryplan-physical-scan.scm
@@ -302,6 +302,9 @@ one compilation result. All consumers share the same boundary/coverage proof. */
 				(list (scan_feedback_key spec bindings) bindings))
 			_ (list nil values)))))
 
+/* Preserve the original filter inputs as static dependency metadata before
+pruning. These columns belong to cache registration, not residual readers: an
+index-enforced predicate must stay a dependency without being evaluated twice. */
 (define scan_plan_compile_filter (lambda (column_expr filter_expr)
 	(begin
 		(define columns (scan_plan_columns column_expr))
@@ -321,7 +324,7 @@ one compilation result. All consumers share the same boundary/coverage proof. */
 					(match (scan_plan_pack bounds '()) '(packed values)
 						(match (scan_plan_feedback params columns body values) '(feedback bindings)
 							(list (scan_access_schema packed (if (equal? mapped '()) '() ((car mapped) "map_columns"))
-								feedback (scan_plan_covered remaining_filter))
+								feedback (scan_plan_covered remaining_filter) columns)
 								bindings remaining_columns remaining_filter)))))))))
 
 /* The returned expression is evaluated by the caller, so references to its

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -666,14 +666,34 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		"single-character text patterns use a broad prior")
 	(assert (text_pattern_selectivity_prior "%needle%") 0.01
 		"long text patterns use the selective prior floor")
-	(assert (membership_runtime_source_rows_expr
-		(list "f" "memcp-tests" "membership_text_source" false nil)
-		(list (quote strlike) "filename" "%alternate%" "utf8mb4_general_ci")
-		20000)
-		(list (quote max) 1
-			(list (quote *) 20000
-				(list (quote text_pattern_selectivity_prior) "%alternate%")))
-		"membership text guards use the prior without emitting a zero-hit scan")
+	/* Membership guards must repeat learned cardinalities, including zero.
+	Only unknown metadata falls back to the text prior. Check the emitted
+	metadata read separately, then execute its cardinality expression against
+	deterministic observations without creating a table during startup. */
+	(define membership_text_source
+		(list "f" "memcp-tests" "membership_text_source" false nil))
+	(define membership_text_condition
+		(list (quote strlike) "filename" "%alternate%" "utf8mb4_general_ci"))
+	(define membership_text_rows_expr (membership_runtime_source_rows_expr
+		membership_text_source membership_text_condition 20000))
+	(assert (match membership_text_rows_expr
+		((symbol planner_estimated_matching_rows) estimate 20000 _fallback)
+		(equal? estimate (query_scoped_source_filter_estimate_expr
+			membership_text_source membership_text_condition 0))
+		_ false)
+		true "membership text guards read metadata with zero sampling budget")
+	(define membership_text_rows (lambda (observation)
+		(match membership_text_rows_expr
+			((symbol planner_estimated_matching_rows) _estimate input_rows fallback)
+			(eval (list (quote planner_estimated_matching_rows)
+				(list (quote quote) observation) input_rows fallback))
+			_ (error "unexpected membership cardinality expression"))))
+	(assert (membership_text_rows nil) 200
+		"membership text guards use the text prior for unknown metadata")
+	(assert (membership_text_rows (list (list (quote rows) 0) (list (quote coverage) (quote feedback)))) 0
+		"membership text guards preserve learned zero instead of the text prior")
+	(assert (membership_text_rows (list (list (quote rows) 3500) (list (quote coverage) (quote feedback)))) 3500
+		"membership text guards preserve learned positive cardinalities")
 	(assert (planner_estimated_matching_rows
 		(list
 			(list (quote rows) 512)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -666,6 +666,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		"single-character text patterns use a broad prior")
 	(assert (text_pattern_selectivity_prior "%needle%") 0.01
 		"long text patterns use the selective prior floor")
+	/* Exact access removes duplicate per-row filter work, while the readset
+	retains its original inputs for cache dependency registration. */
+	(define exact_readset_plan (scan_plan_compile_filter
+		(list (quote quote) '("allowed" "unused"))
+		(list (quote lambda) (list (quote allowed) (quote unused))
+			(list (quote equal?) (quote allowed) 1))))
+	(assert (scan_plan_columns (nth exact_readset_plan 2)) '()
+		"exact scan access leaves no duplicate residual column readers")
+	(assert (scan_plan_lambda (nth exact_readset_plan 3)) (list '() true)
+		"exact scan access prunes its predicate instead of evaluating it twice")
+	(define exact_readset_schema (car exact_readset_plan))
+	(assert (nth (car exact_readset_schema) 2) '("allowed" "unused")
+		"scan metadata retains declared filter reads before residual pruning")
+	(assert (nth (car (scan_access_cover (scan_access_shift exact_readset_schema 2) true)) 2)
+		'("allowed" "unused") "scan coverage and slot shifts preserve filter read metadata")
 	/* Membership guards must repeat learned cardinalities, including zero.
 	Only unknown metadata falls back to the text prior. Check the emitted
 	metadata read separately, then execute its cardinality expression against

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -858,12 +858,13 @@ func scanTableReference(expr scm.Scmer) (tableRef, bool) {
 // scanJoinInfo describes a source table scanned by a computor and the equality
 // join conditions connecting source columns to computor input columns.
 type scanJoinInfo struct {
-	schema    string
-	table     string
-	srcCols   []string // source table columns in equality filter
-	inputCols []string // corresponding computor input column names
-	condCols  []string // source table columns read by compiled access or the residual filter
-	mapCols   []string // source table columns read by the scan mapper
+	schema       string
+	table        string
+	srcCols      []string // source table columns in equality filter
+	inputCols    []string // corresponding computor input column names
+	condCols     []string // complete filter readset supplied by the plan producer
+	unknownReads bool     // preparation-local: no complete filter dependency metadata available
+	mapCols      []string // source table columns read by the scan mapper
 }
 
 // extractScanJoinInfo walks a computor lambda and returns one scanJoinInfo per
@@ -913,13 +914,20 @@ func extractScanJoinInfoBody(expr scm.Scmer, outerParams []scm.Scmer) []scanJoin
 		if len(condCols) > 0 {
 			info.srcCols, info.inputCols = extractEqualityJoins(items[filterIdx], condCols, outerParams)
 		}
-		// Exact access boundaries may remove predicates from the residual filter.
-		// Those columns still affect the cached result even when their boundary
-		// is constant or a residual equality already supplies the reverse join.
-		accessCols, accessSrcCols, accessInputCols := extractCompiledScanDependencies(items[3], items[4], outerParams)
-		info.condCols = mergeUniqueStrings(info.condCols, accessCols)
+		// The plan producer owns the full filter readset, independently of the
+		// residual callback's actual input columns. Read this immutable data only
+		// during cache registration; never rediscover dependencies from boundaries.
+		if schema, static := scanStaticListElements(items[3]); static {
+			if columns, known := scanAccessReadColumns(schema); known {
+				info.condCols = columns
+			} else {
+				info.unknownReads = len(schema) != 0
+			}
+		} else {
+			info.unknownReads = true
+		}
 		if len(info.srcCols) == 0 {
-			info.srcCols, info.inputCols = accessSrcCols, accessInputCols
+			info.srcCols, info.inputCols = extractCompiledScanEqualityJoins(items[3], items[4], outerParams)
 		}
 		// A physical table expression can itself be a plan (for example a
 		// recset_project_join whose producer prepares correlated stage caches).
@@ -940,19 +948,22 @@ func extractScanJoinInfoBody(expr scm.Scmer, outerParams []scm.Scmer) []scanJoin
 	return result
 }
 
-func extractCompiledScanDependencies(schemaExpr, valuesExpr scm.Scmer, computorParams []scm.Scmer) (condCols, srcCols, inputCols []string) {
+func extractCompiledScanEqualityJoins(schemaExpr, valuesExpr scm.Scmer, computorParams []scm.Scmer) (srcCols, inputCols []string) {
 	schema, schemaOK := scanStaticListElements(schemaExpr)
 	if !schemaOK {
-		return nil, nil, nil
+		return nil, nil
 	}
 	if len(schema) < scanAccessSchemaHeaderSize {
-		return nil, nil, nil
+		return nil, nil
 	}
 	meta, valid := decodeScanAccessHeader(stripSourceInfo(schema[0]))
 	if !valid {
-		return nil, nil, nil
+		return nil, nil
 	}
 	valueItems, valuesOK := scanStaticListElements(valuesExpr)
+	if !valuesOK {
+		return nil, nil
+	}
 	count := meta.count
 	for i := 0; i < count; i++ {
 		offset := scanAccessSchemaHeaderSize + i*scanAccessBoundaryStride
@@ -960,9 +971,7 @@ func extractCompiledScanDependencies(schemaExpr, valuesExpr scm.Scmer, computorP
 			continue
 		}
 		boundary := ScanBoundaryFromScmer(stripSourceInfo(schema[offset]))
-		condCols = append(condCols, boundary.ColumnName())
-		condCols = append(condCols, boundary.MapColumns()...)
-		if !valuesOK || boundary.Analyzer() != EqualMatcher {
+		if boundary.Analyzer() != EqualMatcher {
 			continue
 		}
 		lowerSlot := boundary.LowerSlot()
@@ -975,7 +984,7 @@ func extractCompiledScanDependencies(schemaExpr, valuesExpr scm.Scmer, computorP
 			inputCols = append(inputCols, inputCol)
 		}
 	}
-	return condCols, srcCols, inputCols
+	return srcCols, inputCols
 }
 
 func compiledScanOuterColumn(expr scm.Scmer, computorParams []scm.Scmer) (string, bool) {
@@ -1519,6 +1528,11 @@ func mergeUniqueStrings(parts ...[]string) []string {
 }
 
 func scanRelevantSourceCols(ref scanJoinInfo, srcTable *table) []string {
+	if ref.unknownReads {
+		// Legacy/opaque access plans must not suppress a relevant mutation based
+		// on an incomplete residual readset. Selective target keys remain usable.
+		return nil
+	}
 	result := mergeUniqueStrings(ref.condCols, ref.mapCols)
 	if srcTable == nil {
 		return result

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -862,7 +862,7 @@ type scanJoinInfo struct {
 	table     string
 	srcCols   []string // source table columns in equality filter
 	inputCols []string // corresponding computor input column names
-	condCols  []string // source table columns read by the scan filter
+	condCols  []string // source table columns read by compiled access or the residual filter
 	mapCols   []string // source table columns read by the scan mapper
 }
 
@@ -913,9 +913,13 @@ func extractScanJoinInfoBody(expr scm.Scmer, outerParams []scm.Scmer) []scanJoin
 		if len(condCols) > 0 {
 			info.srcCols, info.inputCols = extractEqualityJoins(items[filterIdx], condCols, outerParams)
 		}
+		// Exact access boundaries may remove predicates from the residual filter.
+		// Those columns still affect the cached result even when their boundary
+		// is constant or a residual equality already supplies the reverse join.
+		accessCols, accessSrcCols, accessInputCols := extractCompiledScanDependencies(items[3], items[4], outerParams)
+		info.condCols = mergeUniqueStrings(info.condCols, accessCols)
 		if len(info.srcCols) == 0 {
-			info.srcCols, info.inputCols = extractCompiledScanEqualityJoins(items[3], items[4], outerParams)
-			info.condCols = mergeUniqueStrings(info.condCols, info.srcCols)
+			info.srcCols, info.inputCols = accessSrcCols, accessInputCols
 		}
 		// A physical table expression can itself be a plan (for example a
 		// recset_project_join whose producer prepares correlated stage caches).
@@ -936,22 +940,19 @@ func extractScanJoinInfoBody(expr scm.Scmer, outerParams []scm.Scmer) []scanJoin
 	return result
 }
 
-func extractCompiledScanEqualityJoins(schemaExpr, valuesExpr scm.Scmer, computorParams []scm.Scmer) (srcCols, inputCols []string) {
+func extractCompiledScanDependencies(schemaExpr, valuesExpr scm.Scmer, computorParams []scm.Scmer) (condCols, srcCols, inputCols []string) {
 	schema, schemaOK := scanStaticListElements(schemaExpr)
 	if !schemaOK {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if len(schema) < scanAccessSchemaHeaderSize {
-		return nil, nil
+		return nil, nil, nil
 	}
 	meta, valid := decodeScanAccessHeader(stripSourceInfo(schema[0]))
 	if !valid {
-		return nil, nil
+		return nil, nil, nil
 	}
 	valueItems, valuesOK := scanStaticListElements(valuesExpr)
-	if !valuesOK {
-		return nil, nil
-	}
 	count := meta.count
 	for i := 0; i < count; i++ {
 		offset := scanAccessSchemaHeaderSize + i*scanAccessBoundaryStride
@@ -959,7 +960,9 @@ func extractCompiledScanEqualityJoins(schemaExpr, valuesExpr scm.Scmer, computor
 			continue
 		}
 		boundary := ScanBoundaryFromScmer(stripSourceInfo(schema[offset]))
-		if boundary.Analyzer() != EqualMatcher {
+		condCols = append(condCols, boundary.ColumnName())
+		condCols = append(condCols, boundary.MapColumns()...)
+		if !valuesOK || boundary.Analyzer() != EqualMatcher {
 			continue
 		}
 		lowerSlot := boundary.LowerSlot()
@@ -972,7 +975,7 @@ func extractCompiledScanEqualityJoins(schemaExpr, valuesExpr scm.Scmer, computor
 			inputCols = append(inputCols, inputCol)
 		}
 	}
-	return srcCols, inputCols
+	return condCols, srcCols, inputCols
 }
 
 func compiledScanOuterColumn(expr scm.Scmer, computorParams []scm.Scmer) (string, bool) {
@@ -1834,6 +1837,44 @@ func registerInvalidationPropagationTrigger(prefix string, srcTable, targetTable
 	return triggerName
 }
 
+// reuseComputeDependencyTrigger rebinds current generated code without repeating
+// compilation. Restored dependency guards may omit columns learned by a newer
+// analyzer, so they remain inert until installComputeDependencyTrigger replaces
+// the entire compiled description. Callers serialize registration with schemalock.
+func (t *table) reuseComputeDependencyTrigger(name string, acquire func(*TxContext) bool, release func()) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := range t.Triggers {
+		trigger := &t.Triggers[i]
+		if trigger.Name == name {
+			if trigger.needsRegeneration {
+				return false
+			}
+			trigger.Acquire = acquire
+			trigger.Release = release
+			return true
+		}
+	}
+	return false
+}
+
+func (t *table) installComputeDependencyTrigger(trigger TriggerDescription) {
+	// Compile outside the table lock, just like AddTrigger. Replacing the whole
+	// description also discards obsolete FuncPlan, native and vectorized bodies.
+	finalizeTriggerCompilation(&trigger)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := range t.Triggers {
+		if t.Triggers[i].Name == trigger.Name {
+			// Generated dependency triggers keep their fixed priority and original
+			// slot; concurrent readers see either complete immutable description.
+			t.Triggers[i] = trigger
+			return
+		}
+	}
+	t.addTriggerLocked(trigger)
+}
+
 // registerComputeTriggers installs AfterInsert/AfterUpdate/AfterDelete triggers
 // on source tables so that changes automatically invalidate the computed column.
 // AfterInvalidate edges propagate changes through nested computed caches. It also
@@ -1887,15 +1928,7 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 
 		for _, timing := range []TriggerTiming{AfterInsert, AfterUpdate, AfterDelete} {
 			triggerName := ".cache:" + t.Name + ":" + name + "|scan" + strconv.Itoa(refIdx) + "|" + srcTable.Name + "|" + timing.String()
-			// idempotency: skip if trigger already exists
-			exists := false
-			for _, tr := range srcTable.Triggers {
-				if tr.Name == triggerName {
-					exists = true
-					break
-				}
-			}
-			if !exists {
+			if !srcTable.reuseComputeDependencyTrigger(triggerName, acquireTarget, releaseTarget) {
 				var body scm.Scmer
 				if incremental && timing != AfterInvalidate {
 					// scan layout: [fn, tx, table, accessSchema, accessValues,
@@ -1930,7 +1963,7 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 				if timing == AfterUpdate {
 					body = wrapUpdateBodyWithRelevantChangeGuard(body, relevantCols)
 				}
-				srcTable.AddTrigger(TriggerDescription{
+				srcTable.installComputeDependencyTrigger(TriggerDescription{
 					Name:     triggerName,
 					Timing:   timing,
 					IsSystem: true,
@@ -1939,8 +1972,6 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 					Acquire:  acquireTarget,
 					Release:  releaseTarget,
 				})
-			} else {
-				srcTable.SetTriggerTarget(triggerName, acquireTarget, releaseTarget)
 			}
 			registeredNames = append(registeredNames, triggerRef{ref.schema, triggerName})
 		}
@@ -2037,15 +2068,7 @@ func (t *table) registerORCDependencyTriggers(name string, col *column, refs []s
 		relevantCols := scanRelevantSourceCols(ref, srcTable)
 		for _, timing := range []TriggerTiming{AfterInsert, AfterUpdate, AfterDelete} {
 			triggerName := ".orcdep:" + t.Name + ":" + name + "|scan" + strconv.Itoa(refIdx) + "|" + srcTable.Name + "|" + timing.String()
-			exists := false
-			for _, tr := range srcTable.Triggers {
-				if tr.Name == triggerName {
-					exists = true
-					break
-				}
-			}
-			if exists {
-				srcTable.SetTriggerTarget(triggerName, acquireTarget, releaseTarget)
+			if srcTable.reuseComputeDependencyTrigger(triggerName, acquireTarget, releaseTarget) {
 				continue
 			}
 			tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(t.Name)})
@@ -2060,7 +2083,7 @@ func (t *table) registerORCDependencyTriggers(name string, col *column, refs []s
 			if timing == AfterUpdate {
 				body = wrapUpdateBodyWithRelevantChangeGuard(body, relevantCols)
 			}
-			srcTable.AddTrigger(TriggerDescription{
+			srcTable.installComputeDependencyTrigger(TriggerDescription{
 				Name:     triggerName,
 				Timing:   timing,
 				IsSystem: true,

--- a/storage/compute_trigger_test.go
+++ b/storage/compute_trigger_test.go
@@ -175,6 +175,10 @@ func TestComputeTriggersGuardRelevantSourceColumns(t *testing.T) {
 	src.CreateColumn("note", "TEXT", nil, nil)
 
 	computor := lambdaAst([]string{"ref_id"}, nestedScanAst("tcomputetrigger", "src", "ref_id"))
+	computor.Slice()[2].Slice()[3] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice([]scm.Scmer{
+		scm.NewSlice([]scm.Scmer{newScanAccessHeader(0, scanAccessConsumerScan, 0, -1), scm.NewNil(),
+			scm.NewSlice([]scm.Scmer{scm.NewString("ref_id")})}),
+	})})
 	refs := extractScanJoinInfo(computor)
 	base.registerComputeTriggers("cached", computor)
 
@@ -280,7 +284,7 @@ func TestExtractScanJoinInfoUsesCompiledAccessWhenResidualIsEmpty(t *testing.T) 
 	}
 }
 
-func TestExtractScanJoinInfoIncludesCompiledFilterDependencies(t *testing.T) {
+func TestExplicitReadDependenciesSurvivePrunedFilters(t *testing.T) {
 	for _, residual := range []bool{false, true} {
 		for _, dynamicValues := range []bool{false, true} {
 			t.Run(fmt.Sprintf("residual=%t/dynamic_values=%t", residual, dynamicValues), func(t *testing.T) {
@@ -292,11 +296,10 @@ func TestExtractScanJoinInfoIncludesCompiledFilterDependencies(t *testing.T) {
 						nil nil false))`)
 				root := stripSourceInfo(computor).Slice()
 				scan := stripSourceInfo(root[2]).Slice()
+				readColumns := scm.NewSlice([]scm.Scmer{scm.NewString("source_ref"), scm.NewString("allowed"), scm.NewString("priority"), scm.NewString("weight")})
 				schema := scm.NewSlice([]scm.Scmer{
-					newScanAccessHeader(3, scanAccessConsumerScan, 0, -1),
+					scm.NewSlice([]scm.Scmer{newScanAccessHeader(1, scanAccessConsumerScan, 0, -1), scm.NewNil(), readColumns}),
 					newScanBoundarySpec("source_ref", EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
-					newScanBoundarySpec("allowed", EqualMatcher, 1, 1, true, true, "", false, -1, nil, nil, "", false),
-					newScanBoundarySpec(".score", RangeMatcher, 1, -1, true, true, "", false, 2, []string{"priority", "weight"}, nil, "", false),
 				})
 				scan[3] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), schema})
 				if residual {
@@ -310,9 +313,12 @@ func TestExtractScanJoinInfoIncludesCompiledFilterDependencies(t *testing.T) {
 				if len(refs) != 1 {
 					t.Fatalf("expected one source dependency, got %#v", refs)
 				}
-				for _, column := range []string{"source_ref", "allowed", ".score", "priority", "weight"} {
+				if refs[0].unknownReads {
+					t.Fatal("explicit complete readset was classified as unknown")
+				}
+				for _, column := range []string{"source_ref", "allowed", "priority", "weight"} {
 					if !slices.Contains(refs[0].condCols, column) {
-						t.Errorf("compiled predicate dependency %q missing from %#v", column, refs[0])
+						t.Errorf("explicit predicate dependency %q missing from %#v", column, refs[0])
 					}
 				}
 				if residual || !dynamicValues {
@@ -324,6 +330,37 @@ func TestExtractScanJoinInfoIncludesCompiledFilterDependencies(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestLegacyScanAccessDoesNotClaimCompleteReadDependencies(t *testing.T) {
+	for _, access := range []scm.Scmer{
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice([]scm.Scmer{
+			newScanAccessHeader(0, scanAccessConsumerScan, 0, -1),
+		})}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice([]scm.Scmer{
+			scm.NewSlice([]scm.Scmer{newScanAccessHeader(0, scanAccessConsumerScan, 0, -1), scm.NewNil()}),
+		})}),
+		scm.NewSymbol("dynamic_access"),
+	} {
+		scan := nestedScanAst("legacy", "src", "ref_id")
+		scan.Slice()[3] = access
+		refs := extractScanJoinInfo(lambdaAst([]string{"ref_id"}, scan))
+		if len(refs) != 1 || !refs[0].unknownReads {
+			t.Fatalf("legacy/dynamic access claimed a complete filter readset: %#v", refs)
+		}
+		if got := scanRelevantSourceCols(refs[0], nil); len(got) != 0 {
+			t.Fatalf("legacy access restricted update invalidation to partial readset: %v", got)
+		}
+		if strings.Join(refs[0].srcCols, ",") != "ref_id" || strings.Join(refs[0].inputCols, ",") != "ref_id" {
+			t.Fatalf("legacy read uncertainty discarded selective reverse join: %#v", refs[0])
+		}
+	}
+	scan := nestedScanAst("legacy", "src", "ref_id")
+	scan.Slice()[3] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice(nil)})
+	refs := extractScanJoinInfo(lambdaAst([]string{"ref_id"}, scan))
+	if len(refs) != 1 || refs[0].unknownReads || len(scanRelevantSourceCols(refs[0], nil)) != 2 {
+		t.Fatalf("empty access lost its complete residual/mapper readset: %#v", refs)
 	}
 }
 
@@ -349,6 +386,10 @@ func TestRestoredComputeDependencyTriggersRefreshGuards(t *testing.T) {
 	for _, orc := range []bool{false, true} {
 		t.Run(fmt.Sprintf("orc=%t", orc), func(t *testing.T) {
 			computor := lambdaAst([]string{"ref_id"}, nestedScanAst(schemaName, "src", "ref_id"))
+			computor.Slice()[2].Slice()[3] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice([]scm.Scmer{
+				scm.NewSlice([]scm.Scmer{newScanAccessHeader(0, scanAccessConsumerScan, 0, -1), scm.NewNil(),
+					scm.NewSlice([]scm.Scmer{scm.NewString("ref_id")})}),
+			})})
 			register := func() {
 				if orc {
 					base.registerORCDependencyTriggers("cached", base.Columns[1], extractScanJoinInfo(computor))
@@ -385,10 +426,9 @@ func TestRestoredComputeDependencyTriggersRefreshGuards(t *testing.T) {
 			}
 			scan := computor.Slice()[2].Slice()
 			scan[3] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice([]scm.Scmer{
-				newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),
-				newScanBoundarySpec("allowed", EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
+				scm.NewSlice([]scm.Scmer{newScanAccessHeader(0, scanAccessConsumerScan, 0, -1), scm.NewNil(),
+					scm.NewSlice([]scm.Scmer{scm.NewString("ref_id"), scm.NewString("allowed")})}),
 			})})
-			scan[4] = listAst(scm.NewInt(1))
 			register()
 			register()
 			after := make([]string, len(src.Triggers))

--- a/storage/compute_trigger_test.go
+++ b/storage/compute_trigger_test.go
@@ -18,7 +18,10 @@ package storage
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -274,6 +277,152 @@ func TestExtractScanJoinInfoUsesCompiledAccessWhenResidualIsEmpty(t *testing.T) 
 		len(refs[0].srcCols) != 1 || refs[0].srcCols[0] != "source_ref" ||
 		len(refs[0].inputCols) != 1 || refs[0].inputCols[0] != "ref_id" {
 		t.Fatalf("compiled access dependency was not extracted: %#v; plan=%s", refs, serializeScmerForTest(computor))
+	}
+}
+
+func TestExtractScanJoinInfoIncludesCompiledFilterDependencies(t *testing.T) {
+	for _, residual := range []bool{false, true} {
+		for _, dynamicValues := range []bool{false, true} {
+			t.Run(fmt.Sprintf("residual=%t/dynamic_values=%t", residual, dynamicValues), func(t *testing.T) {
+				computor := scm.Read(t.Name(), `(lambda (ref_id)
+					(scan nil (table "tcompileddependency" "src")
+						'() (list ref_id 1)
+						'() (lambda () true)
+						'("value") (lambda (acc value) value)
+						nil nil false))`)
+				root := stripSourceInfo(computor).Slice()
+				scan := stripSourceInfo(root[2]).Slice()
+				schema := scm.NewSlice([]scm.Scmer{
+					newScanAccessHeader(3, scanAccessConsumerScan, 0, -1),
+					newScanBoundarySpec("source_ref", EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
+					newScanBoundarySpec("allowed", EqualMatcher, 1, 1, true, true, "", false, -1, nil, nil, "", false),
+					newScanBoundarySpec(".score", RangeMatcher, 1, -1, true, true, "", false, 2, []string{"priority", "weight"}, nil, "", false),
+				})
+				scan[3] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), schema})
+				if residual {
+					scan[5] = scm.Read(t.Name(), `'("source_ref")`)
+					scan[6] = scm.Read(t.Name(), `(lambda (source_ref) (equal? source_ref (outer 1 ref_id)))`)
+				}
+				if dynamicValues {
+					scan[4] = scm.NewSymbol("runtime_values")
+				}
+				refs := extractScanJoinInfo(computor)
+				if len(refs) != 1 {
+					t.Fatalf("expected one source dependency, got %#v", refs)
+				}
+				for _, column := range []string{"source_ref", "allowed", ".score", "priority", "weight"} {
+					if !slices.Contains(refs[0].condCols, column) {
+						t.Errorf("compiled predicate dependency %q missing from %#v", column, refs[0])
+					}
+				}
+				if residual || !dynamicValues {
+					if strings.Join(refs[0].srcCols, ",") != "source_ref" || strings.Join(refs[0].inputCols, ",") != "ref_id" {
+						t.Fatalf("constant/expression filters changed selective join mapping: %#v", refs[0])
+					}
+				} else if len(refs[0].srcCols) != 0 || len(refs[0].inputCols) != 0 {
+					t.Fatalf("dynamic access values manufactured a reverse mapping: %#v", refs[0])
+				}
+			})
+		}
+	}
+}
+
+// A schema written by an older binary can contain generated guards that omit
+// compiled-only predicates. Rebinding their target must also replace that code.
+func TestRestoredComputeDependencyTriggersRefreshGuards(t *testing.T) {
+	oldBasepath := Basepath
+	Basepath = t.TempDir()
+	defer func() { Basepath = oldBasepath }()
+	Init(scm.Globalenv)
+	LoadDatabases()
+	const schemaName = "trestoredcomputedependency"
+	defer databases.Remove(schemaName)
+	CreateDatabase(schemaName, false)
+	base, _ := CreateTable(schemaName, "base", Safe, false)
+	src, _ := CreateTable(schemaName, "src", Safe, false)
+	base.CreateColumn("ref_id", "INT", nil, nil)
+	base.CreateColumn("cached", "INT", nil, nil)
+	src.CreateColumn("ref_id", "INT", nil, nil)
+	src.CreateColumn("val", "INT", nil, nil)
+	src.CreateColumn("allowed", "INT", nil, nil)
+
+	for _, orc := range []bool{false, true} {
+		t.Run(fmt.Sprintf("orc=%t", orc), func(t *testing.T) {
+			computor := lambdaAst([]string{"ref_id"}, nestedScanAst(schemaName, "src", "ref_id"))
+			register := func() {
+				if orc {
+					base.registerORCDependencyTriggers("cached", base.Columns[1], extractScanJoinInfo(computor))
+				} else {
+					base.registerComputeTriggers("cached", computor)
+				}
+			}
+			register()
+			prefix := ".cache:base:cached|scan0|src|"
+			if orc {
+				prefix = ".orcdep:base:cached|scan0|src|"
+			}
+			old, found := findTriggerByPrefixAndTiming(src.Triggers, prefix, AfterUpdate)
+			if !found || strings.Contains(triggerPlanStringForTest(old), `"allowed"`) {
+				t.Fatal("fixture must begin with the old incomplete update guard")
+			}
+			encoded, err := json.Marshal(src.Triggers)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var restored []TriggerDescription
+			if err := json.Unmarshal(encoded, &restored); err != nil {
+				t.Fatal(err)
+			}
+			src.mu.Lock()
+			src.Triggers = restored
+			src.mu.Unlock()
+			// Exercise lazy compilation too: cached native/vector code from the
+			// restored body must not survive replacement of its scalar procedure.
+			src.GetTriggers(AfterUpdate)
+			before := make([]string, len(src.Triggers))
+			for i, tr := range src.Triggers {
+				before[i] = tr.Name
+			}
+			scan := computor.Slice()[2].Slice()
+			scan[3] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice([]scm.Scmer{
+				newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),
+				newScanBoundarySpec("allowed", EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
+			})})
+			scan[4] = listAst(scm.NewInt(1))
+			register()
+			register()
+			after := make([]string, len(src.Triggers))
+			for i, tr := range src.Triggers {
+				after[i] = tr.Name
+			}
+			if !slices.Equal(before, after) {
+				t.Fatalf("refresh changed trigger count/order: %v -> %v", before, after)
+			}
+			updated, found := findTriggerByPrefixAndTiming(src.Triggers, prefix, AfterUpdate)
+			if !found {
+				t.Fatal("updated trigger missing")
+			}
+			plan := triggerPlanStringForTest(updated)
+			for _, want := range []string{`(get_assoc OLD "allowed")`, `(get_assoc NEW "allowed")`} {
+				if !strings.Contains(plan, want) {
+					t.Fatalf("restored trigger kept obsolete dependency guard, missing %s:\n%s", want, plan)
+				}
+			}
+			parsedBody := stripSourceInfo(scm.Read(t.Name(), plan)).Slice()
+			guard := scm.Eval(lambdaAst([]string{"OLD", "NEW"}, parsedBody[1]), &scm.Globalenv)
+			oldRow := src.rowToDict(dataset{scm.NewInt(7), scm.NewInt(10), scm.NewInt(1)})
+			newRow := src.rowToDict(dataset{scm.NewInt(7), scm.NewInt(10), scm.NewInt(0)})
+			if !scm.ToBool(scm.Apply(guard, oldRow, newRow)) {
+				t.Fatal("updated guard suppressed an allowed-only mutation")
+			}
+			if scm.ToBool(scm.Apply(guard, oldRow, oldRow)) {
+				t.Fatal("updated guard invalidated an unchanged source row")
+			}
+			if !updated.acquireTarget(nil) {
+				t.Fatal("refreshed trigger target remained inert")
+			}
+			updated.releaseTarget()
+		})
 	}
 }
 

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -88,7 +88,7 @@ func newScanAccessHeader(count int, consumer string, projections int, mapperSlot
 func decodeScanAccessHeader(value scm.Scmer) (scanAccessSchemaMeta, bool) {
 	if value.IsSlice() {
 		header := value.Slice()
-		if len(header) != 2 {
+		if len(header) != 2 && len(header) != 3 {
 			return scanAccessSchemaMeta{}, false
 		}
 		value = header[0]
@@ -309,7 +309,9 @@ func shiftCompiledScanAccessSlots(schemaValue scm.Scmer, shift int) scm.Scmer {
 		if clone[1].Int() >= 0 {
 			clone[1] = scm.NewInt(clone[1].Int() + int64(shift))
 		}
-		shifted[0] = scm.NewSlice([]scm.Scmer{shifted[0].Slice()[0], scm.NewSlice(clone)})
+		header := append([]scm.Scmer(nil), shifted[0].Slice()...)
+		header[1] = scm.NewSlice(clone)
+		shifted[0] = scm.NewSlice(header)
 	}
 	for offset, count := scanAccessSchemaHeaderSize, meta.count; count > 0; offset, count = offset+scanAccessBoundaryStride, count-1 {
 		boundary := ScanBoundaryFromScmer(shifted[offset])
@@ -343,7 +345,7 @@ func markCoveredScanAccessSchema(schema, residual scm.Scmer) scm.Scmer {
 	if !valid {
 		return schema
 	}
-	items[0] = preserveScanFeedbackHeader(newScanAccessHeader(meta.count, scanAccessConsumerCoveredScan, meta.projections, meta.mapperSlot), items[0])
+	items[0] = preserveScanAccessHeaderMetadata(newScanAccessHeader(meta.count, scanAccessConsumerCoveredScan, meta.projections, meta.mapperSlot), items[0])
 	return scm.NewSlice(items)
 }
 

--- a/storage/scan_access_data.go
+++ b/storage/scan_access_data.go
@@ -26,7 +26,19 @@ func initScanAccessData(en *scm.Env) {
 	}
 	declare("scan_access_schema", func(a ...scm.Scmer) scm.Scmer {
 		boundaries, projections := a[0].Slice(), a[1].Slice()
-		if len(boundaries) == 0 && len(projections) == 0 && a[2].IsNil() {
+		knownReads := len(a) > 4 && !a[4].IsNil()
+		if knownReads {
+			if !a[4].IsSlice() {
+				panic("scan access read columns must be a list of strings")
+			}
+			for _, column := range a[4].Slice() {
+				if !column.IsString() {
+					panic("scan access read columns must be a list of strings")
+				}
+			}
+		}
+		// A genuinely empty access/readset keeps the existing empty-plan ABI.
+		if len(boundaries) == 0 && len(projections) == 0 && a[2].IsNil() && (!knownReads || len(a[4].Slice()) == 0) {
 			return scm.NewSlice(nil)
 		}
 		consumer := scanAccessConsumerScan
@@ -34,14 +46,16 @@ func initScanAccessData(en *scm.Env) {
 			consumer = scanAccessConsumerCoveredScan
 		}
 		header := newScanAccessHeader(len(boundaries), consumer, len(projections), -1)
-		if !a[2].IsNil() {
+		if knownReads {
+			header = scm.NewSlice([]scm.Scmer{header, a[2], a[4]})
+		} else if !a[2].IsNil() {
 			header = scm.NewSlice([]scm.Scmer{header, a[2]})
 		}
 		result := make([]scm.Scmer, 1, 1+len(boundaries)+len(projections))
 		result[0] = header
 		result = append(result, boundaries...)
 		return scm.NewSlice(append(result, projections...))
-	}, "packs explicit boundaries, projections, feedback metadata and coverage into an immutable operator argument")
+	}, "packs explicit boundaries, projections, feedback, coverage and optional full filter read columns into an immutable operator argument; read columns are registration metadata, not scan inputs")
 	declare("scan_access_schema?", func(a ...scm.Scmer) scm.Scmer {
 		if !a[0].IsSlice() || len(a[0].Slice()) == 0 {
 			return scm.NewBool(false)
@@ -65,10 +79,32 @@ func initScanAccessData(en *scm.Env) {
 		if scm.ToBool(a[1]) {
 			consumer = scanAccessConsumerCoveredScan
 		}
-		items[0] = preserveScanFeedbackHeader(newScanAccessHeader(meta.count, consumer, meta.projections, meta.mapperSlot), items[0])
+		items[0] = preserveScanAccessHeaderMetadata(newScanAccessHeader(meta.count, consumer, meta.projections, meta.mapperSlot), items[0])
 		return scm.NewSlice(items)
 	}, "records planner-proven residual coverage in a physical schema")
 	declare("scan_feedback_key", func(a ...scm.Scmer) scm.Scmer {
 		return staticFilterFeedbackKey(a[0], a[1].Slice())
 	}, "prebinds explicit statistics identity tokens to literal values")
+}
+
+// scanAccessReadColumns consumes the producer's explicit filter dependencies.
+// Called only when registering computed-cache dependencies, never by scan readers.
+// Old headers omit this field; unknown is deliberately distinct from an empty set.
+func scanAccessReadColumns(schema []scm.Scmer) ([]string, bool) {
+	if len(schema) == 0 || !schema[0].IsSlice() {
+		return nil, false
+	}
+	header := schema[0].Slice()
+	if len(header) != 3 || !header[2].IsSlice() {
+		return nil, false
+	}
+	columns := header[2].Slice()
+	result := make([]string, len(columns))
+	for i, column := range columns {
+		if !column.IsString() {
+			return nil, false
+		}
+		result[i] = column.String()
+	}
+	return result, true
 }

--- a/storage/scan_batch_rewrite.go
+++ b/storage/scan_batch_rewrite.go
@@ -395,7 +395,21 @@ func rewriteInnerScanToBatch(inner []scm.Scmer, pseudocols, pseudoparams []scm.S
 	// rewritten residual once here so scan_batch still receives the one ABI.
 	if schemaItems, schemaOK := scanStaticListElements(accessSchema); schemaOK && scanAccessSchemaIsEmpty(schemaItems) {
 		if compiledSchema, bindings, compiled := compileScanAccessMode(filterColumns, filterFn, true); compiled {
-			accessSchema = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), compiledSchema})
+			// Recompilation may rebuild value slots and feedback, but the producer's
+			// complete readset is independent of both and must survive unchanged.
+			if len(schemaItems) > 0 && schemaItems[0].IsSlice() && len(schemaItems[0].Slice()) == 3 {
+				items := append([]scm.Scmer(nil), compiledSchema.Slice()...)
+				if len(items) == 0 {
+					items = []scm.Scmer{newScanAccessHeader(0, scanAccessConsumerScan, 0, -1)}
+				}
+				feedback := scanFeedbackMetadata(items)
+				header := items[0]
+				if header.IsSlice() {
+					header = header.Slice()[0]
+				}
+				items[0] = scm.NewSlice([]scm.Scmer{header, feedback, schemaItems[0].Slice()[2]})
+				compiledSchema = scm.NewSlice(items)
+			}
 			accessValues = scanAccessValuesExpr(bindings)
 			_, residual := pruneScanResidual(filterColumns, filterFn, true)
 			accessSchema = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), markCoveredScanAccessSchema(compiledSchema, residual)})

--- a/storage/scan_batch_rewrite_test.go
+++ b/storage/scan_batch_rewrite_test.go
@@ -149,3 +149,42 @@ func TestParallelScanOptimizerAvoidsFrameLocalAccessValues(t *testing.T) {
 		t.Fatalf("parallel scan access values use frame-local storage: %s", plan)
 	}
 }
+
+func TestScanBatchRecompilePreservesExplicitFilterReadSet(t *testing.T) {
+	call := nestedScanBatchRewriteCall(scm.NewSymbol("inner_id"))
+	inner := call[8].Slice()[2].Slice()
+	readColumns := scm.NewSlice([]scm.Scmer{scm.NewString("allowed")})
+	schema := scm.NewSlice([]scm.Scmer{
+		scm.NewSlice([]scm.Scmer{newScanAccessHeader(0, scanAccessConsumerScan, 0, -1), scm.NewNil(), readColumns}),
+	})
+	inner[3] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), schema})
+	inner[5] = readColumns
+	inner[7] = readColumns
+	original := scm.SerializeToString(schema, &scm.Globalenv)
+
+	rewritten := rewriteInnerScanToBatch(inner,
+		[]scm.Scmer{scm.NewString("#0")}, []scm.Scmer{scm.NewSymbol("batch_key")},
+		map[string]string{"outer_id": "batch_key"}, nil, 1)
+	if len(rewritten) == 0 {
+		t.Fatal("batch rewrite rejected the metadata-only access schema")
+	}
+	items, ok := scanStaticListElements(rewritten[3])
+	if !ok || len(items) < 2 {
+		t.Fatal("batch rewrite did not compile the residual equality into access")
+	}
+	meta, valid := decodeScanAccessHeader(items[0])
+	if !valid || meta.count != 1 {
+		t.Fatalf("expected one recompiled boundary, got %#v", meta)
+	}
+	boundary := ScanBoundaryFromScmer(items[1])
+	if boundary.ColumnName() != "allowed" || boundary.LowerSlot() != -2 {
+		t.Fatalf("expected allowed equality against batch slot #0, got %s", scm.String(items[1]))
+	}
+	columns, known := scanAccessReadColumns(items)
+	if !known || len(columns) != 1 || columns[0] != "allowed" {
+		t.Fatalf("batch recompile lost producer readset or added pseudo columns: known=%t columns=%v", known, columns)
+	}
+	if got := scm.SerializeToString(schema, &scm.Globalenv); got != original {
+		t.Fatal("batch recompile mutated the original shared metadata")
+	}
+}

--- a/storage/scan_feedback.go
+++ b/storage/scan_feedback.go
@@ -482,20 +482,22 @@ func (t *table) filterFeedbackFingerprint() uint64 {
 	return 0
 }
 
-// A wrapped header carries optional serializable feedback metadata. The original
+// A wrapped header carries optional feedback and filter-readset metadata. The original
 // integer header and boundary layout remain readable, including persisted plans.
 func scanFeedbackMetadata(schema []scm.Scmer) scm.Scmer {
 	if len(schema) > 0 && schema[0].IsSlice() {
 		header := schema[0].Slice()
-		if len(header) == 2 {
+		if len(header) == 2 || len(header) == 3 {
 			return header[1]
 		}
 	}
 	return scm.NewNil()
 }
-func preserveScanFeedbackHeader(header, old scm.Scmer) scm.Scmer {
-	if old.IsSlice() && len(old.Slice()) == 2 {
-		return scm.NewSlice([]scm.Scmer{header, old.Slice()[1]})
+func preserveScanAccessHeaderMetadata(header, old scm.Scmer) scm.Scmer {
+	if old.IsSlice() && (len(old.Slice()) == 2 || len(old.Slice()) == 3) {
+		fields := append([]scm.Scmer(nil), old.Slice()...)
+		fields[0] = header
+		return scm.NewSlice(fields)
 	}
 	return header
 }

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -318,7 +318,7 @@ func compileScanOrderAccess(schemaExpr, valuesExpr, sortColsExpr, sortDirsExpr s
 	result := make([]scm.Scmer, 0, len(schema)+len(compiled))
 	header := newScanAccessHeader(meta.count+len(compiled), meta.consumer, meta.projections, meta.mapperSlot)
 	if len(schema) > 0 {
-		header = preserveScanFeedbackHeader(header, schema[0])
+		header = preserveScanAccessHeaderMetadata(header, schema[0])
 	}
 	result = append(result, header)
 	if len(schema) > scanAccessSchemaHeaderSize {

--- a/storage/scan_order_coverage_test.go
+++ b/storage/scan_order_coverage_test.go
@@ -397,3 +397,66 @@ func TestDirectScanOrderOuterRowSupportsWideProjection(t *testing.T) {
 		t.Fatalf("outer callback received %d arguments, want %d", got, want)
 	}
 }
+
+func TestExplicitScanReadSetSurvivesHeaderTransforms(t *testing.T) {
+	Init(scm.Globalenv)
+	readColumns := scm.NewSlice([]scm.Scmer{scm.NewString("allowed"), scm.NewString("priority"), scm.NewString("weight")})
+	feedback := scm.NewSlice([]scm.Scmer{
+		scm.NewSlice([]scm.Scmer{scm.NewInt(0)}), scm.NewInt(0), scm.NewString("allowed"), scm.NewFloat(0.1),
+	})
+	for _, withFeedback := range []bool{false, true} {
+		name := "without_feedback"
+		spec := scm.NewNil()
+		if withFeedback {
+			name, spec = "with_feedback", feedback
+		}
+		t.Run(name, func(t *testing.T) {
+			boundary := newScanBoundarySpec("allowed", EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false)
+			schema := scm.Apply(scm.Globalenv.Vars[scm.Symbol("scan_access_schema")],
+				scm.NewSlice([]scm.Scmer{boundary}), scm.NewSlice(nil), spec, scm.NewBool(false), readColumns)
+			metadataOnly := scm.Apply(scm.Globalenv.Vars[scm.Symbol("scan_access_schema")],
+				scm.NewSlice(nil), scm.NewSlice(nil), spec, scm.NewBool(false), readColumns)
+			if len(metadataOnly.Slice()) != 1 || !scm.Equal(metadataOnly.Slice()[0].Slice()[2], readColumns) {
+				t.Fatalf("readset-only schema was dropped without access boundaries: %s", scm.String(metadataOnly))
+			}
+			original := scm.SerializeToString(schema, &scm.Globalenv)
+			shifted := shiftCompiledScanAccessSlots(schema, 3)
+			covered := scm.Apply(scm.Globalenv.Vars[scm.Symbol("scan_access_cover")], schema, scm.NewBool(true))
+			marked := markCoveredScanAccessSchema(schema, lambdaAst(nil, scm.NewBool(true)))
+			direction, _ := persistableTestOrder(false)
+			ordered, _, ok := compileScanOrderAccess(
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), schema}), listAst(scm.NewInt(1)),
+				scm.NewSlice([]scm.Scmer{scm.NewString("rank")}), scm.NewSlice([]scm.Scmer{direction}))
+			if !ok {
+				t.Fatal("order compilation rejected explicit read metadata")
+			}
+			orderItems, _ := scanStaticListElements(ordered)
+			for _, value := range []scm.Scmer{schema, shifted, covered, marked, scm.NewSlice(orderItems)} {
+				items := value.Slice()
+				header := items[0]
+				if !header.IsSlice() || len(header.Slice()) != 3 || !scm.Equal(header.Slice()[2], readColumns) {
+					t.Fatalf("header transformation lost explicit read columns: %s", scm.String(value))
+				}
+				meta, valid := decodeScanAccessHeader(header)
+				if !valid || meta.projections != 0 || len(items) != 1+meta.count {
+					t.Fatalf("read metadata became runtime projection/boundary reads: %#v, %s", meta, scm.String(value))
+				}
+				if withFeedback == header.Slice()[1].IsNil() {
+					t.Fatalf("header transformation changed feedback presence: %s", scm.String(value))
+				}
+			}
+			if got := ScanBoundaryFromScmer(shifted.Slice()[1]).LowerSlot(); got != 3 {
+				t.Fatalf("boundary slot shift = %d, want 3", got)
+			}
+			if withFeedback {
+				shiftedSpec := shifted.Slice()[0].Slice()[1].Slice()
+				if shiftedSpec[0].Slice()[0].Int() != 3 || shiftedSpec[1].Int() != 3 {
+					t.Fatal("readset preservation prevented feedback slot relocation")
+				}
+			}
+			if scm.SerializeToString(schema, &scm.Globalenv) != original {
+				t.Fatal("header transformation mutated its shared input")
+			}
+		})
+	}
+}

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -161,6 +161,9 @@ type TriggerDescription struct {
 	VectorFunc scm.Scmer             `json:"-"`                   // Vectorized trigger: (lambda (OLD_batch NEW_batch) ...) for batch execution
 	Acquire    func(*TxContext) bool `json:"-"`                   // Optional lock-free pin for an ephemeral trigger target
 	Release    func()                `json:"-"`                   // Releases a successful Acquire
+	// Guarded by table.mu after publication. Generated dependency code restored
+	// from a previous binary must be regenerated before its target is rebound.
+	needsRegeneration bool
 }
 
 func acquireCacheUse(users *int64) bool {
@@ -273,6 +276,7 @@ func (tr *TriggerDescription) UnmarshalJSON(data []byte) error {
 	tr.IsSystem = persist.IsSystem
 	tr.Hidden = persist.Hidden
 	tr.Priority = persist.Priority
+	tr.needsRegeneration = strings.HasPrefix(tr.Name, ".cache:") || strings.HasPrefix(tr.Name, ".orcdep:")
 	tr.Async = persist.Async
 	tr.FuncPlan = scm.NewNil()
 	tr.VectorFunc = scm.NewNil()
@@ -465,6 +469,11 @@ func (t *table) AddTrigger(trigger TriggerDescription) {
 	finalizeTriggerCompilation(&trigger)
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.addTriggerLocked(trigger)
+}
+
+// addTriggerLocked inserts a compiled trigger while the caller holds t.mu.
+func (t *table) addTriggerLocked(trigger TriggerDescription) {
 	// Keep trigger list ordered by priority (lower = earlier). For equal
 	// priorities preserve registration order by inserting after existing ties.
 	insertAt := len(t.Triggers)

--- a/tests/performance/batch-observation-cost.yaml
+++ b/tests/performance/batch-observation-cost.yaml
@@ -136,3 +136,66 @@ test_cases:
 
   - name: "Learned LIKE selectivity retains the cheap cached batch plan"
     scm: *boc_cached_plan
+
+  - name: "Revoke an ACL value enforced entirely by compiled scan access"
+    sql: "UPDATE boc_acl SET allowed = 0 WHERE id = 14"
+    expect:
+      affected_rows: 1
+
+  - name: "Revoked ACL value is visible in the source row"
+    sql: "SELECT id, allowed FROM boc_acl WHERE id = 14"
+    expect:
+      data: [{id: 14, allowed: 0}]
+
+  - name: "Cached membership excludes a revoked grant from the ordered page"
+    sql: *boc_query
+    expect:
+      data: [{id: 19996, allowed: 1}, {id: 19994, allowed: 1}, {id: 19992, allowed: 1}, {id: 19990, allowed: 1}, {id: 19988, allowed: 1}]
+
+  - name: "OFFSET follows updated ACL membership"
+    sql: &boc_updated_offset |
+      SELECT d.id FROM boc_document d
+      LEFT JOIN boc_acl label ON label.id = d.domain_id
+      WHERE d.file_id IN (
+        SELECT id FROM boc_file WHERE filename LIKE '%alternate%'
+        UNION SELECT id FROM boc_file WHERE body LIKE '%commonneedle%'
+      ) AND EXISTS (SELECT 1 FROM boc_acl a WHERE a.id = d.domain_id AND a.allowed = 1)
+      ORDER BY d.rank_value DESC LIMIT 2 OFFSET 1
+    expect: &boc_denied_offset
+      data: [{id: 19994}, {id: 19992}]
+
+  - name: "A NULL grant remains denied"
+    sql: "UPDATE boc_acl SET allowed = NULL WHERE id = 14"
+    expect:
+      affected_rows: 1
+
+  - name: "NULL ACL values do not reappear through cached membership"
+    sql: *boc_updated_offset
+    expect: *boc_denied_offset
+
+  - name: "Restore a previously cached ACL grant"
+    sql: "UPDATE boc_acl SET allowed = 1 WHERE id = 14"
+    expect:
+      affected_rows: 1
+
+  - name: "Cached membership includes the restored grant"
+    sql: *boc_query
+    expect: *boc_page
+
+  - name: "Delete a warmed ACL grant"
+    sql: "DELETE FROM boc_acl WHERE id = 14"
+    expect:
+      affected_rows: 1
+
+  - name: "Missing grants are excluded before OFFSET"
+    sql: *boc_updated_offset
+    expect: *boc_denied_offset
+
+  - name: "Reinsert a removed ACL grant"
+    sql: "INSERT INTO boc_acl VALUES (14, 1)"
+    expect:
+      affected_rows: 1
+
+  - name: "Cached membership includes the reinserted grant"
+    sql: *boc_query
+    expect: *boc_page

--- a/tests/planner/joins/adaptive-filter-selectivity.yaml
+++ b/tests/planner/joins/adaptive-filter-selectivity.yaml
@@ -92,8 +92,10 @@ test_cases:
       (begin
         (define callback (list 'lambda (list 'x) (list '>= 'x (list 'quote '(200)))))
         (define access (eval (compile_scan_access '("id") callback)))
-        (if (list? (car (car access)))
-          (error "quoted list incorrectly acquired a scalar feedback identity") true))
+        (define header (car (car access)))
+        (if (and (equal? (nth header 1) nil)
+          (equal? (nth header 2) '("id"))) true
+          (error "quoted list must retain its readset without a scalar feedback identity")))
     expect:
       result_contains: ["true"]
 


### PR DESCRIPTION
Index-enforced predicates could disappear from computed-cache invalidation dependencies. For example, revoking a grant with `UPDATE ... SET allowed = 0` left a document in a cached LIMIT/OFFSET result because `allowed` had been removed from the residual filter.

`lib/queryplan-physical-scan.scm` now preserves the original filter-column readset before pruning, separately from residual callback inputs. Storage consumes that immutable metadata only during cache registration. It does not reconstruct the readset from index boundaries or add ACL semantics. The existing selective target-key hooks are unchanged. Legacy/opaque access plans without complete metadata cannot suppress updates using a partial readset.

Readsets survive coverage changes, value-slot shifts, order specialization, and batch recompilation. Restored compute/ORC dependency triggers are regenerated once before rebinding their targets; current triggers reuse their compiled code. No scan-loop checks, extra residual column readers, or repeated predicate evaluations are introduced. Existing mutation triggers use the complete dependencies.

Validation:

- ACL mutation regression: 19/19 passed; revocation, NULL, deletion and reinstatement covered.
- Explicit readset, legacy-header, restored-trigger and header-transform tests passed. Feedback-shift and batch-recompile tests reproduced metadata loss before their fixes.
- Scheme startup: 1283/1283. `go test ./...` passed.
- Full default `./git-pre-commit --fail-fast` passed on the final change: 6994/7021 cases, zero critical failures and 27 existing noncritical cases. The three compile-time guards also passed in this complete run.
- The instrumented `make test` run was stopped after three compile-time budget failures (wide derived scalar projection, independent nested scalar aggregates, holistic dependent joins). Both affected suites subsequently passed all 44 cases in isolation with the same candidate coverage binary and with a separately built baseline coverage binary. The long-run timing cause remains unproven; limits and expectations were not relaxed.
- Manual read-path A/B against `43d0c8140`: identical 20,000-row fixture, fresh servers, `GOMAXPROCS=2`, TracePrint off, three warmups and 15 samples per query; 76/76 responses matched the oracle. LIMIT warm median 2.2938 → 2.5421 ms (+0.2483 ms / +10.83%); OFFSET 89.4826 → 93.2668 ms (+3.7842 ms / +4.23%). First executions 109.649 → 102.876 ms and 187.685 → 190.390 ms respectively. Baseline is listed first; candidate was measured before baseline, with no concurrent test workload. This single sequential comparison is a regression check, not evidence of a speedup.

The existing noncritical SQL/RDF conformance cases remain unchanged. The Scheme membership-estimate startup assertion is updated to the existing metadata-reader behavior, including learned zero and unknown-metadata fallback.


CI follow-up: the first normal Performance A/B run failed its single cold `Uncached arithmetic aggregate performance` sample (25.137 → 99.601 ms; 80 ms limit). An isolated ABBA check of exact CI base `6696ed905` and merge candidate `a091cd359`, with unchanged 60,000-row fixture, fresh servers, `GOMAXPROCS=2`, zero warmups and one cold sample per server, produced base 16.554/20.901 ms and candidate 19.491/18.559 ms (median +1.59%); all eight measured query results matched. Both local binaries were uninstrumented; `-buildvcs=false` was needed for temporary worktree build stamping. This does not establish the cause of the CI outlier. The failed CI job was rerun without changing code or limits; JIT Performance A/B already passed.