### PR TITLE
Fix missing aggregate columns for UNION-based KPI queries

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -9391,6 +9391,29 @@ stars through the same catalog-aware path used by physical lowering. */
 				(wrap_plan_with_distinct_resultrow (lower_union_all_successive block)))
 			(neumann_fail "build_queryplan" "unknown UNION mode")))))
 
+/* UNION roots retain the catalogs of their query-block branches. Physical
+prepare ownership and missing-handle completion must see those stages too. */
+(define physical_node_stage_catalog (lambda (node)
+	(if (query_block? node)
+		(stage_catalog_with_nested (query_block_stage_catalog node))
+		(if (union_block? node)
+			(unique_stages_by_id
+				(merge (map (union_branches node) physical_node_stage_catalog)))
+			'()))))
+
+(define physical_node_with_stage_catalog (lambda (node)
+	(if (query_block? node)
+		(query_block_with_full_stage_catalog node)
+		(if (union_block? node)
+			(make_union_block
+				(union_mode node)
+				(map (union_branches node) physical_node_with_stage_catalog)
+				(union_order node)
+				(union_limit node)
+				(union_offset node)
+				(union_facts node))
+			node))))
+
 /* Physical preparation expands and attaches the canonical stage catalog once,
 without emitting runtime operators. Keeping this boundary explicit makes
 analysis and emission independently measurable while preserving the normal
@@ -9408,14 +9431,9 @@ build_queryplan contract. */
 					(list (quote physical_planning_tx) tx)))
 			(ir_root ir)))
 		(define contextual_root (apply_join_optimizer_plan_node contextual_input))
-		(define stages (if (query_block? contextual_root)
-			(stage_catalog_with_nested (query_block_stage_catalog contextual_root))
-			'()))
 		(make_ir
 			(ir_kind ir)
-			(if (query_block? contextual_root)
-				(query_block_with_full_stage_catalog_using contextual_root stages)
-				contextual_root)
+			(physical_node_with_stage_catalog contextual_root)
 			(map (ir_stages ir) apply_join_optimizer_plan_stage)
 			(ir_context_of ir)
 			(ir_return ir)))))
@@ -9503,11 +9521,10 @@ build_queryplan contract. */
 their physical recipe has been merged into another owner. Keep those logical
 handles callable without rebuilding the already consolidated carrier. */
 (define complete_emitted_prepare_bindings (lambda (ir plan)
-	(if (not (query_block? (ir_root ir)))
+	(if (not (or (query_block? (ir_root ir)) (union_block? (ir_root ir))))
 		plan
 		(begin
-			(define catalog (unique_stages_by_id
-				(stage_catalog_with_nested (query_block_stage_catalog (ir_root ir)))))
+			(define catalog (physical_node_stage_catalog (ir_root ir)))
 			(define bound_keys (emitted_prepare_binding_keys plan '()))
 			(define called_keys (emitted_prepare_call_keys plan '()))
 			(define missing_roots (filter catalog (lambda (stage)
@@ -9637,13 +9654,10 @@ recipe in one zero-argument helper. */
 					(quoted_runtime_list '())))))))
 
 (define closed_group_prepare_consolidation_required? (lambda (ir)
-	(and (query_block? (ir_root ir))
-		(reduce
-			(stage_catalog_with_nested
-				(query_block_stage_catalog (ir_root ir)))
-			(lambda (shared stage)
-				(or shared (stage_shared_prepare? stage)))
-			false))))
+	(reduce (physical_node_stage_catalog (ir_root ir))
+		(lambda (shared stage)
+			(or shared (stage_shared_prepare? stage)))
+		false)))
 
 /* Recipe emission is a two-step physical pass: normal lowering records which
 lazy stage keys are actually reachable, then this collector emits one closed
@@ -9653,8 +9667,7 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 	(if (not (closed_group_prepare_consolidation_required? ir))
 		plan
 		(begin
-			(define catalog (stage_catalog_with_nested
-				(query_block_stage_catalog (ir_root ir))))
+			(define catalog (physical_node_stage_catalog (ir_root ir)))
 			/* Unique carriers already own exactly one initializer. The consolidation
 			pass exists only for canonical backbones shared by multiple logical
 			stages; without one, its repeated full-plan usage and rewrite walks are

--- a/tests/integration/regressions/nested-aggregate-carrier.yaml
+++ b/tests/integration/regressions/nested-aggregate-carrier.yaml
@@ -19,6 +19,12 @@ metadata:
   isolated: true
 
 setup:
+  - sql: "DROP TABLE IF EXISTS nac_kpi_item"
+  - sql: "DROP TABLE IF EXISTS nac_kpi_offer"
+  - sql: "CREATE TABLE nac_kpi_offer (id INT PRIMARY KEY, created INT, customer INT)"
+  - sql: "CREATE TABLE nac_kpi_item (offer_id INT, quantity INT, price INT)"
+  - sql: "INSERT INTO nac_kpi_offer VALUES (1, 2, 1), (2, 3, 1), (3, 12, 2), (4, 13, 2)"
+  - sql: "INSERT INTO nac_kpi_item VALUES (1, 2, 10), (1, 1, 5), (2, 3, 10), (3, 1, 7)"
   - sql: "DROP TABLE IF EXISTS nac_team_item"
   - sql: "DROP TABLE IF EXISTS nac_ticket"
   - sql: "DROP TABLE IF EXISTS nac_state"
@@ -48,6 +54,8 @@ setup:
   - scm: '(settings "ShardSize" 60000)'
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS nac_kpi_item"
+  - sql: "DROP TABLE IF EXISTS nac_kpi_offer"
   - sql: "DROP TABLE IF EXISTS nac_team_item"
   - sql: "DROP TABLE IF EXISTS nac_ticket"
   - sql: "DROP TABLE IF EXISTS nac_state"
@@ -97,3 +105,103 @@ test_cases:
       rows: 1
       data:
         - {assigned_count: null}
+
+  - name: "KPI UNION prepares all nested aggregate columns cold"
+    sql: |
+      SELECT history.period, params.pindex,
+        COALESCE((SELECT COUNT(1) FROM nac_kpi_offer counted
+          WHERE counted.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) AS offers,
+        COALESCE((SELECT SUM((SELECT SUM(item.quantity * item.price)
+          FROM nac_kpi_item item WHERE item.offer_id = summed.id LIMIT 1))
+          FROM nac_kpi_offer summed
+          WHERE summed.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) AS total,
+        COALESCE((SELECT SUM((SELECT SUM(position.quantity * position.price)
+          FROM nac_kpi_item position WHERE position.offer_id = repeated.id LIMIT 1))
+          FROM nac_kpi_offer repeated
+          WHERE repeated.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) / 5 AS per_day,
+        COALESCE((SELECT AVG((SELECT SUM(element.quantity * element.price)
+          FROM nac_kpi_item element WHERE element.offer_id = averaged.id LIMIT 1))
+          FROM nac_kpi_offer averaged
+          WHERE averaged.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) AS average,
+        (SELECT COUNT(DISTINCT distinct_offer.customer) FROM nac_kpi_offer distinct_offer
+          WHERE distinct_offer.created BETWEEN history.start_time AND history.end_time LIMIT 1) AS customers
+      FROM (SELECT 0 AS period, 0 AS start_time, 9 AS end_time
+        UNION SELECT 1 AS period, 10 AS start_time, 19 AS end_time
+        UNION SELECT 2 AS period, 20 AS start_time, 29 AS end_time) history
+      CROSS JOIN (SELECT 0 AS pindex) params
+      ORDER BY history.period
+    expect:
+      rows: 3
+      data:
+        - {period: 0, pindex: 0, offers: 2, total: 55, per_day: 11, average: 27.5, customers: 1}
+        - {period: 1, pindex: 0, offers: 2, total: 7, per_day: 1.4, average: 7, customers: 1}
+        - {period: 2, pindex: 0, offers: 0, total: 0, per_day: 0, average: 0, customers: 0}
+
+  - name: "KPI UNION reuses all nested aggregate columns warm"
+    sql: |
+      SELECT history.period, params.pindex,
+        COALESCE((SELECT COUNT(1) FROM nac_kpi_offer counted
+          WHERE counted.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) AS offers,
+        COALESCE((SELECT SUM((SELECT SUM(item.quantity * item.price)
+          FROM nac_kpi_item item WHERE item.offer_id = summed.id LIMIT 1))
+          FROM nac_kpi_offer summed
+          WHERE summed.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) AS total,
+        COALESCE((SELECT SUM((SELECT SUM(position.quantity * position.price)
+          FROM nac_kpi_item position WHERE position.offer_id = repeated.id LIMIT 1))
+          FROM nac_kpi_offer repeated
+          WHERE repeated.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) / 5 AS per_day,
+        COALESCE((SELECT AVG((SELECT SUM(element.quantity * element.price)
+          FROM nac_kpi_item element WHERE element.offer_id = averaged.id LIMIT 1))
+          FROM nac_kpi_offer averaged
+          WHERE averaged.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) AS average,
+        (SELECT COUNT(DISTINCT distinct_offer.customer) FROM nac_kpi_offer distinct_offer
+          WHERE distinct_offer.created BETWEEN history.start_time AND history.end_time LIMIT 1) AS customers
+      FROM (SELECT 0 AS period, 0 AS start_time, 9 AS end_time
+        UNION SELECT 1 AS period, 10 AS start_time, 19 AS end_time
+        UNION SELECT 2 AS period, 20 AS start_time, 29 AS end_time) history
+      CROSS JOIN (SELECT 0 AS pindex) params
+      ORDER BY history.period
+    expect:
+      rows: 3
+      data:
+        - {period: 0, pindex: 0, offers: 2, total: 55, per_day: 11, average: 27.5, customers: 1}
+        - {period: 1, pindex: 0, offers: 2, total: 7, per_day: 1.4, average: 7, customers: 1}
+        - {period: 2, pindex: 0, offers: 0, total: 0, per_day: 0, average: 0, customers: 0}
+
+  - name: "KPI UNION ALL retains aggregate producers across branches"
+    sql: |
+      SELECT history.period, params.pindex,
+        COALESCE((SELECT COUNT(1) FROM nac_kpi_offer counted
+          WHERE counted.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) AS offers,
+        COALESCE((SELECT SUM((SELECT SUM(item.quantity * item.price)
+          FROM nac_kpi_item item WHERE item.offer_id = summed.id LIMIT 1))
+          FROM nac_kpi_offer summed
+          WHERE summed.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) AS total,
+        COALESCE((SELECT SUM((SELECT SUM(position.quantity * position.price)
+          FROM nac_kpi_item position WHERE position.offer_id = repeated.id LIMIT 1))
+          FROM nac_kpi_offer repeated
+          WHERE repeated.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) / 5 AS per_day,
+        COALESCE((SELECT AVG((SELECT SUM(element.quantity * element.price)
+          FROM nac_kpi_item element WHERE element.offer_id = averaged.id LIMIT 1))
+          FROM nac_kpi_offer averaged
+          WHERE averaged.created BETWEEN history.start_time AND history.end_time LIMIT 1), 0) AS average,
+        (SELECT COUNT(DISTINCT distinct_offer.customer) FROM nac_kpi_offer distinct_offer
+          WHERE distinct_offer.created BETWEEN history.start_time AND history.end_time LIMIT 1) AS customers
+      FROM (SELECT 0 AS period, 0 AS start_time, 9 AS end_time
+        UNION ALL SELECT 1 AS period, 10 AS start_time, 19 AS end_time
+        UNION ALL SELECT 2 AS period, 20 AS start_time, 29 AS end_time) history
+      CROSS JOIN (SELECT 0 AS pindex) params
+      ORDER BY history.period
+    expect:
+      rows: 3
+      data:
+        - {period: 0, pindex: 0, offers: 2, total: 55, per_day: 11, average: 27.5, customers: 1}
+        - {period: 1, pindex: 0, offers: 2, total: 7, per_day: 1.4, average: 7, customers: 1}
+        - {period: 2, pindex: 0, offers: 0, total: 0, per_day: 0, average: 0, customers: 0}
+
+  - name: "KPI aggregate rejects a missing user column"
+    sql: |
+      SELECT (SELECT SUM(item.missing_price) FROM nac_kpi_item item
+        WHERE item.offer_id = offer.id) AS total
+      FROM nac_kpi_offer offer
+    expect: {error: true}


### PR DESCRIPTION
Nested correlated KPI aggregates over a derived UNION of time periods can fail with `Column does not exist: … .grp:… .agg_…`. Physical preparation and the final prepare-ownership/completion passes only collected stages for query-block roots, leaving UNION branch consumers without all aggregate-column producers.

Recursively attach physical stage catalogs to UNION branches and include their stages in closed-group prepare consolidation and missing-handle completion. This retains the existing canonical group-cache identities and preparation recipes while ensuring every required aggregate column is initialized.

Regression coverage extends `nested-aggregate-carrier.yaml` with repeated nested SUMs, AVG, COUNT DISTINCT, UNION/UNION ALL, cold/warm reuse, empty periods, and a missing-column rejection. All three positive KPI cases fail on the baseline with the reported missing internal column and pass with the fix.

Validation:
- Interpreter: 36/36 cases across the carrier, composed aggregate, and correlated domain suites.
- JIT: 5/5 carrier regression cases plus 61/61 UNION and scalar-probe cases.
- Original reported SQL: cold and warm execution against independent synthetic tables, with populated periods, returns the expected KPI values.
- Full hook-equivalent suite (`MEMCP_FAIL_FAST=1 ./git-pre-commit`): passed. The 27 existing noncritical failures (deep correlation and RDF conformance) were reproduced unchanged on baseline `43d0c8140`.
- Changed Scheme file needs no formatting changes; its seven existing bracket-scanner warnings match the baseline. `git diff --check` passed.
