### PR TITLE
Keep the driver row for a correlated COUNT(DISTINCT) with an empty group

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -3087,6 +3087,14 @@ without separately proving two-valued semantics. */
 			where_corr_pairs having_corr_pairs))))
 		(define local_value_expr (decorrelate_expr_with_pairs inner_default all_corr_pairs value_expr))
 		(define ags (dedupe_aggregates_by_col (merge (list (extract_aggregates local_value_expr) (list aggregate_count_descriptor)))))
+		/* COUNT(DISTINCT)/GROUP_CONCAT(DISTINCT) lower to a merge_unique LIST
+		accumulator whose empty-group row the physical group cache does not emit, so
+		`preserve_empty_domain` cannot make an INNER join safe here. Keep the stage
+		source as a real LEFT join; a no-match outer row then reads NULL and
+		count_distinct_read_expr / group_concat_distinct_read_expr coalesce it to
+		0 / NULL. Neumann NK15 3.2: outer joins keep unmatched tuples. */
+		(define ags_have_list_accumulator (reduce ags (lambda (found ag)
+			(or found (count_distinct_descriptor? ag))) false))
 		(if (empty_list? ags)
 			(neumann_fail "untangle_query" "table-backed scalar subquery without aggregate needs partition_limit=2 and overflow checking")
 			true)
@@ -3126,7 +3134,7 @@ without separately proving two-valued semantics. */
 					(list (quote condition) stage_condition)
 					(list (quote domain) outer_domain)
 					(list (quote lookup-keys) lookup_keys)
-					(list (quote preserve_empty_domain) true)
+					(list (quote preserve_empty_domain) (not ags_have_list_accumulator))
 					(list (quote null_semantics) (quote aggregate))
 					(list (quote partition_by) keys)
 					(list (quote result_max_rows_per_partition) 1))
@@ -3138,7 +3146,7 @@ without separately proving two-valued semantics. */
 			stage_alias
 			(group_stage_schema stage)
 			(make_stage_output_relation stage_id)
-			(or (stage_source_outer? outer_sources) (not (equal? local_having true)))
+			(or (stage_source_outer? outer_sources) (not (equal? local_having true)) ags_have_list_accumulator)
 			(make_stage_lookup_condition stage_alias key_names lookup_keys post_condition)))
 		(define presence_expr (list (quote get_column) stage_alias false (aggregate_col_name aggregate_count_descriptor) false))
 		(define scalar_value_expr (replace_group_expr stage_input inner_default stage_alias keys key_names ags local_value_expr))

--- a/tests/planner/subqueries/scalar-subselect-patterns.yaml
+++ b/tests/planner/subqueries/scalar-subselect-patterns.yaml
@@ -501,3 +501,20 @@ test_cases:
       FROM sq_prop
     expect:
       rows: 4
+
+  # Pattern 7: a correlated COUNT(DISTINCT) must keep the driver row for a
+  # parent with no matching inner rows (result 0), not drop it -- the
+  # list-accumulator empty-group case. sq_doc 3 has no sq_prop.
+  - name: "Correlated COUNT(DISTINCT) keeps rows with an empty inner group"
+    sql: |
+      SELECT sq_doc.ID,
+        (SELECT COUNT(DISTINCT sq_prop.type) FROM sq_prop
+         WHERE sq_prop.doc = sq_doc.ID LIMIT 1) AS distinct_types
+      FROM sq_doc
+      ORDER BY sq_doc.ID
+    expect:
+      rows: 3
+      data:
+        - {ID: 1, distinct_types: 2}
+        - {ID: 2, distinct_types: 2}
+        - {ID: 3, distinct_types: 0}


### PR DESCRIPTION
## Bug

A correlated scalar `COUNT(DISTINCT c)` / `GROUP_CONCAT(DISTINCT c)` subquery drops the outer driver row when the subquery has no matching inner rows — it should yield `0` / `NULL` and keep the row. `COUNT(*)`, `COUNT(c)`, `SUM`, `MIN`, `MAX` behave correctly.

Only bites when the correlation flows through a **non-constant** column (a `?` / `@var` prepared parameter, or a non-folded derived-table column). With literal bounds the planner constant-folds them into the inner `WHERE`, the subquery is not correlated, and it works — which is why no existing test caught it.

Reproducer:
```sql
SELECT h.period,
  (SELECT COUNT(DISTINCT x.customer) FROM o x
   WHERE x.created BETWEEN h.s AND h.e LIMIT 1) AS c
FROM (SELECT @w1 AS period, @w2 AS s, @w3 AS e) h   -- w2=20, w3=29 → empty period
```
→ **0 rows** (expected `{period: 2, c: 0}`).

## Cause

`make_scalar_aggregate_stage_rewrite` lowers the subquery to a group stage with a `merge_unique` **list** accumulator (neutral `(list)`) and `(preserve_empty_domain true)`. `join_optimizer_guaranteed_singleton_source?` trusts that fact and joins the stage source **INNER**. But the physical group cache doesn't emit the neutral-`(list)` row for an empty-domain group the way it does for a count-like accumulator → the no-match domain value gets no stage row → the INNER join drops the outer row.

## Fix

When the stage's aggregates contain a list accumulator (`count_distinct_descriptor?`): `preserve_empty_domain false` + keep the stage source as a real **LEFT** join. A no-match outer row then reads `NULL`, which `count_distinct_read_expr` / `group_concat_distinct_read_expr` already coalesce to `0` / `NULL`.

Matches Neumann NK15 §3.2: *"for outer joins we always have to replicate the dependent join if the inner side depends on it, otherwise we cannot keep unmatched tuples"*.

## Tests

- New `scalar-subselect-patterns.yaml` case.
- Regression sweep of `tests/planner/{subqueries,aggregates,set-operations,order-window}` + `tests/integration/regressions` clean.
- `tests/integration/regressions/nested-aggregate-carrier.yaml` still 17/17.

## Not addressed

Correlated `GROUP_CONCAT(DISTINCT)` returns a wrong concatenation for **non-empty** groups (every driver row gets the first group's value) — a separate pre-existing bug in the per-partition list read. This PR only stops the empty-group row from being dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSuVhbwv6pvf3WiNPCRUht