### PR TITLE
Perf-test KPI plan-cache reuse across rotating period bounds

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -3087,6 +3087,14 @@ without separately proving two-valued semantics. */
 			where_corr_pairs having_corr_pairs))))
 		(define local_value_expr (decorrelate_expr_with_pairs inner_default all_corr_pairs value_expr))
 		(define ags (dedupe_aggregates_by_col (merge (list (extract_aggregates local_value_expr) (list aggregate_count_descriptor)))))
+		/* COUNT(DISTINCT)/GROUP_CONCAT(DISTINCT) lower to a merge_unique LIST
+		accumulator whose empty-group row the physical group cache does not emit, so
+		`preserve_empty_domain` cannot make an INNER join safe here. Keep the stage
+		source as a real LEFT join; a no-match outer row then reads NULL and
+		count_distinct_read_expr / group_concat_distinct_read_expr coalesce it to
+		0 / NULL. Neumann NK15 3.2: outer joins keep unmatched tuples. */
+		(define ags_have_list_accumulator (reduce ags (lambda (found ag)
+			(or found (count_distinct_descriptor? ag))) false))
 		(if (empty_list? ags)
 			(neumann_fail "untangle_query" "table-backed scalar subquery without aggregate needs partition_limit=2 and overflow checking")
 			true)
@@ -3126,7 +3134,7 @@ without separately proving two-valued semantics. */
 					(list (quote condition) stage_condition)
 					(list (quote domain) outer_domain)
 					(list (quote lookup-keys) lookup_keys)
-					(list (quote preserve_empty_domain) true)
+					(list (quote preserve_empty_domain) (not ags_have_list_accumulator))
 					(list (quote null_semantics) (quote aggregate))
 					(list (quote partition_by) keys)
 					(list (quote result_max_rows_per_partition) 1))
@@ -3138,7 +3146,7 @@ without separately proving two-valued semantics. */
 			stage_alias
 			(group_stage_schema stage)
 			(make_stage_output_relation stage_id)
-			(or (stage_source_outer? outer_sources) (not (equal? local_having true)))
+			(or (stage_source_outer? outer_sources) (not (equal? local_having true)) ags_have_list_accumulator)
 			(make_stage_lookup_condition stage_alias key_names lookup_keys post_condition)))
 		(define presence_expr (list (quote get_column) stage_alias false (aggregate_col_name aggregate_count_descriptor) false))
 		(define scalar_value_expr (replace_group_expr stage_input inner_default stage_alias keys key_names ags local_value_expr))

--- a/lib/sql-parameters.scm
+++ b/lib/sql-parameters.scm
@@ -57,6 +57,31 @@ the complete statement. Tokenization uses the runtime's generic regex engine. */
 			(if (has? '("FROM" "WHERE" "HAVING" "LIMIT" "OFFSET" "GROUP" "ORDER" "UNION" "ON") word)
 				(scope "clause" (if (equal? word "ON") "WHERE" word)))))))
 
+(define sql_parameter_next_significant (lambda (tokens i)
+	(if (>= i (count tokens)) nil
+		(if (regexp_test (nth tokens i) "^(?:[ \\t\\r\\n]|--|#|/\\*)")
+			(sql_parameter_next_significant tokens (+ i 1))
+			(nth tokens i)))))
+
+/* One item of an all-constant projection row, e.g. each literal in
+`SELECT 0 AS i, 1704067200 AS s, 1789037871 AS e` (the shape a generated query
+emits for a UNION of synthetic period rows). Such a literal is the whole
+select-list expression: it only appears verbatim in the result and never
+influences plan shape, selectivity or grouping, so it is a forced candidate that
+survives an unsafe scope. Recognised lexically: it opens a select item (previous
+significant token is SELECT or a comma), sits at the scope's own paren depth and
+is directly AS-aliased. The caller gates this on const_row_ok, which additionally
+requires the entire select list to be constant-AS items. */
+(define sql_parameter_select_const_item (lambda (const_row_ok scope depth previous_token idx tokens)
+	(and const_row_ok
+		(not (nil? scope))
+		(equal? depth (scope "depth"))
+		(equal? (scope "clause") "SELECT")
+		(has? '("SELECT" ",") previous_token)
+		(match (sql_parameter_next_significant tokens (+ idx 1))
+			next (equal? (toUpper next) "AS")
+			_ false))))
+
 /* Candidates retain their owning scope until all tokens have been visited:
 a later GROUP/HAVING may disqualify an earlier literal in that scope. The
 sessions and token buffers belong to this one lexical compilation only. */
@@ -64,6 +89,11 @@ sessions and token buffers belong to this one lexical compilation only. */
 	(if (not (sql_parameter_prefix query)) (list query '() (fnv_hash query))
 		(begin
 			(define tokens (sql_parameter_tokens query))
+			/* Only fold constant projection items when the whole SELECT list is a
+			constant row (`SELECT <num> AS a, <num> AS b [...] FROM|UNION|)`), the shape a
+			generated query produces for a UNION of synthetic period rows. A lone
+			`1 AS _flag` mixed with real columns stays exact -- it is a match carrier. */
+			(define const_row_ok (regexp_test query "(?is)SELECT\\s+-?(?:0[xX][0-9a-fA-F]+|[0-9]+(?:\\.[0-9]*)?(?:[eE][+-]?[0-9]+)?)\\s+AS\\s+(?:`[^`]+`|[A-Za-z_$][A-Za-z0-9_$]*)\\s*(?:,\\s*-?(?:0[xX][0-9a-fA-F]+|[0-9]+(?:\\.[0-9]*)?(?:[eE][+-]?[0-9]+)?)\\s+AS\\s+(?:`[^`]+`|[A-Za-z_$][A-Za-z0-9_$]*)\\s*)*(?:FROM\\b|UNION\\b|\\)|;|$)"))
 			(define candidates (newsession))
 			(define pieces (newsession))
 			(define result (for (list 0 0 -1 "" "" '() false 0 0)
@@ -106,20 +136,28 @@ sessions and token buffers belong to this one lexical compilation only. */
 														(if (and (< (+ idx 2) (count tokens)) (regexp_test (nth tokens (+ idx 2)) "^[a-zA-Z0-9_$]"))
 															(begin (pieces piece_count token) (list (+ idx 1) depth type_depth previous_word token scopes false candidate_count (+ piece_count 1))) (begin (candidates candidate_count (list piece_count scope false (simplify (concat "-" number)))) (begin (pieces piece_count (concat "-" number)) (list (+ idx 2) depth type_depth previous_word "literal" scopes false (+ candidate_count 1) (+ piece_count 1))))))
 													(if (regexp_test token "^[0-9]")
-														(if (or (>= type_depth 0) (not (sql_parameter_scope_allows scope))
+														(if (or (>= type_depth 0)
+															(and (not (sql_parameter_scope_allows scope)) (not (sql_parameter_select_const_item const_row_ok scope depth previous_token idx tokens)))
 															(and (not (nil? scope)) (equal? (scope "order_depth") depth) (or (equal? previous_word "BY") (equal? previous_token ",")))
 															(and (< (+ idx 1) (count tokens)) (regexp_test (nth tokens (+ idx 1)) "^[a-zA-Z0-9_$]")))
-															(begin (pieces piece_count token) (list (+ idx 1) depth type_depth previous_word "literal" scopes false candidate_count (+ piece_count 1))) (begin (candidates candidate_count (list piece_count scope false (simplify token))) (begin (pieces piece_count token) (list (+ idx 1) depth type_depth previous_word "literal" scopes false (+ candidate_count 1) (+ piece_count 1)))))
+															(begin (pieces piece_count token) (list (+ idx 1) depth type_depth previous_word "literal" scopes false candidate_count (+ piece_count 1))) (begin (candidates candidate_count (list piece_count scope (sql_parameter_select_const_item const_row_ok scope depth previous_token idx tokens) (simplify token))) (begin (pieces piece_count token) (list (+ idx 1) depth type_depth previous_word "literal" scopes false (+ candidate_count 1) (+ piece_count 1)))))
 														(begin (pieces piece_count token) (list (+ idx 1) depth type_depth previous_word token scopes (or (equal? token "?") (and (equal? token "/") (< (+ idx 1) (count tokens)) (equal? (nth tokens (+ idx 1)) "*"))) candidate_count (+ piece_count 1)))))))))))))))
 			(match result '(_idx _depth _type _word _token scopes invalid candidate_count piece_count)
-				(if (or invalid (equal? scopes '()) ((car scopes) "unsafe") (equal? candidate_count 0))
+				(if (or invalid (equal? scopes '()) (equal? candidate_count 0))
 					(list query '() (fnv_hash query))
 					(begin
+						/* A forced candidate (a constant projection item) is safe even in an unsafe
+						scope; any other literal is kept only when neither its scope nor the outer
+						query block is unsafe. */
+						(define top_unsafe ((car scopes) "unsafe"))
 						(define accepted (filter (map (produceN candidate_count) (lambda (idx) (candidates idx)))
-							(lambda (candidate) (or (nth candidate 2) (not ((cadr candidate) "unsafe"))))))
-						(reduce accepted (lambda (_ candidate) (pieces (car candidate) "?")) nil)
-						(define normalized (apply concat (map (produceN piece_count) (lambda (idx) (pieces idx)))))
-						(list normalized (map accepted (lambda (candidate) (nth candidate 3))) (fnv_hash normalized)))))))))
+							(lambda (candidate) (or (nth candidate 2) (and (not top_unsafe) (not ((cadr candidate) "unsafe")))))))
+						(if (equal? accepted '())
+							(list query '() (fnv_hash query))
+							(begin
+								(reduce accepted (lambda (_ candidate) (pieces (car candidate) "?")) nil)
+								(define normalized (apply concat (map (produceN piece_count) (lambda (idx) (pieces idx)))))
+								(list normalized (map accepted (lambda (candidate) (nth candidate 3))) (fnv_hash normalized)))))))))))
 
 /* Keep exact SQL variants out of the parser while sharing their compiled plan.
 Only parameterized results enter the small front cache; exact-only statements

--- a/tests/performance/kpi-period-cache-reuse.yaml
+++ b/tests/performance/kpi-period-cache-reuse.yaml
@@ -1,0 +1,122 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# A generated dashboard rebuilds the period derived table on every request with
+# now() baked in as a literal, so the exact query text -- and the plan-cache key
+# -- changes each time. With constant-projection-row parameterization the
+# compiled plan is shared across those literal variants; without it every
+# request pays a full nested-aggregate re-plan.
+#
+# The COUNT(DISTINCT) column additionally exercises the correlated list-
+# accumulator path: once the period bounds are session values the subquery is
+# genuinely correlated, and the empty period must still produce a row with 0.
+metadata:
+  version: '1.0'
+  description: KPI period plan is reused across rotating now()-style period bounds
+  isolated: true
+  ci: false
+  perf_ci: true
+  performance_rows: 1000
+
+test_cases:
+  # 20 KPI executions, each with a different end_time literal on period 0 that is
+  # already past every offer, so the result is identical every time. With plan
+  # reuse this is one nested-aggregate compile plus 19 cache hits; without it, 20
+  # compiles.
+  - name: "KPI plan is reused across rotating period-bound literals"
+    performance_rows: 1000
+    threshold_ms: 4000
+    # Periods 0-4 each hold {rows} offers with 3 distinct customers; period 5 is empty.
+    setup:
+      - sql: "DROP TABLE IF EXISTS kpr_item"
+      - sql: "DROP TABLE IF EXISTS kpr_offer"
+      - sql: "CREATE TABLE kpr_offer (id INT PRIMARY KEY, created BIGINT, customer INT) ENGINE=sloppy"
+      - sql: "CREATE TABLE kpr_item (offer_id INT, quantity INT, unit_price INT) ENGINE=sloppy"
+      - scm: |
+          (begin
+            (map (produceN 5) (lambda (p)
+              (insert (table "{database}" "kpr_offer") '("id" "created" "customer")
+                (map (produceN {rows}) (lambda (i)
+                  (list (+ 1 i (* p {rows})) (+ (* p 1000) (mod i 1000)) (mod i 3)))))))
+            (insert (table "{database}" "kpr_item") '("offer_id" "quantity" "unit_price")
+              (map (produceN (* 5 {rows})) (lambda (i)
+                (list (+ 1 (floor (/ i 5))) (+ 1 (mod i 5)) (+ 1 (mod (floor (/ i 5)) 100))))))
+            (rebuild)
+            (* 6 {rows}))
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "{database}")
+        (define kpi (lambda (bound) (concat
+          "SELECT h.period,"
+          " (SELECT COUNT(1) FROM kpr_offer counted WHERE counted.created BETWEEN h.s AND h.e LIMIT 1) AS oc,"
+          " COALESCE((SELECT SUM((SELECT SUM(it.quantity * it.unit_price) FROM kpr_item it WHERE it.offer_id = s.id LIMIT 1))"
+          "   FROM kpr_offer s WHERE s.created BETWEEN h.s AND h.e LIMIT 1), 0) AS os"
+          " FROM (SELECT 0 AS period, 0 AS s, " (string bound) " AS e"
+          "   UNION SELECT 1 AS period, 1000 AS s, 1999 AS e"
+          "   UNION SELECT 2 AS period, 2000 AS s, 2999 AS e"
+          "   UNION SELECT 3 AS period, 3000 AS s, 3999 AS e"
+          "   UNION SELECT 4 AS period, 4000 AS s, 4999 AS e"
+          "   UNION SELECT 5 AS period, 90000 AS s, 99999 AS e) h"
+          " ORDER BY h.period")))
+        (define rows (newsession))
+        (rows "n" 0)
+        (define emit (lambda (_row) (rows "n" (+ (rows "n") 1))))
+        (map (produceN 20) (lambda (i)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "{database}" (kpi (+ 6000000 i)) nil "root" sess true)
+            emit (lambda (_fields) nil))))
+        (if (equal? (rows "n") 120) true (error (concat "rotating KPI literals changed the row count: " (string (rows "n"))))))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+
+  # Same rotation, but the customers column is COUNT(DISTINCT). Once the bounds
+  # are session values the subquery is correlated; the empty period 5 must still
+  # yield a row with customers = 0.
+  - name: "KPI COUNT(DISTINCT) keeps every period and reuses the plan"
+    performance_rows: 1000
+    threshold_ms: 4000
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "{database}")
+        (define kpi (lambda (bound) (concat
+          "SELECT h.period,"
+          " (SELECT COUNT(1) FROM kpr_offer counted WHERE counted.created BETWEEN h.s AND h.e LIMIT 1) AS oc,"
+          " (SELECT COUNT(DISTINCT c.customer) FROM kpr_offer c WHERE c.created BETWEEN h.s AND h.e LIMIT 1) AS customers"
+          " FROM (SELECT 0 AS period, 0 AS s, " (string bound) " AS e"
+          "   UNION SELECT 1 AS period, 1000 AS s, 1999 AS e"
+          "   UNION SELECT 2 AS period, 2000 AS s, 2999 AS e"
+          "   UNION SELECT 3 AS period, 3000 AS s, 3999 AS e"
+          "   UNION SELECT 4 AS period, 4000 AS s, 4999 AS e"
+          "   UNION SELECT 5 AS period, 90000 AS s, 99999 AS e) h"
+          " ORDER BY h.period")))
+        (define acc (newsession))
+        (acc "rows" 0)
+        (acc "empty_customers" -1)
+        (define emit (lambda (row) (begin
+          (acc "rows" (+ (acc "rows") 1))
+          (if (equal? (get_assoc row "period") 5)
+            (acc "empty_customers" (get_assoc row "customers"))
+            nil))))
+        (map (produceN 20) (lambda (i)
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parse_sql) "{database}" (kpi (+ 6000000 i)) nil "root" sess true)
+            emit (lambda (_fields) nil))))
+        (if (not (equal? (acc "rows") 120))
+          (error (concat "rotating COUNT(DISTINCT) KPI changed the row count: " (string (acc "rows"))))
+          (if (not (equal? (acc "empty_customers") 0))
+            (error (concat "empty period dropped or wrong COUNT(DISTINCT): " (string (acc "empty_customers"))))
+            true)))
+    expect:
+      rows: 1
+      result_contains: ["true"]
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS kpr_item"
+  - sql: "DROP TABLE IF EXISTS kpr_offer"

--- a/tests/planner/core/query-cache-growth.yaml
+++ b/tests/planner/core/query-cache-growth.yaml
@@ -148,5 +148,35 @@ test_cases:
         "ok")
     expect:
       data: ["ok"]
+  - name: "Constant projection row folds to shared placeholders"
+    scm: |
+      (match (parameterize_sql_select_literals "SELECT h.i FROM (SELECT 0 AS i, 1704067200 AS s, 1789037871 AS e UNION SELECT 1 AS i, 1672531200 AS s, 1704067199 AS e) h") '(normalized bindings shape_hash)
+        (if (and (equal? normalized "SELECT h.i FROM (SELECT ? AS i, ? AS s, ? AS e UNION SELECT ? AS i, ? AS s, ? AS e) h")
+          (equal? bindings (list 0 1704067200 1789037871 1 1672531200 1704067199))
+          (equal? shape_hash (fnv_hash normalized)))
+          "ok" (error (concat "const-row mismatch: " normalized " / " bindings))))
+    expect:
+      data: ["ok"]
+  - name: "Constant projection row shape is now()-invariant"
+    scm: |
+      (if (equal?
+        (nth (parameterize_sql_select_literals "SELECT 0 AS i, 1704067200 AS s, 1789037871 AS e FROM dual") 2)
+        (nth (parameterize_sql_select_literals "SELECT 0 AS i, 1704067200 AS s, 1789099999 AS e FROM dual") 2))
+        "ok" (error "const-row shape hash still varies with the literal"))
+    expect:
+      data: ["ok"]
+  - name: "Mixed projection keeps a lone carrier literal exact"
+    scm: |
+      (begin
+        (map (list
+          "SELECT d.id, 1 AS _count FROM items d WHERE d.label LIKE '%x%'"
+          "SELECT 1 AS marker, id FROM items WHERE id = 3"
+          "SELECT count(*), 5 AS n FROM items") (lambda (query)
+          (match (parameterize_sql_select_literals query) '(normalized bindings shape_hash)
+            (if (match normalized (regex "(?s)^SELECT (?:count\\(\\*\\)|d\\.id, 1 AS _count|1 AS marker, id)" _) true false)
+              true (error (concat "carrier literal was folded: " normalized))))))
+        "ok")
+    expect:
+      data: ["ok"]
 cleanup:
   - sql: "DROP TABLE IF EXISTS cg_rows"

--- a/tests/planner/subqueries/scalar-subselect-patterns.yaml
+++ b/tests/planner/subqueries/scalar-subselect-patterns.yaml
@@ -501,3 +501,20 @@ test_cases:
       FROM sq_prop
     expect:
       rows: 4
+
+  # Pattern 7: a correlated COUNT(DISTINCT) must keep the driver row for a
+  # parent with no matching inner rows (result 0), not drop it -- the
+  # list-accumulator empty-group case. sq_doc 3 has no sq_prop.
+  - name: "Correlated COUNT(DISTINCT) keeps rows with an empty inner group"
+    sql: |
+      SELECT sq_doc.ID,
+        (SELECT COUNT(DISTINCT sq_prop.type) FROM sq_prop
+         WHERE sq_prop.doc = sq_doc.ID LIMIT 1) AS distinct_types
+      FROM sq_doc
+      ORDER BY sq_doc.ID
+    expect:
+      rows: 3
+      data:
+        - {ID: 1, distinct_types: 2}
+        - {ID: 2, distinct_types: 2}
+        - {ID: 3, distinct_types: 0}


### PR DESCRIPTION
Stacked on #883 (carrying the #884 planner fix as its second commit); targeted at master. Until #883/#884 land, this PR shows their three commits and then slims to the one new perf suite.

## What this measures

`tests/performance/kpi-period-cache-reuse.yaml` reproduces the generated-dashboard workload behind #883: a KPI query whose period derived table is `SELECT <const> AS period, <const> AS s, <now()-varying const> AS e UNION ...`, so the query text and the plan-cache key change on every request.

Two cases, each 20 executions through one shared `newcachemap` with a rotating period-0 bound:

| case | shape | guards |
|---|---|---|
| KPI plan is reused across rotating period-bound literals | `COUNT(1)` + nested `SUM((SELECT SUM ...))` | #883 constant-projection-row parameterization |
| KPI COUNT(DISTINCT) keeps every period and reuses the plan | + correlated `COUNT(DISTINCT c.customer)`, asserts the empty trailing period still yields a row with `0` | #884 empty-group row-drop fix |

## Results (local, `PERF_TEST=1`)

- Branch: 2/2 green, ~1.2s / ~0.6s vs a 4s threshold, stable across repeated runs.
- master: warmup fails outright — the churn of near-identical constant-folded plans through the cache trips a non-deterministic `bind_query_names: unknown relation alias: h` on the empty trailing period. #883's parameterization keeps the derived-table columns non-constant, removing the re-plan cost and sidestepping that bind path. (#884's logical-plan diff is a no-op for case 1; case 1 is carried entirely by #883.)

`performance-ab` / `jit-performance-ab` run the suite against both the PR-merge binary and the base (`master`) binary; the base side is expected to report the warmup failure above until #883 merges.

## Notes

- `metadata: ci:false, perf_ci:true` — picked up by the performance-CI batch only, not the SQL correctness run.
- Fixture: 5 non-empty periods × 1000 offers + 5000 line items (`ENGINE=sloppy`), built once in case 1's per-case `setup`; case 2 reuses it, matching `kpi-period-aggregates.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSuVhbwv6pvf3WiNPCRUht
