### PR TITLE
Let commit trailers waive named perf-ab regressions in review

### DIFF
--- a/.github/workflows/jit-performance.yml
+++ b/.github/workflows/jit-performance.yml
@@ -36,12 +36,26 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           path: candidate
+          fetch-depth: 0 # full history: needed to list this PR's commit messages below
 
       - name: Check out exact base revision
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'master' }}
           path: base
+
+      - name: Collect accepted-regression waivers from this PR's commits
+        # A commit can name an exact perf case it knowingly regresses (see
+        # `Perf-Regression-Accepted:` in run_sql_tests.py) instead of a
+        # maintainer bypassing this check by hand. Scoped to this PR's own
+        # commits only -- never to master or an unrelated PR. workflow_dispatch
+        # has no PR to scope to, so it gets no waivers file at all.
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C candidate log ${{ github.event.pull_request.base.sha }}..HEAD --format=%B \
+            > "$GITHUB_WORKSPACE/jit-perf-regression-waivers.txt"
 
       - name: Check out patched Go compiler
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -126,6 +140,7 @@ jobs:
             MEMCP_TEST_JOBS=4 \
             MEMCP_TEST_WORKTREE="$GITHUB_WORKSPACE/candidate" \
             MEMCP_TEST_DATA_DIR=/tmp/memcp-jit-perf-candidate \
+            PERF_REGRESSION_WAIVERS_FILE="$GITHUB_WORKSPACE/jit-perf-regression-waivers.txt" \
             python3 -u "$runner" --perf-ci --jobs 4 --log-times)
 
       - name: Upload measured JIT base

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           path: candidate
+          fetch-depth: 0 # full history: needed to list this PR's commit messages below
 
       - name: Check out exact base revision
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -44,6 +45,17 @@ jobs:
 
       - name: Install test dependencies
         run: pip install requests PyYAML
+
+      - name: Collect accepted-regression waivers from this PR's commits
+        # A commit can name an exact perf case it knowingly regresses (see
+        # `Perf-Regression-Accepted:` in run_sql_tests.py) instead of a
+        # maintainer bypassing this check by hand. Scoped to this PR's own
+        # commits only -- never to master or an unrelated PR.
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C candidate log ${{ github.event.pull_request.base.sha }}..HEAD --format=%B \
+            > "$GITHUB_WORKSPACE/perf-regression-waivers.txt"
 
       - name: Build base and candidate
         shell: bash
@@ -91,6 +103,7 @@ jobs:
             MEMCP_TEST_JOBS=4 \
             MEMCP_TEST_WORKTREE="$GITHUB_WORKSPACE/candidate" \
             MEMCP_TEST_DATA_DIR=/tmp/memcp-perf-candidate \
+            PERF_REGRESSION_WAIVERS_FILE="$GITHUB_WORKSPACE/perf-regression-waivers.txt" \
             python3 -u "$runner" --perf-ci --jobs 4 --log-times)
 
       - name: Upload measured base

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -430,6 +430,53 @@ def performance_case_key(spec_file: str, name: str) -> str:
     return f"{normalized}::{name}"
 
 
+# A commit that knowingly trades performance for something else (a correctness
+# fix, a necessary architectural change) can say so explicitly instead of
+# forcing a maintainer to bypass CI by hand. One line per accepted case, using
+# the exact key `performance_case_key` already prints in a "Too slow" failure:
+#
+#   Perf-Regression-Accepted: tests/performance/foo.yaml::Some case name | why
+#
+# The key must match exactly -- no prefixes, no globs -- so a waiver can only
+# ever cover the specific case it names. Waivers only ever come from the
+# commit messages of the PR under review (see PERF_REGRESSION_WAIVERS_FILE
+# below); there is no way to waive a case outside of that review, and the
+# waiver's reason is permanently in `git log` for whoever reads it next.
+PERF_REGRESSION_ACCEPTED_RE = re.compile(r"^Perf-Regression-Accepted:\s*(.+)$", re.MULTILINE)
+
+
+def parse_perf_regression_waivers(commit_messages: str) -> Dict[str, str]:
+    waivers: Dict[str, str] = {}
+    for match in PERF_REGRESSION_ACCEPTED_RE.finditer(commit_messages or ""):
+        rest = match.group(1).strip()
+        if "|" in rest:
+            key, reason = rest.split("|", 1)
+            key, reason = key.strip(), reason.strip()
+        else:
+            key, reason = rest, ""
+        if key:
+            waivers[key] = reason
+    return waivers
+
+
+def load_perf_regression_waivers() -> Dict[str, str]:
+    """Load accepted-regression waivers for this run, if any.
+
+    Source: PERF_REGRESSION_WAIVERS_FILE, a file the CI workflow populates
+    with `git log <base>..<head> --format=%B` for the PR under review.
+    Unset (the default, including every local/manual run): no waivers, every
+    regression fails exactly as before.
+    """
+    path = os.environ.get("PERF_REGRESSION_WAIVERS_FILE")
+    if not path:
+        return {}
+    try:
+        commit_messages = Path(path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    return parse_perf_regression_waivers(commit_messages)
+
+
 def performance_case_fingerprint(
     test_case: Dict[str, Any], suite_setup: Any = None, suite_syntax: Any = None
 ) -> str:
@@ -699,6 +746,8 @@ class SQLTestRunner:
         self.perf_baselines = {}  # test_name -> {"time_ms": float, "rows": int}
         self.perf_results = {}  # test_name -> {"time_ms": float, "rows": int}
         self.perf_seen = set()
+        self.perf_regression_waivers: Dict[str, str] = load_perf_regression_waivers()  # case_key -> reason
+        self.waived_regressions = []  # [(name, case_key, reason, elapsed_ms, threshold_ms)]
         self.log_times = log_times  # emit QUERY_TIME ns=... lines for A/B benchmarking
         self.fail_fast = fail_fast
         self.current_spec_file = None
@@ -1793,9 +1842,19 @@ class SQLTestRunner:
                 f"{elapsed_ms:.3f}ms per repetition ({change_pct:+.1f}%)"
             )
         if is_perf_test and PERF_AB_MODE != "record" and elapsed_ms > threshold_ms:
-            diag = self._run_on_fail(test_case, database)
-            return self._record_fail(name, f"Too slow: {elapsed_ms:.1f}ms > {threshold_ms:.0f}ms", query, response,
-                                     test_case.get("expect"), is_noncritical, elapsed_ms, threshold_ms, diag)
+            waiver_reason = self.perf_regression_waivers.get(perf_key)
+            if waiver_reason is None:
+                diag = self._run_on_fail(test_case, database)
+                print(f"    Hint: if this regression is known and accepted, add to a commit message:")
+                print(f"      Perf-Regression-Accepted: {perf_key} | <reason>")
+                return self._record_fail(name, f"Too slow: {elapsed_ms:.1f}ms > {threshold_ms:.0f}ms", query, response,
+                                         test_case.get("expect"), is_noncritical, elapsed_ms, threshold_ms, diag)
+            # A commit trailer named this exact case: report the regression
+            # loudly but let the case through to the normal success path
+            # below (which still validates expect: and records the real
+            # numbers) instead of failing the build.
+            self.waived_regressions.append((name, perf_key, waiver_reason, elapsed_ms, threshold_ms))
+            print(f"⚠️  Accepted perf regression: {name} ({elapsed_ms:.1f}ms > {threshold_ms:.0f}ms) — {waiver_reason}")
 
         # Hard wall-clock limit — applies to every non-perf test case. A query
         # without an explicit `max_time` annotation must finish within
@@ -2074,6 +2133,7 @@ class SQLTestRunner:
             return True
 
         suite_start = time.perf_counter()
+        waived_before_suite = len(self.waived_regressions)
         self.ensure_runner_config_loaded()
 
         # Load performance baselines for this machine
@@ -2212,6 +2272,11 @@ class SQLTestRunner:
                 print(f"   {'⚠️' if is_noncrit else '❌'} {name}{suffix}")
         else:
             print("🎉 All tests passed!")
+        suite_waivers = self.waived_regressions[waived_before_suite:]
+        if suite_waivers:
+            print(f"⚠️  Accepted regressions: {len(suite_waivers)}")
+            for waived_name, waived_key, waived_reason, waived_ms, waived_threshold_ms in suite_waivers:
+                print(f"   ⚠️  {waived_name} ({waived_ms:.1f}ms > {waived_threshold_ms:.0f}ms) — {waived_reason}")
         print(f"⏱️  Suite duration: {self._format_duration(time.perf_counter() - suite_start)}")
         print("="*60)
 

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -46,8 +46,10 @@ from run_sql_tests import (  # noqa: E402
     discover_performance_ci_suites,
     is_error_response,
     initialize_performance_recording,
+    load_perf_regression_waivers,
     load_performance_scale,
     observe_atomic_json,
+    parse_perf_regression_waivers,
     performance_ab_threshold_ms,
     performance_architecture,
     performance_case_fingerprint,
@@ -808,6 +810,94 @@ class SuiteIsolationContractTest(unittest.TestCase):
             encoding="utf-8",
         )
         self.assertIn('fail_fast_mode="${MEMCP_FAIL_FAST:-0}"', hook)
+
+class PerfRegressionWaiverContractTest(unittest.TestCase):
+    def test_parses_one_waiver_with_reason(self) -> None:
+        waivers = parse_perf_regression_waivers(
+            "Fix the thing\n\n"
+            "Perf-Regression-Accepted: tests/performance/foo.yaml::Slow case | "
+            "correlated plan is required for correctness here\n"
+        )
+        self.assertEqual(
+            waivers,
+            {"tests/performance/foo.yaml::Slow case": "correlated plan is required for correctness here"},
+        )
+
+    def test_parses_multiple_waivers_across_commits(self) -> None:
+        # git log --format=%B concatenates one PR's commit bodies like this.
+        waivers = parse_perf_regression_waivers(
+            "commit one\n\nPerf-Regression-Accepted: a.yaml::A | reason a\n\n"
+            "commit two\n\nPerf-Regression-Accepted: b.yaml::B | reason b\n"
+        )
+        self.assertEqual(waivers, {"a.yaml::A": "reason a", "b.yaml::B": "reason b"})
+
+    def test_reason_is_optional(self) -> None:
+        waivers = parse_perf_regression_waivers("Perf-Regression-Accepted: a.yaml::A\n")
+        self.assertEqual(waivers, {"a.yaml::A": ""})
+
+    def test_ignores_unrelated_commit_text(self) -> None:
+        self.assertEqual(parse_perf_regression_waivers("just a normal commit message\n"), {})
+        self.assertEqual(parse_perf_regression_waivers(""), {})
+        self.assertEqual(parse_perf_regression_waivers(None), {})
+
+    def test_key_matching_is_exact_no_prefix_or_glob(self) -> None:
+        waivers = parse_perf_regression_waivers(
+            "Perf-Regression-Accepted: a.yaml::Exact case | ok\n"
+        )
+        self.assertIn("a.yaml::Exact case", waivers)
+        self.assertNotIn("a.yaml::Exact case (extended)", waivers)
+        self.assertNotIn("a.yaml::Exact", waivers)
+
+    def test_load_from_file_env_var(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            waivers_file = Path(tmp) / "waivers.txt"
+            waivers_file.write_text("Perf-Regression-Accepted: a.yaml::A | ok\n")
+            with mock.patch.dict(os.environ, {"PERF_REGRESSION_WAIVERS_FILE": str(waivers_file)}):
+                self.assertEqual(load_perf_regression_waivers(), {"a.yaml::A": "ok"})
+
+    def test_load_is_empty_without_env_var_or_missing_file(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PERF_REGRESSION_WAIVERS_FILE", None)
+            self.assertEqual(load_perf_regression_waivers(), {})
+        with mock.patch.dict(os.environ, {"PERF_REGRESSION_WAIVERS_FILE": "/nonexistent/path"}):
+            self.assertEqual(load_perf_regression_waivers(), {})
+
+    def test_waived_case_passes_through_and_is_recorded(self) -> None:
+        runner = SQLTestRunner("http://localhost:1")
+        runner.perf_regression_waivers = {"?::SCM must be measured": "known, accepted"}
+        response = SimpleNamespace(status_code=200, text="true", headers={})
+        clock = itertools.count(0, 1_000_000)
+        with mock.patch("run_sql_tests.PERF_TEST_ENABLED", True), \
+                mock.patch("run_sql_tests.PERF_AB_MODE", ""), \
+                mock.patch("run_sql_tests.find_memcp_pid", return_value=None), \
+                mock.patch("run_sql_tests.time.monotonic_ns", side_effect=lambda: next(clock)), \
+                mock.patch("run_sql_tests.requests.post", return_value=response):
+            result = runner.run_test_case({
+                "name": "SCM must be measured", "scm": "true", "threshold_ms": 0.01,
+                "repetitions": 2, "warmup": 0, "expect": {"rows": 1},
+            }, "memcp-tests")
+        self.assertTrue(result)
+        self.assertEqual(len(runner.waived_regressions), 1)
+        self.assertEqual(runner.waived_regressions[0][0], "SCM must be measured")
+        self.assertEqual(runner.waived_regressions[0][2], "known, accepted")
+
+    def test_unrelated_waiver_does_not_cover_a_different_case(self) -> None:
+        runner = SQLTestRunner("http://localhost:1")
+        runner.perf_regression_waivers = {"?::Some other case": "known, accepted"}
+        response = SimpleNamespace(status_code=200, text="true", headers={})
+        clock = itertools.count(0, 1_000_000)
+        with mock.patch("run_sql_tests.PERF_TEST_ENABLED", True), \
+                mock.patch("run_sql_tests.PERF_AB_MODE", ""), \
+                mock.patch("run_sql_tests.find_memcp_pid", return_value=None), \
+                mock.patch("run_sql_tests.time.monotonic_ns", side_effect=lambda: next(clock)), \
+                mock.patch("run_sql_tests.requests.post", return_value=response):
+            result = runner.run_test_case({
+                "name": "SCM must be measured", "scm": "true", "threshold_ms": 0.01,
+                "repetitions": 2, "warmup": 0, "expect": {"rows": 1},
+            }, "memcp-tests")
+        self.assertFalse(result)
+        self.assertEqual(runner.waived_regressions, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Perf A/B (`performance-ab` / `jit-performance-ab`) is a hard gate: any candidate case above its threshold fails the build. There has been no principled way to land a change that knowingly trades some performance for something else worth more — only a maintainer bypassing the check by hand, which is undocumented, easy to forget to revert, and invisible to anyone reading history later.

This adds a narrow, self-scoping alternative instead of an admin toggle: name the exact regressed case in a commit trailer, with a reason, and the guard lets that one case through while reporting it loudly.

```
Perf-Regression-Accepted: tests/performance/foo.yaml::Some case name | reason
```

The key is exactly the `<suite>::<case>` string `performance_case_key()` already computes — and a regressed case without a matching trailer now prints it as a copy-paste hint.

## How it's scoped

- **Exact match only.** No prefixes, no globs — a waiver can never cover more than the one case it names.
- **Per-PR, not global.** The workflow extracts `git log base..HEAD --format=%B` for *this PR's own commits* into a file passed only to the `compare` run (never `record` — the baseline stays honest). No branch-protection setting changes, nothing that could linger and silently affect unrelated PRs or master.
- **Local runs are unaffected.** `PERF_REGRESSION_WAIVERS_FILE` unset → `{}` → every regression fails exactly as it does today.
- **Permanent, visible record.** The reason lives in `git log`, not in a temporary CI setting nobody remembers to revert.

## What changes on a waived case

The threshold-fail branch in `run_test_case` checks the waiver dict before failing; a match prints the regression with its real numbers and falls through to the normal success path. The A/B threshold math, baseline recording, and `expect:` validation are all untouched — a waived case still has to produce correct results, it just isn't allowed to fail the build on speed alone.

## Tests

`tools/test_sql_runner_contract.py::PerfRegressionWaiverContractTest` — trailer parsing (single/multiple/optional-reason/unrelated-text), exact-key-only matching, `load_perf_regression_waivers` file/env-var behavior, and two `run_test_case` integration cases (waived case passes through and is recorded; a differently-named case is *not* covered by an unrelated waiver). Full suite: 64/64 green.

## Motivating case (follow-up, not in this PR)

#883's constant-projection-row parameterizer regresses a specific nested-`AVG` KPI shape ~8–12× because the correlated `AVG` decorrelation path is pathological — but that exact shape (fixed, never-changing literals across repeated calls) doesn't occur with real users; every real KPI board recomputes its period bounds from `now()`. This mechanism is what would let #883 land with that one named, understood, and permanently documented regression, without touching branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSuVhbwv6pvf3WiNPCRUht