### PR TITLE
feat(dashboard): expose blob storage stats and on-demand cleanup

### DIFF
--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -372,6 +372,7 @@ body{display:flex;flex-direction:column}
 <div class="tab-bar">
 <button class="tab-btn" id="tabbtn-db-tables" onclick="_switchDbTab('tables')">Tables</button>
 <button class="tab-btn" id="tabbtn-db-errors" onclick="_switchDbTab('errors')" data-admin-only>Errors</button>
+<button class="tab-btn" id="tabbtn-db-blobs" onclick="_switchDbTab('blobs')" data-admin-only>Blobs</button>
 <button class="tab-btn" id="tabbtn-db-console" onclick="_switchDbTab('console')">Console</button>
 </div>
 <div class="tab-panel" id="tabpanel-db-tables">
@@ -400,6 +401,22 @@ body{display:flex;flex-direction:column}
 <div style="display:flex;gap:8px;align-items:center;padding:10px 0" id="db-errors-pagination"></div>
 </div>
 </div><!-- end tabpanel-db-errors -->
+
+<div class="tab-panel" id="tabpanel-db-blobs" data-admin-only>
+<div class="browse-wrap">
+<div style="margin-bottom:12px;display:flex;gap:8px;align-items:center">
+<span id="db-blobs-status" style="color:#888;font-size:.8rem"></span>
+<button class="btn-warn" id="btn-reload-db-blobs" onclick="loadDbBlobs()">Reload</button>
+<button class="btn-danger" id="btn-cleanup-db-blobs" onclick="runDbBlobCleanup()">Run Cleanup</button>
+</div>
+<table class="browse-table" id="tbl-db-blobs">
+<thead><tr><th>Referenced</th><th>Listed on disk</th><th>Unreferenced</th><th>Missing</th></tr></thead>
+<tbody id="db-blobs-tbody"><tr><td colspan="4" style="color:#888;text-align:center">Loading…</td></tr></tbody>
+</table>
+<div id="db-blobs-missing" style="margin-top:10px;font-size:.8rem;color:#888"></div>
+<div id="db-blobs-cleanup-result" style="margin-top:10px;font-size:.85rem"></div>
+</div>
+</div><!-- end tabpanel-db-blobs -->
 
 <div class="tab-panel" id="tabpanel-db-console">
 <div class="console-wrap">
@@ -1110,7 +1127,7 @@ var _dbTab="tables";
 var _dbTabDb=null;
 function _switchDbTab(tab){
 _dbTab=tab;
-var tabs=["tables","errors","console"];
+var tabs=["tables","errors","blobs","console"];
 for(var i=0;i<tabs.length;i++){
 var p=document.getElementById("tabpanel-db-"+tabs[i]);
 var b=document.getElementById("tabbtn-db-"+tabs[i]);
@@ -1122,6 +1139,7 @@ if(tab==="tables") location.hash="db/"+encodeURIComponent(_dbTabDb);
 else location.hash="db/"+encodeURIComponent(_dbTabDb)+"/+"+tab;
 }
 if(tab==="errors") loadDbErrors();
+if(tab==="blobs") loadDbBlobs();
 if(tab==="console"){
 var lbl=document.getElementById("db-console-dbname");
 if(lbl)lbl.textContent=_dbTabDb||"";
@@ -1156,7 +1174,7 @@ if(b)b.classList.toggle("active",tabs[i]===tab);
 
 function _switchDbTabQuiet(tab){
 _dbTab=tab;
-var tabs=["tables","errors","console"];
+var tabs=["tables","errors","blobs","console"];
 for(var i=0;i<tabs.length;i++){
 var p=document.getElementById("tabpanel-db-"+tabs[i]);
 var b=document.getElementById("tabbtn-db-"+tabs[i]);
@@ -1227,6 +1245,40 @@ if(r.query)html+='<div style="color:#888;font-size:.7rem;text-transform:uppercas
 html+='<div style="color:#e74c3c;font-size:.7rem;text-transform:uppercase;margin:10px 0 4px">Error</div><pre style="color:#e74c3c;background:#1a1a2e;padding:10px;border-radius:4px;white-space:pre-wrap;word-break:break-all;font-size:.85rem">'+esc(r.error||"")+'</pre>';
 document.getElementById("error-detail-content").innerHTML=html;
 document.getElementById("error-detail-modal").style.display="flex";
+}
+
+/* DB blob storage stats for view-tables Blobs tab */
+function loadDbBlobs(){
+if(!_dbTabDb)return;
+var status=document.getElementById("db-blobs-status");
+if(status)status.textContent="Loading…";
+apiFetch(base+"/dashboard/api/db/"+encodeURIComponent(_dbTabDb)+"/blobs",renderDbBlobsTable);
+}
+function renderDbBlobsTable(data){
+var tbody=document.getElementById("db-blobs-tbody");
+if(!tbody)return;
+if(!data){tbody.innerHTML='<tr><td colspan="4" style="color:#e74c3c;text-align:center">Failed to load blob statistics.</td></tr>';return;}
+var missing=data.missing_blobs||[];
+tbody.innerHTML="<tr><td class='r'>"+fmt(data.referenced_blobs||0)+"</td><td class='r'>"+fmt(data.listed_blobs||0)+"</td><td class='r'>"+fmt(data.unreferenced_blobs||0)+"</td><td class='r'"+(missing.length?" style='color:#e74c3c'":"")+">"+fmt(missing.length)+"</td></tr>";
+var status=document.getElementById("db-blobs-status");
+if(status)status.textContent=data.unreferenced_blobs?data.unreferenced_blobs+" unreferenced blob(s) can be reclaimed by cleanup":"No unreferenced blobs";
+var missingEl=document.getElementById("db-blobs-missing");
+if(missingEl)missingEl.innerHTML=missing.length?("<b style='color:#e74c3c'>Missing (referenced but unreadable):</b> "+missing.map(esc).join(", ")):"";
+}
+function runDbBlobCleanup(){
+if(!_dbTabDb)return;
+if(!window.confirm("Run blob cleanup for database '"+_dbTabDb+"'? This permanently deletes disk objects proven unreferenced."))return;
+var result=document.getElementById("db-blobs-cleanup-result");
+if(result)result.innerHTML="<span style='color:#888'>Running cleanup…</span>";
+fetch(base+"/dashboard/api/db/"+encodeURIComponent(_dbTabDb)+"/blobs/cleanup",{method:"POST",credentials:"same-origin"})
+.then(function(r){if(!r.ok)throw new Error(r.status);return r.json();})
+.then(function(data){
+if(result)result.innerHTML=data.complete
+?("<span style='color:#2ecc71'>Cleanup complete: "+fmt(data.blobs_deleted||0)+" blob(s) and "+fmt(data.shards_deleted||0)+" shard file(s) deleted.</span>")
+:("<span style='color:#f39c12'>Ownership check was incomplete (a rebuild may be publishing) — nothing was deleted. Try again shortly.</span>");
+loadDbBlobs();
+})
+.catch(function(e){if(result)result.innerHTML="<span style='color:#e74c3c'>Cleanup failed: "+esc(e.message)+"</span>"});
 }
 
 function apiFetch(url,cb){
@@ -1530,7 +1582,7 @@ return;
 /* db/NAME/+errors or db/NAME/+console — literal + sigil for special tabs
    Table routes use @ sigil (db/NAME/@TABLE); both + and @ are encoded by
    encodeURIComponent (%2B / %40) so neither can appear literally from user data */
-m=hash.match(/^db\/([^/]+)\/\+(errors|console)$/);
+m=hash.match(/^db\/([^/]+)\/\+(errors|blobs|console)$/);
 if(m){
 var dbX=decodeURIComponent(m[1]),tabX=m[2];
 showView("view-tables");
@@ -1542,6 +1594,7 @@ setBreadcrumb([{label:"All Databases",href:"#databases"},{label:dbX}]);
 document.getElementById("tables-title").textContent="Tables in "+dbX;
 _switchDbTabQuiet(tabX);
 if(tabX==="errors") loadDbErrors();
+if(tabX==="blobs") loadDbBlobs();
 if(tabX==="console"){
 var lbl=document.getElementById("db-console-dbname");
 if(lbl)lbl.textContent=dbX;

--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -256,6 +256,24 @@ eviction registrations or planner snapshots as a substitute for resident RAM. */
 						",\"indexes\":" index_items "}"))
 				)))
 			)
+			/* API: blob storage statistics for a database (admin only) */
+			(regex "^/dashboard/api/db/([^/]+)/blobs/cleanup$" _ dbname) (begin
+				(if (dashboard_check_admin req)
+					(dashboard_send_json res (json_encode_assoc (blob_cleanup dbname)))
+					(dashboard_send_401 res))
+			)
+			(regex "^/dashboard/api/db/([^/]+)/blobs$" _ dbname) (begin
+				(if (dashboard_check_admin req) (begin
+					(define report (blob_inventory dbname))
+					(define missing (get_assoc report "missing_blobs"))
+					(dashboard_send_json res (concat
+						"{\"referenced_blobs\":" (json_encode (get_assoc report "referenced_blobs"))
+						",\"listed_blobs\":" (json_encode (get_assoc report "listed_blobs"))
+						",\"unreferenced_blobs\":" (json_encode (get_assoc report "unreferenced_blobs"))
+						",\"missing_blobs\":" (dashboard_json_array (map missing (lambda (h) (json_encode h))))
+						"}"))
+				) (dashboard_send_401 res))
+			)
 			/* API: table detail with columns, shards, meta */
 			(regex "^/dashboard/api/db/([^/]+)/([^/]+)$" _ dbname tblname) (begin
 				(dashboard_check_db req res dbname (lambda (is_admin) (begin

--- a/storage/gc.go
+++ b/storage/gc.go
@@ -40,15 +40,17 @@ const blobManifestHeader = "memcp-blob-references-v2\n"
 
 // CleanDatabase removes only disk objects proven unowned by the complete active
 // generation. It serializes against rebuild/repartition publication, but does
-// not stop ordinary queries or DML.
-func CleanDatabase(db *database) (blobsDeleted, shardsDeleted int) {
+// not stop ordinary queries or DML. complete reports whether the ownership scan
+// could prove every active generation's references (false means this pass
+// deleted nothing and should simply be retried later).
+func CleanDatabase(db *database) (blobsDeleted, shardsDeleted int, complete bool) {
 	// Startup cleanup runs immediately after the lazy database catalog is
 	// discovered. An unloaded schema is not an empty schema: load its committed
 	// topology before proving that any disk object is unowned.
 	db.ensureLoaded()
 	db.persistenceLifecycle.Lock()
 	defer db.persistenceLifecycle.Unlock()
-	blobsDeleted = cleanBlobs(db)
+	blobsDeleted, complete = cleanBlobs(db)
 	shardsDeleted = cleanShards(db)
 	return
 }
@@ -58,14 +60,13 @@ func CleanDatabase(db *database) (blobsDeleted, shardsDeleted int) {
 // metadata and can lag after a crash, so it is never proof that deletion is
 // safe. Missing legacy manifests are reconstructed from committed column files;
 // corrupt manifests and all ambiguous I/O failures remain a fail-closed no-op.
-func cleanBlobs(db *database) int {
+func cleanBlobs(db *database) (deleted int, complete bool) {
 	references, complete := activeBlobReferences(db, true)
 	if !complete {
 		fmt.Printf("blob cleanup %s: ownership check incomplete; retaining all blobs\n", db.Name)
-		return 0
+		return 0, false
 	}
 
-	deleted := 0
 	db.persistence.WalkBlobs(func(hash string) {
 		defer db.lockBlobRef(hash)()
 		if _, live := references[hash]; !live {
@@ -73,7 +74,7 @@ func cleanBlobs(db *database) int {
 			deleted++
 		}
 	})
-	return deleted
+	return deleted, true
 }
 
 // BlobInventory describes listed objects, not payload readability or integrity.
@@ -359,10 +360,17 @@ func extractShardUUID(name string) string {
 // Clean runs CleanDatabase on all loaded databases and returns a summary string.
 func Clean() string {
 	totalBlobs, totalShards := 0, 0
+	incomplete := 0
 	for _, db := range databases.GetAll() {
-		b, s := CleanDatabase(db)
+		b, s, complete := CleanDatabase(db)
 		totalBlobs += b
 		totalShards += s
+		if !complete {
+			incomplete++
+		}
+	}
+	if incomplete > 0 {
+		return fmt.Sprintf("cleaned %d orphaned blobs, %d orphaned shard files (%d database(s) skipped: ownership check incomplete, retry later)", totalBlobs, totalShards, incomplete)
 	}
 	return fmt.Sprintf("cleaned %d orphaned blobs, %d orphaned shard files", totalBlobs, totalShards)
 }

--- a/storage/gc_test.go
+++ b/storage/gc_test.go
@@ -133,7 +133,7 @@ func TestCleanNoOrphans(t *testing.T) {
 	})
 
 	db := GetDatabase("gcdb")
-	b, s := CleanDatabase(db)
+	b, s, _ := CleanDatabase(db)
 	if b != 0 || s != 0 {
 		t.Errorf("expected 0 blobs, 0 shards deleted; got %d blobs, %d shards", b, s)
 	}
@@ -175,7 +175,7 @@ func TestCleanOrphanedBlob(t *testing.T) {
 	os.WriteFile(filepath.Join(orphanPath, orphanHash), []byte("fake"), 0640)
 
 	db := GetDatabase("gcdb")
-	b, _ := CleanDatabase(db)
+	b, _, _ := CleanDatabase(db)
 	if b != 1 {
 		t.Errorf("expected 1 orphaned blob deleted, got %d", b)
 	}
@@ -227,7 +227,7 @@ func TestCleanBlobsBackfillsMissingLegacyManifest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deleted, _ := CleanDatabase(tbl.schema)
+	deleted, _, _ := CleanDatabase(tbl.schema)
 	if deleted != 1 {
 		t.Fatalf("cleanup deleted %d blobs after legacy backfill, want 1 orphan", deleted)
 	}
@@ -282,7 +282,7 @@ func TestStartupCleanLoadsColdSchemaBeforeBlobDeletion(t *testing.T) {
 	if cold == nil || cold.srState != COLD {
 		t.Fatal("expected lazily loaded database after catalog discovery")
 	}
-	deleted, _ := CleanDatabase(cold)
+	deleted, _, _ := CleanDatabase(cold)
 	if deleted != 1 {
 		t.Fatalf("startup cleanup deleted %d blobs, want only the legacy orphan", deleted)
 	}
@@ -320,7 +320,7 @@ func TestCleanBlobsRejectsCorruptManifest(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(orphanPath, orphanHash), []byte("orphan"), 0640); err != nil {
 		t.Fatal(err)
 	}
-	deleted, _ := CleanDatabase(tbl.schema)
+	deleted, _, _ := CleanDatabase(tbl.schema)
 	if deleted != 0 {
 		t.Fatalf("cleanup trusted a corrupt manifest and deleted %d blobs", deleted)
 	}
@@ -389,7 +389,7 @@ func TestCleanOrphanedShardFile(t *testing.T) {
 	os.WriteFile(filepath.Join(Basepath, "gcdb", fakeName), []byte("garbage"), 0640)
 
 	db := GetDatabase("gcdb")
-	_, s := CleanDatabase(db)
+	_, s, _ := CleanDatabase(db)
 	if s != 1 {
 		t.Errorf("expected 1 orphaned shard file deleted, got %d", s)
 	}
@@ -417,7 +417,7 @@ func TestCleanIdempotent(t *testing.T) {
 
 	db := GetDatabase("gcdb")
 	CleanDatabase(db)
-	b, s := CleanDatabase(db)
+	b, s, _ := CleanDatabase(db)
 	if b != 0 || s != 0 {
 		t.Errorf("second Clean: expected 0+0, got %d+%d", b, s)
 	}
@@ -429,7 +429,7 @@ func TestCleanEmptyDatabase(t *testing.T) {
 
 	CreateDatabase("gcdb", false)
 	db := GetDatabase("gcdb")
-	b, s := CleanDatabase(db)
+	b, s, _ := CleanDatabase(db)
 	if b != 0 || s != 0 {
 		t.Errorf("empty db: expected 0+0, got %d+%d", b, s)
 	}
@@ -502,7 +502,7 @@ func TestCleanAfterRebuildSupersedesShards(t *testing.T) {
 	}
 
 	// GC should remove UUID-A files.
-	_, s := CleanDatabase(db)
+	_, s, _ := CleanDatabase(db)
 	if s == 0 {
 		t.Error("expected at least 1 orphaned shard file deleted, got 0")
 	}
@@ -553,7 +553,7 @@ func TestBlobManifestUpgradesIncompleteV1(t *testing.T) {
 	databases.Remove("gcdb")
 	LoadDatabases()
 	db := GetDatabase("gcdb")
-	if deleted, _ := CleanDatabase(db); deleted != 0 {
+	if deleted, _, _ := CleanDatabase(db); deleted != 0 {
 		t.Fatalf("upgrade deleted %d live blobs", deleted)
 	}
 	if len(blobFiles(t, "gcdb")) != len(values) {
@@ -596,7 +596,7 @@ func TestBlobManifestSurvivesUnchangedColdRebuild(t *testing.T) {
 	if !bytes.Equal(before, after) {
 		t.Fatal("unchanged cold rebuild overwrote ownership with a partial column map")
 	}
-	if deleted, _ := CleanDatabase(db); deleted != 0 {
+	if deleted, _, _ := CleanDatabase(db); deleted != 0 {
 		t.Fatalf("cold rebuild lost %d live blobs", deleted)
 	}
 }
@@ -648,7 +648,7 @@ func TestBlobUndercountRetainsCommittedOwners(t *testing.T) {
 			if got := len(blobFiles(t, "gcdb")); got != 3 {
 				t.Fatalf("decrement deleted committed blobs: got %d, want 3", got)
 			}
-			if deleted, _ := CleanDatabase(db); deleted != 0 {
+			if deleted, _, _ := CleanDatabase(db); deleted != 0 {
 				t.Fatalf("cleanup deleted %d owned blobs", deleted)
 			}
 			references, complete := activeBlobReferences(db, true)
@@ -668,7 +668,7 @@ func TestBlobUndercountRetainsCommittedOwners(t *testing.T) {
 			if got := len(blobFiles(t, "gcdb")); got != 3 {
 				t.Fatalf("drop deleted blobs before ownership check: %d", got)
 			}
-			if deleted, _ := CleanDatabase(db); deleted != 3 {
+			if deleted, _, _ := CleanDatabase(db); deleted != 3 {
 				t.Fatalf("cleanup deleted %d orphans, want 3", deleted)
 			}
 		})
@@ -713,7 +713,7 @@ func TestBlobInventoryListsMissingReferencesWithoutFetchingPayloads(t *testing.T
 	if report.Referenced != 3 || report.Listed != 3 || len(report.Missing) != 0 || report.Unreferenced != 0 {
 		t.Fatalf("healthy inventory: %+v", report)
 	}
-	if deleted, _ := CleanDatabase(db); deleted != 0 {
+	if deleted, _, _ := CleanDatabase(db); deleted != 0 {
 		t.Fatalf("cleanup deleted %d live blobs", deleted)
 	}
 	// Missing legacy manifests are discovered without publishing a backfill.
@@ -755,7 +755,7 @@ func TestBlobInventoryListsMissingReferencesWithoutFetchingPayloads(t *testing.T
 		t.Fatal("audit deleted the orphan")
 	}
 	db.persistence = backend
-	if deleted, _ := CleanDatabase(db); deleted != 1 {
+	if deleted, _, _ := CleanDatabase(db); deleted != 1 {
 		t.Fatalf("cleanup retained an unowned blob because another file is missing: deleted %d", deleted)
 	}
 	if got := len(blobFiles(t, "gcdb")); got != 0 {
@@ -860,13 +860,13 @@ func (w *pausingBlobWriter) Close() error {
 	return err
 }
 
-// readContentColumn scans the "content" column, recovering a panic instead of
-// crashing the test process so a missing-blob corruption surfaces as a
-// regular test failure.
-func readContentColumn(tbl *table) (values []string, panicked any) {
+// readColumn scans a single column, recovering a panic instead of crashing
+// the test process so a missing-blob corruption surfaces as a regular test
+// failure.
+func readColumn(tbl *table, col string) (values []string, panicked any) {
 	defer func() { panicked = recover() }()
-	tbl.scan(nil, newScanAccessSchema(scanAccessConsumerScan, nil, -1), nil, []string{}, trueCondition(), []string{"content"},
-		// mapReduce receives (accumulator, content); a[0] is the fold
+	tbl.scan(nil, newScanAccessSchema(scanAccessConsumerScan, nil, -1), nil, []string{}, trueCondition(), []string{col},
+		// mapReduce receives (accumulator, value); a[0] is the fold
 		// accumulator (unused here), a[1] is the requested column value.
 		scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { values = append(values, a[1].String()); return a[0] }),
 		scm.NewNil(), scm.NewNil(), false)
@@ -950,7 +950,7 @@ func TestOverflowRebuildBlobSurvivesConcurrentClean(t *testing.T) {
 		t.Fatal("CleanDatabase did not resume after the overflow rebuild published its generation")
 	}
 
-	values, panicked := readContentColumn(tbl)
+	values, panicked := readColumn(tbl, "content")
 	if panicked != nil {
 		t.Fatalf("reading the uploaded rows panicked (a blob was deleted from under the in-flight rebuild): %v", panicked)
 	}
@@ -969,4 +969,95 @@ func TestOverflowRebuildBlobSurvivesConcurrentClean(t *testing.T) {
 		}
 		t.Fatalf("uploaded row content corrupted by a concurrent GC race")
 	}
+}
+
+// blobCleanupCall invokes the "blob_cleanup" scm builtin registered by
+// storage.go's scm.Declare and returns its flat-list report as a map.
+func blobCleanupCall(t *testing.T, dbname string) map[string]scm.Scmer {
+	t.Helper()
+	fn, ok := scm.Globalenv.Vars[scm.Symbol("blob_cleanup")]
+	if !ok {
+		t.Fatal("blob_cleanup is not registered")
+	}
+	result := scm.Apply(fn, scm.NewString(dbname)).Slice()
+	if len(result)%2 != 0 {
+		t.Fatalf("blob_cleanup returned an odd-length list: %d", len(result))
+	}
+	report := make(map[string]scm.Scmer, len(result)/2)
+	for i := 0; i < len(result); i += 2 {
+		report[result[i].String()] = result[i+1]
+	}
+	return report
+}
+
+// TestBlobCleanupSCMFunction covers the "blob_cleanup" scm builtin that the
+// dashboard's cleanup action calls: a normal pass reports its deletions and
+// complete=true, while a pass that cannot prove ownership (the same corrupt
+// manifest fixture TestCleanBlobsRejectsCorruptManifest uses) reports
+// complete=false and deletes nothing, rather than silently claiming success.
+func TestBlobCleanupSCMFunction(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		defer setupGCTest(t)()
+		CreateDatabase("gcdb", false)
+		tbl, _ := CreateTable("gcdb", "docs", Safe, false)
+		tbl.CreateColumn("id", "INT", nil, nil)
+		tbl.CreateColumn("content", "TEXT", nil, nil)
+		insertLongRows(t, tbl, []string{
+			strings.Repeat("X", maxInlineBlobBytes+800),
+			strings.Repeat("Y", maxInlineBlobBytes+800),
+			strings.Repeat("Z", maxInlineBlobBytes+800),
+		})
+		if len(blobFiles(t, "gcdb")) == 0 {
+			t.Skip("no blobs created — OverlayBlob threshold not met")
+		}
+
+		orphanHash := "abcdefabcdefabcdefabcdefabcdefab"
+		orphanPath := filepath.Join(Basepath, "gcdb", "blob", orphanHash[:2], orphanHash[2:4])
+		if err := os.MkdirAll(orphanPath, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(orphanPath, orphanHash), []byte("fake"), 0640); err != nil {
+			t.Fatal(err)
+		}
+
+		report := blobCleanupCall(t, "gcdb")
+		if got := scm.ToInt(report["blobs_deleted"]); got != 1 {
+			t.Fatalf("blobs_deleted = %d, want 1", got)
+		}
+		if !report["complete"].Bool() {
+			t.Fatal("complete = false, want true for a provable ownership scan")
+		}
+	})
+
+	t.Run("incomplete", func(t *testing.T) {
+		defer setupGCTest(t)()
+		CreateDatabase("gcdb", false)
+		tbl, _ := CreateTable("gcdb", "docs", Safe, false)
+		tbl.CreateColumn("id", "INT", nil, nil)
+		tbl.CreateColumn("content", "TEXT", nil, nil)
+		insertLongRows(t, tbl, []string{
+			strings.Repeat("p", maxInlineBlobBytes+1),
+			strings.Repeat("q", maxInlineBlobBytes+1),
+			strings.Repeat("r", maxInlineBlobBytes+1),
+		})
+
+		// Corrupt the active shard's manifest (bad checksum): the same fixture
+		// TestCleanBlobsRejectsCorruptManifest uses to force an unprovable scan.
+		shard := tbl.ActiveShards()[0]
+		writer := tbl.schema.persistence.WriteColumn(shard.uuid.String(), blobManifestColumn)
+		if _, err := writer.Write([]byte(blobManifestHeader + strings.Repeat("0", 64) + "\n" + strings.Repeat("f", 64) + "\n")); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		report := blobCleanupCall(t, "gcdb")
+		if got := scm.ToInt(report["blobs_deleted"]); got != 0 {
+			t.Fatalf("blobs_deleted = %d, want 0 for an unprovable scan", got)
+		}
+		if report["complete"].Bool() {
+			t.Fatal("complete = true, want false for a corrupt manifest")
+		}
+	})
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3534,6 +3534,26 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "blob_cleanup",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			db := GetDatabase(scm.String(a[0]))
+			if db == nil {
+				panic("blob_cleanup: database does not exist: " + scm.String(a[0]))
+			}
+			blobsDeleted, shardsDeleted, complete := CleanDatabase(db)
+			return scm.NewSlice([]scm.Scmer{
+				scm.NewString("blobs_deleted"), scm.NewInt(int64(blobsDeleted)),
+				scm.NewString("shards_deleted"), scm.NewInt(int64(shardsDeleted)),
+				scm.NewString("complete"), scm.NewBool(complete),
+			})
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", HasSideEffects: true,
+			Description: "Explicit maintenance cleanup: deletes disk objects proven unowned by the complete active generation. complete=false means the ownership scan could not be proven this pass (e.g. a concurrent rebuild is publishing) and nothing was deleted; simply retry later.",
+			Params:      []*scm.TypeDescriptor{{Kind: "string", Label: "database"}},
+			Return:      &scm.TypeDescriptor{Kind: "list"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "stat",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if len(a) == 0 {


### PR DESCRIPTION
## Summary
- `CleanDatabase` now returns whether its ownership scan was complete, instead of silently discarding that flag — a caller can now tell "nothing was orphaned" apart from "the scan couldn't be proven this pass, retry later."
- New `blob_cleanup` scm function beside the existing `blob_inventory`, wrapping `CleanDatabase` and returning `blobs_deleted`, `shards_deleted`, and `complete`.
- New admin-gated "Blobs" tab per database in the dashboard: shows live referenced/listed/unreferenced/missing blob counts (via the existing `blob_inventory`), and a "Run Cleanup" button that reports what was actually deleted — or that the ownership scan was inconclusive and nothing was touched, rather than implying success.

No change to deletion semantics or locking: `cleanBlobs`'s manifest-based ownership proof is untouched. This is a reporting/dashboard-access addition on top of already-existing, already-tested cleanup logic (the same `CleanDatabase` used by the once-per-startup automatic sweep, now also reachable on demand).

## Test plan
- `go test ./storage/...` green (existing suite plus a new `TestBlobCleanupSCMFunction` covering the `blob_cleanup` scm builtin's report shape, including `complete=false` on a forced-incomplete/corrupt-manifest scan).
- Full `make test` pre-commit suite green (only the pre-existing, already-waived "SCM must be measured" perf-AB noise, unrelated to this change).
- Manually verified end-to-end over HTTP: `GET /dashboard/api/db/<db>/blobs` and `POST /dashboard/api/db/<db>/blobs/cleanup` against a running instance, auth-gating (401 without/with wrong admin creds), and that the existing `/dashboard/api/db/<db>/<table>` route is unaffected by the new route ordering.
- New dashboard JS syntax-checked (`node --check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK5KbaqTtfgrto796BLkkP