### PR TITLE
fix(ci): pull minio from quay.io instead of Docker Hub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,13 +138,19 @@ jobs:
 
       - name: Start S3-compatible storage
         run: |
-          docker pull minio/minio:latest
-          docker image inspect --format='Testing {{index .RepoDigests 0}}' minio/minio:latest
+          # quay.io is MinIO's other official registry for this image. Docker
+          # Hub anonymous pulls are rate-limited per source IP, and that pool
+          # is shared across every GitHub-hosted runner worldwide -- pulling
+          # from quay.io instead avoids that shared-IP exhaustion (confirmed
+          # on master itself: docker.io/minio/minio:latest intermittently
+          # fails with "pull access denied" unrelated to any code change).
+          docker pull quay.io/minio/minio:latest
+          docker image inspect --format='Testing {{index .RepoDigests 0}}' quay.io/minio/minio:latest
           docker run --detach --name memcp-minio \
             --publish 9000:9000 \
             --env MINIO_ROOT_USER \
             --env MINIO_ROOT_PASSWORD \
-            minio/minio:latest server /data
+            quay.io/minio/minio:latest server /data
           for attempt in $(seq 1 60); do
             if curl --fail --silent http://127.0.0.1:9000/minio/health/ready >/dev/null; then
               exit 0


### PR DESCRIPTION
## Summary
- `alternative-storage`'s `docker pull minio/minio:latest` intermittently fails with "pull access denied" -- Docker Hub rate-limits anonymous pulls per source IP, a pool shared across every GitHub-hosted runner. Confirmed this happens on master itself (run 34686763713, 2026-09-12), unrelated to any code change.
- MinIO also publishes to `quay.io/minio/minio`, verified to exist via the quay.io API, which has a separate rate limit and avoids the shared-pool exhaustion.

## Test plan
- [ ] `alternative-storage` job passes on this PR's CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK5KbaqTtfgrto796BLkkP